### PR TITLE
fix: ensure additional rewards reflect deletions by disabling browser…

### DIFF
--- a/src/app/api/streamer/additional-rewards/route.ts
+++ b/src/app/api/streamer/additional-rewards/route.ts
@@ -63,7 +63,13 @@ export async function GET(request: NextRequest) {
       return handleDatabaseError(error, "Additional Rewards API: GET");
     }
 
-    return NextResponse.json(rewards || []);
+    // キャッシュを無効化して、削除後も常に最新のデータを返す
+    // Disable caching to ensure fresh data is returned after deletions
+    return NextResponse.json(rewards || [], {
+      headers: {
+        "Cache-Control": "no-store, no-cache, must-revalidate",
+      },
+    });
   } catch (error) {
     return handleApiError(error, "Additional Rewards API: GET");
   }

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -134,8 +134,11 @@ export default function ChannelPointSettings({
   // DBから追加報酬を取得
   const fetchAdditionalRewards = useCallback(async () => {
     try {
+      // キャッシュを無効化して常に最新のデータを取得
+      // Disable cache to always fetch fresh data after additions/deletions
       const response = await fetch("/api/streamer/additional-rewards", {
         credentials: "include",
+        cache: "no-store",
       });
       if (response.ok) {
         const data = await response.json();


### PR DESCRIPTION
… caching

Disable caching in both the API response headers and fetch request to ensure UI always displays the latest additional rewards after deletions.