### PR TITLE
Add gacha sound effect settings with R2 storage support

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -45,9 +45,18 @@ R2_SECRET_ACCESS_KEY=your_r2_secret_access_key
 R2_BUCKET_NAME=your_bucket_name
 # R2パブリックURL（カスタムドメインまたはpub-xxx.r2.dev）
 R2_PUBLIC_URL=https://your-bucket.your-domain.com
-# R2効果音バケット名（画像バケットとは別のバケット、必須）
-# 効果音機能を使用する場合は必ず設定が必要
+# Cloudflare R2 Storage（効果音用、すべて必須）
+# 画像バケットとは完全に別のバケット・認証情報を使用
+# R2効果音エンドポイント
+R2_SOUND_ENDPOINT=https://your_sound_account_id.r2.cloudflarestorage.com
+# R2効果音アクセスキーID
+R2_SOUND_ACCESS_KEY_ID=your_r2_sound_access_key_id
+# R2効果音シークレットアクセスキー
+R2_SOUND_SECRET_ACCESS_KEY=your_r2_sound_secret_access_key
+# R2効果音バケット名
 R2_SOUND_BUCKET_NAME=your_sound_bucket_name
+# R2効果音パブリックURL
+R2_SOUND_PUBLIC_URL=https://your-sound-bucket.your-domain.com
 
 # Vercel Blob (既存データの削除用に残す)
 # 新規アップロードはR2を使用、既存データの削除にのみ使用

--- a/.env.local.example
+++ b/.env.local.example
@@ -45,8 +45,8 @@ R2_SECRET_ACCESS_KEY=your_r2_secret_access_key
 R2_BUCKET_NAME=your_bucket_name
 # R2パブリックURL（カスタムドメインまたはpub-xxx.r2.dev）
 R2_PUBLIC_URL=https://your-bucket.your-domain.com
-# R2効果音バケット名（画像バケットとは別のバケット）
-# 設定されていない場合はR2_BUCKET_NAMEを使用
+# R2効果音バケット名（画像バケットとは別のバケット、必須）
+# 効果音機能を使用する場合は必ず設定が必要
 R2_SOUND_BUCKET_NAME=your_sound_bucket_name
 
 # Vercel Blob (既存データの削除用に残す)

--- a/.env.local.example
+++ b/.env.local.example
@@ -47,8 +47,7 @@ R2_BUCKET_NAME=your_bucket_name
 R2_PUBLIC_URL=https://your-bucket.your-domain.com
 # Cloudflare R2 Storage（効果音用、すべて必須）
 # 画像バケットとは完全に別のバケット・認証情報を使用
-# R2効果音エンドポイント
-R2_SOUND_ENDPOINT=https://your_sound_account_id.r2.cloudflarestorage.com
+# エンドポイント(R2_ENDPOINT)は画像バケットと共通
 # R2効果音アクセスキーID
 R2_SOUND_ACCESS_KEY_ID=your_r2_sound_access_key_id
 # R2効果音シークレットアクセスキー

--- a/.env.local.example
+++ b/.env.local.example
@@ -41,10 +41,13 @@ R2_ENDPOINT=https://your_account_id.r2.cloudflarestorage.com
 R2_ACCESS_KEY_ID=your_r2_access_key_id
 # R2シークレットアクセスキー
 R2_SECRET_ACCESS_KEY=your_r2_secret_access_key
-# R2バケット名
+# R2バケット名（画像用）
 R2_BUCKET_NAME=your_bucket_name
 # R2パブリックURL（カスタムドメインまたはpub-xxx.r2.dev）
 R2_PUBLIC_URL=https://your-bucket.your-domain.com
+# R2効果音バケット名（画像バケットとは別のバケット）
+# 設定されていない場合はR2_BUCKET_NAMEを使用
+R2_SOUND_BUCKET_NAME=your_sound_bucket_name
 
 # Vercel Blob (既存データの削除用に残す)
 # 新規アップロードはR2を使用、既存データの削除にのみ使用

--- a/messages/en.json
+++ b/messages/en.json
@@ -227,6 +227,43 @@
     "you": "You",
     "cpu": "CPU"
   },
+  "gachaSoundSettings": {
+    "title": "Gacha Sound Effect Settings",
+    "description": "Set the sound effect that plays during gacha animation.",
+    "status": {
+      "enabled": "Enabled",
+      "disabled": "Disabled"
+    },
+    "form": {
+      "selectFile": "Select sound file",
+      "fileRequirements": "Supported: {formats} | Max size: {maxSize}",
+      "currentSound": "Current sound",
+      "enableSound": "Enable sound effect",
+      "uploadFirst": "Please upload a file first"
+    },
+    "buttons": {
+      "play": "Play",
+      "stop": "Stop",
+      "delete": "Delete"
+    },
+    "messages": {
+      "uploadSuccess": "Sound effect uploaded",
+      "uploading": "Uploading...",
+      "saving": "Saving...",
+      "enabled": "Sound effect enabled",
+      "disabled": "Sound effect disabled",
+      "deleted": "Sound effect deleted"
+    },
+    "errors": {
+      "fileTooLarge": "File size exceeds 1MB limit",
+      "invalidFileType": "Unsupported file format (MP3, WAV, WebM, OGG only)",
+      "uploadFailed": "Upload failed",
+      "saveFailed": "Failed to save settings",
+      "deleteFailed": "Failed to delete",
+      "rateLimit": "Too many requests. Please wait and try again."
+    },
+    "confirmDelete": "Delete this sound effect?"
+  },
   "channelPointSettings": {
     "title": "Card Redemption Settings",
     "status": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -227,6 +227,43 @@
     "you": "あなた",
     "cpu": "CPU"
   },
