### PR TITLE
Add overlay preview component to settings page

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -4,6 +4,7 @@ import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { getStreamerData } from "@/lib/dashboard-data";
 import ChannelPointSettings from "@/components/ChannelPointSettings";
 import CopyButton from "@/components/CopyButton";
+import OverlayPreview from "@/components/OverlayPreview";
 
 // Note: Page is automatically dynamic due to cookies() usage in getSession()
 // cookies()使用により自動的に動的ページになるため、force-dynamicは不要
@@ -84,6 +85,15 @@ export default async function SettingsPage() {
           streamerId={streamerData.streamer.id}
           currentRewardId={streamerData.streamer.channel_point_reward_id}
           currentRewardName={streamerData.streamer.channel_point_reward_name}
+        />
+      </div>
+
+      {/* Overlay Preview Section - オーバーレイ設定とプレビュー */}
+      {/* URLパラメータでオーバーレイ表示をカスタマイズできるプレビュー機能 */}
+      <div className="mt-8">
+        <OverlayPreview
+          streamerId={streamerData.streamer.id}
+          baseUrl={process.env.NEXT_PUBLIC_APP_URL || ""}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
Added a new Overlay Preview section to the dashboard settings page, allowing streamers to preview and customize their overlay configuration with URL parameters.

## Changes
- Imported the new `OverlayPreview` component
- Added a new "Overlay Preview Section" below the Channel Point Settings
- Passed `streamerId` and `baseUrl` props to enable dynamic overlay preview functionality
- The preview feature supports URL parameter customization for overlay display

## Implementation Details
- The overlay preview section is positioned with `mt-8` spacing for visual separation
- Uses `process.env.NEXT_PUBLIC_APP_URL` for the base URL, with a fallback to an empty string
- Includes Japanese comments documenting the overlay customization capability
- Maintains consistency with existing settings page layout and component structure