### PR TITLE
Add support for multiple gacha rewards per streamer

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -287,7 +287,11 @@
       "createRewardFailed": "Failed to create reward",
       "saveFailed": "Failed to save settings",
       "saveSuccess": "Saved (EventSub registration complete)",
-      "eventsubFailed": "Settings saved, but EventSub registration failed. Please verify the URL is accessible externally."
+      "eventsubFailed": "Settings saved, but EventSub registration failed. Please verify the URL is accessible externally.",
+      "additionalRewardAdded": "Additional reward registered",
+      "additionalRewardFailed": "Failed to register additional reward",
+      "additionalRewardRemoved": "Additional reward removed",
+      "additionalRewardRemoveFailed": "Failed to remove additional reward"
     },
     "form": {
       "selectReward": "Select channel point reward for card redemption",
@@ -298,14 +302,23 @@
       "allRewards": "All Rewards",
       "eventsubStatus": "EventSub Status",
       "noSubscriptions": "No EventSub subscriptions. Click save to register.",
-      "localTunnelNote": "* Local environment requires ngrok or similar tunnel"
+      "localTunnelNote": "* Local environment requires ngrok or similar tunnel",
+      "additionalRewards": "Additional Gacha Rewards",
+      "additionalRewardsDescription": "In addition to the main reward, you can configure additional rewards that also trigger gacha.",
+      "unknownReward": "Unknown reward",
+      "noAdditionalRewardsAvailable": "No additional rewards available.",
+      "setMainRewardFirst": "Please set the main reward first."
     },
     "buttons": {
       "createReward": "Create TwiCa Reward (100 points)",
-      "saveEventSub": "Save & Register EventSub"
+      "saveEventSub": "Save & Register EventSub",
+      "creating": "Creating...",
+      "addAdditional": "Add",
+      "remove": "Remove"
     },
     "options": {
       "selectReward": "-- Select Reward --",
+      "selectAdditionalReward": "-- Select Additional Reward --",
       "points": "points",
       "disabled": "[Disabled]"
     }

--- a/messages/en.json
+++ b/messages/en.json
@@ -288,10 +288,10 @@
       "saveFailed": "Failed to save settings",
       "saveSuccess": "Saved (EventSub registration complete)",
       "eventsubFailed": "Settings saved, but EventSub registration failed. Please verify the URL is accessible externally.",
-      "additionalRewardAdded": "Additional reward registered",
-      "additionalRewardFailed": "Failed to register additional reward",
-      "additionalRewardRemoved": "Additional reward removed",
-      "additionalRewardRemoveFailed": "Failed to remove additional reward"
+      "additionalRewardAdded": "Channel point added",
+      "additionalRewardFailed": "Failed to add channel point",
+      "additionalRewardRemoved": "Channel point removed",
+      "additionalRewardRemoveFailed": "Failed to remove channel point"
     },
     "form": {
       "selectReward": "Select channel point reward for card redemption",
@@ -303,11 +303,11 @@
       "eventsubStatus": "EventSub Status",
       "noSubscriptions": "No EventSub subscriptions. Click save to register.",
       "localTunnelNote": "* Local environment requires ngrok or similar tunnel",
-      "additionalRewards": "Additional Gacha Rewards",
-      "additionalRewardsDescription": "In addition to the main reward, you can configure additional rewards that also trigger gacha.",
-      "unknownReward": "Unknown reward",
-      "noAdditionalRewardsAvailable": "No additional rewards available.",
-      "setMainRewardFirst": "Please set the main reward first."
+      "additionalRewards": "Additional Channel Points",
+      "additionalRewardsDescription": "In addition to the main channel point, you can configure additional channel points that also trigger card draws.",
+      "unknownReward": "Unknown channel point",
+      "noAdditionalRewardsAvailable": "No additional channel points available.",
+      "setMainRewardFirst": "Please set the main channel point first."
     },
     "buttons": {
       "createReward": "Create TwiCa Reward (100 points)",
@@ -318,7 +318,7 @@
     },
     "options": {
       "selectReward": "-- Select Reward --",
-      "selectAdditionalReward": "-- Select Additional Reward --",
+      "selectAdditionalReward": "-- Select Channel Point to Add --",
       "points": "points",
       "disabled": "[Disabled]"
     }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -287,7 +287,11 @@
       "createRewardFailed": "報酬の作成に失敗しました",
       "saveFailed": "設定の保存に失敗しました",
       "saveSuccess": "保存しました（EventSub登録完了）",
-      "eventsubFailed": "設定は保存しましたが、EventSub登録に失敗しました。URLが外部からアクセス可能か確認してください。"
+      "eventsubFailed": "設定は保存しましたが、EventSub登録に失敗しました。URLが外部からアクセス可能か確認してください。",
+      "additionalRewardAdded": "追加報酬を登録しました",
+      "additionalRewardFailed": "追加報酬の登録に失敗しました",
+      "additionalRewardRemoved": "追加報酬を削除しました",
+      "additionalRewardRemoveFailed": "追加報酬の削除に失敗しました"
     },
     "form": {
       "selectReward": "カード引き換えに使用するチャネルポイント報酬を選択",
@@ -298,14 +302,23 @@
       "allRewards": "全報酬",
       "eventsubStatus": "EventSub ステータス",
       "noSubscriptions": "EventSubサブスクリプションがありません。保存ボタンを押して登録してください。",
-      "localTunnelNote": "※ ローカル環境ではngrokなどのトンネルが必要です"
+      "localTunnelNote": "※ ローカル環境ではngrokなどのトンネルが必要です",
+      "additionalRewards": "追加ガチャ報酬",
+      "additionalRewardsDescription": "メインの報酬に加えて、追加の報酬でもガチャを引けるように設定できます。",
+      "unknownReward": "不明な報酬",
+      "noAdditionalRewardsAvailable": "追加できる報酬がありません。",
+      "setMainRewardFirst": "まずメインの報酬を設定してください。"
     },
     "buttons": {
       "createReward": "TwiCa用報酬を作成（100ポイント）",
-      "saveEventSub": "保存 & EventSub登録"
+      "saveEventSub": "保存 & EventSub登録",
+      "creating": "作成中...",
+      "addAdditional": "追加",
+      "remove": "削除"
     },
     "options": {
       "selectReward": "-- 報酬を選択 --",
+      "selectAdditionalReward": "-- 追加する報酬を選択 --",
       "points": "ポイント",
       "disabled": "[無効]"
     }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -288,10 +288,10 @@
       "saveFailed": "設定の保存に失敗しました",
       "saveSuccess": "保存しました（EventSub登録完了）",
       "eventsubFailed": "設定は保存しましたが、EventSub登録に失敗しました。URLが外部からアクセス可能か確認してください。",