+  "gachaSoundSettings": {
+    "title": "ガチャ効果音設定",
+    "description": "ガチャ演出時に再生される効果音を設定できます。",
+    "status": {
+      "enabled": "有効",
+      "disabled": "無効"
+    },
+    "form": {
+      "selectFile": "効果音ファイルを選択",
+      "fileRequirements": "対応形式: {formats} | 最大サイズ: {maxSize}",
+      "currentSound": "現在の効果音",
+      "enableSound": "効果音を有効にする",
+      "uploadFirst": "先にファイルをアップロードしてください"
+    },
+    "buttons": {
+      "play": "再生",
+      "stop": "停止",
+      "delete": "削除"
+    },
+    "messages": {
+      "uploadSuccess": "効果音をアップロードしました",
+      "uploading": "アップロード中...",
+      "saving": "保存中...",
+      "enabled": "効果音を有効にしました",
+      "disabled": "効果音を無効にしました",
+      "deleted": "効果音を削除しました"
+    },
+    "errors": {
+      "fileTooLarge": "ファイルサイズが1MBを超えています",
+      "invalidFileType": "対応していないファイル形式です（MP3, WAV, WebM, OGGのみ）",
+      "uploadFailed": "アップロードに失敗しました",
+      "saveFailed": "設定の保存に失敗しました",
+      "deleteFailed": "削除に失敗しました",
+      "rateLimit": "リクエストが多すぎます。しばらく待ってから再試行してください。"
+    },
+    "confirmDelete": "この効果音を削除しますか？"
+  },
   "channelPointSettings": {
     "title": "カード引き換え設定",
     "status": {

--- a/src/app/api/streamer/[streamerId]/sound-settings/route.ts
+++ b/src/app/api/streamer/[streamerId]/sound-settings/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
+import { ERROR_MESSAGES } from "@/lib/constants";
+
+interface RouteParams {
+  params: Promise<{ streamerId: string }>;
+}
+
+/**
+ * 配信者の効果音設定を取得
+ * 認証不要のパブリックエンドポイント（オーバーレイから呼び出される）
+ * GET /api/streamer/[streamerId]/sound-settings
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: RouteParams
+): Promise<NextResponse> {
+  try {
+    const { streamerId } = await params;
+
+    if (!streamerId) {
+      return NextResponse.json(
+        { error: ERROR_MESSAGES.STREAMER_ID_REQUIRED },
+        { status: 400 }
+      );
+    }
+
+    const supabaseAdmin = getSupabaseAdmin();
+
+    // 配信者の効果音設定のみを取得
+    // パブリックエンドポイントなので必要最小限の情報のみ返す
+    const { data: streamer, error } = await supabaseAdmin
+      .from("streamers")
+      .select("gacha_sound_url, gacha_sound_enabled")
+      .eq("id", streamerId)
+      .single();
+
+    if (error) {
+      return handleDatabaseError(error, "Streamer Sound Settings API");
+    }
+
+    if (!streamer) {
+      return NextResponse.json(
+        { error: ERROR_MESSAGES.STREAMER_NOT_FOUND },
+        { status: 404 }
+      );
+    }
+
+    // 効果音設定を返す
+    return NextResponse.json({
+      soundUrl: streamer.gacha_sound_url,
+      soundEnabled: streamer.gacha_sound_enabled ?? true, // デフォルトはtrue
+    });
+  } catch (error) {
+    return handleApiError(error, "Streamer Sound Settings API");
+  }
+}

--- a/src/app/api/streamer/settings/route.ts
+++ b/src/app/api/streamer/settings/route.ts
@@ -48,7 +48,14 @@ export async function POST(request: NextRequest) {
   try {
     const supabaseAdmin = getSupabaseAdmin();
     const body = await request.json();
-    const { streamerId, channelPointRewardId, channelPointRewardName } = body;
+    const {
+      streamerId,
+      channelPointRewardId,
+      channelPointRewardName,
+      // ガチャ効果音設定（オプション）
+      gachaSoundUrl,
+      gachaSoundEnabled,
+    } = body;
 
     // Verify ownership
     const { data: streamer } = await supabaseAdmin
@@ -62,12 +69,36 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
     }
 
+    // 更新するフィールドを動的に構築
+    // チャネルポイント設定と効果音設定の両方に対応
+    const updateData: Record<string, unknown> = {};
+
+    // チャネルポイント報酬設定（従来の機能）
+    if (channelPointRewardId !== undefined) {
+      updateData.channel_point_reward_id = channelPointRewardId;
+    }
+    if (channelPointRewardName !== undefined) {
+      updateData.channel_point_reward_name = channelPointRewardName;
+    }
+
+    // ガチャ効果音設定
+    // gachaSoundUrl: 効果音ファイルのURL（nullで削除）
+    if (gachaSoundUrl !== undefined) {
+      updateData.gacha_sound_url = gachaSoundUrl;
+    }
+    // gachaSoundEnabled: 効果音の有効/無効フラグ
+    if (gachaSoundEnabled !== undefined) {
+      updateData.gacha_sound_enabled = gachaSoundEnabled;
+    }
+
+    // 更新するフィールドがない場合はエラー
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
+    }
+
     const { error } = await supabaseAdmin
       .from("streamers")
-      .update({
-        channel_point_reward_id: channelPointRewardId,
-        channel_point_reward_name: channelPointRewardName,
-      })
+      .update(updateData)
       .eq("id", streamerId);
 
     if (error) {

--- a/src/app/api/upload/sound/route.ts
+++ b/src/app/api/upload/sound/route.ts
@@ -1,0 +1,260 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createHash } from 'crypto';
+import { getSession, canUseStreamerFeatures } from '@/lib/session';
+import { handleApiError, handleBlobError } from '@/lib/error-handler';
+import { checkRateLimit, rateLimits, getRateLimitIdentifier } from '@/lib/rate-limit';
+import { ERROR_MESSAGES, SOUND_UPLOAD_CONFIG } from '@/lib/constants';
+import { getSoundFileTypeFromBuffer, getFileExtension, isValidSoundExtension } from '@/lib/file-utils';
+import { logger } from '@/lib/logger';
+import { validateCSRFToken } from '@/lib/csrf';
+import { uploadSoundToR2WithRetry, deleteSoundFromR2 } from '@/lib/r2-client';
+import type { Session } from '@/lib/session';
+
+interface ValidateRequestResult {
+  error?: NextResponse;
+  session?: Session;
+}
+
+/**
+ * リクエストのバリデーション
+ * セッション、レート制限、配信者権限を検証
+ */
+async function validateRequest(request: NextRequest): Promise<ValidateRequestResult> {
+  const session = await getSession();
+
+  // レート制限チェック（1分あたり10リクエストまで）
+  const identifier = await getRateLimitIdentifier(request, session?.twitchUserId);
+  const rateLimitResult = await checkRateLimit(rateLimits.upload, identifier, 10, 60 * 1000);
+
+  if (!rateLimitResult.success) {
+    return {
+      error: NextResponse.json(
+        {
+          error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+          retryAfter: rateLimitResult.reset,
+        },
+        {
+          status: 429,
+          headers: {
+            'X-RateLimit-Limit': String(rateLimitResult.limit),
+            'X-RateLimit-Remaining': String(rateLimitResult.remaining),
+            'X-RateLimit-Reset': String(rateLimitResult.reset),
+          },
+        }
+      ),
+    };
+  }
+
+  if (!session) {
+    return {
+      error: NextResponse.json({ error: ERROR_MESSAGES.NOT_AUTHENTICATED }, { status: 401 }),
+    };
+  }
+
+  // 効果音アップロードは配信者のみに許可
+  // アフィリエイト/パートナーのみがガチャ機能を使用可能
+  if (!canUseStreamerFeatures(session)) {
+    return {
+      error: NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 }),
+    };
+  }
+
+  return { session };
+}
+
+/**
+ * 効果音ファイルのバリデーション
+ * ファイルサイズ(1MB以下)、拡張子、MIMEタイプを検証
+ */
+async function validateSoundFile(file: File | null): Promise<NextResponse | null> {
+  if (!file) {
+    return NextResponse.json({ error: ERROR_MESSAGES.NO_FILE_SELECTED }, { status: 400 });
+  }
+
+  if (!file.name || file.name.trim() === '') {
+    return NextResponse.json({ error: ERROR_MESSAGES.FILE_NAME_EMPTY }, { status: 400 });
+  }
+
+  // ファイルサイズチェック（1MB制限）
+  if (file.size > SOUND_UPLOAD_CONFIG.MAX_FILE_SIZE) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.SOUND_FILE_SIZE_EXCEEDED },
+      { status: 400 }
+    );
+  }
+
+  // 拡張子チェック
+  const ext = getFileExtension(file.name);
+  if (!ext || !isValidSoundExtension(ext)) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.INVALID_SOUND_FILE_TYPE },
+      { status: 400 }
+    );
+  }
+
+  return null;
+}
+
+/**
+ * 効果音ファイルをR2にアップロード
+ * 1MB制限で、MP3/WAV/WebM/OGG形式をサポート
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  // CSRFトークン検証
+  const csrfValidation = await validateCSRFToken(request);
+  if (!csrfValidation.valid) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.FORBIDDEN },
+      { status: 403 }
+    );
+  }
+
+  // リクエストとセッション検証
+  const { error: rateLimitError, session } = await validateRequest(request);
+  if (rateLimitError) {
+    return rateLimitError;
+  }
+
+  let buffer: Buffer | null = null;
+  let fileName: string | null = null;
+
+  try {
+    const formData = await request.formData();
+    const file = formData.get('file') as File | null;
+
+    // ファイルバリデーション
+    const fileValidationError = await validateSoundFile(file);
+    if (fileValidationError) {
+      return fileValidationError;
+    }
+
+    const ext = getFileExtension(file!.name);
+    buffer = Buffer.from(await file!.arrayBuffer());
+
+    // マジックナンバーによる実際のファイルタイプ検証
+    // 拡張子偽装を防止するため、ファイル内容から実際の形式を判定
+    const actualType = getSoundFileTypeFromBuffer(buffer);
+    const expectedType = SOUND_UPLOAD_CONFIG.EXT_TO_MIME_TYPE[ext as keyof typeof SOUND_UPLOAD_CONFIG.EXT_TO_MIME_TYPE];
+
+    if (actualType !== expectedType) {
+      logger.warn(`Sound file content does not match extension. Expected: ${expectedType}, Actual: ${actualType}`);
+      return NextResponse.json(
+        { error: ERROR_MESSAGES.SOUND_CONTENT_MISMATCH },
+        { status: 400 }
+      );
+    }
+
+    // ファイル名生成: sound_{userPrefix}_{uniqueSuffix}.{ext}
+    // "sound_"プレフィックスで画像ファイルと区別
+    const userPrefix = createHash('sha256')
+      .update(session!.twitchUserId)
+      .digest('hex')
+      .substring(0, 8);
+
+    const uniqueSuffix = createHash('sha256')
+      .update(`${session!.twitchUserId}-sound-${Date.now()}`)
+      .digest('hex')
+      .substring(0, 8);
+
+    fileName = `sound_${userPrefix}_${uniqueSuffix}.${ext}`;
+
+    // R2効果音バケットにアップロード（リトライ付き）
+    const uploadResult = await uploadSoundToR2WithRetry(fileName, buffer, actualType);
+
+    if ('error' in uploadResult) {
+      return handleBlobError(
+        new Error(uploadResult.error),
+        "Sound Upload API: Failed to upload to R2",
+        { userId: session!.twitchUserId, fileName, fileSize: buffer.length }
+      );
+    }
+
+    logger.info(`[Sound Upload] Successfully uploaded: ${fileName}, size: ${buffer.length} bytes`);
+    return NextResponse.json({ url: uploadResult.url });
+  } catch (error) {
+    // R2アップロードエラーのハンドリング
+    const storageError = error instanceof Error && (
+      error.message.includes('quota') ||
+      error.message.includes('limit') ||
+      error.message.includes('authentication') ||
+      error.message.includes('service unavailable') ||
+      error.message.includes('AccessDenied') ||
+      error.message.includes('NetworkingError')
+    );
+
+    if (storageError) {
+      return handleBlobError(
+        error,
+        "Sound Upload API: R2 storage error",
+        { userId: session?.twitchUserId, fileName: fileName || 'unknown', fileSize: buffer?.length }
+      );
+    }
+
+    return handleApiError(error, "Sound Upload API");
+  }
+}
+
+/**
+ * 効果音ファイルをR2から削除
+ */
+export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  // CSRFトークン検証
+  const csrfValidation = await validateCSRFToken(request);
+  if (!csrfValidation.valid) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.FORBIDDEN },
+      { status: 403 }
+    );
+  }
+
+  // リクエストとセッション検証
+  const { error: rateLimitError, session } = await validateRequest(request);
+  if (rateLimitError) {
+    return rateLimitError;
+  }
+
+  try {
+    const { url } = await request.json();
+
+    if (!url || typeof url !== 'string') {
+      return NextResponse.json(
+        { error: ERROR_MESSAGES.INVALID_REQUEST },
+        { status: 400 }
+      );
+    }
+
+    // URLからファイル名を抽出
+    // 例: https://bucket.r2.dev/sound_abc12345_def67890.mp3 -> sound_abc12345_def67890.mp3
+    const fileName = url.split('/').pop();
+    if (!fileName) {
+      return NextResponse.json(
+        { error: ERROR_MESSAGES.INVALID_REQUEST },
+        { status: 400 }
+      );
+    }
+
+    // ファイル名からユーザープレフィックスを検証
+    // 自分のファイルのみ削除可能にするためのセキュリティチェック
+    const userPrefix = createHash('sha256')
+      .update(session!.twitchUserId)
+      .digest('hex')
+      .substring(0, 8);
+
+    // "sound_"プレフィックス + ユーザープレフィックスの形式を検証
+    if (!fileName.startsWith(`sound_${userPrefix}_`)) {
+      logger.warn(`[Sound Delete] Unauthorized delete attempt: ${fileName} by user ${session!.twitchUserId}`);
+      return NextResponse.json(
+        { error: ERROR_MESSAGES.FORBIDDEN },
+        { status: 403 }
+      );
+    }
+
+    // R2から削除
+    await deleteSoundFromR2(fileName);
+
+    logger.info(`[Sound Delete] Successfully deleted: ${fileName}`);
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return handleApiError(error, "Sound Delete API");
+  }
+}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -4,6 +4,7 @@ import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { getStreamerData } from "@/lib/dashboard-data";
 import ChannelPointSettings from "@/components/ChannelPointSettings";
 import OverlayPreview from "@/components/OverlayPreview";
