### PR TITLE
fix: コンパクトカードの縦サイズも小さくなるよう修正

### DIFF
--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -106,8 +106,10 @@ export default function CollectionCard({
   // 画像サイズに基づいてカードサイズのクラスを決定
   // Small cards use reduced dimensions to better display small images like emotes
   // 小さいカードはエモートなどの小さい画像をより良く表示するために縮小されたサイズを使用
+  // h-fit: カードの高さをコンテンツに合わせる（グリッド内で縦も小さくなる）
+  // self-start: グリッドセル内で上揃えにする
   const cardClasses = isSmallImage && sizeChecked
-    ? "group relative overflow-hidden rounded-lg bg-gray-700 max-w-[160px] mx-auto"
+    ? "group relative overflow-hidden rounded-lg bg-gray-700 max-w-[160px] h-fit self-start mx-auto"
     : "group relative overflow-hidden rounded-lg bg-gray-700";
 
   // Image container classes - smaller for small images

--- a/src/components/StreamerCollection.tsx
+++ b/src/components/StreamerCollection.tsx
@@ -87,10 +87,11 @@ export default async function StreamerCollection({ streamer, cards, stats }: Str
           // Grid layout for cards - uses responsive columns
           // Small images (< 400px) are automatically displayed in compact cards
           // via the CollectionCard component's image size detection
+          // items-start: グリッドアイテムを上揃えにして、コンパクトカードの高さを維持
           // カード用グリッドレイアウト - レスポンシブな列数を使用
           // 小さい画像（400px未満）はCollectionCardコンポーネントの
           // 画像サイズ検出により自動的にコンパクトカードで表示される
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 items-start">
             {cards.map((card, index) => {
               const rarityInfo = getRarityInfo(card.rarity);
               // First 4 cards get priority for LCP optimization


### PR DESCRIPTION
h-fitとself-startクラスを追加し、グリッドにitems-startを追加することで
小さい画像のカードが縦方向も適切に縮小されるようになった