### PR TITLE
test: add coverage for additionalInfo passing and non-Error object ha…

### DIFF
--- a/tests/unit/error-handler.test.ts
+++ b/tests/unit/error-handler.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleApiError, handleDatabaseError, handleBlobError } from '@/lib/error-handler';
+import { logErrorFromLogger } from '@/lib/sentry/error-handler';
 
 // sentry/error-handler のモック（logErrorFromLogger を error-handler.ts が直接使用する）
 vi.mock('@/lib/sentry/error-handler', () => ({
@@ -80,6 +81,54 @@ describe('error-handler', () => {
     it('非 Error オブジェクトも処理できる', async () => {
       const response = await handleBlobError('string error', 'blob');
       expect(response.status).toBe(500);
+    });
+
+    it('additionalInfo が logErrorFromLogger に正しく渡される', async () => {
+      const additionalInfo = { userId: '123', action: 'upload' };
+      await handleBlobError(new Error('fail'), 'blob context', additionalInfo);
+
+      expect(logErrorFromLogger).toHaveBeenCalledWith(
+        'blob context: fail',
+        [expect.any(Error), additionalInfo]
+      );
+    });
+
+    it('additionalInfo が未指定の場合は error のみ渡される', async () => {
+      await handleBlobError(new Error('fail'), 'blob context');
+
+      expect(logErrorFromLogger).toHaveBeenCalledWith(
+        'blob context: fail',
+        [expect.any(Error)]
+      );
+    });
+  });
+
+  describe('非 Error オブジェクトの処理', () => {
+    it('string エラーを正しく処理する', async () => {
+      const response = await handleApiError('string error', 'test');
+      expect(response.status).toBe(500);
+      expect(logErrorFromLogger).toHaveBeenCalledWith(
+        'test:',
+        ['string error']
+      );
+    });
+
+    it('number エラーを正しく処理する', async () => {
+      const response = await handleApiError(123, 'test');
+      expect(response.status).toBe(500);
+      expect(logErrorFromLogger).toHaveBeenCalled();
+    });
+
+    it('null エラーを正しく処理する', async () => {
+      const response = await handleApiError(null, 'test');
+      expect(response.status).toBe(500);
+      expect(logErrorFromLogger).toHaveBeenCalled();
+    });
+
+    it('undefined エラーを正しく処理する', async () => {
+      const response = await handleApiError(undefined, 'test');
+      expect(response.status).toBe(500);
+      expect(logErrorFromLogger).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
…ndling

Review で指摘されたテストカバレッジ不足を解消:
- handleBlobError の additionalInfo が logErrorFromLogger に正しく渡されるか検証
- handleApiError に string/number/null/undefined を渡した場合の処理を検証