+import GachaSoundSettings from "@/components/GachaSoundSettings";
 
 // Note: Page is automatically dynamic due to cookies() usage in getSession()
 // cookies()使用により自動的に動的ページになるため、force-dynamicは不要
@@ -61,11 +62,20 @@ export default async function SettingsPage() {
         baseUrl={process.env.NEXT_PUBLIC_APP_URL || ""}
         cards={streamerData.cards}
         sideContent={
-          <ChannelPointSettings
-            streamerId={streamerData.streamer.id}
-            currentRewardId={streamerData.streamer.channel_point_reward_id}
-            currentRewardName={streamerData.streamer.channel_point_reward_name}
-          />
+          <>
+            <ChannelPointSettings
+              streamerId={streamerData.streamer.id}
+              currentRewardId={streamerData.streamer.channel_point_reward_id}
+              currentRewardName={streamerData.streamer.channel_point_reward_name}
+            />
+            {/* ガチャ効果音設定 */}
+            {/* Gacha sound effect settings */}
+            <GachaSoundSettings
+              streamerId={streamerData.streamer.id}
+              currentSoundUrl={streamerData.streamer.gacha_sound_url ?? null}
+              currentSoundEnabled={streamerData.streamer.gacha_sound_enabled ?? true}
+            />
+          </>
         }
       />
     </div>

--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -104,14 +104,49 @@ export default function OverlayPage() {
   // 画像が小さい（400x400未満）かどうかを判定するためのState
   // 小さい画像の場合はsmallModeを自動適用するために使用
   const [isSmallImage, setIsSmallImage] = useState(false);
+  // ガチャ効果音設定
+  // streamerから取得した効果音URLと有効/無効状態を保持
+  const [soundSettings, setSoundSettings] = useState<{
+    soundUrl: string | null;
+    soundEnabled: boolean;
+  }>({ soundUrl: null, soundEnabled: true });
   const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
   const connectionStatusRef = useRef(connectionStatus);
   const connectionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // 効果音再生用のオーディオ要素への参照
+  const audioRef = useRef<HTMLAudioElement | null>(null);
 
   useEffect(() => {
     connectionStatusRef.current = connectionStatus;
   }, [connectionStatus]);
+
+  // 効果音設定を取得
+  // オーバーレイ初期化時にstreamerの効果音設定をAPIから取得
+  // 認証不要のパブリックエンドポイントを使用
+  useEffect(() => {
+    const fetchSoundSettings = async () => {
+      try {
+        const response = await fetch(`/api/streamer/${streamerId}/sound-settings`);
+        if (response.ok) {
+          const data = await response.json();
+          setSoundSettings({
+            soundUrl: data.soundUrl,
+            soundEnabled: data.soundEnabled ?? true,
+          });
+          // 効果音URLが設定されている場合、Audio要素を作成してプリロード
+          // OBSブラウザソースでの再生遅延を軽減するため
+          if (data.soundUrl && data.soundEnabled) {
+            audioRef.current = new Audio(data.soundUrl);
+            audioRef.current.preload = "auto";
+          }
+        }
+      } catch (error) {
+        logger.error("Failed to fetch sound settings:", error);
+      }
+    };
+    fetchSoundSettings();
+  }, [streamerId]);
 
   // URLパラメータからオーバーレイオプションを解析
   // Parse overlay options from URL parameters
@@ -178,6 +213,38 @@ export default function OverlayPage() {
     });
   }, []);
 
