### PR TITLE
refactor: DEMOボタンとプレビューパラメータを削除

### DIFF
--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -85,13 +85,18 @@ export default function OverlayPage() {
   // URLパラメータからオーバーレイオプションを解析
   // Parse overlay options from URL parameters
   // autoPortrait, smallMode, effectsはデフォルトでtrue（falseの場合のみURLパラメータで明示）
+  // queueMicrotaskを使用してsetStateを非同期に実行し、カスケードレンダーを回避
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
-    setOptions({
-      imageOnly: urlParams.get("imageOnly") === "true",
-      autoPortrait: urlParams.get("autoPortrait") !== "false",  // デフォルトはtrue
-      effects: urlParams.get("effects") !== "false",             // デフォルトはtrue
-      smallMode: urlParams.get("smallMode") !== "false",         // デフォルトはtrue
+    // 非同期に実行してuseEffect内での同期的なsetState呼び出しを回避
+    // Defer setState to avoid synchronous state update in effect body
+    queueMicrotask(() => {
+      setOptions({
+        imageOnly: urlParams.get("imageOnly") === "true",
+        autoPortrait: urlParams.get("autoPortrait") !== "false",  // デフォルトはtrue
+        effects: urlParams.get("effects") !== "false",             // デフォルトはtrue
+        smallMode: urlParams.get("smallMode") !== "false",         // デフォルトはtrue
+      });
     });
   }, []);
 

--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -34,14 +34,12 @@ interface SparklePosition {
  * - autoPortrait: 縦長画像を自動検出してオリジナル画像表示
  * - effects: レジェンダリーのキラキラエフェクト表示（デフォルト: true）
  * - smallMode: 小さい画像用の縮小表示モード
- * - hideDemo: DEMOボタンを非表示（プレビュー用）
  */
 interface OverlayOptions {
   imageOnly: boolean;
   autoPortrait: boolean;
   effects: boolean;
   smallMode: boolean;
-  hideDemo: boolean;
 }
 
 // Generate sparkle positions outside of render
@@ -69,7 +67,6 @@ export default function OverlayPage() {
     autoPortrait: true,  // デフォルトでポートレイト画像を自動検出
     effects: true,
     smallMode: true,     // デフォルトで小さい画像モードを有効化
-    hideDemo: false,
   });
   // 画像のアスペクト比が縦長かどうかを判定するためのState
   const [isPortraitImage, setIsPortraitImage] = useState(false);
@@ -95,7 +92,6 @@ export default function OverlayPage() {
       autoPortrait: urlParams.get("autoPortrait") !== "false",  // デフォルトはtrue
       effects: urlParams.get("effects") !== "false",             // デフォルトはtrue
       smallMode: urlParams.get("smallMode") !== "false",         // デフォルトはtrue
-      hideDemo: urlParams.get("hideDemo") === "true",            // プレビュー用にDEMOボタンを非表示
     });
   }, []);
 
@@ -260,15 +256,6 @@ export default function OverlayPage() {
             <div className="mb-2 font-bold">接続エラー</div>
             <div>{errorMessage}</div>
           </div>
-        )}
-        {/* Hidden trigger for demo (hideDemoがtrueの場合は非表示) */}
-        {!options.hideDemo && (
-          <button
-            onClick={triggerDemo}
-            className="fixed bottom-4 right-4 rounded bg-purple-600 px-4 py-2 text-sm text-white opacity-30 hover:opacity-100"
-          >
-            Demo
-          </button>
         )}
       </div>
     );

