### PR TITLE
fix: add missing error reporting to chat-service and eventsub handler

### DIFF
--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -162,9 +162,10 @@ export async function POST(request: NextRequest) {
       { subscription }
     );
 
-    // Sentryにも報告して追跡可能にする
-    reportError(new Error(`EventSub revocation: ${revocationReason}`), {
-      context: "EventSub Revocation",
+    // Supabaseに記録してGitHub Issue化する（awaitしないとWorkers打ち切りで記録されない）
+    // Must await — Cloudflare Workers terminates background promises after response
+    await reportError(new Error(`EventSub revocation: ${revocationReason}`), {
+      context: "eventsub:revocation",
       type: "eventsub",
       revocationReason,
       subscriptionType,
@@ -216,6 +217,14 @@ async function handleRedemption(messageId: string, event: {
       // Error in gacha but don't throw, as webhook should return 200
       // ガチャでエラーが発生してもthrowしない。webhookは200を返す必要がある
       logger.warn('[handleRedemption] Gacha execution failed', { messageId });
+      // ガチャ失敗はユーザー影響が大きいためSupabaseに記録してGitHub Issue化する
+      // Gacha failure directly impacts users, so report to Supabase for GitHub Issue tracking
+      await reportError(new Error(`Gacha execution failed: ${result.error}`), {
+        context: 'eventsub:handleRedemption',
+        messageId,
+        broadcasterUserId: event.broadcaster_user_id,
+        gachaError: result.error,
+      });
       return;
     }
 
@@ -279,6 +288,13 @@ async function handleRedemption(messageId: string, event: {
         // Chat send failure is logged only, does not block gacha processing
         logger.warn('[handleRedemption] Chat announcement threw error', {
           error: err instanceof Error ? err.message : String(err),
+          broadcasterTwitchUserId: event.broadcaster_user_id,
+          streamerId: streamer.id,
+        });
+        // チャット通知の例外（DB クエリ失敗等）も追跡する
+        // Track chat announcement exceptions (e.g. DB query failures)
+        await reportError(err, {
+          context: 'eventsub:sendChatAnnouncement',
           broadcasterTwitchUserId: event.broadcaster_user_id,
           streamerId: streamer.id,
         });

--- a/src/lib/sentry/error-handler.ts
+++ b/src/lib/sentry/error-handler.ts
@@ -32,8 +32,8 @@
 // userId は Supabase Auth の UUID であり PII に該当するため除外
 const SENSITIVE_KEYS = [
   'password', 'token', 'authorization', 'cookie', 'secret',
-  'apikey', 'userid', 'api_key', 'access_token', 'refresh_token',
-  'client_secret', 'credential', 'private_key',
+  'apikey', 'userid', 'username', 'api_key', 'access_token', 'refresh_token',
+  'client_secret', 'credential', 'private_key', 'email', 'ip_address',
 ]
 
 /**

--- a/src/lib/twitch/chat-service.ts
+++ b/src/lib/twitch/chat-service.ts
@@ -2,6 +2,7 @@ import { getEnvVar } from '@/lib/env-validation'
 import { getTwitchAccessToken, removeScope } from './token-manager'
 import { ADDITIONAL_SCOPES } from './auth'
 import { logger } from '@/lib/logger'
+import { reportApiError, reportError } from '@/lib/sentry/error-handler'
 
 const TWITCH_API_URL = 'https://api.twitch.tv/helix'
 
@@ -98,16 +99,14 @@ export class TwitchChatService {
 
       if (!response.ok) {
         const errorBody: TwitchApiError = await response.json().catch(() => ({}))
-        logger.error('Failed to send chat message', {
-          status: response.status,
-          error: errorBody,
-          broadcasterTwitchUserId,
-        })
 
         // 401かつスコープ不足の場合、DBからスコープを削除して不整合を解消する
         // トークンが実際にはuser:write:chatを持っていないケースへの自己修復
         // On 401 with missing scope, remove the scope from DB to fix token/scope mismatch.
         // Self-healing for cases where the token doesn't actually have user:write:chat.
+        //
+        // 自己修復をエラー報告より先に実行する（エラー報告の失敗が自己修復をブロックしないため）
+        // Execute self-healing before error reporting so reporting failure doesn't block healing.
         //
         // Twitch APIのスコープ不足時のエラーメッセージは複数パターンがある:
         // - "User access token requires the user:write:chat scope." (実際に観測済み)
@@ -126,12 +125,23 @@ export class TwitchChatService {
               broadcasterTwitchUserId,
             })
           } catch (removeScopeError) {
-            logger.error('Failed to remove invalid scope during self-healing', {
+            // 自己修復失敗をSupabaseに記録（繰り返し発生する可能性があるため追跡が重要）
+            // reportError 内部で console.error も出力される
+            await reportError(removeScopeError, {
+              context: 'chat-service:removeScope:self-healing',
               broadcasterTwitchUserId,
-              error: removeScopeError,
             })
           }
         }
+
+        // Supabase に記録し、Cron Worker 経由で GitHub Issue を自動作成する
+        // Report to Supabase so the Cron Worker can create a GitHub Issue
+        // 自己修復の後に配置（自己修復が確実に実行されるようにするため）
+        // Placed after self-healing to ensure healing runs regardless of reporting outcome
+        await reportApiError('/helix/chat/messages', 'POST',
+          new Error(`Twitch API ${response.status}: ${errorBody.message || 'Unknown error'}`),
+          { broadcasterTwitchUserId, status: response.status, twitchError: errorBody.error }
+        )
 
         return false
       }
@@ -143,8 +153,10 @@ export class TwitchChatService {
 
       return true
     } catch (error) {
-      logger.error('Error sending chat message', {
-        error,
+      // ネットワークエラーなど予期しない例外をSupabaseに記録
+      // reportError 内部で console.error も出力される
+      await reportError(error, {
+        context: 'chat-service:sendChatMessage',
         broadcasterTwitchUserId,
       })
       return false

--- a/tests/unit/chat-service.test.ts
+++ b/tests/unit/chat-service.test.ts
@@ -1,18 +1,31 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TwitchChatService } from '@/lib/twitch/chat-service';
 import { getTwitchAccessToken, removeScope } from '@/lib/twitch/token-manager';
+import { reportApiError, reportError } from '@/lib/sentry/error-handler';
 
 vi.mock('@/lib/twitch/token-manager');
 vi.mock('@/lib/env-validation', () => ({
   getEnvVar: vi.fn().mockReturnValue('test-client-id'),
 }));
+// reportApiError/reportError は Supabase を使うため mock で差し替え
+vi.mock('@/lib/sentry/error-handler', () => ({
+  reportApiError: vi.fn().mockResolvedValue(undefined),
+  reportError: vi.fn().mockResolvedValue(undefined),
+}));
 
 describe('TwitchChatService', () => {
   let service: TwitchChatService;
+  const originalFetch = global.fetch;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // 各テストの独立性を保つため fetch mock を初期化
+    global.fetch = vi.fn();
     service = new TwitchChatService();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
   });
 
   describe('sendChatMessage - self-healing', () => {
@@ -21,7 +34,7 @@ describe('TwitchChatService', () => {
       vi.mocked(removeScope).mockResolvedValue(undefined);
 
       // Twitch APIが401を返すケース（実際に観測されたエラー形式）
-      global.fetch = vi.fn().mockResolvedValue({
+      vi.mocked(global.fetch).mockResolvedValue({
         ok: false,
         status: 401,
         json: () => Promise.resolve({
@@ -29,7 +42,7 @@ describe('TwitchChatService', () => {
           status: 401,
           message: 'User access token requires the user:write:chat scope.',
         }),
-      });
+      } as Response);
 
       const result = await service.sendChatMessage('123456789', 'test message');
 
@@ -42,7 +55,7 @@ describe('TwitchChatService', () => {
       vi.mocked(removeScope).mockResolvedValue(undefined);
 
       // Twitch APIドキュメントの汎用エラー形式
-      global.fetch = vi.fn().mockResolvedValue({
+      vi.mocked(global.fetch).mockResolvedValue({
         ok: false,
         status: 401,
         json: () => Promise.resolve({
@@ -50,7 +63,7 @@ describe('TwitchChatService', () => {
           status: 401,
           message: 'Insufficient authorization in token',
         }),
-      });
+      } as Response);
 
       const result = await service.sendChatMessage('123456789', 'test message');
 
@@ -62,7 +75,7 @@ describe('TwitchChatService', () => {
       vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
 
       // トークン自体が無効なケース（スコープ問題ではない）
-      global.fetch = vi.fn().mockResolvedValue({
+      vi.mocked(global.fetch).mockResolvedValue({
         ok: false,
         status: 401,
         json: () => Promise.resolve({
@@ -70,7 +83,7 @@ describe('TwitchChatService', () => {
           status: 401,
           message: 'OAuth token is missing',
         }),
-      });
+      } as Response);
 
       const result = await service.sendChatMessage('123456789', 'test message');
 
@@ -81,7 +94,7 @@ describe('TwitchChatService', () => {
     it('403 エラーでは removeScope が呼ばれない', async () => {
       vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
 
-      global.fetch = vi.fn().mockResolvedValue({
+      vi.mocked(global.fetch).mockResolvedValue({
         ok: false,
         status: 403,
         json: () => Promise.resolve({
@@ -89,7 +102,7 @@ describe('TwitchChatService', () => {
           status: 403,
           message: 'User access token requires the user:write:chat scope.',
         }),
-      });
+      } as Response);
 
       const result = await service.sendChatMessage('123456789', 'test message');
 
@@ -101,7 +114,7 @@ describe('TwitchChatService', () => {
       vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
       vi.mocked(removeScope).mockRejectedValue(new Error('DB error'));
 
-      global.fetch = vi.fn().mockResolvedValue({
+      vi.mocked(global.fetch).mockResolvedValue({
         ok: false,
         status: 401,
         json: () => Promise.resolve({
@@ -109,7 +122,7 @@ describe('TwitchChatService', () => {
           status: 401,
           message: 'User access token requires the user:write:chat scope.',
         }),
-      });
+      } as Response);
 
       const result = await service.sendChatMessage('123456789', 'test message');
 
@@ -130,16 +143,127 @@ describe('TwitchChatService', () => {
     it('送信成功時は true を返し removeScope は呼ばれない', async () => {
       vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
 
-      global.fetch = vi.fn().mockResolvedValue({
+      vi.mocked(global.fetch).mockResolvedValue({
         ok: true,
         status: 200,
         json: () => Promise.resolve({ data: [{ message_id: 'msg-123' }] }),
-      });
+      } as Response);
 
       const result = await service.sendChatMessage('123456789', 'test message');
 
       expect(result).toBe(true);
       expect(removeScope).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('sendChatMessage - error reporting', () => {
+    it('API エラー時に reportApiError が正しい引数で呼ばれる', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({
+          error: 'Unauthorized',
+          status: 401,
+          message: 'User access token requires the user:write:chat scope.',
+        }),
+      } as Response);
+
+      await service.sendChatMessage('123456789', 'test message');
+
+      expect(reportApiError).toHaveBeenCalledWith(
+        '/helix/chat/messages',
+        'POST',
+        expect.any(Error),
+        expect.objectContaining({
+          broadcasterTwitchUserId: '123456789',
+          status: 401,
+          twitchError: 'Unauthorized',
+        }),
+      );
+    });
+
+    it('ネットワークエラー時に reportError が呼ばれる', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+
+      vi.mocked(global.fetch).mockRejectedValue(new Error('Network error'));
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      expect(result).toBe(false);
+      expect(reportError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          context: 'chat-service:sendChatMessage',
+          broadcasterTwitchUserId: '123456789',
+        }),
+      );
+    });
+
+    it('送信成功時は reportApiError/reportError が呼ばれない', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: [{ message_id: 'msg-123' }] }),
+      } as Response);
+
+      await service.sendChatMessage('123456789', 'test message');
+
+      expect(reportApiError).not.toHaveBeenCalled();
+      expect(reportError).not.toHaveBeenCalled();
+    });
+
+    it('self-healing 失敗時に reportApiError と reportError の両方が呼ばれる', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+      const dbError = new Error('DB error');
+      vi.mocked(removeScope).mockRejectedValue(dbError);
+
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({
+          error: 'Unauthorized',
+          status: 401,
+          message: 'User access token requires the user:write:chat scope.',
+        }),
+      } as Response);
+
+      await service.sendChatMessage('123456789', 'test message');
+
+      // reportApiError (API失敗) の引数も検証
+      expect(reportApiError).toHaveBeenCalledWith(
+        '/helix/chat/messages',
+        'POST',
+        expect.any(Error),
+        expect.objectContaining({ broadcasterTwitchUserId: '123456789', status: 401 }),
+      );
+      // reportError (self-healing失敗) の引数も検証
+      expect(reportError).toHaveBeenCalledWith(
+        dbError,
+        expect.objectContaining({
+          context: 'chat-service:removeScope:self-healing',
+          broadcasterTwitchUserId: '123456789',
+        }),
+      );
+    });
+
+    it('reportApiError が reject しても sendChatMessage は false を返す', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+      vi.mocked(reportApiError).mockRejectedValue(new Error('Supabase down'));
+
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: 'Internal Server Error' }),
+      } as Response);
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      // reportApiError が失敗しても、外側の catch で捕捉されて false を返す
+      expect(result).toBe(false);
     });
   });
 });

--- a/tests/unit/sentry-error-handler.test.ts
+++ b/tests/unit/sentry-error-handler.test.ts
@@ -147,6 +147,8 @@ describe('sentry/error-handler', () => {
         access_token: 'tok',
         refresh_token: 'ref',
         api_key: 'key',
+        email: 'user@example.com',
+        safeName: 'visible',
       });
 
       const insertArg = mockInsert.mock.calls[0][0];
@@ -155,7 +157,9 @@ describe('sentry/error-handler', () => {
       expect(insertArg.context.access_token).toBe('[REDACTED]');
       expect(insertArg.context.refresh_token).toBe('[REDACTED]');
       expect(insertArg.context.api_key).toBe('[REDACTED]');
-      expect(insertArg.context.username).toBe('public');
+      expect(insertArg.context.username).toBe('[REDACTED]');
+      expect(insertArg.context.email).toBe('[REDACTED]');
+      expect(insertArg.context.safeName).toBe('visible');
     });
 
     it('ネストしたオブジェクトも再帰的にサニタイズする', async () => {


### PR DESCRIPTION
Errors in chat-service.ts and eventsub/route.ts were only logged via logger.error() but never reported to Supabase, so the Cron Worker could not create GitHub Issues automatically (introduced in #239).

Changes:
- chat-service.ts: add reportApiError for Twitch API failures, reportError for self-healing failures and unexpected exceptions
- eventsub/route.ts: add reportError for gacha failures, chat announcement exceptions; fix missing await on revocation reportError
- error-handler.ts: add username/email/ip_address to SENSITIVE_KEYS
- Comprehensive test coverage for error reporting paths (12 tests)

Reviewed by 5 specialized agents (security, performance, test quality, code quality, coverage) with all P0-P2 findings addressed.