### PR TITLE
fix: resolve token/scope mismatch causing 401 on chat message send

### DIFF
--- a/src/app/api/auth/twitch/login/route.ts
+++ b/src/app/api/auth/twitch/login/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { getTwitchAuthUrl } from '@/lib/twitch/auth'
+import { getTwitchAuthUrl, ADDITIONAL_SCOPES } from '@/lib/twitch/auth'
 import { cookies } from 'next/headers'
 import { checkRateLimit, rateLimits, getClientIp } from '@/lib/rate-limit'
 import { handleAuthError } from '@/lib/auth-error-handler'
@@ -7,6 +7,9 @@ import { reportAuthError } from '@/lib/sentry/error-handler'
 import { setRequestContext, clearUserContext } from '@/lib/sentry/user-context'
 import { ERROR_MESSAGES, STATE_COOKIE_OPTIONS, COOKIE_NAMES } from '@/lib/constants'
 import { getBaseUrl } from '@/lib/url-utils'
+import { getSession } from '@/lib/session'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { logger } from '@/lib/logger'
 
 // Web Crypto APIのcrypto.randomUUID()を使用（Cloudflare Workers互換）
 // Using Web Crypto API crypto.randomUUID() for Cloudflare Workers compatibility
@@ -50,7 +53,51 @@ export async function GET(request: Request) {
     const cookieStore = await cookies()
     cookieStore.set('twitch_auth_state', state, STATE_COOKIE_OPTIONS)
 
-    const authUrl = getTwitchAuthUrl(redirectUri, state)
+    // 既存セッションがある場合、以前取得済みの追加スコープをOAuthリクエストに含める
+    // これにより通常ログインでも新トークンにuser:write:chat等が付与され、
+    // DBのtwitch_scopesと実際のトークンの不整合を防ぐ
+    // If user has existing session, include previously granted additional scopes
+    // in the OAuth request so the new token retains them (e.g., user:write:chat)
+    let preservedScopes: string[] = []
+    try {
+      const session = await getSession()
+      if (session?.twitchUserId) {
+        const supabaseAdmin = getSupabaseAdmin()
+        const { data: user } = await supabaseAdmin
+          .from('users')
+          .select('twitch_scopes')
+          .eq('twitch_user_id', session.twitchUserId)
+          .maybeSingle()
+
+        if (user?.twitch_scopes) {
+          // 有効な追加スコープのみ抽出（デフォルトスコープは既にAUTH_SCOPESに含まれる）
+          // Extract only valid additional scopes (default scopes already in AUTH_SCOPES)
+          const validAdditionalScopes = Object.values(ADDITIONAL_SCOPES) as string[]
+          preservedScopes = user.twitch_scopes.filter(
+            (s: string) => validAdditionalScopes.includes(s)
+          )
+
+          if (preservedScopes.length > 0) {
+            logger.info('Login: preserving additional scopes from existing session', {
+              twitchUserId: session.twitchUserId,
+              preservedScopes,
+            })
+          }
+        }
+      }
+    } catch {
+      // スコープ取得失敗はログイン処理をブロックしない
+      // Scope lookup failure should not block the login flow
+    }
+
+    // forceVerify: falseで同意画面を強制しない（既存スコープの保持のみなので再同意不要）
+    // forceVerify: false skips forced consent screen (just preserving already-granted scopes)
+    const authUrl = getTwitchAuthUrl(
+      redirectUri,
+      state,
+      preservedScopes.length > 0 ? preservedScopes : undefined,
+      preservedScopes.length > 0 ? { forceVerify: false } : undefined
+    )
 
     // Check if direct redirect is requested (for server-side redirects)
     // サーバーサイドリダイレクト用に直接リダイレクトが要求されているかチェック

--- a/src/lib/twitch/auth.ts
+++ b/src/lib/twitch/auth.ts
@@ -43,12 +43,17 @@ export const ADDITIONAL_SCOPES = {
  * @param redirectUri - コールバックURL
  * @param state - CSRF防止用のstate値
  * @param additionalScopes - 追加で要求するスコープ（オプション機能用）
+ * @param options - 追加オプション
+ * @param options.forceVerify - force_verifyの明示的制御。
+ *   trueまたは未指定(additionalScopes有り時): Twitchの同意画面を強制表示。
+ *   false: 同意画面を強制しない（通常ログインで既存スコープを保持する場合に使用）。
  * @returns Twitch認証ページのURL
  */
 export function getTwitchAuthUrl(
   redirectUri: string,
   state: string,
-  additionalScopes?: string[]
+  additionalScopes?: string[],
+  options?: { forceVerify?: boolean }
 ): string {
   const clientId = getEnvVar('NEXT_PUBLIC_TWITCH_CLIENT_ID', true)!
 
@@ -67,11 +72,17 @@ export function getTwitchAuthUrl(
     state: state,
   })
 
-  // 追加スコープがある場合はforce_verifyを有効化
-  // ユーザーが新しいスコープの同意画面を必ず表示するようにする
-  // Without force_verify, Twitch may auto-approve with existing scopes
-  // and skip the consent screen for new scopes
-  if (additionalScopes && additionalScopes.length > 0) {
+  // force_verifyの制御:
+  // - options.forceVerifyがfalseなら同意画面を強制しない（既存スコープ保持時）
+  // - options.forceVerifyがtrueまたは未指定でadditionalScopesがある場合は強制表示
+  // Control force_verify:
+  // - If options.forceVerify is explicitly false, skip (preserving existing scopes on login)
+  // - If true or unset with additionalScopes, force consent screen for new scope grants
+  const shouldForceVerify = options?.forceVerify === false
+    ? false
+    : (additionalScopes && additionalScopes.length > 0)
+
+  if (shouldForceVerify) {
     params.set('force_verify', 'true')
   }
 

--- a/src/lib/twitch/chat-service.ts
+++ b/src/lib/twitch/chat-service.ts
@@ -108,7 +108,18 @@ export class TwitchChatService {
         // トークンが実際にはuser:write:chatを持っていないケースへの自己修復
         // On 401 with missing scope, remove the scope from DB to fix token/scope mismatch.
         // Self-healing for cases where the token doesn't actually have user:write:chat.
-        if (response.status === 401 && errorBody.message?.includes('user:write:chat')) {
+        //
+        // Twitch APIのスコープ不足時のエラーメッセージは複数パターンがある:
+        // - "User access token requires the user:write:chat scope." (実際に観測済み)
+        // - "Insufficient authorization in token" (Twitch公式ドキュメントの汎用形式)
+        // Both known Twitch error messages for insufficient scope are handled:
+        // - Explicit scope name in message (observed in production)
+        // - Generic "Insufficient authorization" (per Twitch API docs)
+        const isScopeError = response.status === 401 && (
+          errorBody.message?.includes('user:write:chat') ||
+          errorBody.message?.includes('Insufficient authorization')
+        )
+        if (isScopeError) {
           try {
             await removeScope(broadcasterTwitchUserId, ADDITIONAL_SCOPES.CHAT_WRITE)
             logger.warn('Removed invalid user:write:chat scope from DB (self-healing)', {

--- a/src/lib/twitch/chat-service.ts
+++ b/src/lib/twitch/chat-service.ts
@@ -1,5 +1,6 @@
 import { getEnvVar } from '@/lib/env-validation'
-import { getTwitchAccessToken } from './token-manager'
+import { getTwitchAccessToken, removeScope } from './token-manager'
+import { ADDITIONAL_SCOPES } from './auth'
 import { logger } from '@/lib/logger'
 
 const TWITCH_API_URL = 'https://api.twitch.tv/helix'
@@ -102,6 +103,25 @@ export class TwitchChatService {
           error: errorBody,
           broadcasterTwitchUserId,
         })
+
+        // 401かつスコープ不足の場合、DBからスコープを削除して不整合を解消する
+        // トークンが実際にはuser:write:chatを持っていないケースへの自己修復
+        // On 401 with missing scope, remove the scope from DB to fix token/scope mismatch.
+        // Self-healing for cases where the token doesn't actually have user:write:chat.
+        if (response.status === 401 && errorBody.message?.includes('user:write:chat')) {
+          try {
+            await removeScope(broadcasterTwitchUserId, ADDITIONAL_SCOPES.CHAT_WRITE)
+            logger.warn('Removed invalid user:write:chat scope from DB (self-healing)', {
+              broadcasterTwitchUserId,
+            })
+          } catch (removeScopeError) {
+            logger.error('Failed to remove invalid scope during self-healing', {
+              broadcasterTwitchUserId,
+              error: removeScopeError,
+            })
+          }
+        }
+
         return false
       }
 

--- a/src/lib/twitch/token-manager.ts
+++ b/src/lib/twitch/token-manager.ts
@@ -177,6 +177,59 @@ export async function hasScope(twitchUserId: string, scope: string): Promise<boo
 }
 
 /**
+ * ユーザーのTwitchスコープから特定のスコープを削除する
+ * トークンが実際にはスコープを持っていないことが判明した場合（401エラー等）に使用
+ * Remove a specific scope from a user's Twitch scopes in the database.
+ * Used when it's discovered the token doesn't actually have the scope (e.g., 401 error)
+ * @param twitchUserId - TwitchユーザーID
+ * @param scope - 削除するスコープ（例: 'user:write:chat'）
+ */
+export async function removeScope(twitchUserId: string, scope: string): Promise<void> {
+  const supabaseAdmin = getSupabaseAdmin();
+
+  const { data: user, error: fetchError } = await supabaseAdmin
+    .from('users')
+    .select('twitch_scopes')
+    .eq('twitch_user_id', twitchUserId)
+    .maybeSingle();
+
+  if (fetchError) {
+    if (fetchError.code === 'PGRST204') {
+      return;
+    }
+    logger.error('Failed to fetch scopes for removal', { twitchUserId, scope, error: fetchError });
+    return;
+  }
+
+  if (!user?.twitch_scopes || !user.twitch_scopes.includes(scope)) {
+    return;
+  }
+
+  // 指定スコープを除外した配列で更新
+  // Update with the scope filtered out
+  const updatedScopes = user.twitch_scopes.filter((s: string) => s !== scope);
+
+  const { error: updateError } = await supabaseAdmin
+    .from('users')
+    .update({ twitch_scopes: updatedScopes })
+    .eq('twitch_user_id', twitchUserId);
+
+  if (updateError) {
+    if (updateError.code === 'PGRST204') {
+      return;
+    }
+    logger.error('Failed to remove scope', { twitchUserId, scope, error: updateError });
+    return;
+  }
+
+  logger.info('Removed invalid scope from user', {
+    twitchUserId,
+    removedScope: scope,
+    remainingScopes: updatedScopes,
+  });
+}
+
+/**
  * ユーザーのTwitchスコープをデータベースに保存（全置換）
  * 再認証時に使用: ユーザーが明示的にスコープを選択した結果を保存する
  * Save Twitch scopes to database for a user (full replace)

--- a/tests/unit/chat-service.test.ts
+++ b/tests/unit/chat-service.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TwitchChatService } from '@/lib/twitch/chat-service';
+import { getTwitchAccessToken, removeScope } from '@/lib/twitch/token-manager';
+
+vi.mock('@/lib/twitch/token-manager');
+vi.mock('@/lib/env-validation', () => ({
+  getEnvVar: vi.fn().mockReturnValue('test-client-id'),
+}));
+
+describe('TwitchChatService', () => {
+  let service: TwitchChatService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new TwitchChatService();
+  });
+
+  describe('sendChatMessage - self-healing', () => {
+    it('401 + スコープ名を含むエラーで removeScope が呼ばれる', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+      vi.mocked(removeScope).mockResolvedValue(undefined);
+
+      // Twitch APIが401を返すケース（実際に観測されたエラー形式）
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({
+          error: 'Unauthorized',
+          status: 401,
+          message: 'User access token requires the user:write:chat scope.',
+        }),
+      });
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      expect(result).toBe(false);
+      expect(removeScope).toHaveBeenCalledWith('123456789', 'user:write:chat');
+    });
+
+    it('401 + "Insufficient authorization" エラーでも removeScope が呼ばれる', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+      vi.mocked(removeScope).mockResolvedValue(undefined);
+
+      // Twitch APIドキュメントの汎用エラー形式
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({
+          error: 'Unauthorized',
+          status: 401,
+          message: 'Insufficient authorization in token',
+        }),
+      });
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      expect(result).toBe(false);
+      expect(removeScope).toHaveBeenCalledWith('123456789', 'user:write:chat');
+    });
+
+    it('401 だがスコープ無関係のエラーでは removeScope が呼ばれない', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+
+      // トークン自体が無効なケース（スコープ問題ではない）
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({
+          error: 'Unauthorized',
+          status: 401,
+          message: 'OAuth token is missing',
+        }),
+      });
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      expect(result).toBe(false);
+      expect(removeScope).not.toHaveBeenCalled();
+    });
+
+    it('403 エラーでは removeScope が呼ばれない', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: () => Promise.resolve({
+          error: 'Forbidden',
+          status: 403,
+          message: 'User access token requires the user:write:chat scope.',
+        }),
+      });
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      expect(result).toBe(false);
+      expect(removeScope).not.toHaveBeenCalled();
+    });
+
+    it('removeScope が失敗しても sendChatMessage は false を返す（例外をスローしない）', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+      vi.mocked(removeScope).mockRejectedValue(new Error('DB error'));
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({
+          error: 'Unauthorized',
+          status: 401,
+          message: 'User access token requires the user:write:chat scope.',
+        }),
+      });
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      expect(result).toBe(false);
+      expect(removeScope).toHaveBeenCalled();
+    });
+
+    it('アクセストークンがない場合は API を呼ばず false を返す', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue(null);
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      expect(result).toBe(false);
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(removeScope).not.toHaveBeenCalled();
+    });
+
+    it('送信成功時は true を返し removeScope は呼ばれない', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: [{ message_id: 'msg-123' }] }),
+      });
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      expect(result).toBe(true);
+      expect(removeScope).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/twitch-token-manager.test.ts
+++ b/tests/unit/twitch-token-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getTwitchAccessToken, saveTwitchTokens, deleteTwitchTokens } from '@/lib/twitch/token-manager';
+import { getTwitchAccessToken, saveTwitchTokens, deleteTwitchTokens, removeScope } from '@/lib/twitch/token-manager';
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import { refreshTwitchToken } from '@/lib/twitch/auth';
 
@@ -179,6 +179,91 @@ describe('Twitch Token Manager', () => {
           twitch_token_expires_at: null,
         })
       );
+    });
+  });
+
+  describe('removeScope', () => {
+    it('指定スコープをtwitch_scopesから削除する', async () => {
+      const mockSupabaseAdmin: MockSupabaseAdmin = {
+        from: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: {
+            twitch_scopes: ['user:read:email', 'channel:read:redemptions', 'user:write:chat'],
+          },
+          error: null,
+        }),
+        update: vi.fn().mockReturnThis(),
+      };
+
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabaseAdmin as never);
+
+      await removeScope('123456789', 'user:write:chat');
+
+      expect(mockSupabaseAdmin.update).toHaveBeenCalledWith({
+        twitch_scopes: ['user:read:email', 'channel:read:redemptions'],
+      });
+    });
+
+    it('スコープが存在しない場合はDB更新しない', async () => {
+      const mockSupabaseAdmin: MockSupabaseAdmin = {
+        from: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: {
+            twitch_scopes: ['user:read:email', 'channel:read:redemptions'],
+          },
+          error: null,
+        }),
+        update: vi.fn().mockReturnThis(),
+      };
+
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabaseAdmin as never);
+
+      await removeScope('123456789', 'user:write:chat');
+
+      // update は select/eq チェーンの一部として呼ばれないことを確認
+      // from は select チェーンで1回呼ばれるが、update チェーンでは呼ばれない
+      expect(mockSupabaseAdmin.update).not.toHaveBeenCalled();
+    });
+
+    it('twitch_scopesがnullの場合はDB更新しない', async () => {
+      const mockSupabaseAdmin: MockSupabaseAdmin = {
+        from: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: { twitch_scopes: null },
+          error: null,
+        }),
+        update: vi.fn().mockReturnThis(),
+      };
+
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabaseAdmin as never);
+
+      await removeScope('123456789', 'user:write:chat');
+
+      expect(mockSupabaseAdmin.update).not.toHaveBeenCalled();
+    });
+
+    it('DBフェッチエラー時は例外をスローせず静かに返す', async () => {
+      const mockSupabaseAdmin: MockSupabaseAdmin = {
+        from: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: null,
+          error: { code: 'PGRST000', message: 'Connection failed' },
+        }),
+        update: vi.fn().mockReturnThis(),
+      };
+
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabaseAdmin as never);
+
+      // 例外がスローされないことを確認
+      await expect(removeScope('123456789', 'user:write:chat')).resolves.toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Normal login overwrote access token without user:write:chat while DB preserved the scope via mergeTwitchScopes, causing hasScope() to return true but actual API calls to fail with 401. Login flow now includes previously granted additional scopes in OAuth request (without force_verify) so new tokens retain them. Added self-healing: on 401 scope error, removeScope() clears invalid scope from DB to prevent repeated failures.