+  /**
+   * 効果音を再生
+   * OBSブラウザソースでの再生に対応するため、
+   * Audio要素を使用して再生を試行
+   */
+  const playGachaSound = useCallback(() => {
+    // 効果音が無効または未設定の場合はスキップ
+    if (!soundSettings.soundEnabled || !soundSettings.soundUrl) {
+      return;
+    }
+
+    try {
+      // プリロード済みのAudio要素がある場合はそれを使用
+      if (audioRef.current) {
+        audioRef.current.currentTime = 0;
+        audioRef.current.play().catch((error) => {
+          // OBSブラウザソースでは自動再生制限により失敗する場合がある
+          // ユーザー操作がないと再生できないが、オーバーレイでは無視
+          logger.warn("Failed to play gacha sound:", error);
+        });
+      } else if (soundSettings.soundUrl) {
+        // フォールバック: 新しいAudio要素を作成して再生
+        const audio = new Audio(soundSettings.soundUrl);
+        audio.play().catch((error) => {
+          logger.warn("Failed to play gacha sound (fallback):", error);
+        });
+      }
+    } catch (error) {
+      logger.error("Error playing gacha sound:", error);
+    }
+  }, [soundSettings.soundEnabled, soundSettings.soundUrl]);
+
   // Display gacha result with animation
   const displayResult = useCallback(async (data: GachaResult) => {
     // Clear any existing animation
@@ -198,6 +265,11 @@ export default function OverlayPage() {
     animationTimeoutRef.current = setTimeout(() => {
       setShowCard(true);
 
+      // 効果音を再生（カード表示と同時）
+      // OBSブラウザソースでは自動再生制限があるため、
+      // 再生に失敗しても処理は継続
+      playGachaSound();
+
       // Hide after display
       animationTimeoutRef.current = setTimeout(() => {
         setShowCard(false);
@@ -206,7 +278,7 @@ export default function OverlayPage() {
         }, 500);
       }, 6000);
     }, 100);
-  }, [checkImageAspectRatio]);
+  }, [checkImageAspectRatio, playGachaSound]);
 
   // デバッグログを追加するヘルパー関数
   // OBSブラウザソースでの接続問題を調査するために使用

