### PR TITLE
Add real-time gacha result broadcasting to overlay

### DIFF
--- a/src/app/api/gacha/route.ts
+++ b/src/app/api/gacha/route.ts
@@ -8,6 +8,8 @@ import { setUserContext, setRequestContext } from "@/lib/sentry/user-context";
 import { GACHA_COST, ERROR_MESSAGES } from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
+import { broadcastGachaResult, GachaBroadcastPayload } from "@/lib/realtime";
+import { logger } from "@/lib/logger";
 import type { GachaSuccessResponse, GachaErrorResponse, ApiRateLimitResponse } from "@/types/api";
 
 export async function POST(request: NextRequest) {
@@ -102,6 +104,29 @@ export async function POST(request: NextRequest) {
         { error: errorMessage },
         { status: 500 }
       );
+    }
+
+    // ガチャ成功時、オーバーレイにリアルタイム通知を送信
+    // Broadcast gacha result to overlay via Supabase Realtime
+    const payload: GachaBroadcastPayload = {
+      type: "gacha",
+      card: {
+        id: result.data.card.id,
+        name: result.data.card.name,
+        description: result.data.card.description,
+        image_url: result.data.card.image_url,
+        rarity: result.data.card.rarity,
+      },
+      userTwitchUsername: result.data.userTwitchUsername,
+    };
+
+    try {
+      await broadcastGachaResult(streamerId, payload);
+      logger.info(`Gacha result broadcast sent to streamer ${streamerId}`);
+    } catch (broadcastError) {
+      // ブロードキャストエラーはログに記録するが、ガチャ自体は成功扱い
+      // Log broadcast errors but still return success (gacha was executed successfully)
+      logger.error("Failed to broadcast gacha result:", { broadcastError });
     }
 
     return NextResponse.json<GachaSuccessResponse>({


### PR DESCRIPTION
## Summary
This PR adds real-time broadcasting of gacha results to the overlay via Supabase Realtime. When a user successfully performs a gacha pull, the result is now immediately broadcast to the streamer's overlay for live display.

## Key Changes
- Added real-time broadcast functionality to the gacha POST endpoint
- Imported `broadcastGachaResult` and `GachaBroadcastPayload` from the realtime library
- Created a payload containing the gacha card details and user information
- Implemented error handling that logs broadcast failures without affecting the gacha success response
- Added logging for successful broadcasts

## Implementation Details
- The broadcast is sent asynchronously after the gacha result is confirmed
- Broadcast errors are caught and logged but don't cause the API to return a failure response, ensuring the gacha transaction is still considered successful from the user's perspective
- The payload includes essential card information (id, name, description, image_url, rarity) and the user's Twitch username for overlay display
- Both English and Japanese comments are included for clarity