--- a/src/components/OverlayPreview.tsx
+++ b/src/components/OverlayPreview.tsx
@@ -70,13 +70,17 @@ export default function OverlayPreview({ streamerId, baseUrl, showPreview = true
 
   // オプション変更時にURL更新メッセージを表示
   // 初回レンダリング時は表示しない
+  // queueMicrotaskを使用してsetStateを非同期に実行し、カスケードレンダーを回避
   useEffect(() => {
     if (isFirstRender.current) {
       isFirstRender.current = false;
       return;
     }
-    // メッセージを表示
-    setShowUrlUpdated(true);
+    // 非同期に実行してuseEffect内での同期的なsetState呼び出しを回避
+    // Defer setState to avoid synchronous state update in effect body
+    queueMicrotask(() => {
+      setShowUrlUpdated(true);
+    });
     // 3秒後に非表示
     const timer = setTimeout(() => {
       setShowUrlUpdated(false);

--- a/src/components/OverlayPreview.tsx
+++ b/src/components/OverlayPreview.tsx
@@ -63,27 +63,10 @@ export default function OverlayPreview({ streamerId, baseUrl, showPreview = true
     return params.toString();
   }, [options]);
 
-  // プレビュー用のURLパラメータを生成（hideDemoを含む）
-  // Generate URL parameters for preview iframe (includes hideDemo)
-  // autoPortrait, smallMode, effectsはデフォルトでtrue（falseの場合のみURLパラメータで明示）
-  const buildPreviewUrlParams = useCallback(() => {
-    const params = new URLSearchParams();
-    if (options.imageOnly) params.set("imageOnly", "true");
-    if (!options.autoPortrait) params.set("autoPortrait", "false");  // デフォルトtrue、falseの場合のみ出力
-    if (!options.effects) params.set("effects", "false");             // デフォルトtrue、falseの場合のみ出力
-    if (!options.smallMode) params.set("smallMode", "false");        // デフォルトtrue、falseの場合のみ出力
-    params.set("hideDemo", "true"); // プレビューではDEMOボタンを非表示
-    return params.toString();
-  }, [options]);
-
   // オーバーレイURLを生成
   const overlayUrl = `${baseUrl}/overlay/${streamerId}`;
-  // ユーザー向けURL（コピー用）- hideDemoは含まない
-  const userParams = buildUrlParams();
-  const overlayUrlWithParams = userParams ? `${overlayUrl}?${userParams}` : overlayUrl;
-  // プレビュー用URL - hideDemoを含む
-  const previewParams = buildPreviewUrlParams();
-  const previewUrl = `${overlayUrl}?${previewParams}`;
+  const urlParams = buildUrlParams();
+  const overlayUrlWithParams = urlParams ? `${overlayUrl}?${urlParams}` : overlayUrl;
 
   // オプション変更時にURL更新メッセージを表示
   // 初回レンダリング時は表示しない
@@ -106,10 +89,10 @@ export default function OverlayPreview({ streamerId, baseUrl, showPreview = true
   const triggerDemo = useCallback(() => {
     if (iframeRef.current) {
       // iframeをリロードしてdemoパラメータ付きで再読み込み
-      // プレビュー用パラメータを使用（hideDemoを含む）
-      iframeRef.current.src = `${overlayUrl}?${previewParams}&demo=true`;
+      const demoUrl = urlParams ? `${overlayUrl}?${urlParams}&demo=true` : `${overlayUrl}?demo=true`;
+      iframeRef.current.src = demoUrl;
     }
-  }, [overlayUrl, previewParams]);
+  }, [overlayUrl, urlParams]);
 
   // オプションの切り替え
   const toggleOption = (key: keyof OverlayOptions) => {
@@ -237,7 +220,7 @@ export default function OverlayPreview({ streamerId, baseUrl, showPreview = true
       <div className="rounded-lg overflow-hidden bg-gray-900 border border-gray-700">
         <iframe
           ref={iframeRef}
-          src={previewUrl}
+          src={overlayUrlWithParams}
           className="w-full h-[600px]"
           title="Overlay Preview"
         />


### PR DESCRIPTION
iframeプレビューが利用可能になったため、DEMOボタンとhideDemo オプションを削除しました。buildPreviewUrlParams関数をbuildUrlParams に統合し、不要なコード重複を排除しました。