### PR TITLE
fix: use Supabase RPC to avoid Cloudflare Workers subrequest limit on…

### DIFF
--- a/src/app/api/cards/batch-update/route.ts
+++ b/src/app/api/cards/batch-update/route.ts
@@ -136,9 +136,16 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Verify all cards belong to this streamer
-    // 全カードがこの配信者に属しているか確認
+    // 同一IDが複数含まれると、RPC関数のROW_COUNTと期待件数が不一致になり
+    // 誤って「部分更新」と判定されるため、重複を事前に排除
     const cardIds = updates.map(u => u.id);
+    const uniqueCardIds = new Set(cardIds);
+    if (uniqueCardIds.size !== cardIds.length) {
+      return NextResponse.json(
+        { error: "同じカードIDが複数含まれています" },
+        { status: 400 }
+      );
+    }
     const { data: existingCards } = await supabaseAdmin
       .from("cards")
       .select("id")
@@ -152,29 +159,33 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Perform batch update using multiple single updates
-    // Supabase doesn't support true batch updates, so we use a transaction-like approach
-    // 複数の単一更新を使用してバッチ更新を実行
-    // Supabaseは真のバッチ更新をサポートしていないため、トランザクション的なアプローチを使用
-    const updatePromises = updates.map(update =>
-      supabaseAdmin
-        .from("cards")
-        .update({ drop_rate: update.dropRate })
-        .eq("id", update.id)
-        .eq("streamer_id", streamerId)
+    // RPC関数を使って全カードのdrop_rateを1回のDB呼び出しで一括更新
+    // 従来は各カードごとに個別のSupabase UPDATE（=個別のHTTP fetch）を発行していたが、
+    // Cloudflare Workersのサブリクエスト上限（50回/リクエスト）を超過するため、
+    // PostgreSQLストアドプロシージャで1リクエストに集約
+    const rpcPayload = updates.map(u => ({ id: u.id, drop_rate: u.dropRate }));
+    const { data: rpcResult, error: rpcError } = await supabaseAdmin.rpc(
+      "batch_update_card_drop_rates",
+      {
+        p_streamer_id: streamerId,
+        p_updates: rpcPayload,
+      }
     );
 
-    const results = await Promise.all(updatePromises);
-
-    // Check for any errors
-    // エラーがないかチェック
-    const errors = results.filter(r => r.error);
-    if (errors.length > 0) {
-      return handleDatabaseError(errors[0].error!, "Cards Batch Update API: Failed to update cards");
+    if (rpcError) {
+      return handleDatabaseError(rpcError, "Cards Batch Update API: Failed to update cards");
     }
 
-    // Fetch updated cards to return
-    // 更新されたカードを取得して返す
+    // RPC関数が返す更新件数と期待件数を照合し、一部のカードが更新されなかった場合を検出
+    const updatedCount = rpcResult?.updated_count ?? 0;
+    if (updatedCount !== updates.length) {
+      return handleDatabaseError(
+        { message: `Expected ${updates.length} updates but only ${updatedCount} succeeded`, details: "", hint: "", code: "" },
+        "Cards Batch Update API: Partial update detected"
+      );
+    }
+
+    // 更新後のカードデータを取得して返す
     const { data: updatedCards, error: fetchError } = await supabaseAdmin
       .from("cards")
       .select()

--- a/supabase/migrations/00011_add_batch_update_card_drop_rates.sql
+++ b/supabase/migrations/00011_add_batch_update_card_drop_rates.sql
@@ -1,0 +1,50 @@
+-- Migration: Add batch_update_card_drop_rates RPC function
+-- カードのdrop_rateを一括更新するRPC関数を追加
+--
+-- 目的:
+-- - Cloudflare Workersのサブリクエスト上限（50回/リクエスト）を回避
+-- - 従来は各カードごとに個別のUPDATEクエリを発行していたため、
+--   カード数が多い場合にサブリクエスト上限を超過してエラーが発生していた
+-- - この関数により、全カードの更新を1回のDB呼び出しで完了できる
+
+-- batch_update_card_drop_rates: 複数カードのdrop_rateを一括更新
+-- p_streamer_id: 更新対象カードの所有ストリーマーID（セキュリティのため必須）
+-- p_updates: [{id: カードID, drop_rate: 新しいドロップレート}] のJSON配列
+--
+-- セキュリティ:
+-- - streamer_idの一致を必ず検証し、他のストリーマーのカードは更新不可
+-- - drop_rateの範囲チェック(0〜1)はテーブルのCHECK制約で担保
+-- - REVOKE/GRANTで実行権限をservice_roleのみに限定（デフォルトではpublicが実行可能なため）
+-- - SECURITY DEFINERは不要（service_roleは既にRLSをバイパスできる）
+CREATE OR REPLACE FUNCTION batch_update_card_drop_rates(
+  p_streamer_id UUID,
+  p_updates JSONB
+) RETURNS JSONB AS $$
+DECLARE
+  v_updated_count INT;
+BEGIN
+  -- JSONB配列の各要素を展開し、cardsテーブルをJOIN UPDATEで一括更新
+  -- streamer_idの一致を必ず検証することで、他のストリーマーのカードへの不正更新を防止
+  UPDATE cards
+  SET
+    drop_rate = (u.value->>'drop_rate')::DECIMAL(5,4),
+    updated_at = NOW()
+  FROM jsonb_array_elements(p_updates) AS u(value)
+  WHERE cards.id = (u.value->>'id')::UUID
+    AND cards.streamer_id = p_streamer_id;
+
+  GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+
+  -- 更新件数を返却（呼び出し元で期待件数との照合に使用）
+  RETURN jsonb_build_object('updated_count', v_updated_count);
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION batch_update_card_drop_rates IS
+  '複数カードのdrop_rateを1回のDB呼び出しで一括更新。Cloudflare Workersのサブリクエスト制限対策';
+
+-- 実行権限をservice_roleのみに限定
+-- デフォルトではpublicロールに EXECUTE が付与されるため、明示的に剥奪してservice_roleにのみ許可
+-- これによりSupabase anon keyからの直接呼び出しを防止
+REVOKE ALL ON FUNCTION batch_update_card_drop_rates(UUID, JSONB) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION batch_update_card_drop_rates(UUID, JSONB) TO service_role;

--- a/tests/unit/cards-batch-update-api.test.ts
+++ b/tests/unit/cards-batch-update-api.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/cards/batch-update/route'
+import { getSession, canUseStreamerFeatures } from '@/lib/session'
+import { checkRateLimit } from '@/lib/rate-limit'
+import { validateCSRFToken } from '@/lib/csrf'
+import { validateContentType } from '@/lib/request-validation'
+import { createMockQueryBuilder, createMockResponse } from '../utils/supabase-mock'
+
+vi.mock('@/lib/session')
+vi.mock('@/lib/rate-limit')
+vi.mock('@/lib/csrf')
+vi.mock('@/lib/request-validation')
+vi.mock('@/lib/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/constants')>()
+  return {
+    ...actual,
+  }
+})
+vi.mock('@/lib/supabase/admin', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/supabase/admin')>()
+  return {
+    ...actual,
+    getSupabaseAdmin: vi.fn(),
+  }
+})
+
+const mockGetSession = vi.mocked(getSession)
+const mockCheckRateLimit = vi.mocked(checkRateLimit)
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken)
+const mockValidateContentType = vi.mocked(validateContentType)
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)
+
+/**
+ * batch-update APIルートでは from() と rpc() の両方を使うため、
+ * SupabaseMockBuilder ではなく手動でモックを構築する
+ *
+ * 呼び出し順序:
+ * 1. from("streamers").select().eq().eq().maybeSingle()  → ストリーマー確認
+ * 2. from("cards").select("id").eq().in()                → カード所有権確認（暗黙のawait）
+ * 3. rpc("batch_update_card_drop_rates", ...)            → 一括更新
+ * 4. from("cards").select().eq().in()                    → 更新後データ取得（暗黙のawait）
+ */
+function createBatchUpdateMock(options: {
+  streamer?: { id: string; twitch_user_id: string } | null
+  existingCards?: { id: string }[]
+  rpcResult?: { updated_count: number } | null
+  rpcError?: Error | null
+  updatedCards?: Record<string, unknown>[]
+  updatedCardsError?: Error | null
+}) {
+  let fromCallCount = 0
+
+  // from()が呼ばれるたびに異なるクエリビルダーを返す
+  const fromMock = vi.fn().mockImplementation((table: string) => {
+    fromCallCount++
+
+    if (table === 'streamers') {
+      // 1回目: ストリーマー所有権確認
+      const qb = createMockQueryBuilder()
+      ;(qb.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue(
+        createMockResponse(options.streamer ?? null)
+      )
+      return qb
+    }
+
+    if (table === 'cards') {
+      if (fromCallCount <= 2) {
+        // 2回目: カード所有権確認（from("cards")の1回目）
+        // in() の後に暗黙の await で then() が呼ばれるため、
+        // チェーンの最終メソッドが Promise を返す必要がある
+        const qb = createMockQueryBuilder()
+        // in() メソッドが呼ばれた時点で結果を返すようにする
+        const resultPromise = Promise.resolve(
+          createMockResponse(options.existingCards ?? [])
+        )
+        ;(qb.in as ReturnType<typeof vi.fn>).mockReturnValue({
+          ...qb,
+          then: resultPromise.then.bind(resultPromise),
+        })
+        return qb
+      } else {
+        // 3回目: 更新後データ取得（from("cards")の2回目）
+        const qb = createMockQueryBuilder()
+        const resultPromise = Promise.resolve(
+          createMockResponse(options.updatedCards ?? [], options.updatedCardsError ?? null)
+        )
+        ;(qb.in as ReturnType<typeof vi.fn>).mockReturnValue({
+          ...qb,
+          then: resultPromise.then.bind(resultPromise),
+        })
+        return qb
+      }
+    }
+
+    return createMockQueryBuilder()
+  })
+
+  // rpc() モック
+  const rpcMock = vi.fn().mockResolvedValue({
+    data: options.rpcResult ?? null,
+    error: options.rpcError ?? null,
+  })
+
+  return { from: fromMock, rpc: rpcMock }
+}
+
+function createRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost:3000/api/cards/batch-update', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'X-CSRF-Token': 'test-csrf-token',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/cards/batch-update', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // 認証・認可のデフォルトモック（全テストで通過させる）
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'twitch-user-123',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/avatar.jpg',
+      broadcasterType: 'affiliate',
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      version: 1,
+    })
+
+    mockCanUseStreamerFeatures.mockReturnValue(true)
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: Date.now() + 60000,
+    })
+
+    mockValidateCSRFToken.mockResolvedValue({ valid: true })
+    mockValidateContentType.mockReturnValue(null)
+  })
+
+  describe('重複IDバリデーション', () => {
+    it('同一カードIDが含まれる場合は400を返す', async () => {
+      // ストリーマー確認を通過させるため、最低限のモックが必要
+      const mockSupabase = createBatchUpdateMock({
+        streamer: { id: 'streamer-1', twitch_user_id: 'twitch-user-123' },
+      })
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      // 同一ID "card-1" を2つ含むリクエスト
+      const request = createRequest({
+        streamerId: 'streamer-1',
+        updates: [
+          { id: 'card-1', dropRate: 0.5 },
+          { id: 'card-1', dropRate: 0.3 },
+          { id: 'card-2', dropRate: 0.2 },
+        ],
+      })
+
+      const response = await POST(request)
+
+      expect(response.status).toBe(400)
+      const data = await response.json()
+      expect(data.error).toBe('同じカードIDが複数含まれています')
+    })
+
+    it('全て異なるカードIDであれば重複チェックを通過する', async () => {
+      const cardIds = ['card-1', 'card-2', 'card-3']
+      const mockSupabase = createBatchUpdateMock({
+        streamer: { id: 'streamer-1', twitch_user_id: 'twitch-user-123' },
+        existingCards: cardIds.map(id => ({ id })),
+        rpcResult: { updated_count: 3 },
+        updatedCards: cardIds.map(id => ({ id, streamer_id: 'streamer-1', drop_rate: 0.5 })),
+      })
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const request = createRequest({
+        streamerId: 'streamer-1',
+        updates: [
+          { id: 'card-1', dropRate: 0.5 },
+          { id: 'card-2', dropRate: 0.3 },
+          { id: 'card-3', dropRate: 0.2 },
+        ],
+      })
+
+      const response = await POST(request)
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.success).toBe(true)
+      expect(data.updated).toBe(3)
+    })
+  })
+
+  describe('RPC呼び出し', () => {
+    it('batch_update_card_drop_rates RPCに正しいパラメータを渡す', async () => {
+      const cardIds = ['card-1', 'card-2']
+      const mockSupabase = createBatchUpdateMock({
+        streamer: { id: 'streamer-1', twitch_user_id: 'twitch-user-123' },
+        existingCards: cardIds.map(id => ({ id })),
+        rpcResult: { updated_count: 2 },
+        updatedCards: cardIds.map(id => ({ id, streamer_id: 'streamer-1', drop_rate: 0.5 })),
+      })
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const request = createRequest({
+        streamerId: 'streamer-1',
+        updates: [
+          { id: 'card-1', dropRate: 0.5 },
+          { id: 'card-2', dropRate: 0.3 },
+        ],
+      })
+
+      await POST(request)
+
+      // RPC関数名とパラメータの検証
+      expect(mockSupabase.rpc).toHaveBeenCalledWith(
+        'batch_update_card_drop_rates',
+        {
+          p_streamer_id: 'streamer-1',
+          p_updates: [
+            { id: 'card-1', drop_rate: 0.5 },
+            { id: 'card-2', drop_rate: 0.3 },
+          ],
+        }
+      )
+    })
+
+    it('RPCエラー時はデータベースエラーレスポンスを返す', async () => {
+      const mockSupabase = createBatchUpdateMock({
+        streamer: { id: 'streamer-1', twitch_user_id: 'twitch-user-123' },
+        existingCards: [{ id: 'card-1' }],
+        rpcError: new Error('RPC function error'),
+      })
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const request = createRequest({
+        streamerId: 'streamer-1',
+        updates: [{ id: 'card-1', dropRate: 0.5 }],
+      })
+
+      const response = await POST(request)
+
+      // handleDatabaseErrorが500を返す
+      expect(response.status).toBe(500)
+    })
+
+    it('更新件数が期待と異なる場合は部分更新エラーを返す', async () => {
+      const mockSupabase = createBatchUpdateMock({
+        streamer: { id: 'streamer-1', twitch_user_id: 'twitch-user-123' },
+        existingCards: [{ id: 'card-1' }, { id: 'card-2' }],
+        // 2件送ったが1件しか更新されなかった
+        rpcResult: { updated_count: 1 },
+      })
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const request = createRequest({
+        streamerId: 'streamer-1',
+        updates: [
+          { id: 'card-1', dropRate: 0.5 },
+          { id: 'card-2', dropRate: 0.3 },
+        ],
+      })
+
+      const response = await POST(request)
+
+      expect(response.status).toBe(500)
+    })
+  })
+
+  describe('既存バリデーション（リグレッション防止）', () => {
+    it('空のupdates配列は400を返す', async () => {
+      const request = createRequest({
+        streamerId: 'streamer-1',
+        updates: [],
+      })
+
+      const response = await POST(request)
+
+      expect(response.status).toBe(400)
+    })
+
+    it('バッチサイズ上限（100件）超過は400を返す', async () => {
+      // 101件の更新データを生成
+      const updates = Array.from({ length: 101 }, (_, i) => ({
+        id: `card-${i}`,
+        dropRate: 0.5,
+      }))
+
+      const request = createRequest({
+        streamerId: 'streamer-1',
+        updates,
+      })
+
+      const response = await POST(request)
+
+      expect(response.status).toBe(400)
+      const data = await response.json()
+      expect(data.error).toContain('100')
+    })
+
+    it('不正なdropRate値は400を返す', async () => {
+      const mockSupabase = createBatchUpdateMock({
+        streamer: { id: 'streamer-1', twitch_user_id: 'twitch-user-123' },
+      })
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const request = createRequest({
+        streamerId: 'streamer-1',
+        updates: [{ id: 'card-1', dropRate: 1.5 }],  // 0〜1の範囲外
+      })
+
+      const response = await POST(request)
+
+      expect(response.status).toBe(400)
+    })
+  })
+})

