### PR TITLE
Add cleanup of old sound files after successful upload

### DIFF
--- a/src/components/GachaSoundSettings.tsx
+++ b/src/components/GachaSoundSettings.tsx
@@ -93,6 +93,31 @@ export default function GachaSoundSettings({
 
       if (response.ok) {
         const data = await response.json();
+        const oldSoundUrl = soundUrl;
+
+        // 既存の効果音ファイルがある場合はR2から削除
+        // 新しいファイルのアップロード成功後に削除することで、失敗時もデータを失わない
+        if (oldSoundUrl) {
+          try {
+            const deleteResponse = await fetch("/api/upload/sound", {
+              method: "DELETE",
+              credentials: "include",
+              headers: {
+                "Content-Type": "application/json",
+                "X-CSRF-Token": getCsrfTokenFromCookie(),
+              },
+              body: JSON.stringify({ url: oldSoundUrl }),
+            });
+            if (!deleteResponse.ok) {
+              // 削除に失敗してもアップロードは成功しているので、ログのみ出力
+              logger.warn("Failed to delete old sound file:", oldSoundUrl);
+            }
+          } catch (deleteError) {
+            // 削除エラーでも新しいファイルのアップロードは成功しているので続行
+            logger.warn("Error deleting old sound file:", deleteError);
+          }
+        }
+
         setSoundUrl(data.url);
         setMessage(t("messages.uploadSuccess"));
         setIsError(false);


### PR DESCRIPTION
## Summary
Added logic to delete old sound files from R2 storage after successfully uploading a new gacha sound file. This improves storage management by removing obsolete files while maintaining data integrity.

## Key Changes
- After a successful sound file upload, the old sound file URL is now deleted from R2 storage
- Deletion is performed **after** the new upload succeeds to prevent data loss if the upload fails
- Deletion failures are logged as warnings but don't interrupt the upload flow, since the new file has already been successfully uploaded
- Added proper error handling for both network errors and non-OK responses during deletion

## Implementation Details
- The old sound URL is captured before the new upload completes
- A DELETE request is sent to `/api/upload/sound` with the old file URL
- CSRF token is included in the deletion request for security
- Errors during deletion are caught and logged separately:
  - Non-OK responses are logged as warnings
  - Network/exception errors are also logged as warnings
- The user sees a success message regardless of whether the old file deletion succeeds, since the primary operation (new upload) completed successfully