### PR TITLE
fix: allow Cloudflare Insights beacon script in CSP

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -341,8 +341,10 @@ export const SECURITY_HEADERS = {
   // Development CSP includes 'unsafe-eval' for Next.js fast refresh and dev tools
   // 開発用CSPにはNext.jsのfast refreshと開発ツールのため'unsafe-eval'を含む
   // media-src: R2バケットからの効果音再生を許可
-  CSP_DEVELOPMENT: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; media-src 'self' https:; connect-src 'self' https: localhost:* wss:; font-src 'self' data:; worker-src 'self' blob:;",
-  CSP_PRODUCTION: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; media-src 'self' https:; connect-src 'self' https: wss:; font-src 'self' data:; worker-src 'self' blob:;",
+  // Cloudflare Insights (static.cloudflareinsights.com) のビーコンスクリプトを許可
+  // Allow Cloudflare Insights beacon script from static.cloudflareinsights.com
+  CSP_DEVELOPMENT: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; media-src 'self' https:; connect-src 'self' https: localhost:* wss:; font-src 'self' data:; worker-src 'self' blob:;",
+  CSP_PRODUCTION: "default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; media-src 'self' https:; connect-src 'self' https: wss:; font-src 'self' data:; worker-src 'self' blob:;",
   HSTS: 'max-age=31536000; includeSubDomains; preload',
 } as const
 


### PR DESCRIPTION
Add https://static.cloudflareinsights.com to script-src in both development and production CSP directives. The beacon script was being blocked by the Content Security Policy.