### PR TITLE
Disable Next.js Image Optimization for Pre-optimized Card Images

### DIFF
--- a/src/app/battle/page.tsx
+++ b/src/app/battle/page.tsx
@@ -181,12 +181,14 @@ export default function BattlePage() {
                     >
                       <div className="aspect-[3/4] bg-gray-700">
                         {userCard.card.image_url ? (
+                          // unoptimized: ImageCropperで最適化済みのため、Vercel Image Transformationsをスキップしてコスト削減
                           <Image
                             src={userCard.card.image_url}
                             alt={userCard.card.name}
                             width={200}
                             height={300}
                             className="h-full w-full object-cover"
+                            unoptimized
                           />
                         ) : (
                           <div className="flex h-full items-center justify-center text-4xl">
@@ -222,12 +224,14 @@ export default function BattlePage() {
                     <div className="flex items-center gap-4 mb-4">
                       <div className="h-20 w-20 bg-gray-700 rounded-lg flex items-center justify-center">
                         {selectedCard.card.image_url ? (
+                          // unoptimized: ImageCropperで最適化済みのため、Vercel Image Transformationsをスキップしてコスト削減
                           <Image
                             src={selectedCard.card.image_url}
                             alt={selectedCard.card.name}
                             width={80}
                             height={80}
                             className="h-full w-full object-cover rounded-lg"
+                            unoptimized
                           />
                         ) : (
                           <div className="text-2xl">🎴</div>
@@ -292,12 +296,14 @@ export default function BattlePage() {
                     <div className="flex items-center gap-4 mb-4">
                       <div className="h-24 w-24 bg-gray-700 rounded-lg flex items-center justify-center">
                         {battleResult.userCard.image_url ? (
+                          // unoptimized: ImageCropperで最適化済みのため、Vercel Image Transformationsをスキップしてコスト削減
                           <Image
                             src={battleResult.userCard.image_url}
                             alt={battleResult.userCard.name}
                             width={96}
                             height={96}
                             className="h-full w-full object-cover rounded-lg"
+                            unoptimized
                           />
                         ) : (
                           <div className="text-3xl">🎴</div>
@@ -316,12 +322,14 @@ export default function BattlePage() {
                     <div className="flex items-center gap-4 mb-4">
                       <div className="h-24 w-24 bg-gray-700 rounded-lg flex items-center justify-center">
                         {battleResult.opponentCard.image_url ? (
+                          // unoptimized: ImageCropperで最適化済みのため、Vercel Image Transformationsをスキップしてコスト削減
                           <Image
                             src={battleResult.opponentCard.image_url}
                             alt={battleResult.opponentCard.name}
                             width={96}
                             height={96}
                             className="h-full w-full object-cover rounded-lg"
+                            unoptimized
                           />
                         ) : (
                           <div className="text-3xl">🎴</div>

--- a/src/app/battle/stats/page.tsx
+++ b/src/app/battle/stats/page.tsx
@@ -183,12 +183,14 @@ export default function BattleStatsPage() {
                       <div className="flex items-center gap-4">
                         <div className="h-16 w-16 bg-gray-700 rounded-lg flex items-center justify-center flex-shrink-0">
                           {card.cardImage ? (
+                            // unoptimized: ImageCropperで最適化済みのため、Vercel Image Transformationsをスキップしてコスト削減
                             <Image
                               src={card.cardImage}
                               alt={card.cardName}
                               width={64}
                               height={64}
                               className="h-full w-full object-cover rounded-lg"
+                              unoptimized
                             />
                           ) : (
                             <div className="text-2xl">🎴</div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -114,6 +114,7 @@ export default async function DashboardPage() {
                 >
                   <div className="aspect-square bg-gray-700">
                     {card.image_url ? (
+                      // unoptimized: ImageCropperで最適化済みのため、Vercel Image Transformationsをスキップしてコスト削減
                       <Image
                         src={card.image_url}
                         alt={card.name}
@@ -121,6 +122,7 @@ export default async function DashboardPage() {
                         height={200}
                         className="h-full w-full object-cover"
                         priority={isPriority}
+                        unoptimized
                       />
                     ) : (
                       <div className="flex h-full items-center justify-center text-4xl text-gray-600">

--- a/src/components/AnimatedBattle.tsx
+++ b/src/components/AnimatedBattle.tsx
@@ -118,12 +118,14 @@ export default function AnimatedBattle({
                 shakeUser ? 'animate-bounce' : ''
               }`}>
                 {userCard.image_url ? (
+                  // unoptimized: ImageCropperで最適化済みのため、Vercel Image Transformationsをスキップしてコスト削減
                   <Image
                     src={userCard.image_url}
                     alt={userCard.name}
                     width={128}
                     height={128}
                     className="h-full w-full object-cover rounded-lg"
+                    unoptimized
                   />
                 ) : (
                   <div className="text-4xl">🎴</div>
@@ -168,12 +170,14 @@ export default function AnimatedBattle({
                 shakeOpponent ? 'animate-bounce' : ''
               }`}>
                 {opponentCard.image_url ? (
+                  // unoptimized: ImageCropperで最適化済みのため、Vercel Image Transformationsをスキップしてコスト削減
                   <Image
                     src={opponentCard.image_url}
                     alt={opponentCard.name}
                     width={128}
                     height={128}
                     className="h-full w-full object-cover rounded-lg"
+                    unoptimized
                   />
                 ) : (
                   <div className="text-4xl">🎴</div>

--- a/src/components/GachaHistorySection.tsx
+++ b/src/components/GachaHistorySection.tsx
@@ -71,12 +71,14 @@ export default function GachaHistorySection({
               <div key={entry.id} className="flex items-center gap-4 p-4">
                 <div className="h-12 w-12 flex-shrink-0 overflow-hidden rounded-lg bg-gray-700">
                   {entry.cards.image_url ? (
+                    // unoptimized: ImageCropperで最適化済みのため、Vercel Image Transformationsをスキップしてコスト削減
                     <Image
                       src={entry.cards.image_url}
                       alt={entry.cards.name}
                       width={48}
                       height={48}
                       className="h-full w-full object-cover"
+                      unoptimized
                     />
                   ) : (
                     <div className="flex h-full items-center justify-center text-xl">


### PR DESCRIPTION
## Summary
This PR adds the `unoptimized` prop to all Next.js `Image` components that display card images throughout the application. Since card images are already optimized by the ImageCropper component, disabling Vercel Image Transformations reduces unnecessary image processing costs.

## Key Changes
- Added `unoptimized` prop to 9 `Image` components across 5 files
- Added explanatory comments indicating that images are pre-optimized by ImageCropper
- Affected pages and components:
  - `src/app/battle/page.tsx` (4 Image components)
  - `src/app/battle/stats/page.tsx` (1 Image component)
  - `src/app/dashboard/page.tsx` (1 Image component)
  - `src/components/AnimatedBattle.tsx` (2 Image components)
  - `src/components/GachaHistorySection.tsx` (1 Image component)

## Implementation Details
- The `unoptimized` prop tells Next.js to skip its built-in Image Optimization API
- This is safe because all card images are already processed and optimized by the ImageCropper component before being stored
- Reduces Vercel Image Transformations API calls and associated costs
- No visual or functional changes to the application