### PR TITLE
fix: sort cards by rarity hierarchy instead of alphabetical order

### DIFF
--- a/src/app/api/cards/route.ts
+++ b/src/app/api/cards/route.ts
@@ -199,20 +199,18 @@ async function fetchCardsFromDB(
     // Legacy behavior handled in caller
   }
 
-  // Apply sorting
-  // 並び替えを適用
+  // Apply sorting - all fields use DB-side sorting for correct pagination
+  // 並び替えを適用 - ページネーション整合性のため全フィールドDB側でソート
   const ascending = sortDirection === "asc";
-  query = query.order(sortField, { ascending });
-
-  // Apply pagination
-  // ページネーションを適用
+  // Use rarity_order generated column (CASE-based: legendary=1, epic=2, rare=3, common=4)
+  // instead of rarity text column which sorts alphabetically
+  // rarityテキストカラムはアルファベット順になるため、rarity_order generated columnを使用
+  const dbSortField = sortField === "rarity" ? "rarity_order" : sortField;
+  query = query.order(dbSortField, { ascending });
   query = query.range(offset, offset + limit - 1);
 
   const { data: cards, error, count } = await query;
-
-  if (error) {
-    throw error;
-  }
+  if (error) throw error;
 
   logger.info(`[Perf] fetchCardsFromDB: ${Date.now() - start}ms (${cards?.length || 0} cards)`);
 

--- a/supabase/migrations/00014_add_rarity_order_column.sql
+++ b/supabase/migrations/00014_add_rarity_order_column.sql
@@ -1,0 +1,30 @@
+-- Migration: Add rarity_order generated column for proper hierarchy sorting
+-- レアリティ階層順ソート用のgenerated columnを追加
+--
+-- 背景:
+-- Supabase JS client (PostgREST) はORDER BYにCASE式を使用できない。
+-- rarityカラムを直接ソートするとアルファベット順(c→e→l→r)になり、
+-- 意図したレアリティ階層(legendary→epic→rare→common)にならない。
+--
+-- 解決策:
+-- GENERATED ALWAYS ASでレアリティ階層順の数値カラムを自動生成。
+-- rarityカラムが更新されると自動的に再計算されるため、メンテナンス不要。
+-- DB側でソート・ページネーションが完結し、全件取得が不要になる。
+
+ALTER TABLE cards ADD COLUMN rarity_order SMALLINT GENERATED ALWAYS AS (
+  CASE rarity
+    WHEN 'legendary' THEN 1
+    WHEN 'epic' THEN 2
+    WHEN 'rare' THEN 3
+    WHEN 'common' THEN 4
+    ELSE 5
+  END
+) STORED;
+
+-- Index for efficient sorting by rarity hierarchy
+-- レアリティ階層順ソートの効率化用インデックス
+CREATE INDEX idx_cards_rarity_order ON cards(rarity_order);
+
+-- Drop the old rarity text index as it's no longer used
+-- rarity text カラムのインデックスは不要になるため削除（rarity_orderを使用）
+DROP INDEX IF EXISTS idx_cards_rarity;