--- a/tests/unit/migration-batch-update-rpc.test.ts
+++ b/tests/unit/migration-batch-update-rpc.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+/**
+ * マイグレーションファイルの静的検証
+ * 実際のDB接続なしで、SQLの構造的な正しさを検証する
+ *
+ * RPC関数の権限設定は実行時テストではなく静的検証で担保する理由:
+ * - ユニットテスト環境にはSupabaseインスタンスが無い
+ * - マイグレーションファイルの構造が正しければ、適用時に正しく設定される
+ * - CIでマイグレーションファイルの破損・欠落を検知できる
+ */
+describe('マイグレーション: 00011_add_batch_update_card_drop_rates', () => {
+  const migrationPath = resolve(
+    __dirname,
+    '../../supabase/migrations/00011_add_batch_update_card_drop_rates.sql'
+  )
+  let sql: string
+
+  // マイグレーションファイルの読み込み（テスト全体で1回のみ）
+  try {
+    sql = readFileSync(migrationPath, 'utf-8')
+  } catch {
+    sql = ''
+  }
+
+  it('マイグレーションファイルが存在する', () => {
+    expect(sql.length).toBeGreaterThan(0)
+  })
+
+  describe('RPC関数の定義', () => {
+    it('batch_update_card_drop_rates関数が定義されている', () => {
+      expect(sql).toContain('CREATE OR REPLACE FUNCTION batch_update_card_drop_rates')
+    })
+
+    it('p_streamer_id (UUID) パラメータを受け取る', () => {
+      expect(sql).toMatch(/p_streamer_id\s+UUID/)
+    })
+
+    it('p_updates (JSONB) パラメータを受け取る', () => {
+      expect(sql).toMatch(/p_updates\s+JSONB/)
+    })
+
+    it('戻り値はJSONB型である', () => {
+      expect(sql).toMatch(/RETURNS\s+JSONB/)
+    })
+
+    it('streamer_idの一致を検証するWHERE句が含まれる', () => {
+      // 他のストリーマーのカードを更新できないことを保証するクエリ条件
+      expect(sql).toContain('cards.streamer_id = p_streamer_id')
+    })
+
+    it('updated_countを返す', () => {
+      // 呼び出し元で更新件数を検証できるようにROW_COUNTを返す
+      expect(sql).toContain('GET DIAGNOSTICS v_updated_count = ROW_COUNT')
+      expect(sql).toContain("'updated_count'")
+    })
+  })
+
+  describe('セキュリティ: 実行権限の制限', () => {
+    it('PUBLIC からの EXECUTE 権限が剥奪されている', () => {
+      // デフォルトではpublicロールにEXECUTEが付与されるため、
+      // 明示的なREVOKEがなければanon keyから直接呼び出し可能になってしまう
+      expect(sql).toMatch(/REVOKE\s+ALL\s+ON\s+FUNCTION\s+batch_update_card_drop_rates.*FROM\s+PUBLIC/i)
+    })
+
+    it('service_role にのみ EXECUTE 権限が付与されている', () => {
+      // supabaseAdminクライアント（service_role key使用）からのみ呼び出し可能にする
+      expect(sql).toMatch(/GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+batch_update_card_drop_rates.*TO\s+service_role/i)
+    })
+
+    it('SECURITY DEFINER が使われていない', () => {
+      // SECURITY DEFINERは関数作成者の権限で実行されるため、
+      // 不要な権限昇格を避けるために使用しない
+      // service_roleは既にRLSをバイパスできるため不要
+      // コメント行（-- で始まる行）を除外し、SQLステートメント部分のみを検証
+      const sqlStatements = sql
+        .split('\n')
+        .filter(line => !line.trimStart().startsWith('--'))
+        .join('\n')
+      expect(sqlStatements).not.toContain('SECURITY DEFINER')
+    })
+  })
+})


### PR DESCRIPTION
… cards batch-update

カード一括更新で各カードごとに個別のSupabase UPDATE（HTTP fetch）を
発行していたため、Cloudflare Workersのサブリクエスト上限（50回）を超過して
エラーが発生していた。PostgreSQL RPC関数で全更新を1回のDB呼び出しに集約。

- Add batch_update_card_drop_rates RPC function (migration 00011)
- REVOKE PUBLIC / GRANT service_role for RPC execution security
- Add duplicate card ID validation (400 error) to prevent ROW_COUNT mismatch
- Add unit tests for API route and migration SQL structure