### PR TITLE
fix: replace .single() with .maybeSingle() to eliminate Supabase 406 …

### DIFF
--- a/src/app/api/auth/twitch/callback/route.ts
+++ b/src/app/api/auth/twitch/callback/route.ts
@@ -195,7 +195,7 @@ export async function GET(request: NextRequest) {
         .from('users')
         .select('tos_accepted_at')
         .eq('twitch_user_id', twitchUser.id)
-        .single()
+        .maybeSingle()
 
       hasTosAccepted = userData?.tos_accepted_at !== null
 

--- a/src/app/api/battle/[battleId]/route.ts
+++ b/src/app/api/battle/[battleId]/route.ts
@@ -99,7 +99,7 @@ export async function GET(
       .from('users')
       .select('id, twitch_user_id')
       .eq('twitch_user_id', session.twitchUserId)
-      .single()
+      .maybeSingle()
 
     if (userError || !userData) {
       return handleDatabaseError(userError ?? new Error('User not found'), "Failed to fetch user data")
@@ -150,7 +150,7 @@ export async function GET(
       `)
       .eq('id', battleId)
       .eq('user_id', userData.id)
-      .single()
+      .maybeSingle()
 
     if (battleError || !battleData) {
       return handleDatabaseError(battleError ?? new Error('Battle not found'), "Failed to fetch battle data")

--- a/src/app/api/battle/start/route.ts
+++ b/src/app/api/battle/start/route.ts
@@ -73,7 +73,7 @@ export async function POST(request: NextRequest) {
       .from('users')
       .select('id, twitch_user_id')
       .eq('twitch_user_id', session.twitchUserId)
-      .single()
+      .maybeSingle()
 
     if (userError || !userData) {
       return handleDatabaseError(userError ?? new Error('User not found'), "Battle Start API: Failed to fetch user data")
@@ -118,7 +118,7 @@ export async function POST(request: NextRequest) {
       `)
       .eq('id', userCardId)
       .eq('user_id', userData.id)
-      .single()
+      .maybeSingle()
 
     if (userCardError || !userCardData) {
       return handleDatabaseError(userCardError ?? new Error('Card not found or not owned by user'), "Battle Start API: Failed to fetch user card")
@@ -177,7 +177,7 @@ export async function POST(request: NextRequest) {
         battle_log: battleResult.logs
       })
       .select()
-      .single()
+      .maybeSingle()
       
     if (battleData) {
       setGameContext({ 

--- a/src/app/api/battle/stats/route.ts
+++ b/src/app/api/battle/stats/route.ts
@@ -64,7 +64,7 @@ export async function GET(request: NextRequest) {
       .from('users')
       .select('id, twitch_user_id')
       .eq('twitch_user_id', session.twitchUserId)
-      .single()
+      .maybeSingle()
 
     if (userError || !userData) {
       return handleDatabaseError(userError ?? new Error('User not found'), "Failed to fetch user data")
@@ -75,9 +75,10 @@ export async function GET(request: NextRequest) {
       .from('battle_stats')
       .select('id, total_battles, wins, losses, draws, win_rate, updated_at')
       .eq('user_id', userData.id)
-      .single()
+      .maybeSingle()
 
-    if (statsError && statsError.code !== 'PGRST116') { // PGRST116 is "not found"
+    // maybeSingle()を使用しているため、行が見つからない場合はerrorではなくdata=nullが返る
+    if (statsError) {
       return handleDatabaseError(statsError, "Failed to fetch battle stats")
     }
 

--- a/src/app/api/cards/[id]/route.ts
+++ b/src/app/api/cards/[id]/route.ts
@@ -118,7 +118,7 @@ export async function PUT(
       .from("cards")
       .select("streamer_id, image_url, streamers!inner(twitch_user_id)")
       .eq("id", id)
-      .single();
+      .maybeSingle();
 
     const twitchUserId = extractTwitchUserId(card?.streamers);
 
@@ -182,7 +182,7 @@ export async function PUT(
       .update(updateData)
       .eq("id", id)
       .select()
-      .single();
+      .maybeSingle();
 
     if (error) {
       return handleDatabaseError(error, "Failed to update card");
@@ -243,7 +243,7 @@ export async function DELETE(
       .from("cards")
       .select("streamer_id, image_url, streamers!inner(twitch_user_id)")
       .eq("id", id)
-      .single();
+      .maybeSingle();
 
     const twitchUserId = extractTwitchUserId(card?.streamers);
 

--- a/src/app/api/cards/batch-update/route.ts
+++ b/src/app/api/cards/batch-update/route.ts
@@ -107,7 +107,7 @@ export async function POST(request: NextRequest) {
       .select("id")
       .eq("id", streamerId)
       .eq("twitch_user_id", session.twitchUserId)
-      .single();
+      .maybeSingle();
 
     if (!streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });

--- a/src/app/api/cards/batch/route.ts
+++ b/src/app/api/cards/batch/route.ts
@@ -110,7 +110,7 @@ export async function POST(request: NextRequest) {
       .select("id")
       .eq("id", streamerId)
       .eq("twitch_user_id", session.twitchUserId)
-      .single();
+      .maybeSingle();
 
     if (!streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });

--- a/src/app/api/cards/route.ts
+++ b/src/app/api/cards/route.ts
@@ -111,7 +111,7 @@ export async function POST(request: NextRequest) {
       .select("id")
       .eq("id", streamerId)
       .eq("twitch_user_id", session.twitchUserId)
-      .single();
+      .maybeSingle();
 
     if (!streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
@@ -135,7 +135,7 @@ export async function POST(request: NextRequest) {
         drop_rate: dropRate,
       })
       .select()
-      .single();
+      .maybeSingle();
 
     if (error) {
       return handleDatabaseError(error, "Cards API: Failed to create card");
@@ -280,7 +280,7 @@ export async function GET(request: NextRequest) {
       .select("id")
       .eq("id", streamerId)
       .eq("twitch_user_id", session?.twitchUserId)
-      .single();
+      .maybeSingle();
 
     if (streamerError || !streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });

--- a/src/app/api/gacha-history/[id]/route.ts
+++ b/src/app/api/gacha-history/[id]/route.ts
@@ -60,7 +60,7 @@ export async function DELETE(
       .from("gacha_history")
       .select("user_twitch_id")
       .eq("id", id)
-      .single();
+      .maybeSingle();
 
     if (fetchError || !history) {
       return handleDatabaseError(fetchError, "Fetching gacha history for deletion");

--- a/src/app/api/gacha/demo/route.ts
+++ b/src/app/api/gacha/demo/route.ts
@@ -142,7 +142,7 @@ export async function POST(request: NextRequest) {
         .from("cards")
         .select("*")
         .eq("id", cardId)
-        .single();
+        .maybeSingle();
 
       if (!error && card) {
         return respondWithCard(card, streamerId);

--- a/src/app/api/streamer/[streamerId]/sound-settings/route.ts
+++ b/src/app/api/streamer/[streamerId]/sound-settings/route.ts
@@ -34,7 +34,7 @@ export async function GET(
       .from("streamers")
       .select("gacha_sound_url, gacha_sound_enabled")
       .eq("id", streamerId)
-      .single();
+      .maybeSingle();
 
     if (error) {
       return handleDatabaseError(error, "Streamer Sound Settings API");

--- a/src/app/api/streamer/additional-rewards/route.ts
+++ b/src/app/api/streamer/additional-rewards/route.ts
@@ -45,7 +45,7 @@ export async function GET(request: NextRequest) {
       .from("streamers")
       .select("id")
       .eq("twitch_user_id", session.twitchUserId)
-      .single();
+      .maybeSingle();
 
     if (!streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
@@ -132,7 +132,7 @@ export async function POST(request: NextRequest) {
       .from("streamers")
       .select("id, channel_point_reward_id")
       .eq("twitch_user_id", session.twitchUserId)
-      .single();
+      .maybeSingle();
 
     if (!streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
@@ -166,7 +166,7 @@ export async function POST(request: NextRequest) {
         reward_name: rewardName || null,
       })
       .select()
-      .single();
+      .maybeSingle();
 
     if (error) {
       // Handle unique constraint violation (reward already added)
@@ -232,7 +232,7 @@ export async function DELETE(request: NextRequest) {
       .from("streamers")
       .select("id")
       .eq("twitch_user_id", session.twitchUserId)
-      .single();
+      .maybeSingle();
 
     if (!streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });

--- a/src/app/api/streamer/settings/route.ts
+++ b/src/app/api/streamer/settings/route.ts
@@ -67,7 +67,7 @@ export async function POST(request: NextRequest) {
       .select("id")
       .eq("id", streamerId)
       .eq("twitch_user_id", session.twitchUserId)
-      .single();
+      .maybeSingle();
 
     if (!streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });

--- a/src/app/api/tos/accept/route.ts
+++ b/src/app/api/tos/accept/route.ts
@@ -89,7 +89,7 @@ export async function GET() {
       .from('users')
       .select('tos_accepted_at')
       .eq('twitch_user_id', session.twitchUserId)
-      .single()
+      .maybeSingle()
 
     if (error) {
       logger.error('Failed to check TOS acceptance', {

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -201,7 +201,7 @@ async function handleRedemption(messageId: string, event: {
     .from('gacha_history')
     .select('id')
     .eq('event_id', messageId)
-    .single();
+    .maybeSingle();
 
   if (existingHistory) {
     logger.info('[handleRedemption] Skipped - already processed', { messageId });
@@ -241,7 +241,7 @@ async function handleRedemption(messageId: string, event: {
       .from("streamers")
       .select("id, chat_announcement_enabled, chat_announcement_template")
       .eq("twitch_user_id", event.broadcaster_user_id)
-      .single();
+      .maybeSingle();
 
     logger.info('[handleRedemption] Streamer query result', {
       found: !!streamer,
@@ -370,7 +370,7 @@ async function sendChatAnnouncement(
       .from('users')
       .select('id')
       .eq('twitch_user_id', userId)
-      .single();
+      .maybeSingle();
 
     if (user) {
       // user_cardsテーブルから所持枚数を取得

--- a/src/app/api/twitch/eventsub/subscribe/route.ts
+++ b/src/app/api/twitch/eventsub/subscribe/route.ts
@@ -118,7 +118,7 @@ export async function POST(request: NextRequest) {
       .from("streamers")
       .select("id")
       .eq("twitch_user_id", session.twitchUserId)
-      .single();
+      .maybeSingle();
 
     if (!streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });

--- a/src/app/api/user-cards/route.ts
+++ b/src/app/api/user-cards/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: NextRequest) {
       .from('users')
       .select('id, twitch_user_id')
       .eq('twitch_user_id', session.twitchUserId)
-      .single()
+      .maybeSingle()
 
     if (userError || !userData) {
       return handleDatabaseError(userError ?? new Error('User not found'), "Failed to fetch user data")

--- a/src/app/tos/page.tsx
+++ b/src/app/tos/page.tsx
@@ -27,7 +27,7 @@ export default async function TosPage() {
         .from('users')
         .select('tos_accepted_at')
         .eq('twitch_user_id', session.twitchUserId)
-        .single();
+        .maybeSingle();
 
       hasAccepted = userData?.tos_accepted_at !== null;
     } catch {

--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -32,7 +32,7 @@ export const getStreamerData = cache(async (twitchUserId: string) => {
       cards (*)
     `)
     .eq("twitch_user_id", twitchUserId)
-    .single();
+    .maybeSingle();
 
   if (!streamer) return null;
 
@@ -67,7 +67,7 @@ export const getStreamerDataPaginated = cache(async (
     .from("streamers")
     .select("*")
     .eq("twitch_user_id", twitchUserId)
-    .single();
+    .maybeSingle();
 
   if (!streamer) return null;
 
@@ -129,7 +129,7 @@ async function fetchUserCardsFromDB(twitchUserId: string): Promise<CardWithDetai
       )
     `)
     .eq("twitch_user_id", twitchUserId)
-    .single();
+    .maybeSingle();
   logger.info(`[Perf] getUserCards query: ${Date.now() - startQuery}ms`);
 
   if (!user || !user.user_cards) {
@@ -224,7 +224,7 @@ async function fetchUserCardsForStreamerFromDB(
       )
     `)
     .eq("twitch_user_id", twitchUserId)
-    .single();
+    .maybeSingle();
   logger.info(`[Perf] getUserCardsForStreamer query: ${Date.now() - startQuery}ms`);
 
   if (!user || !user.user_cards) {
@@ -292,7 +292,7 @@ export const getStreamerById = cache(async (streamerId: string): Promise<Streame
     .from("streamers")
     .select("*")
     .eq("id", streamerId)
-    .single();
+    .maybeSingle();
 
   return streamer;
 });
@@ -321,7 +321,7 @@ export const getUserCardDetail = cache(async (
     `)
     .eq("id", cardId)
     .eq("streamer_id", streamerId)
-    .single();
+    .maybeSingle();
 
   if (!card) {
     logger.info(`[Perf] getUserCardDetail (card not found): ${Date.now() - start}ms`);
@@ -339,7 +339,7 @@ export const getUserCardDetail = cache(async (
       )
     `)
     .eq("twitch_user_id", twitchUserId)
-    .single();
+    .maybeSingle();
 
   // Count how many of this specific card the user owns
   // ユーザーがこの特定のカードを何枚所有しているかをカウント

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -69,7 +69,7 @@ export class GachaService {
           .from('users')
           .select('id')
           .eq('twitch_user_id', userTwitchId)
-          .single()
+          .maybeSingle()
       ])
 
       if (historyResult.error) {
@@ -93,7 +93,7 @@ export class GachaService {
             ignoreDuplicates: true,
           })
           .select('id')
-          .single()
+          .maybeSingle()
 
         if (createError) {
           logger.warn('Failed to create user:', createError.message)
@@ -150,7 +150,7 @@ export class GachaService {
         .from('streamers')
         .select('id, channel_point_reward_id')
         .eq('twitch_user_id', event.broadcaster_user_id)
-        .single()
+        .maybeSingle()
 
       if (streamerError || !streamer) {
         return err('Streamer not found')
@@ -169,11 +169,10 @@ export class GachaService {
         .select('id')
         .eq('streamer_id', streamer.id)
         .eq('reward_id', event.reward.id)
-        .single()
+        .maybeSingle()
 
-      if (additionalError && additionalError.code !== 'PGRST116') {
-        // PGRST116 = no rows found, which is expected if reward is not registered
-        // PGRST116 = 行が見つからない、これは報酬が登録されていない場合に期待される
+      // maybeSingle()を使用しているため、行が見つからない場合はerrorではなくdata=nullが返る
+      if (additionalError) {
         logger.warn(`Error checking additional reward: ${additionalError.message}`)
       }
 

--- a/src/lib/storage-db.ts
+++ b/src/lib/storage-db.ts
@@ -152,14 +152,10 @@ export async function removeBlobFile(url: string): Promise<BlobFileInfo | null> 
       .from('blob_files')
       .select('user_prefix, file_size, storage_type')
       .eq('url', url)
-      .single();
+      .maybeSingle();
 
+    // maybeSingle()を使用しているため、行が見つからない場合はerrorではなくdata=nullが返る
     if (selectError) {
-      // ファイルが見つからない場合（404）は正常なケースとして処理
-      if (selectError.code === 'PGRST116') {
-        logger.warn(`[StorageDB] Blob file not found in DB: ${url}`);
-        return null;
-      }
       logger.error('[StorageDB] Failed to get blob file record:', selectError);
       throw new Error(`Failed to get blob file: ${selectError.message}`);
     }

--- a/src/lib/twitch/token-manager.ts
+++ b/src/lib/twitch/token-manager.ts
@@ -20,15 +20,9 @@ export async function getTwitchAccessToken(twitchUserId: string): Promise<string
     .from('users')
     .select('twitch_access_token, twitch_refresh_token, twitch_token_expires_at')
     .eq('twitch_user_id', twitchUserId)
-    .single();
+    .maybeSingle();
 
   if (dbError) {
-    // PGRST116 means no rows returned - user not found, which is an expected case
-    if (dbError.code === 'PGRST116') {
-      logger.warn('User not found in database', { twitchUserId });
-      return null;
-    }
-
     // PGRST204 means column not found - token columns may not exist in schema
     if (dbError.code === 'PGRST204') {
       logger.warn('Twitch token columns not found in schema', { twitchUserId, error: dbError });
@@ -36,6 +30,7 @@ export async function getTwitchAccessToken(twitchUserId: string): Promise<string
     }
 
     // Other database errors are unexpected and should be thrown
+    // maybeSingle()を使用しているため、行が見つからない場合はerrorではなくdata=nullが返る
     logger.error('Database error fetching user tokens', { twitchUserId, error: dbError });
     throw new TwitchTokenError(
       'Failed to fetch user tokens from database',
@@ -159,19 +154,15 @@ export async function hasScope(twitchUserId: string, scope: string): Promise<boo
     .from('users')
     .select('twitch_scopes')
     .eq('twitch_user_id', twitchUserId)
-    .single();
+    .maybeSingle();
 
   if (error) {
-    // PGRST116 means no rows returned - user not found
-    if (error.code === 'PGRST116') {
-      logger.warn('User not found when checking scope', { twitchUserId, scope });
-      return false;
-    }
     // PGRST204 means column not found - twitch_scopes column may not exist
     if (error.code === 'PGRST204') {
       logger.warn('twitch_scopes column not found in schema', { twitchUserId, scope });
       return false;
     }
+    // maybeSingle()を使用しているため、行が見つからない場合はerrorではなくdata=nullが返る
     logger.error('Database error checking scope', { twitchUserId, scope, error });
     return false;
   }


### PR DESCRIPTION
…errors

.single() returns 406 (PGRST116) when no rows are found, which shows as 4xx errors in Supabase dashboard. .maybeSingle() returns null with 200 status instead, while still erroring on multiple rows.

Also cleaned up now-unreachable PGRST116 error handling code.