-      "additionalRewardAdded": "追加報酬を登録しました",
-      "additionalRewardFailed": "追加報酬の登録に失敗しました",
-      "additionalRewardRemoved": "追加報酬を削除しました",
-      "additionalRewardRemoveFailed": "追加報酬の削除に失敗しました"
+      "additionalRewardAdded": "引き換えチャネルポイントを追加しました",
+      "additionalRewardFailed": "引き換えチャネルポイントの追加に失敗しました",
+      "additionalRewardRemoved": "引き換えチャネルポイントを削除しました",
+      "additionalRewardRemoveFailed": "引き換えチャネルポイントの削除に失敗しました"
     },
     "form": {
       "selectReward": "カード引き換えに使用するチャネルポイント報酬を選択",
@@ -303,11 +303,11 @@
       "eventsubStatus": "EventSub ステータス",
       "noSubscriptions": "EventSubサブスクリプションがありません。保存ボタンを押して登録してください。",
       "localTunnelNote": "※ ローカル環境ではngrokなどのトンネルが必要です",
-      "additionalRewards": "追加ガチャ報酬",
-      "additionalRewardsDescription": "メインの報酬に加えて、追加の報酬でもガチャを引けるように設定できます。",
-      "unknownReward": "不明な報酬",
-      "noAdditionalRewardsAvailable": "追加できる報酬がありません。",
-      "setMainRewardFirst": "まずメインの報酬を設定してください。"
+      "additionalRewards": "引き換えチャネルポイント追加",
+      "additionalRewardsDescription": "メインのチャネルポイントに加えて、別のチャネルポイントでもカードを引けるように設定できます。",
+      "unknownReward": "不明なチャネルポイント",
+      "noAdditionalRewardsAvailable": "追加できるチャネルポイントがありません。",
+      "setMainRewardFirst": "まずメインのチャネルポイントを設定してください。"
     },
     "buttons": {
       "createReward": "TwiCa用報酬を作成（100ポイント）",
@@ -318,7 +318,7 @@
     },
     "options": {
       "selectReward": "-- 報酬を選択 --",
-      "selectAdditionalReward": "-- 追加する報酬を選択 --",
+      "selectAdditionalReward": "-- 追加するチャネルポイントを選択 --",
       "points": "ポイント",
       "disabled": "[無効]"
     }