--- a/tests/unit/cards-get-api.test.ts
+++ b/tests/unit/cards-get-api.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '@/app/api/cards/route'
+import { getSession } from '@/lib/session'
+import { checkRateLimit } from '@/lib/rate-limit'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { createMockQueryBuilder, createMockResponse } from '../utils/supabase-mock'
+
+vi.mock('@/lib/session')
+vi.mock('@/lib/rate-limit')
+vi.mock('@/lib/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/constants')>()
+  return { ...actual }
+})
+vi.mock('@/lib/supabase/admin', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/supabase/admin')>()
+  return {
+    ...actual,
+    getSupabaseAdmin: vi.fn(),
+  }
+})
+vi.mock('@/lib/sentry/error-handler', () => ({
+  reportError: vi.fn(),
+  reportApiError: vi.fn(),
+  logErrorFromLogger: vi.fn(),
+}))
+// unstable_cache をバイパスし、関数を即時実行させる
+// Bypass unstable_cache so the wrapped function runs directly
+vi.mock('next/cache', () => ({
+  unstable_cache: (fn: () => Promise<unknown>) => fn,
+}))
+
+const mockGetSession = vi.mocked(getSession)
+const mockCheckRateLimit = vi.mocked(checkRateLimit)
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin)
+
+/**
+ * Cards GET APIテスト用のSupabaseモックを構築
+ * Build Supabase mock for Cards GET API tests
+ *
+ * GET内部の呼び出し順序:
+ * 1. from("streamers").select("id").eq().eq().maybeSingle()  → ストリーマー認証
+ * 2. from("cards").select("*", { count: "exact" }).eq()...   → カード取得
+ *
+ * カードクエリは暗黙の await（.then()）で解決されるため、
+ * queryBuilder 自体を thenable にする必要がある
+ */
+function setupCardsMock(options: {
+  streamer?: { id: string } | null
+  cards?: Record<string, unknown>[]
+  cardsError?: Error | null
+}) {
+  // ストリーマー確認用クエリビルダー
+  const streamerQuery = createMockQueryBuilder()
+  ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue(
+    createMockResponse(options.streamer ?? null)
+  )
+
+  // カード取得用クエリビルダー（暗黙のawaitに対応）
+  const cardsQuery = createMockQueryBuilder()
+  const cardsResponse = {
+    data: options.cards ?? [],
+    error: options.cardsError ?? null,
+    count: options.cards?.length ?? 0,
+  }
+  // PostgREST returns result via implicit await (thenable)
+  // PostgRESTは暗黙のawait（thenable）で結果を返す
+  ;(cardsQuery as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
+    resolve(cardsResponse)
+    return cardsQuery
+  }
+
+  mockGetSupabaseAdmin.mockReturnValue({
+    from: vi.fn((table: string) => {
+      if (table === 'streamers') return streamerQuery
+      if (table === 'cards') {
+        return cardsQuery
+      }
+      return createMockQueryBuilder()
+    }),
+  } as ReturnType<typeof getSupabaseAdmin>)
+
+  return { streamerQuery, cardsQuery }
+}
+
+function createRequest(params: Record<string, string> = {}): NextRequest {
+  const url = new URL('http://localhost/api/cards')
+  Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value))
+  return new NextRequest(url)
+}
+
+describe('GET /api/cards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'user123',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      broadcasterType: 'affiliate',
+      issuedAt: Date.now(),
+    })
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 100,
+      remaining: 99,
+      reset: Math.floor(Date.now() / 1000) + 60,
+    })
+  })
+
+  describe('rarity sort field mapping', () => {
+    it('sortField=rarity の場合、rarity_order カラムでorder()が呼ばれる', async () => {
+      const { cardsQuery } = setupCardsMock({
+        streamer: { id: 'streamer-1' },
+        cards: [
+          { id: '1', rarity: 'legendary', drop_rate: 0.05, rarity_order: 1 },
+          { id: '2', rarity: 'common', drop_rate: 0.5, rarity_order: 4 },
+        ],
+      })
+
+      await GET(createRequest({
+        streamerId: 'streamer-1',
+        sortField: 'rarity',
+        sortDirection: 'asc',
+      }))
+
+      // rarity ではなく rarity_order でDBソートされることを検証
+      expect(cardsQuery.order).toHaveBeenCalledWith('rarity_order', { ascending: true })
+    })
+
+    it('sortField=created_at の場合、created_at カラムでorder()が呼ばれる', async () => {
+      const { cardsQuery } = setupCardsMock({
+        streamer: { id: 'streamer-1' },
+        cards: [],
+      })
+
+      await GET(createRequest({
+        streamerId: 'streamer-1',
+        sortField: 'created_at',
+        sortDirection: 'desc',
+      }))
+
+      expect(cardsQuery.order).toHaveBeenCalledWith('created_at', { ascending: false })
+    })
+
+    it('sortField=drop_rate の場合、drop_rate カラムでorder()が呼ばれる', async () => {
+      const { cardsQuery } = setupCardsMock({
+        streamer: { id: 'streamer-1' },
+        cards: [],
+      })
+
+      await GET(createRequest({
+        streamerId: 'streamer-1',
+        sortField: 'drop_rate',
+        sortDirection: 'asc',
+      }))
+
+      expect(cardsQuery.order).toHaveBeenCalledWith('drop_rate', { ascending: true })
+    })
+
+    it('不正なsortFieldはcreated_atにフォールバックする', async () => {
+      const { cardsQuery } = setupCardsMock({
+        streamer: { id: 'streamer-1' },
+        cards: [],
+      })
+
+      await GET(createRequest({
+        streamerId: 'streamer-1',
+        sortField: 'invalid_field',
+        sortDirection: 'desc',
+      }))
+
+      expect(cardsQuery.order).toHaveBeenCalledWith('created_at', { ascending: false })
+    })
+  })
+
+  describe('pagination', () => {
+    it('rarity ソート時もDB側でrange()が呼ばれる', async () => {
+      const { cardsQuery } = setupCardsMock({
+        streamer: { id: 'streamer-1' },
+        cards: [],
+      })
+
+      await GET(createRequest({
+        streamerId: 'streamer-1',
+        sortField: 'rarity',
+        limit: '10',
+        offset: '20',
+      }))
+
+      // DB側でページネーションが適用されることを検証
+      expect(cardsQuery.range).toHaveBeenCalledWith(20, 29)
+      expect(cardsQuery.order).toHaveBeenCalledWith('rarity_order', { ascending: false })
+    })
+  })
+
+  describe('sort direction', () => {
+    it('asc でレアリティソートした場合 ascending: true', async () => {
+      const { cardsQuery } = setupCardsMock({
+        streamer: { id: 'streamer-1' },
+        cards: [],
+      })
+
+      await GET(createRequest({
+        streamerId: 'streamer-1',
+        sortField: 'rarity',
+        sortDirection: 'asc',
+      }))
+
+      expect(cardsQuery.order).toHaveBeenCalledWith('rarity_order', { ascending: true })
+    })
+
+    it('desc でレアリティソートした場合 ascending: false', async () => {
+      const { cardsQuery } = setupCardsMock({
+        streamer: { id: 'streamer-1' },
+        cards: [],
+      })
+
+      await GET(createRequest({
+        streamerId: 'streamer-1',
+        sortField: 'rarity',
+        sortDirection: 'desc',
+      }))
+
+      expect(cardsQuery.order).toHaveBeenCalledWith('rarity_order', { ascending: false })
+    })
+
+    it('不正なsortDirectionはdescにフォールバックする', async () => {
+      const { cardsQuery } = setupCardsMock({
+        streamer: { id: 'streamer-1' },
+        cards: [],
+      })
+
+      await GET(createRequest({
+        streamerId: 'streamer-1',
+        sortField: 'rarity',
+        sortDirection: 'invalid',
+      }))
+
+      expect(cardsQuery.order).toHaveBeenCalledWith('rarity_order', { ascending: false })
+    })
+  })
+
+  describe('error handling', () => {
+    it('streamerId が未指定の場合 400 を返す', async () => {
+      const response = await GET(createRequest({}))
+      expect(response.status).toBe(400)
+    })
+
+    it('ストリーマーが見つからない場合 403 を返す', async () => {
+      setupCardsMock({ streamer: null, cards: [] })
+
+      const response = await GET(createRequest({ streamerId: 'nonexistent' }))
+      expect(response.status).toBe(403)
+    })
+  })
+})


### PR DESCRIPTION
Add rarity_order GENERATED ALWAYS AS column to cards table so DB-side sorting uses the intended hierarchy (legendary=1 > epic=2 > rare=3 > common=4) instead of alphabetical text ordering. This keeps pagination fully on the DB side, avoiding PostgREST row-limit truncation.