### PR TITLE
Filter out browser extension errors from Sentry tracking

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -18,6 +18,22 @@ Sentry.init({
   replaysOnErrorSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 1.0,
 
   beforeSend(event) {
+    // Filter out errors from browser extensions (MetaMask, etc.)
+    // These are not application errors and should not be tracked
+    // Common patterns: app:// protocol, moz-extension://, chrome-extension://
+    const frames = event.exception?.values?.[0]?.stacktrace?.frames || []
+    const isExtensionError = frames.some(
+      (frame) =>
+        frame.filename?.startsWith('app://') ||
+        frame.filename?.startsWith('moz-extension://') ||
+        frame.filename?.startsWith('chrome-extension://') ||
+        frame.filename?.includes('inpage.js') ||
+        frame.filename?.includes('content-script')
+    )
+    if (isExtensionError) {
+      return null // Drop the event
+    }
+
     if (event.user) {
       delete event.user.email
       delete event.user.ip_address


### PR DESCRIPTION
## Summary
Added filtering logic to prevent browser extension errors (MetaMask, etc.) from being tracked in Sentry. These errors originate from third-party extensions and are not application errors, so they create noise in error monitoring.

## Changes
- Added extension error detection in the `beforeSend` hook that identifies errors from common browser extensions by checking stack frame filenames
- Filters errors from the following sources:
  - `app://` protocol (generic extension protocol)
  - `moz-extension://` (Firefox extensions)
  - `chrome-extension://` (Chrome extensions)
  - Files named `inpage.js` (common in wallet extensions)
  - Files named `content-script` (common extension pattern)
- Events matching these patterns are dropped (returns `null`) and not sent to Sentry

## Implementation Details
The filter checks the exception stack trace frames before any other processing occurs, ensuring extension errors are caught early and efficiently. This approach is non-invasive and doesn't affect the tracking of legitimate application errors.