--- a/src/app/api/twitch/eventsub/additional-rewards/route.ts
+++ b/src/app/api/twitch/eventsub/additional-rewards/route.ts
@@ -1,0 +1,352 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession, canUseStreamerFeatures } from "@/lib/session";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { handleApiError } from "@/lib/error-handler";
+import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { ERROR_MESSAGES } from "@/lib/constants";
+
+const TWITCH_API_URL = "https://api.twitch.tv/helix";
+
+/**
+ * Get app access token for EventSub subscriptions
+ * EventSubサブスクリプション用のアプリアクセストークンを取得
+ */
+async function getAppAccessToken(): Promise<string> {
+  const response = await fetch("https://id.twitch.tv/oauth2/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      client_id: process.env.TWITCH_CLIENT_ID!,
+      client_secret: process.env.TWITCH_CLIENT_SECRET!,
+      grant_type: "client_credentials",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to get app access token");
+  }
+
+  const data = await response.json();
+  return data.access_token;
+}
+
+/**
+ * POST - Add a new additional gacha reward
+ * 追加ガチャ報酬を新規登録
+ *
+ * This endpoint:
+ * 1. Saves the additional reward to the database
+ * 2. Creates an EventSub subscription for the reward
+ *
+ * このエンドポイント:
+ * 1. 追加報酬をデータベースに保存
+ * 2. 報酬用のEventSubサブスクリプションを作成
+ */
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+
+  const identifier = await getRateLimitIdentifier(request, session?.twitchUserId);
+  const rateLimitResult = await checkRateLimit(rateLimits.eventsubSubscribePost, identifier);
+
+  if (!rateLimitResult.success) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
+      {
+        status: 429,
+        headers: {
+          "X-RateLimit-Limit": String(rateLimitResult.limit),
+          "X-RateLimit-Remaining": String(rateLimitResult.remaining),
+          "X-RateLimit-Reset": String(rateLimitResult.reset),
+        },
+      }
+    );
+  }
+
+  if (!session || !canUseStreamerFeatures(session)) {
+    return NextResponse.json({ error: ERROR_MESSAGES.UNAUTHORIZED }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { rewardId, rewardName } = body;
+
+    if (!rewardId) {
+      return NextResponse.json({ error: ERROR_MESSAGES.MISSING_REWARD_ID }, { status: 400 });
+    }
+
+    const supabaseAdmin = getSupabaseAdmin();
+
+    // Get streamer info
+    // ストリーマー情報を取得
+    const { data: streamer } = await supabaseAdmin
+      .from("streamers")
+      .select("id, channel_point_reward_id")
+      .eq("twitch_user_id", session.twitchUserId)
+      .single();
+
+    if (!streamer) {
+      return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
+    }
+
+    // Check if this reward is already the main reward
+    // この報酬がすでにメイン報酬かどうかチェック
+    if (streamer.channel_point_reward_id === rewardId) {
+      return NextResponse.json(
+        { error: "This reward is already set as the main gacha reward" },
+        { status: 400 }
+      );
+    }
+
+    // Check if this reward is already registered as an additional reward
+    // この報酬がすでに追加報酬として登録されているかチェック
+    const { data: existingReward } = await supabaseAdmin
+      .from("streamer_additional_gacha_rewards")
+      .select("id")
+      .eq("streamer_id", streamer.id)
+      .eq("reward_id", rewardId)
+      .maybeSingle();
+
+    if (existingReward) {
+      return NextResponse.json(
+        { error: "This reward is already registered as an additional gacha reward" },
+        { status: 400 }
+      );
+    }
+
+    // Get app access token
+    // アプリアクセストークンを取得
+    const appAccessToken = await getAppAccessToken();
+
+    // Callback URL for EventSub
+    const callbackUrl = `${process.env.NEXT_PUBLIC_APP_URL}/api/twitch/eventsub`;
+
+    // Create EventSub subscription for the additional reward
+    // 追加報酬用のEventSubサブスクリプションを作成
+    const subscribeResponse = await fetch(
+      `${TWITCH_API_URL}/eventsub/subscriptions`,
+      {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${appAccessToken}`,
+          "Client-Id": process.env.TWITCH_CLIENT_ID!,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          type: "channel.channel_points_custom_reward_redemption.add",
+          version: "1",
+          condition: {
+            broadcaster_user_id: session.twitchUserId,
+            reward_id: rewardId,
+          },
+          transport: {
+            method: "webhook",
+            callback: callbackUrl,
+            secret: process.env.TWITCH_EVENTSUB_SECRET,
+          },
+        }),
+      }
+    );
+
+    if (!subscribeResponse.ok) {
+      const error = await subscribeResponse.json();
+      return handleApiError(error, "EventSub subscription error");
+    }
+
+    // Save the additional reward to the database
+    // 追加報酬をデータベースに保存
+    const { data: newReward, error: insertError } = await supabaseAdmin
+      .from("streamer_additional_gacha_rewards")
+      .insert({
+        streamer_id: streamer.id,
+        reward_id: rewardId,
+        reward_name: rewardName || null,
+      })
+      .select()
+      .single();
+
+    if (insertError) {
+      return handleApiError(insertError, "Failed to save additional reward");
+    }
+
+    return NextResponse.json({
+      success: true,
+      reward: newReward,
+    });
+  } catch (error) {
+    return handleApiError(error, "Additional Rewards API");
+  }
+}
+
+/**
+ * GET - Get all additional gacha rewards for the current streamer
+ * 現在のストリーマーの追加ガチャ報酬一覧を取得
+ */
+export async function GET(request: Request) {
+  const session = await getSession();
+
+  const identifier = await getRateLimitIdentifier(request, session?.twitchUserId);
+  const rateLimitResult = await checkRateLimit(rateLimits.eventsubSubscribeGet, identifier);
+
+  if (!rateLimitResult.success) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
+      {
+        status: 429,
+        headers: {
+          "X-RateLimit-Limit": String(rateLimitResult.limit),
+          "X-RateLimit-Remaining": String(rateLimitResult.remaining),
+          "X-RateLimit-Reset": String(rateLimitResult.reset),
+        },
+      }
+    );
+  }
+
+  if (!session || !canUseStreamerFeatures(session)) {
+    return NextResponse.json({ error: ERROR_MESSAGES.UNAUTHORIZED }, { status: 401 });
+  }
+
+  try {
+    const supabaseAdmin = getSupabaseAdmin();
+
+    // Get streamer info
+    // ストリーマー情報を取得
+    const { data: streamer } = await supabaseAdmin
+      .from("streamers")
+      .select("id")
+      .eq("twitch_user_id", session.twitchUserId)
+      .single();
+
+    if (!streamer) {
+      return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
+    }
+
+    // Get all additional rewards for this streamer
+    // このストリーマーの全追加報酬を取得
+    const { data: additionalRewards, error } = await supabaseAdmin
+      .from("streamer_additional_gacha_rewards")
+      .select("*")
+      .eq("streamer_id", streamer.id)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      return handleApiError(error, "Failed to get additional rewards");
+    }
+
+    return NextResponse.json(additionalRewards || []);
+  } catch (error) {
+    return handleApiError(error, "Additional Rewards GET API");
+  }
+}
+
+/**
+ * DELETE - Remove an additional gacha reward
+ * 追加ガチャ報酬を削除
+ *
+ * Query parameter: rewardId - the reward ID to delete
+ */
+export async function DELETE(request: NextRequest) {
+  const session = await getSession();
+
+  const identifier = await getRateLimitIdentifier(request, session?.twitchUserId);
+  const rateLimitResult = await checkRateLimit(rateLimits.eventsubSubscribePost, identifier);
+
+  if (!rateLimitResult.success) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
+      {
+        status: 429,
+        headers: {
+          "X-RateLimit-Limit": String(rateLimitResult.limit),
+          "X-RateLimit-Remaining": String(rateLimitResult.remaining),
+          "X-RateLimit-Reset": String(rateLimitResult.reset),
+        },
+      }
+    );
+  }
+
+  if (!session || !canUseStreamerFeatures(session)) {
+    return NextResponse.json({ error: ERROR_MESSAGES.UNAUTHORIZED }, { status: 401 });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const rewardId = searchParams.get("rewardId");
+
+    if (!rewardId) {
+      return NextResponse.json({ error: ERROR_MESSAGES.MISSING_REWARD_ID }, { status: 400 });
+    }
+
+    const supabaseAdmin = getSupabaseAdmin();
+
+    // Get streamer info
+    // ストリーマー情報を取得
+    const { data: streamer } = await supabaseAdmin
+      .from("streamers")
+      .select("id")
+      .eq("twitch_user_id", session.twitchUserId)
+      .single();
+
+    if (!streamer) {
+      return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
+    }
+
+    // Get app access token
+    // アプリアクセストークンを取得
+    const appAccessToken = await getAppAccessToken();
+
+    // Find and delete the EventSub subscription for this reward
+    // この報酬のEventSubサブスクリプションを検索して削除
+    const existingResponse = await fetch(
+      `${TWITCH_API_URL}/eventsub/subscriptions`,
+      {
+        headers: {
+          "Authorization": `Bearer ${appAccessToken}`,
+          "Client-Id": process.env.TWITCH_CLIENT_ID!,
+        },
+      }
+    );
+
+    if (existingResponse.ok) {
+      const existingData = await existingResponse.json();
+
+      // Delete the subscription for this specific reward
+      // この特定の報酬のサブスクリプションを削除
+      for (const sub of existingData.data) {
+        if (
+          sub.type === "channel.channel_points_custom_reward_redemption.add" &&
+          sub.condition.broadcaster_user_id === session.twitchUserId &&
+          sub.condition.reward_id === rewardId
+        ) {
+          await fetch(
+            `${TWITCH_API_URL}/eventsub/subscriptions?id=${sub.id}`,
+            {
+              method: "DELETE",
+              headers: {
+                "Authorization": `Bearer ${appAccessToken}`,
+                "Client-Id": process.env.TWITCH_CLIENT_ID!,
+              },
+            }
+          );
+        }
+      }
+    }
+
+    // Delete the additional reward from the database
+    // データベースから追加報酬を削除
+    const { error: deleteError } = await supabaseAdmin
+      .from("streamer_additional_gacha_rewards")
+      .delete()
+      .eq("streamer_id", streamer.id)
+      .eq("reward_id", rewardId);
+
+    if (deleteError) {
+      return handleApiError(deleteError, "Failed to delete additional reward");
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return handleApiError(error, "Additional Rewards DELETE API");
+  }
+}

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -22,6 +22,16 @@ interface EventSubSubscription {
   };
 }
 
+// 追加ガチャ報酬の型定義
+// Type definition for additional gacha rewards
+interface AdditionalGachaReward {
+  id: string;
+  streamer_id: string;
+  reward_id: string;
+  reward_name: string | null;
+  created_at: string;
+}
+
 interface ChannelPointSettingsProps {
   streamerId: string;
   currentRewardId: string | null;
@@ -50,6 +60,12 @@ export default function ChannelPointSettings({
   const [error, setError] = useState("");
   const [eventSubStatus, setEventSubStatus] = useState<"none" | "pending" | "active" | "error">("none");
   const [subscriptions, setSubscriptions] = useState<EventSubSubscription[]>([]);
+  // 追加報酬関連の状態
+  // State for additional rewards
+  const [additionalRewards, setAdditionalRewards] = useState<AdditionalGachaReward[]>([]);
+  const [selectedAdditionalRewardId, setSelectedAdditionalRewardId] = useState("");
+  const [addingAdditional, setAddingAdditional] = useState(false);
+  const [removingAdditional, setRemovingAdditional] = useState<string | null>(null);
 
   const fetchRewards = async () => {
     setLoading(true);
@@ -130,10 +146,27 @@ export default function ChannelPointSettings({
       }
   }, [currentRewardId]);
 
+  // 追加報酬一覧を取得
+  // Fetch additional rewards list
+  const fetchAdditionalRewards = useCallback(async () => {
+    try {
+      const response = await fetch("/api/twitch/eventsub/additional-rewards", {
+        credentials: "include",
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setAdditionalRewards(data);
+      }
+    } catch {
+      logger.error("Failed to fetch additional rewards");
+    }
+  }, []);
+
   useEffect(() => {
     fetchRewards();
     fetchEventSubStatus();
-  }, [fetchEventSubStatus]);
+    fetchAdditionalRewards();
+  }, [fetchEventSubStatus, fetchAdditionalRewards]);
 
   const handleCreateReward = async () => {
     setCreating(true);
@@ -230,6 +263,86 @@ export default function ChannelPointSettings({
     const reward = rewards.find((r) => r.id === rewardId);
     setSelectedRewardName(reward?.title || "");
   };
+
+  // 追加報酬を登録
+  // Add additional reward
+  const handleAddAdditionalReward = async () => {
+    if (!selectedAdditionalRewardId) return;
+
+    setAddingAdditional(true);
+    setMessage("");
+
+    try {
+      const reward = rewards.find((r) => r.id === selectedAdditionalRewardId);
+      const response = await fetch("/api/twitch/eventsub/additional-rewards", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          rewardId: selectedAdditionalRewardId,
+          rewardName: reward?.title || null,
+        }),
+      });
+
+      if (response.ok) {
+        setMessage(t("messages.additionalRewardAdded"));
+        setSelectedAdditionalRewardId("");
+        await fetchAdditionalRewards();
+        await fetchEventSubStatus();
+      } else if (response.status === 429) {
+        const errorData = await response.json();
+        setMessage(errorData.error || t("messages.rateLimit"));
+      } else {
+        const errorData = await response.json();
+        setMessage(errorData.error || t("messages.additionalRewardFailed"));
+      }
+    } catch {
+      setMessage(t("messages.errorOccurred"));
+    } finally {
+      setAddingAdditional(false);
+    }
+  };
+
+  // 追加報酬を削除
+  // Remove additional reward
+  const handleRemoveAdditionalReward = async (rewardId: string) => {
+    setRemovingAdditional(rewardId);
+    setMessage("");
+
+    try {
+      const response = await fetch(
+        `/api/twitch/eventsub/additional-rewards?rewardId=${encodeURIComponent(rewardId)}`,
+        {
+          method: "DELETE",
+          credentials: "include",
+        }
+      );
+
+      if (response.ok) {
+        setMessage(t("messages.additionalRewardRemoved"));
+        await fetchAdditionalRewards();
+        await fetchEventSubStatus();
+      } else if (response.status === 429) {
+        const errorData = await response.json();
+        setMessage(errorData.error || t("messages.rateLimit"));
+      } else {
+        setMessage(t("messages.additionalRewardRemoveFailed"));
+      }
+    } catch {
+      setMessage(t("messages.errorOccurred"));
+    } finally {
+      setRemovingAdditional(null);
+    }
+  };
+
+  // 追加報酬として選択可能な報酬をフィルタリング
+  // Filter rewards available for additional selection
+  const availableForAdditional = rewards.filter(
+    (r) =>
+      r.id !== selectedRewardId && // メイン報酬は除外
+      r.id !== currentRewardId && // 現在のメイン報酬も除外
+      !additionalRewards.some((ar) => ar.reward_id === r.id) // 既に追加済みは除外
+  );
 
   const getEventSubStatusBadge = () => {
     switch (eventSubStatus) {
@@ -372,6 +485,81 @@ export default function ChannelPointSettings({
             )}
            </div>
 
+           {/* Additional Rewards Section */}
+           {/* 追加報酬セクション - メインの報酬とは別に追加の報酬を設定できる */}
+           <div className="rounded-lg bg-gray-700/50 p-4">
+             <h3 className="mb-2 text-sm font-medium text-gray-300">
+               {t("form.additionalRewards")}
+             </h3>
+             <p className="mb-3 text-xs text-gray-500">
+               {t("form.additionalRewardsDescription")}
+             </p>
+
+             {/* Registered additional rewards list */}
+             {/* 登録済みの追加報酬一覧 */}
+             {additionalRewards.length > 0 && (
+               <div className="mb-3 space-y-2">
+                 {additionalRewards.map((reward) => (
+                   <div
+                     key={reward.id}
+                     className="flex items-center justify-between rounded bg-gray-600/50 px-3 py-2"
+                   >
+                     <div>
+                       <span className="text-sm text-gray-200">
+                         {reward.reward_name || t("form.unknownReward")}
+                       </span>
+                       <span className="ml-2 text-xs text-gray-500">
+                         ({reward.reward_id.slice(0, 8)}...)
+                       </span>
+                     </div>
+                     <button
+                       onClick={() => handleRemoveAdditionalReward(reward.reward_id)}
+                       disabled={removingAdditional === reward.reward_id}
+                       className="rounded bg-red-600/20 px-2 py-1 text-xs text-red-400 hover:bg-red-600/30 disabled:opacity-50"
+                     >
+                       {removingAdditional === reward.reward_id
+                         ? tCommon("loading")
+                         : t("buttons.remove")}
+                     </button>
+                   </div>
+                 ))}
+               </div>
+             )}
+
+             {/* Add additional reward form */}
+             {/* 追加報酬の追加フォーム */}
+             {availableForAdditional.length > 0 ? (
+               <div className="flex items-center gap-2">
+                 <select
+                   value={selectedAdditionalRewardId}
+                   onChange={(e) => setSelectedAdditionalRewardId(e.target.value)}
+                   className="flex-1 rounded-lg bg-gray-700 px-3 py-2 text-sm text-gray-200"
+                 >
+                   <option value="">{t("options.selectAdditionalReward")}</option>
+                   {availableForAdditional.map((reward) => (
+                     <option key={reward.id} value={reward.id}>
+                       {reward.title} ({reward.cost} {t("options.points")})
+                       {!reward.is_enabled && t("options.disabled")}
+                     </option>
+                   ))}
+                 </select>
+                 <button
+                   onClick={handleAddAdditionalReward}
+                   disabled={addingAdditional || !selectedAdditionalRewardId}
+                   className="rounded-lg bg-purple-600 px-4 py-2 text-sm text-white hover:bg-purple-700 disabled:opacity-50"
+                 >
+                   {addingAdditional ? tCommon("loading") : t("buttons.addAdditional")}
+                 </button>
+               </div>
+             ) : (
+               <p className="text-xs text-gray-500">
+                 {currentRewardId
+                   ? t("form.noAdditionalRewardsAvailable")
+                   : t("form.setMainRewardFirst")}
+               </p>
+             )}
+           </div>
+
            <div className="flex items-center gap-4">
              <button
                onClick={handleSave}
@@ -381,7 +569,7 @@ export default function ChannelPointSettings({
                {saving ? tCommon("loading") : t("buttons.saveEventSub")}
              </button>
              <button
-               onClick={() => { fetchRewards(); fetchEventSubStatus(); }}
+               onClick={() => { fetchRewards(); fetchEventSubStatus(); fetchAdditionalRewards(); }}
                className="rounded-lg border border-gray-600 px-4 py-2 text-gray-300 hover:bg-gray-700"
              >
                {tCommon("refresh")}

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -147,7 +147,15 @@ export class GachaService {
         return err('Streamer not found')
       }
 
-      if (streamer.channel_point_reward_id !== event.reward.id) {
+      // Check if the reward ID matches the main reward OR any additional reward
+      // メインの報酬ID または 追加報酬のいずれかに一致するかチェック
+      const isValidReward = await this.isValidGachaReward(
+        streamer.id,
+        streamer.channel_point_reward_id,
+        event.reward.id
+      )
+
+      if (!isValidReward) {
         return err('Reward ID mismatch')
       }
 
@@ -155,5 +163,47 @@ export class GachaService {
     } catch (error) {
       return err(`Unexpected error: ${error}`)
     }
+  }
+
+  /**
+   * Check if the given reward ID is valid for gacha
+   * 指定された報酬IDがガチャに有効かどうかをチェック
+   *
+   * Valid if:
+   * - Matches the main channel_point_reward_id, OR
+   * - Matches any reward_id in streamer_additional_gacha_rewards table
+   *
+   * 有効な場合:
+   * - メインの channel_point_reward_id と一致する、または
+   * - streamer_additional_gacha_rewards テーブルの reward_id のいずれかと一致する
+   */
+  private async isValidGachaReward(
+    streamerId: string,
+    mainRewardId: string | null,
+    eventRewardId: string
+  ): Promise<boolean> {
+    // First check the main reward ID (most common case)
+    // まずメインの報酬IDをチェック（最も一般的なケース）
+    if (mainRewardId === eventRewardId) {
+      return true
+    }
+
+    // Check additional rewards table
+    // 追加報酬テーブルをチェック
+    const { data: additionalReward, error } = await this.supabase
+      .from('streamer_additional_gacha_rewards')
+      .select('id')
+      .eq('streamer_id', streamerId)
+      .eq('reward_id', eventRewardId)
+      .maybeSingle()
+
+    if (error) {
+      logger.warn('Error checking additional rewards:', error.message)
+      return false
+    }
+
+    // If a matching additional reward is found, the reward is valid
+    // 一致する追加報酬が見つかった場合、その報酬は有効
+    return additionalReward !== null
   }
 }

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -137,15 +137,11 @@ export class GachaService {
     eventId?: string
   ): Promise<Result<GachaResult>> {
     try {
-      // Fetch streamer and additional channel points in a single query
-      // streamerと追加チャネルポイントを1クエリで取得（効率化）
+      // Fetch streamer (main reward ID only for backward compatibility)
+      // streamerを取得（後方互換性のためメイン報酬IDのみ）
       const { data: streamer, error: streamerError } = await this.supabase
         .from('streamers')
-        .select(`
-          id,
-          channel_point_reward_id,
-          streamer_additional_gacha_rewards (reward_id)
-        `)
+        .select('id, channel_point_reward_id')
         .eq('twitch_user_id', event.broadcaster_user_id)
         .single()
 
@@ -153,53 +149,61 @@ export class GachaService {
         return err('Streamer not found')
       }
 
-      // Check if the reward ID matches the main or any additional channel point
-      // メインまたは追加チャネルポイントのいずれかに一致するかチェック
-      const isValidReward = this.isValidGachaReward(
-        streamer.channel_point_reward_id,
-        streamer.streamer_additional_gacha_rewards,
-        event.reward.id
-      )
-
-      if (!isValidReward) {
-        return err('Reward ID mismatch')
+      // Check main reward ID first (most common case, no extra query)
+      // まずメインの報酬IDをチェック（最も一般的なケース、追加クエリなし）
+      if (streamer.channel_point_reward_id === event.reward.id) {
+        return await this.executeGacha(streamer.id, event.user_id, event.user_name, eventId)
       }
 
-      return await this.executeGacha(streamer.id, event.user_id, event.user_name, eventId)
+      // Main reward ID doesn't match, check additional channel points
+      // メインと一致しない場合のみ、追加チャネルポイントをチェック
+      const isAdditionalValid = await this.checkAdditionalReward(streamer.id, event.reward.id)
+      if (isAdditionalValid) {
+        return await this.executeGacha(streamer.id, event.user_id, event.user_name, eventId)
+      }
+
+      return err('Reward ID mismatch')
     } catch (error) {
       return err(`Unexpected error: ${error}`)
     }
   }
 
   /**
-   * Check if the given reward ID is valid for gacha (synchronous, no DB query)
-   * 指定された報酬IDがガチャに有効かどうかをチェック（同期処理、DBクエリなし）
+   * Check if the reward ID exists in additional channel points table
+   * 追加チャネルポイントテーブルに報酬IDが存在するかチェック
    *
-   * Valid if:
-   * - Matches the main channel_point_reward_id, OR
-   * - Matches any reward_id in the additional rewards array
+   * Returns false if:
+   * - Table doesn't exist (migration not applied) - maintains backward compatibility
+   * - No matching record found
    *
-   * 有効な場合:
-   * - メインの channel_point_reward_id と一致する、または
-   * - 追加チャネルポイント配列の reward_id のいずれかと一致する
+   * 以下の場合はfalseを返す:
+   * - テーブルが存在しない（マイグレーション未適用）- 後方互換性を維持
+   * - 一致するレコードがない
    */
-  private isValidGachaReward(
-    mainRewardId: string | null,
-    additionalRewards: { reward_id: string }[] | null,
+  private async checkAdditionalReward(
+    streamerId: string,
     eventRewardId: string
-  ): boolean {
-    // Check main reward ID first (most common case)
-    // まずメインの報酬IDをチェック（最も一般的なケース）
-    if (mainRewardId === eventRewardId) {
-      return true
-    }
+  ): Promise<boolean> {
+    try {
+      const { data: additionalReward, error } = await this.supabase
+        .from('streamer_additional_gacha_rewards')
+        .select('id')
+        .eq('streamer_id', streamerId)
+        .eq('reward_id', eventRewardId)
+        .maybeSingle()
 
-    // Check additional channel points (already fetched, no extra query)
-    // 追加チャネルポイントをチェック（既に取得済み、追加クエリなし）
-    if (additionalRewards && additionalRewards.length > 0) {
-      return additionalRewards.some(r => r.reward_id === eventRewardId)
-    }
+      // If error (e.g., table doesn't exist), return false for backward compatibility
+      // エラーの場合（テーブルが存在しない等）、後方互換性のためfalseを返す
+      if (error) {
+        logger.warn('Additional rewards check failed (table may not exist):', error.message)
+        return false
+      }
 
-    return false
+      return additionalReward !== null
+    } catch {
+      // Any unexpected error: fall back to main reward only behavior
+      // 予期しないエラー: メイン報酬のみの動作にフォールバック
+      return false
+    }
   }
 }

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -137,9 +137,15 @@ export class GachaService {
     eventId?: string
   ): Promise<Result<GachaResult>> {
     try {
+      // Fetch streamer and additional channel points in a single query
+      // streamerと追加チャネルポイントを1クエリで取得（効率化）
       const { data: streamer, error: streamerError } = await this.supabase
         .from('streamers')
-        .select('id, channel_point_reward_id')
+        .select(`
+          id,
+          channel_point_reward_id,
+          streamer_additional_gacha_rewards (reward_id)
+        `)
         .eq('twitch_user_id', event.broadcaster_user_id)
         .single()
 
@@ -147,11 +153,11 @@ export class GachaService {
         return err('Streamer not found')
       }
 
-      // Check if the reward ID matches the main reward OR any additional reward
-      // メインの報酬ID または 追加報酬のいずれかに一致するかチェック
-      const isValidReward = await this.isValidGachaReward(
-        streamer.id,
+      // Check if the reward ID matches the main or any additional channel point
+      // メインまたは追加チャネルポイントのいずれかに一致するかチェック
+      const isValidReward = this.isValidGachaReward(
         streamer.channel_point_reward_id,
+        streamer.streamer_additional_gacha_rewards,
         event.reward.id
       )
 
@@ -166,44 +172,34 @@ export class GachaService {
   }
 
   /**
-   * Check if the given reward ID is valid for gacha
-   * 指定された報酬IDがガチャに有効かどうかをチェック
+   * Check if the given reward ID is valid for gacha (synchronous, no DB query)
+   * 指定された報酬IDがガチャに有効かどうかをチェック（同期処理、DBクエリなし）
    *
    * Valid if:
    * - Matches the main channel_point_reward_id, OR
-   * - Matches any reward_id in streamer_additional_gacha_rewards table
+   * - Matches any reward_id in the additional rewards array
    *
    * 有効な場合:
    * - メインの channel_point_reward_id と一致する、または
-   * - streamer_additional_gacha_rewards テーブルの reward_id のいずれかと一致する
+   * - 追加チャネルポイント配列の reward_id のいずれかと一致する
    */
-  private async isValidGachaReward(
-    streamerId: string,
+  private isValidGachaReward(
     mainRewardId: string | null,
+    additionalRewards: { reward_id: string }[] | null,
     eventRewardId: string
-  ): Promise<boolean> {
-    // First check the main reward ID (most common case)
+  ): boolean {
+    // Check main reward ID first (most common case)
     // まずメインの報酬IDをチェック（最も一般的なケース）
     if (mainRewardId === eventRewardId) {
       return true
     }
 
-    // Check additional rewards table
-    // 追加報酬テーブルをチェック
-    const { data: additionalReward, error } = await this.supabase
-      .from('streamer_additional_gacha_rewards')
-      .select('id')
-      .eq('streamer_id', streamerId)
-      .eq('reward_id', eventRewardId)
-      .maybeSingle()
-
-    if (error) {
-      logger.warn('Error checking additional rewards:', error.message)
-      return false
+    // Check additional channel points (already fetched, no extra query)
+    // 追加チャネルポイントをチェック（既に取得済み、追加クエリなし）
+    if (additionalRewards && additionalRewards.length > 0) {
+      return additionalRewards.some(r => r.reward_id === eventRewardId)
     }
 
-    // If a matching additional reward is found, the reward is valid
-    // 一致する追加報酬が見つかった場合、その報酬は有効
-    return additionalReward !== null
+    return false
   }
 }

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -137,11 +137,15 @@ export class GachaService {
     eventId?: string
   ): Promise<Result<GachaResult>> {
     try {
-      // Fetch streamer (main reward ID only for backward compatibility)
-      // streamerを取得（後方互換性のためメイン報酬IDのみ）
+      // Fetch streamer and additional channel points in a single query
+      // streamerと追加チャネルポイントを1クエリで取得
       const { data: streamer, error: streamerError } = await this.supabase
         .from('streamers')
-        .select('id, channel_point_reward_id')
+        .select(`
+          id,
+          channel_point_reward_id,
+          streamer_additional_gacha_rewards (reward_id)
+        `)
         .eq('twitch_user_id', event.broadcaster_user_id)
         .single()
 
@@ -149,61 +153,22 @@ export class GachaService {
         return err('Streamer not found')
       }
 
-      // Check main reward ID first (most common case, no extra query)
-      // まずメインの報酬IDをチェック（最も一般的なケース、追加クエリなし）
+      // Check main reward ID first (most common case)
+      // まずメインの報酬IDをチェック（最も一般的なケース）
       if (streamer.channel_point_reward_id === event.reward.id) {
         return await this.executeGacha(streamer.id, event.user_id, event.user_name, eventId)
       }
 
-      // Main reward ID doesn't match, check additional channel points
-      // メインと一致しない場合のみ、追加チャネルポイントをチェック
-      const isAdditionalValid = await this.checkAdditionalReward(streamer.id, event.reward.id)
-      if (isAdditionalValid) {
+      // Check additional channel points
+      // 追加チャネルポイントをチェック
+      const additionalRewards = streamer.streamer_additional_gacha_rewards as { reward_id: string }[] | null
+      if (additionalRewards?.some(r => r.reward_id === event.reward.id)) {
         return await this.executeGacha(streamer.id, event.user_id, event.user_name, eventId)
       }
 
       return err('Reward ID mismatch')
     } catch (error) {
       return err(`Unexpected error: ${error}`)
-    }
-  }
-
-  /**
-   * Check if the reward ID exists in additional channel points table
-   * 追加チャネルポイントテーブルに報酬IDが存在するかチェック
-   *
-   * Returns false if:
-   * - Table doesn't exist (migration not applied) - maintains backward compatibility
-   * - No matching record found
-   *
-   * 以下の場合はfalseを返す:
-   * - テーブルが存在しない（マイグレーション未適用）- 後方互換性を維持
-   * - 一致するレコードがない
-   */
-  private async checkAdditionalReward(
-    streamerId: string,
-    eventRewardId: string
-  ): Promise<boolean> {
-    try {
-      const { data: additionalReward, error } = await this.supabase
-        .from('streamer_additional_gacha_rewards')
-        .select('id')
-        .eq('streamer_id', streamerId)
-        .eq('reward_id', eventRewardId)
-        .maybeSingle()
-
-      // If error (e.g., table doesn't exist), return false for backward compatibility
-      // エラーの場合（テーブルが存在しない等）、後方互換性のためfalseを返す
-      if (error) {
-        logger.warn('Additional rewards check failed (table may not exist):', error.message)
-        return false
-      }
-
-      return additionalReward !== null
-    } catch {
-      // Any unexpected error: fall back to main reward only behavior
-      // 予期しないエラー: メイン報酬のみの動作にフォールバック
-      return false
     }
   }
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -265,6 +265,31 @@ export interface Database {
           updated_at?: string
         }
       }
+      // 追加ガチャ報酬テーブル - メインの報酬とは別に追加の報酬を管理
+      // Additional gacha rewards table - manages additional rewards separate from main reward
+      streamer_additional_gacha_rewards: {
+        Row: {
+          id: string
+          streamer_id: string
+          reward_id: string
+          reward_name: string | null
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          streamer_id: string
+          reward_id: string
+          reward_name?: string | null
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          streamer_id?: string
+          reward_id?: string
+          reward_name?: string | null
+          created_at?: string
+        }
+      }
     }
     Views: {
       [_ in never]: never
@@ -288,6 +313,8 @@ export type Battle = Database['public']['Tables']['battles']['Row'] & {
   opponent_card_data?: OpponentCardData | null
 }
 export type BattleStats = Database['public']['Tables']['battle_stats']['Row']
+// 追加ガチャ報酬の型 - Additional gacha reward type
+export type StreamerAdditionalGachaReward = Database['public']['Tables']['streamer_additional_gacha_rewards']['Row']
 
 // Extended types with relations
 export type CardWithStreamer = Card & {

--- a/supabase/migrations/00008_add_additional_gacha_rewards.sql
+++ b/supabase/migrations/00008_add_additional_gacha_rewards.sql
@@ -1,0 +1,50 @@
+-- Additional Gacha Rewards Table
+-- 追加ガチャ報酬テーブル
+--
+-- This table stores additional channel point rewards that can trigger gacha.
+-- The main reward is still stored in streamers.channel_point_reward_id for backward compatibility.
+-- If no records exist in this table for a streamer, only the main reward triggers gacha.
+-- If records exist, both the main reward AND additional rewards trigger gacha.
+--
+-- このテーブルはガチャをトリガーできる追加のチャンネルポイント報酬を保存します。
+-- 後方互換性のため、メインの報酬は引き続き streamers.channel_point_reward_id に保存されます。
+-- このテーブルにストリーマーのレコードがない場合、メインの報酬のみがガチャをトリガーします。
+-- レコードがある場合、メインの報酬と追加報酬の両方がガチャをトリガーします。
+
+CREATE TABLE streamer_additional_gacha_rewards (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  streamer_id UUID NOT NULL REFERENCES streamers(id) ON DELETE CASCADE,
+  reward_id TEXT NOT NULL,
+  reward_name TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  -- Ensure each reward_id is unique per streamer
+  -- ストリーマーごとに報酬IDが一意であることを保証
+  UNIQUE (streamer_id, reward_id)
+);
+
+-- Index for faster lookup by streamer_id
+-- streamer_idでの高速検索用インデックス
+CREATE INDEX idx_additional_gacha_rewards_streamer_id ON streamer_additional_gacha_rewards(streamer_id);
+
+-- Index for faster lookup by reward_id (used when verifying incoming EventSub events)
+-- reward_idでの高速検索用インデックス（EventSubイベント検証時に使用）
+CREATE INDEX idx_additional_gacha_rewards_reward_id ON streamer_additional_gacha_rewards(reward_id);
+
+-- RLS
+ALTER TABLE streamer_additional_gacha_rewards ENABLE ROW LEVEL SECURITY;
+
+-- Service role can manage additional rewards
+-- サービスロールは追加報酬を管理可能
+CREATE POLICY "Service can manage additional gacha rewards" ON streamer_additional_gacha_rewards
+  FOR ALL USING (true);
+
+-- Public read access for active streamers' rewards (needed for UI)
+-- アクティブなストリーマーの報酬への公開読み取りアクセス（UI用）
+CREATE POLICY "Additional rewards are viewable for active streamers" ON streamer_additional_gacha_rewards
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM streamers
+      WHERE streamers.id = streamer_additional_gacha_rewards.streamer_id
+      AND streamers.is_active = true
+    )
+  );


### PR DESCRIPTION
## Summary
This PR adds the ability for streamers to configure multiple channel point rewards that trigger gacha, in addition to the main reward. Previously, only a single main reward could trigger gacha. Now streamers can register additional rewards that also trigger the gacha system.

## Key Changes

### Backend API
- **New endpoint**: `POST/GET/DELETE /api/twitch/eventsub/additional-rewards`
  - `POST`: Register a new additional gacha reward and create EventSub subscription
  - `GET`: Retrieve all additional rewards for the current streamer
  - `DELETE`: Remove an additional reward and clean up EventSub subscription

### Database
- **New table**: `streamer_additional_gacha_rewards`
  - Stores additional reward IDs per streamer
  - Maintains unique constraint on (streamer_id, reward_id) pairs
  - Includes indexes for efficient lookups by streamer_id and reward_id
  - Includes RLS policies for security

### Gacha Service
- Updated `handleChannelPointRedemption()` to validate rewards against both:
  - Main reward ID (from `streamers.channel_point_reward_id`)
  - Additional rewards (from `streamer_additional_gacha_rewards` table)
- Added `isValidGachaReward()` helper method for validation logic

### UI Components
- **New section**: "Additional Gacha Rewards" in ChannelPointSettings
  - Displays list of registered additional rewards with remove buttons
  - Dropdown to select and add new additional rewards
  - Filters out: main reward, current reward, and already-registered rewards
  - Shows helpful messages when no additional rewards are available

### Localization
- Added English and Japanese translations for:
  - Success/error messages for add/remove operations
  - Form labels and descriptions
  - Button labels ("Add", "Remove")
  - Placeholder text for reward selection

## Implementation Details

- **Backward compatible**: Main reward continues to work as before via `streamers.channel_point_reward_id`
- **EventSub integration**: Each additional reward gets its own EventSub subscription for `channel.channel_points_custom_reward_redemption.add` events
- **Rate limiting**: Applied to all new endpoints using existing rate limit infrastructure
- **Error handling**: Comprehensive validation to prevent duplicate registrations and invalid configurations