--- a/src/components/GachaSoundSettings.tsx
+++ b/src/components/GachaSoundSettings.tsx
@@ -1,0 +1,381 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import { useTranslations } from "next-intl";
+import { logger } from "@/lib/logger";
+import { SOUND_UPLOAD_CONFIG } from "@/lib/constants";
+
+interface GachaSoundSettingsProps {
+  streamerId: string;
+  // 現在の効果音URL（null=未設定）
+  currentSoundUrl: string | null;
+  // 効果音の有効/無効状態
+  currentSoundEnabled: boolean;
+}
+
+/**
+ * CookieからCSRFトークンを取得するヘルパー関数
+ * CSRF保護のためにすべてのAPI呼び出しで使用
+ */
+function getCsrfTokenFromCookie(): string {
+  if (typeof document === "undefined") return "";
+  return document.cookie
+    .split("; ")
+    .find(row => row.startsWith("csrf_token="))
+    ?.split("=")[1] || "";
+}
+
+/**
+ * ガチャ効果音設定コンポーネント
+ * 効果音のアップロード、プレビュー再生、有効/無効切り替えを管理
+ */
+export default function GachaSoundSettings({
+  streamerId,
+  currentSoundUrl,
+  currentSoundEnabled,
+}: GachaSoundSettingsProps) {
+  const t = useTranslations("gachaSoundSettings");
+  const tCommon = useTranslations("common");
+
+  // State管理
+  const [soundUrl, setSoundUrl] = useState<string | null>(currentSoundUrl);
+  const [soundEnabled, setSoundEnabled] = useState(currentSoundEnabled);
+  const [uploading, setUploading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [message, setMessage] = useState("");
+  const [isError, setIsError] = useState(false);
+
+  // オーディオ要素への参照
+  const audioRef = useRef<HTMLAudioElement>(null);
+  // ファイル入力への参照
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  /**
+   * 効果音ファイルをアップロード
+   * 1MB以下のMP3/WAV/WebM/OGGファイルのみ許可
+   */
+  const handleFileUpload = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // ファイルサイズチェック（クライアント側）
+    if (file.size > SOUND_UPLOAD_CONFIG.MAX_FILE_SIZE) {
+      setMessage(t("errors.fileTooLarge"));
+      setIsError(true);
+      return;
+    }
+
+    // ファイルタイプチェック（クライアント側）
+    const allowedTypes = SOUND_UPLOAD_CONFIG.ALLOWED_TYPES as readonly string[];
+    if (!allowedTypes.includes(file.type)) {
+      setMessage(t("errors.invalidFileType"));
+      setIsError(true);
+      return;
+    }
+
+    setUploading(true);
+    setMessage("");
+    setIsError(false);
+
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const response = await fetch("/api/upload/sound", {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "X-CSRF-Token": getCsrfTokenFromCookie(),
+        },
+        body: formData,
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        setSoundUrl(data.url);
+        setMessage(t("messages.uploadSuccess"));
+        setIsError(false);
+
+        // 自動的に設定を保存
+        await saveSettings(data.url, soundEnabled);
+      } else if (response.status === 429) {
+        const errorData = await response.json();
+        setMessage(errorData.error || t("errors.rateLimit"));
+        setIsError(true);
+      } else {
+        const errorData = await response.json();
+        setMessage(errorData.error || t("errors.uploadFailed"));
+        setIsError(true);
+      }
+    } catch (error) {
+      logger.error("Sound upload error:", error);
+      setMessage(t("errors.uploadFailed"));
+      setIsError(true);
+    } finally {
+      setUploading(false);
+      // ファイル入力をリセット（同じファイルを再度選択可能にする）
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  }, [soundEnabled, t, streamerId]);
+
+  /**
+   * 効果音設定を保存
+   */
+  const saveSettings = async (url: string | null, enabled: boolean) => {
+    setSaving(true);
+    try {
+      const response = await fetch("/api/streamer/settings", {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": getCsrfTokenFromCookie(),
+        },
+        body: JSON.stringify({
+          streamerId,
+          gachaSoundUrl: url,
+          gachaSoundEnabled: enabled,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        setMessage(errorData.error || t("errors.saveFailed"));
+        setIsError(true);
+        return false;
+      }
+
+      return true;
+    } catch (error) {
+      logger.error("Save settings error:", error);
+      setMessage(t("errors.saveFailed"));
+      setIsError(true);
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  /**
+   * 効果音の有効/無効を切り替え
+   */
+  const handleToggleEnabled = useCallback(async () => {
+    const newEnabled = !soundEnabled;
+    setSoundEnabled(newEnabled);
+
+    const success = await saveSettings(soundUrl, newEnabled);
+    if (success) {
+      setMessage(newEnabled ? t("messages.enabled") : t("messages.disabled"));
+      setIsError(false);
+    } else {
+      // 失敗した場合は元に戻す
+      setSoundEnabled(!newEnabled);
+    }
+  }, [soundEnabled, soundUrl, t]);
+
+  /**
+   * 効果音を削除
+   */
+  const handleDelete = useCallback(async () => {
+    if (!soundUrl) return;
+
+    // 削除確認
+    if (!confirm(t("confirmDelete"))) {
+      return;
+    }
+
+    setDeleting(true);
+    setMessage("");
+    setIsError(false);
+
+    try {
+      // R2から削除
+      const deleteResponse = await fetch("/api/upload/sound", {
+        method: "DELETE",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": getCsrfTokenFromCookie(),
+        },
+        body: JSON.stringify({ url: soundUrl }),
+      });
+
+      if (!deleteResponse.ok) {
+        const errorData = await deleteResponse.json();
+        setMessage(errorData.error || t("errors.deleteFailed"));
+        setIsError(true);
+        return;
+      }
+
+      // 設定を更新（URLをnullに）
+      const success = await saveSettings(null, soundEnabled);
+      if (success) {
+        setSoundUrl(null);
+        setMessage(t("messages.deleted"));
+        setIsError(false);
+      }
+    } catch (error) {
+      logger.error("Delete sound error:", error);
+      setMessage(t("errors.deleteFailed"));
+      setIsError(true);
+    } finally {
+      setDeleting(false);
+    }
+  }, [soundUrl, soundEnabled, t, streamerId]);
+
+  /**
+   * プレビュー再生
+   */
+  const handlePlayPreview = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.currentTime = 0;
+      audioRef.current.play().catch((error) => {
+        logger.error("Audio play error:", error);
+      });
+    }
+  }, []);
+
+  /**
+   * プレビュー停止
+   */
+  const handleStopPreview = useCallback(() => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current.currentTime = 0;
+    }
+  }, []);
+
+  return (
+    <div className="rounded-xl bg-gray-800 p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-white">
+          {t("title")}
+        </h2>
+        {/* 有効/無効ステータス表示 */}
+        <span
+          className={`inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs ${
+            soundEnabled && soundUrl
+              ? "bg-green-500/20 text-green-400"
+              : "bg-gray-500/20 text-gray-400"
+          }`}
+        >
+          <span
+            className={`h-2 w-2 rounded-full ${
+              soundEnabled && soundUrl ? "bg-green-500" : "bg-gray-500"
+            }`}
+          />
+          {soundEnabled && soundUrl ? t("status.enabled") : t("status.disabled")}
+        </span>
+      </div>
+
+      <p className="mb-4 text-sm text-gray-400">
+        {t("description")}
+      </p>
+
+      <div className="space-y-4">
+        {/* ファイルアップロード */}
+        <div>
+          <label className="mb-1 block text-sm text-gray-300">
+            {t("form.selectFile")}
+          </label>
+          <div className="flex items-center gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={SOUND_UPLOAD_CONFIG.ALLOWED_EXTENSIONS.map(ext => `.${ext}`).join(",")}
+              onChange={handleFileUpload}
+              disabled={uploading}
+              className="block w-full text-sm text-gray-400
+                file:mr-4 file:rounded-lg file:border-0
+                file:bg-purple-600 file:px-4 file:py-2
+                file:text-sm file:font-medium file:text-white
+                hover:file:bg-purple-700 file:disabled:opacity-50
+                file:cursor-pointer file:disabled:cursor-not-allowed"
+            />
+          </div>
+          <p className="mt-1 text-xs text-gray-500">
+            {t("form.fileRequirements", {
+              formats: SOUND_UPLOAD_CONFIG.ALLOWED_EXTENSIONS.map(ext => ext.toUpperCase()).join(", "),
+              maxSize: "1MB",
+            })}
+          </p>
+        </div>
+
+        {/* 現在の効果音 */}
+        {soundUrl && (
+          <div className="rounded-lg bg-gray-700 p-4">
+            <p className="mb-2 text-sm text-gray-300">
+              {t("form.currentSound")}
+            </p>
+            {/* オーディオプレビュー */}
+            <audio ref={audioRef} src={soundUrl} preload="metadata" />
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handlePlayPreview}
+                className="rounded-lg bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700"
+              >
+                {t("buttons.play")}
+              </button>
+              <button
+                onClick={handleStopPreview}
+                className="rounded-lg border border-gray-600 px-3 py-1.5 text-sm text-gray-300 hover:bg-gray-600"
+              >
+                {t("buttons.stop")}
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={deleting}
+                className="rounded-lg bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                {deleting ? tCommon("loading") : t("buttons.delete")}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* 有効/無効切り替え */}
+        <div className="flex items-center gap-3">
+          <label className="relative inline-flex cursor-pointer items-center">
+            <input
+              type="checkbox"
+              checked={soundEnabled}
+              onChange={handleToggleEnabled}
+              disabled={saving || !soundUrl}
+              className="peer sr-only"
+            />
+            <div
+              className={`h-6 w-11 rounded-full bg-gray-600 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-purple-600 peer-checked:after:translate-x-full peer-checked:after:border-white peer-disabled:opacity-50 ${
+                !soundUrl ? "opacity-50" : ""
+              }`}
+            />
+          </label>
+          <span className={`text-sm ${soundUrl ? "text-gray-300" : "text-gray-500"}`}>
+            {t("form.enableSound")}
+          </span>
+          {!soundUrl && (
+            <span className="text-xs text-gray-500">
+              ({t("form.uploadFirst")})
+            </span>
+          )}
+        </div>
+
+        {/* ステータスメッセージ */}
+        {message && (
+          <p className={`text-sm ${isError ? "text-red-400" : "text-green-400"}`}>
+            {message}
+          </p>
+        )}
+
+        {/* ローディング表示 */}
+        {(uploading || saving) && (
+          <p className="text-sm text-gray-400">
+            {uploading ? t("messages.uploading") : t("messages.saving")}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -232,6 +232,12 @@ export const ERROR_MESSAGES = {
   UNABLE_TO_UPLOAD: 'Unable to upload file',
   FILE_CONTENT_MISMATCH: 'File content does not match extension',
 
+  // Sound upload errors
+  // 効果音アップロードエラー
+  INVALID_SOUND_FILE_TYPE: 'Invalid sound file type. Only MP3, WAV, WebM, and OGG are allowed',
+  SOUND_FILE_SIZE_EXCEEDED: 'Sound file size exceeds 1MB limit',
+  SOUND_CONTENT_MISMATCH: 'Sound file content does not match extension',
+
   // General errors
   INTERNAL_ERROR: 'Internal server error',
   OPERATION_FAILED: 'Operation failed',
@@ -357,6 +363,27 @@ export const UPLOAD_CONFIG = {
   // Global storage limit disabled - set to very large value
   // グローバルストレージ制限を撤廃 - 非常に大きな値を設定
   GLOBAL_STORAGE_LIMIT: Number.MAX_SAFE_INTEGER, // No global limit
+} as const
+
+/**
+ * 効果音アップロード設定
+ * ガチャ時に再生される効果音のアップロード制限
+ * 画像アップロードとは別の設定で管理
+ */
+export const SOUND_UPLOAD_CONFIG = {
+  // ファイルサイズ上限: 1MB（効果音は短時間の音声を想定）
+  MAX_FILE_SIZE: 1 * 1024 * 1024,
+  // 許可する音声MIMEタイプ
+  ALLOWED_TYPES: ['audio/mpeg', 'audio/wav', 'audio/webm', 'audio/ogg'] as const,
+  // 許可する拡張子
+  ALLOWED_EXTENSIONS: ['mp3', 'wav', 'webm', 'ogg'] as const,
+  // 拡張子からMIMEタイプへのマッピング
+  EXT_TO_MIME_TYPE: {
+    mp3: 'audio/mpeg',
+    wav: 'audio/wav',
+    webm: 'audio/webm',
+    ogg: 'audio/ogg',
+  } as const,
 } as const
 
 export const STORAGE_LIMIT_MESSAGES = {

--- a/src/lib/file-utils.ts
+++ b/src/lib/file-utils.ts
@@ -1,4 +1,4 @@
-import { UPLOAD_CONFIG } from '@/lib/constants';
+import { UPLOAD_CONFIG, SOUND_UPLOAD_CONFIG } from '@/lib/constants';
 
 export function getFileTypeFromBuffer(buffer: Buffer): string {
   if (buffer.length < 2) {
@@ -36,8 +36,58 @@ export function getFileTypeFromBuffer(buffer: Buffer): string {
   return 'application/octet-stream';
 }
 
+/**
+ * 音声ファイルのMIMEタイプをマジックナンバーから判定
+ * MP3, WAV, WebM, OGGをサポート
+ * 効果音アップロード時にファイル内容の検証に使用
+ */
+export function getSoundFileTypeFromBuffer(buffer: Buffer): string {
+  if (buffer.length < 12) {
+    return 'application/octet-stream';
+  }
+
+  // MP3: ID3タグ (0x49 0x44 0x33) または MPEGフレームヘッダー (0xFF 0xFB/0xFA/0xF3/0xF2)
+  // ID3タグはMP3ファイルのメタデータ（曲名、アーティスト名等）を格納
+  if (buffer[0] === 0x49 && buffer[1] === 0x44 && buffer[2] === 0x33) {
+    return 'audio/mpeg';
+  }
+  // MPEGフレームシンクワード: 0xFF + フレームヘッダーの開始
+  if (buffer[0] === 0xFF && (buffer[1] === 0xFB || buffer[1] === 0xFA || buffer[1] === 0xF3 || buffer[1] === 0xF2)) {
+    return 'audio/mpeg';
+  }
+
+  // WAV: "RIFF....WAVE" フォーマット
+  // RIFF (Resource Interchange File Format) はMicrosoftのマルチメディアファイル形式
+  if (buffer[0] === 0x52 && buffer[1] === 0x49 && buffer[2] === 0x46 && buffer[3] === 0x46 &&
+      buffer[8] === 0x57 && buffer[9] === 0x41 && buffer[10] === 0x56 && buffer[11] === 0x45) {
+    return 'audio/wav';
+  }
+
+  // WebM: EBMLヘッダー (0x1A 0x45 0xDF 0xA3)
+  // WebMはMatroskaベースの動画/音声コンテナフォーマット
+  if (buffer[0] === 0x1A && buffer[1] === 0x45 && buffer[2] === 0xDF && buffer[3] === 0xA3) {
+    return 'audio/webm';
+  }
+
+  // OGG: "OggS" マジックナンバー
+  // Ogg Vorbisはオープンソースの音声圧縮フォーマット
+  if (buffer[0] === 0x4F && buffer[1] === 0x67 && buffer[2] === 0x67 && buffer[3] === 0x53) {
+    return 'audio/ogg';
+  }
+
+  return 'application/octet-stream';
+}
+
 export function isValidExtension(ext: string): ext is typeof UPLOAD_CONFIG.ALLOWED_EXTENSIONS[number] {
   return UPLOAD_CONFIG.ALLOWED_EXTENSIONS.includes(ext as typeof UPLOAD_CONFIG.ALLOWED_EXTENSIONS[number]);
+}
+
+/**
+ * 効果音ファイルの拡張子が許可されているかを検証
+ * MP3, WAV, WebM, OGGのみ許可
+ */
+export function isValidSoundExtension(ext: string): ext is typeof SOUND_UPLOAD_CONFIG.ALLOWED_EXTENSIONS[number] {
+  return SOUND_UPLOAD_CONFIG.ALLOWED_EXTENSIONS.includes(ext as typeof SOUND_UPLOAD_CONFIG.ALLOWED_EXTENSIONS[number]);
 }
 
 export function getFileExtension(fileName: string): string {

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -5,17 +5,26 @@ import { logger } from './logger';
  * R2 Client Configuration
  * Cloudflare R2はS3互換APIを提供するため、AWS SDKを使用
  *
- * 環境変数:
+ * 画像用環境変数:
  * - R2_ENDPOINT: R2エンドポイントURL (例: https://<account_id>.r2.cloudflarestorage.com)
  * - R2_ACCESS_KEY_ID: R2アクセスキーID
  * - R2_SECRET_ACCESS_KEY: R2シークレットアクセスキー
  * - R2_BUCKET_NAME: R2バケット名
  * - R2_PUBLIC_URL: R2パブリックURL (例: https://pub-xxx.r2.dev または カスタムドメイン)
+ *
+ * 効果音用環境変数（すべて必須）:
+ * - R2_SOUND_ENDPOINT: 効果音バケット用エンドポイントURL
+ * - R2_SOUND_ACCESS_KEY_ID: 効果音バケット用アクセスキーID
+ * - R2_SOUND_SECRET_ACCESS_KEY: 効果音バケット用シークレットアクセスキー
+ * - R2_SOUND_BUCKET_NAME: 効果音バケット名
+ * - R2_SOUND_PUBLIC_URL: 効果音バケットのパブリックURL
  */
 
 // R2クライアントをシングルトンパターンで管理
 // リクエストごとにクライアントを作成するとコストがかかるため
 let r2ClientInstance: S3Client | null = null;
+// 効果音バケット用の別クライアント（別アカウント/別認証情報に対応）
+let r2SoundClientInstance: S3Client | null = null;
 
 /**
  * R2クライアントを取得（シングルトン）
@@ -58,6 +67,36 @@ export function getR2Bucket(): string {
 }
 
 /**
+ * 効果音バケット用R2クライアントを取得（シングルトン）
+ * 画像バケットとは別の認証情報を使用
+ * @throws 必要な環境変数が未設定の場合にエラー
+ */
+export function getR2SoundClient(): S3Client {
+  if (r2SoundClientInstance) {
+    return r2SoundClientInstance;
+  }
+
+  const endpoint = process.env.R2_SOUND_ENDPOINT;
+  const accessKeyId = process.env.R2_SOUND_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.R2_SOUND_SECRET_ACCESS_KEY;
+
+  if (!endpoint || !accessKeyId || !secretAccessKey) {
+    throw new Error('Missing R2 sound environment variables: R2_SOUND_ENDPOINT, R2_SOUND_ACCESS_KEY_ID, R2_SOUND_SECRET_ACCESS_KEY');
+  }
+
+  r2SoundClientInstance = new S3Client({
+    region: 'auto',
+    endpoint,
+    credentials: {
+      accessKeyId,
+      secretAccessKey,
+    },
+  });
+
+  return r2SoundClientInstance;
+}
+
+/**
  * R2効果音バケット名を取得
  * 画像バケットとは別に管理するため、専用の環境変数が必須
  * @throws R2_SOUND_BUCKET_NAMEが未設定の場合にエラー
@@ -68,6 +107,19 @@ export function getR2SoundBucket(): string {
     throw new Error('Missing R2_SOUND_BUCKET_NAME environment variable');
   }
   return soundBucket;
+}
+
+/**
+ * 効果音バケットのパブリックURLを取得
+ * @throws R2_SOUND_PUBLIC_URLが未設定の場合にエラー
+ */
+export function getR2SoundPublicUrl(): string {
+  const publicUrl = process.env.R2_SOUND_PUBLIC_URL;
+  if (!publicUrl) {
+    throw new Error('Missing R2_SOUND_PUBLIC_URL environment variable');
+  }
+  // 末尾のスラッシュを除去して統一
+  return publicUrl.replace(/\/$/, '');
 }
 
 /**
@@ -117,7 +169,7 @@ export async function uploadToR2(
 
 /**
  * R2効果音バケットにファイルをアップロード
- * 画像バケットとは別のバケットに保存することで、ストレージを分離管理
+ * 画像バケットとは完全に別のバケット・認証情報を使用
  * @param fileName - ファイル名（キー）
  * @param buffer - ファイルデータ
  * @param contentType - MIMEタイプ（audio/mpeg, audio/wav等）
@@ -128,9 +180,9 @@ export async function uploadSoundToR2(
   buffer: Buffer,
   contentType: string
 ): Promise<string> {
-  const client = getR2Client();
+  const client = getR2SoundClient();
   const bucket = getR2SoundBucket();
-  const publicUrl = getR2PublicUrl();
+  const publicUrl = getR2SoundPublicUrl();
 
   try {
     await client.send(new PutObjectCommand({
@@ -171,10 +223,11 @@ export async function deleteFromR2(fileName: string): Promise<void> {
 
 /**
  * R2効果音バケットからファイルを削除
+ * 画像バケットとは完全に別のバケット・認証情報を使用
  * @param fileName - ファイル名（キー）
  */
 export async function deleteSoundFromR2(fileName: string): Promise<void> {
-  const client = getR2Client();
+  const client = getR2SoundClient();
   const bucket = getR2SoundBucket();
 
   try {

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -13,7 +13,6 @@ import { logger } from './logger';
  * - R2_PUBLIC_URL: R2パブリックURL (例: https://pub-xxx.r2.dev または カスタムドメイン)
  *
  * 効果音用環境変数（すべて必須）:
- * - R2_SOUND_ENDPOINT: 効果音バケット用エンドポイントURL
  * - R2_SOUND_ACCESS_KEY_ID: 効果音バケット用アクセスキーID
  * - R2_SOUND_SECRET_ACCESS_KEY: 効果音バケット用シークレットアクセスキー
  * - R2_SOUND_BUCKET_NAME: 効果音バケット名
@@ -68,7 +67,7 @@ export function getR2Bucket(): string {
 
 /**
  * 効果音バケット用R2クライアントを取得（シングルトン）
- * 画像バケットとは別の認証情報を使用
+ * エンドポイントは共通、認証情報のみ別
  * @throws 必要な環境変数が未設定の場合にエラー
  */
 export function getR2SoundClient(): S3Client {
@@ -76,12 +75,16 @@ export function getR2SoundClient(): S3Client {
     return r2SoundClientInstance;
   }
 
-  const endpoint = process.env.R2_SOUND_ENDPOINT;
+  // エンドポイントは画像バケットと共通
+  const endpoint = process.env.R2_ENDPOINT;
   const accessKeyId = process.env.R2_SOUND_ACCESS_KEY_ID;
   const secretAccessKey = process.env.R2_SOUND_SECRET_ACCESS_KEY;
 
-  if (!endpoint || !accessKeyId || !secretAccessKey) {
-    throw new Error('Missing R2 sound environment variables: R2_SOUND_ENDPOINT, R2_SOUND_ACCESS_KEY_ID, R2_SOUND_SECRET_ACCESS_KEY');
+  if (!endpoint) {
+    throw new Error('Missing R2_ENDPOINT environment variable');
+  }
+  if (!accessKeyId || !secretAccessKey) {
+    throw new Error('Missing R2 sound environment variables: R2_SOUND_ACCESS_KEY_ID, R2_SOUND_SECRET_ACCESS_KEY');
   }
 
   r2SoundClientInstance = new S3Client({

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -47,7 +47,7 @@ export function getR2Client(): S3Client {
 }
 
 /**
- * R2バケット名を取得
+ * R2バケット名を取得（画像用）
  */
 export function getR2Bucket(): string {
   const bucket = process.env.R2_BUCKET_NAME;
@@ -55,6 +55,20 @@ export function getR2Bucket(): string {
     throw new Error('Missing R2_BUCKET_NAME environment variable');
   }
   return bucket;
+}
+
+/**
+ * R2効果音バケット名を取得
+ * R2_SOUND_BUCKET_NAMEが設定されていない場合はR2_BUCKET_NAMEにフォールバック
+ * これにより、画像と効果音を別バケットで管理可能
+ */
+export function getR2SoundBucket(): string {
+  const soundBucket = process.env.R2_SOUND_BUCKET_NAME;
+  if (soundBucket) {
+    return soundBucket;
+  }
+  // フォールバック: 効果音専用バケットが未設定の場合は画像バケットを使用
+  return getR2Bucket();
 }
 
 /**
@@ -103,6 +117,40 @@ export async function uploadToR2(
 }
 
 /**
+ * R2効果音バケットにファイルをアップロード
+ * 画像バケットとは別のバケットに保存することで、ストレージを分離管理
+ * @param fileName - ファイル名（キー）
+ * @param buffer - ファイルデータ
+ * @param contentType - MIMEタイプ（audio/mpeg, audio/wav等）
+ * @returns アップロードされたファイルの公開URL
+ */
+export async function uploadSoundToR2(
+  fileName: string,
+  buffer: Buffer,
+  contentType: string
+): Promise<string> {
+  const client = getR2Client();
+  const bucket = getR2SoundBucket();
+  const publicUrl = getR2PublicUrl();
+
+  try {
+    await client.send(new PutObjectCommand({
+      Bucket: bucket,
+      Key: fileName,
+      Body: buffer,
+      ContentType: contentType,
+    }));
+
+    const url = `${publicUrl}/${fileName}`;
+    logger.info(`[R2 Sound] Uploaded sound file: ${fileName}, size: ${buffer.length} bytes`);
+    return url;
+  } catch (error) {
+    logger.error('[R2 Sound] Failed to upload sound file:', error);
+    throw error;
+  }
+}
+
+/**
  * R2からファイルを削除
  * @param fileName - ファイル名（キー）
  */
@@ -118,6 +166,26 @@ export async function deleteFromR2(fileName: string): Promise<void> {
     logger.info(`[R2] Deleted file: ${fileName}`);
   } catch (error) {
     logger.error('[R2] Failed to delete file:', error);
+    throw error;
+  }
+}
+
+/**
+ * R2効果音バケットからファイルを削除
+ * @param fileName - ファイル名（キー）
+ */
+export async function deleteSoundFromR2(fileName: string): Promise<void> {
+  const client = getR2Client();
+  const bucket = getR2SoundBucket();
+
+  try {
+    await client.send(new DeleteObjectCommand({
+      Bucket: bucket,
+      Key: fileName,
+    }));
+    logger.info(`[R2 Sound] Deleted sound file: ${fileName}`);
+  } catch (error) {
+    logger.error('[R2 Sound] Failed to delete sound file:', error);
     throw error;
   }
 }
@@ -157,6 +225,48 @@ export async function uploadToR2WithRetry(
       // 指数バックオフでリトライ
       const delay = Math.pow(2, attempt) * 1000;
       logger.warn(`[R2] Upload failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms:`, errorMessage);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+
+  return { error: 'Max retries exceeded' };
+}
+
+/**
+ * リトライ付きR2効果音アップロード
+ * 一時的なエラー（ネットワーク障害など）の場合にリトライを行う
+ * @param fileName - ファイル名（キー）
+ * @param buffer - ファイルデータ
+ * @param contentType - MIMEタイプ
+ * @param maxRetries - 最大リトライ回数（デフォルト: 3）
+ * @returns アップロードされたファイルの公開URL、またはエラー
+ */
+export async function uploadSoundToR2WithRetry(
+  fileName: string,
+  buffer: Buffer,
+  contentType: string,
+  maxRetries: number = 3
+): Promise<{ url: string } | { error: string }> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const url = await uploadSoundToR2(fileName, buffer, contentType);
+      return { url };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      // 一時的なエラーかどうかを判定
+      const transientErrors = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'service unavailable', '503', 'NetworkingError'];
+      const isTransient = transientErrors.some(err =>
+        errorMessage.toLowerCase().includes(err.toLowerCase())
+      );
+
+      if (!isTransient || attempt === maxRetries) {
+        return { error: errorMessage };
+      }
+
+      // 指数バックオフでリトライ
+      const delay = Math.pow(2, attempt) * 1000;
+      logger.warn(`[R2 Sound] Upload failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms:`, errorMessage);
       await new Promise(resolve => setTimeout(resolve, delay));
     }
   }

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -59,16 +59,15 @@ export function getR2Bucket(): string {
 
 /**
  * R2効果音バケット名を取得
- * R2_SOUND_BUCKET_NAMEが設定されていない場合はR2_BUCKET_NAMEにフォールバック
- * これにより、画像と効果音を別バケットで管理可能
+ * 画像バケットとは別に管理するため、専用の環境変数が必須
+ * @throws R2_SOUND_BUCKET_NAMEが未設定の場合にエラー
  */
 export function getR2SoundBucket(): string {
   const soundBucket = process.env.R2_SOUND_BUCKET_NAME;
-  if (soundBucket) {
-    return soundBucket;
+  if (!soundBucket) {
+    throw new Error('Missing R2_SOUND_BUCKET_NAME environment variable');
   }
-  // フォールバック: 効果音専用バケットが未設定の場合は画像バケットを使用
-  return getR2Bucket();
+  return soundBucket;
 }
 
 /**

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -23,6 +23,10 @@ export interface Database {
           channel_point_reward_id: string | null
           channel_point_reward_name: string | null
           is_active: boolean
+          // ガチャ効果音URL - R2に保存された音声ファイルのURL
+          gacha_sound_url: string | null
+          // ガチャ効果音の有効/無効フラグ
+          gacha_sound_enabled: boolean
           created_at: string
           updated_at: string
         }
@@ -35,6 +39,8 @@ export interface Database {
           channel_point_reward_id?: string | null
           channel_point_reward_name?: string | null
           is_active?: boolean
+          gacha_sound_url?: string | null
+          gacha_sound_enabled?: boolean
           created_at?: string
           updated_at?: string
         }
@@ -47,6 +53,8 @@ export interface Database {
           channel_point_reward_id?: string | null
           channel_point_reward_name?: string | null
           is_active?: boolean
+          gacha_sound_url?: string | null
+          gacha_sound_enabled?: boolean
           created_at?: string
           updated_at?: string
         }

--- a/supabase/migrations/00007_add_gacha_sound_settings.sql
+++ b/supabase/migrations/00007_add_gacha_sound_settings.sql
@@ -1,0 +1,13 @@
+-- ガチャ効果音設定をstreamersテーブルに追加
+-- Add gacha sound effect settings to streamers table
+
+-- gacha_sound_url: R2に保存された効果音ファイルのURL
+-- gacha_sound_enabled: 効果音の有効/無効フラグ（デフォルトはtrue）
+
+ALTER TABLE streamers
+ADD COLUMN IF NOT EXISTS gacha_sound_url TEXT DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS gacha_sound_enabled BOOLEAN DEFAULT TRUE NOT NULL;
+
+-- コメントを追加
+COMMENT ON COLUMN streamers.gacha_sound_url IS 'URL of the gacha sound effect file stored in R2 (max 1MB, MP3/WAV/WebM/OGG)';
+COMMENT ON COLUMN streamers.gacha_sound_enabled IS 'Whether to play sound effect on gacha (default: true)';


### PR DESCRIPTION
## Summary
This PR adds support for custom sound effects during gacha animations. Streamers can now upload, preview, and manage sound effects that play when gacha results are displayed in the overlay.

## Key Changes

### Backend Infrastructure
- **New API endpoints:**
  - `POST /api/upload/sound` - Upload sound files (1MB max, MP3/WAV/WebM/OGG)
  - `DELETE /api/upload/sound` - Delete uploaded sound files
  - `GET /api/streamer/[streamerId]/sound-settings` - Fetch sound settings (public endpoint for overlay)
  - Updated `POST /api/streamer/settings` - Now supports sound settings alongside channel point settings

- **R2 Storage Configuration:**
  - Separate R2 bucket for sound files (distinct from image storage)
  - New environment variables: `R2_SOUND_ENDPOINT`, `R2_SOUND_ACCESS_KEY_ID`, `R2_SOUND_SECRET_ACCESS_KEY`, `R2_SOUND_BUCKET_NAME`, `R2_SOUND_PUBLIC_URL`
  - Dedicated R2 client instance for sound operations with retry logic

- **Database Schema:**
  - Added `gacha_sound_url` column to store R2 sound file URL
  - Added `gacha_sound_enabled` boolean flag (default: true)
  - Migration: `00007_add_gacha_sound_settings.sql`

### Frontend Components
- **New `GachaSoundSettings` component:**
  - File upload with client-side validation
  - Audio preview (play/stop controls)
  - Enable/disable toggle
  - Delete functionality with confirmation
  - Real-time status messages and error handling

- **Overlay Integration:**
  - Fetches sound settings on initialization
  - Plays sound effect when gacha result is displayed
  - Graceful fallback for OBS browser source autoplay restrictions
  - Audio preloading for reduced latency

### Security & Validation
- CSRF token validation on all sound upload/delete operations
- Rate limiting: 10 requests per minute per user
- File validation:
  - Magic number verification (prevents extension spoofing)
  - File size enforcement (1MB limit)
  - MIME type validation
- User-scoped file naming prevents unauthorized deletion

### Localization
- Added Japanese and English translations for all UI strings
- Error messages, status updates, and button labels fully localized

### Configuration
- New `SOUND_UPLOAD_CONFIG` constant with file type mappings
- New file utility functions: `getSoundFileTypeFromBuffer()`, `isValidSoundExtension()`
- Updated `.env.local.example` with sound storage configuration

## Implementation Details
- Sound files are stored in a completely separate R2 bucket from images for better access control and cost management
- Audio element preloading in overlay reduces playback latency in OBS
- Exponential backoff retry logic for transient R2 upload failures
- User prefix hashing in filenames ensures users can only delete their own files
- Public API endpoint for overlay allows unauthenticated sound retrieval while maintaining security through file naming