### PR TITLE
fix: 既存の効果音がある場合はアップロードUIを非表示に

### DIFF
--- a/src/components/GachaSoundSettings.tsx
+++ b/src/components/GachaSoundSettings.tsx
@@ -93,31 +93,6 @@ export default function GachaSoundSettings({
 
       if (response.ok) {
         const data = await response.json();
-        const oldSoundUrl = soundUrl;
-
-        // 既存の効果音ファイルがある場合はR2から削除
-        // 新しいファイルのアップロード成功後に削除することで、失敗時もデータを失わない
-        if (oldSoundUrl) {
-          try {
-            const deleteResponse = await fetch("/api/upload/sound", {
-              method: "DELETE",
-              credentials: "include",
-              headers: {
-                "Content-Type": "application/json",
-                "X-CSRF-Token": getCsrfTokenFromCookie(),
-              },
-              body: JSON.stringify({ url: oldSoundUrl }),
-            });
-            if (!deleteResponse.ok) {
-              // 削除に失敗してもアップロードは成功しているので、ログのみ出力
-              logger.warn("Failed to delete old sound file:", oldSoundUrl);
-            }
-          } catch (deleteError) {
-            // 削除エラーでも新しいファイルのアップロードは成功しているので続行
-            logger.warn("Error deleting old sound file:", deleteError);
-          }
-        }
-
         setSoundUrl(data.url);
         setMessage(t("messages.uploadSuccess"));
         setIsError(false);
@@ -301,33 +276,36 @@ export default function GachaSoundSettings({
       </p>
 
       <div className="space-y-4">
-        {/* ファイルアップロード */}
-        <div>
-          <label className="mb-1 block text-sm text-gray-300">
-            {t("form.selectFile")}
-          </label>
-          <div className="flex items-center gap-2">
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept={SOUND_UPLOAD_CONFIG.ALLOWED_EXTENSIONS.map(ext => `.${ext}`).join(",")}
-              onChange={handleFileUpload}
-              disabled={uploading}
-              className="block w-full text-sm text-gray-400
-                file:mr-4 file:rounded-lg file:border-0
-                file:bg-purple-600 file:px-4 file:py-2
-                file:text-sm file:font-medium file:text-white
-                hover:file:bg-purple-700 file:disabled:opacity-50
-                file:cursor-pointer file:disabled:cursor-not-allowed"
-            />
+        {/* ファイルアップロード: 既存ファイルがない場合のみ表示 */}
+        {/* 新しいファイルをアップロードするには、先に既存ファイルを削除する必要がある */}
+        {!soundUrl && (
+          <div>
+            <label className="mb-1 block text-sm text-gray-300">
+              {t("form.selectFile")}
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={SOUND_UPLOAD_CONFIG.ALLOWED_EXTENSIONS.map(ext => `.${ext}`).join(",")}
+                onChange={handleFileUpload}
+                disabled={uploading}
+                className="block w-full text-sm text-gray-400
+                  file:mr-4 file:rounded-lg file:border-0
+                  file:bg-purple-600 file:px-4 file:py-2
+                  file:text-sm file:font-medium file:text-white
+                  hover:file:bg-purple-700 file:disabled:opacity-50
+                  file:cursor-pointer file:disabled:cursor-not-allowed"
+              />
+            </div>
+            <p className="mt-1 text-xs text-gray-500">
+              {t("form.fileRequirements", {
+                formats: SOUND_UPLOAD_CONFIG.ALLOWED_EXTENSIONS.map(ext => ext.toUpperCase()).join(", "),
+                maxSize: "1MB",
+              })}
+            </p>
           </div>
-          <p className="mt-1 text-xs text-gray-500">
-            {t("form.fileRequirements", {
-              formats: SOUND_UPLOAD_CONFIG.ALLOWED_EXTENSIONS.map(ext => ext.toUpperCase()).join(", "),
-              maxSize: "1MB",
-            })}
-          </p>
-        </div>
+        )}
 
         {/* 現在の効果音 */}
         {soundUrl && (


### PR DESCRIPTION
重複アップロードを防ぐため、既存ファイルがある場合はアップロード
フォームを非表示にする。新しいファイルをアップロードするには、
先に既存ファイルを削除する必要がある仕様に変更。