### PR TITLE
fix: clear expired session cookies in middleware instead of Server Co…

### DIFF
--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -98,14 +98,10 @@ export const getSession = cache(async (): Promise<Session | null> => {
     const session = parseSession(sessionCookie)
 
     if (session.expiresAt && Date.now() > session.expiresAt) {
-      logger.warn('[Session] Session expired, clearing')
-      await clearSession();
-      try {
-        const { clearCSRFToken } = await import('./csrf')
-        await clearCSRFToken()
-      } catch {
-        // CSRFトークンクリアはセッションクリアの失敗を意味しない
-      }
+      logger.warn('[Session] Session expired')
+      // Cookie cleanup is handled by middleware (updateSession)
+      // ミドルウェア（updateSession）でCookieクリアを処理するため、ここではCookie操作しない
+      // Server ComponentからのCookie書き込みはNext.jsで禁止されている
       logger.info(`[Perf] getSession (expired): ${Date.now() - start}ms`);
       return null;
     }

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from 'next/server'
+import { COOKIE_NAMES, getDeleteCookieOptions } from '@/lib/constants'
 
 /**
  * Middleware session handler
@@ -10,9 +11,38 @@ import { NextResponse, type NextRequest } from 'next/server'
  * このプロジェクトはSupabase Authではなく、Twitch OAuthと独自のセッション管理を使用。
  * 以前のsupabase.auth.getUser()呼び出しは、ページ遷移ごとにSupabaseへの
  * 不要なAPIリクエストを発生させ、大幅な遅延（1リクエストあたり約100-500ms）の原因となっていた。
+ *
+ * Additionally, expired session cookies are cleared here in middleware because
+ * Server Components (layout/page) cannot modify cookies. clearSession() in
+ * getSession() was causing "Cookies can only be modified in a Server Action
+ * or Route Handler" errors.
+ *
+ * 期限切れセッションCookieのクリアもここで行う。Server Component（layout/page）では
+ * Cookieの書き込みが禁止されているため、getSession()内のclearSession()呼び出しが
+ * エラーを引き起こしていた。
  */
 export async function updateSession(request: NextRequest) {
-  // Simply pass through the request - session is managed via custom cookies
-  // リクエストをそのまま通過させる - セッションはカスタムCookieで管理
-  return NextResponse.next({ request })
+  const response = NextResponse.next({ request })
+
+  const sessionCookie = request.cookies.get(COOKIE_NAMES.SESSION)?.value
+  if (sessionCookie) {
+    try {
+      const parsed = JSON.parse(sessionCookie)
+      if (typeof parsed.expiresAt === 'number' && Date.now() > parsed.expiresAt) {
+        // Clear expired session and CSRF cookies via middleware response
+        // ミドルウェアのレスポンス経由で期限切れセッション・CSRFのCookieをクリア
+        const deleteOptions = getDeleteCookieOptions()
+        response.cookies.set(COOKIE_NAMES.SESSION, '', deleteOptions)
+        response.cookies.set(COOKIE_NAMES.CSRF_TOKEN, '', deleteOptions)
+      }
+    } catch {
+      // Clear unparseable session and CSRF cookies
+      // パースできないセッションCookie・CSRFトークンもクリア
+      const deleteOptions = getDeleteCookieOptions()
+      response.cookies.set(COOKIE_NAMES.SESSION, '', deleteOptions)
+      response.cookies.set(COOKIE_NAMES.CSRF_TOKEN, '', deleteOptions)
+    }
+  }
+
+  return response
 }

--- a/tests/unit/session-middleware.test.ts
+++ b/tests/unit/session-middleware.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { updateSession } from '@/lib/supabase/middleware'
+import { COOKIE_NAMES } from '@/lib/constants'
+
+/**
+ * Tests for middleware session cleanup logic.
+ * Expired or malformed session cookies should be cleared in middleware,
+ * because Server Components cannot modify cookies (Next.js restriction).
+ *
+ * ミドルウェアでのセッションクリーンアップロジックのテスト。
+ * 期限切れまたは不正なセッションCookieはミドルウェアでクリアする必要がある。
+ * Server ComponentではCookieの変更がNext.jsにより禁止されているため。
+ */
+describe('updateSession middleware', () => {
+  const validSession = {
+    twitchUserId: '12345',
+    twitchUsername: 'testuser',
+    twitchDisplayName: 'Test User',
+    twitchProfileImageUrl: 'https://example.com/image.png',
+    broadcasterType: 'affiliate',
+    expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+    version: 1,
+  }
+
+  function createRequest(cookies?: Record<string, string>): NextRequest {
+    const url = 'https://example.com/'
+    const request = new NextRequest(url)
+    if (cookies) {
+      for (const [name, value] of Object.entries(cookies)) {
+        request.cookies.set(name, value)
+      }
+    }
+    return request
+  }
+
+  it('should pass through request when no session cookie exists', async () => {
+    const request = createRequest()
+    const response = await updateSession(request)
+
+    // No Set-Cookie headers should be added
+    const setCookieHeader = response.headers.get('set-cookie')
+    expect(setCookieHeader).toBeNull()
+  })
+
+  it('should pass through request when session is valid (not expired)', async () => {
+    const request = createRequest({
+      [COOKIE_NAMES.SESSION]: JSON.stringify(validSession),
+    })
+    const response = await updateSession(request)
+
+    // No Set-Cookie headers should be added for valid sessions
+    const setCookieHeader = response.headers.get('set-cookie')
+    expect(setCookieHeader).toBeNull()
+  })
+
+  it('should clear session and CSRF cookies when session is expired', async () => {
+    const expiredSession = {
+      ...validSession,
+      expiresAt: Date.now() - 1000, // expired 1 second ago
+    }
+    const request = createRequest({
+      [COOKIE_NAMES.SESSION]: JSON.stringify(expiredSession),
+    })
+    const response = await updateSession(request)
+
+    // Verify session cookie is cleared (maxAge=0)
+    const sessionCookie = response.cookies.get(COOKIE_NAMES.SESSION)
+    expect(sessionCookie?.value).toBe('')
+
+    // Verify CSRF cookie is also cleared
+    const csrfCookie = response.cookies.get(COOKIE_NAMES.CSRF_TOKEN)
+    expect(csrfCookie?.value).toBe('')
+  })
+
+  it('should clear both session and CSRF cookies when cookie value is not valid JSON', async () => {
+    const request = createRequest({
+      [COOKIE_NAMES.SESSION]: 'invalid-json-value',
+      [COOKIE_NAMES.CSRF_TOKEN]: 'some-csrf-token',
+    })
+    const response = await updateSession(request)
+
+    // Verify both cookies are cleared for unparseable values
+    const sessionCookie = response.cookies.get(COOKIE_NAMES.SESSION)
+    expect(sessionCookie?.value).toBe('')
+    const csrfCookie = response.cookies.get(COOKIE_NAMES.CSRF_TOKEN)
+    expect(csrfCookie?.value).toBe('')
+  })
+
+  it('should not clear cookies when expiresAt is missing (treat as valid)', async () => {
+    const sessionWithoutExpiry = {
+      ...validSession,
+      expiresAt: undefined,
+    }
+    const request = createRequest({
+      [COOKIE_NAMES.SESSION]: JSON.stringify(sessionWithoutExpiry),
+    })
+    const response = await updateSession(request)
+
+    // No Set-Cookie headers should be added
+    const setCookieHeader = response.headers.get('set-cookie')
+    expect(setCookieHeader).toBeNull()
+  })
+})


### PR DESCRIPTION
…mponents

Server Components cannot modify cookies (Next.js restriction), so getSession() calling clearSession() on expiry caused errors. Move cookie cleanup to middleware where NextResponse cookie writes are allowed.