### PR TITLE
fix: resolve gacha animation overlap and DB atomicity issues

### DIFF
--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -274,8 +274,11 @@ async function handleRedemption(messageId: string, event: {
 
   const supabaseAdmin = getSupabaseAdmin();
 
-  // Idempotency check - skip if this event was already processed
-  // 冪等性チェック：既に処理済みのイベントはスキップ
+  // 事前の冪等性チェック：既に処理済みのイベントはスキップ
+  // RPC内でもON CONFLICTで重複を検知するが、事前チェックがないと
+  // ストリーマー設定やカード構成が変わった後のリトライで
+  // "Reward ID mismatch" や "No cards available" として誤報告されるため、
+  // この事前SELECTは必要（レビュー指摘 P2）
   const { data: existingHistory } = await supabaseAdmin
     .from('gacha_history')
     .select('id')
@@ -292,6 +295,12 @@ async function handleRedemption(messageId: string, event: {
     const result = await gachaService.executeGachaForEventSub(event, messageId);
 
     if (!result.success) {
+      // EventSub重複通知は正常系（リトライによる再送）なのでエラー報告しない
+      // Duplicate event is expected (EventSub retry) - don't report as error
+      if (result.error === 'Duplicate event') {
+        logger.info('[handleRedemption] Skipped - duplicate event (RPC)', { messageId });
+        return null;
+      }
       logger.warn('[handleRedemption] Gacha execution failed', { messageId });
       await reportError(new Error(`Gacha execution failed: ${result.error}`), {
         context: 'eventsub:handleRedemption',

--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -115,6 +115,12 @@ export default function OverlayPage() {
   const animationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cleanupRef = useRef<(() => void) | null>(null);
   const connectionStatusRef = useRef(connectionStatus);
+  // ガチャ結果キュー: アニメーション中に到着した結果をバッファし順番に表示する
+  // 連続引き換え時に前のカードが消えて最後の1件しか表示されない問題を解消
+  const queueRef = useRef<GachaResult[]>([]);
+  const isDisplayingRef = useRef(false);
+  // processQueueの再帰呼び出し用ref（useCallback内で自身を参照するため）
+  const processQueueRef = useRef<() => void>(() => {});
   // displayResultとaddDebugLogをrefで保持することで、
   // subscriptionのuseEffectが不要に再実行されることを防ぐ
   // （soundSettings変更 → playGachaSound再生成 → displayResult再生成 のチェーンで
@@ -306,47 +312,64 @@ export default function OverlayPage() {
     }
   }, [soundSettings.soundEnabled, soundSettings.soundUrl]);
 
-  // Display gacha result with animation
-  const displayResult = useCallback(async (data: GachaResult) => {
-    // Clear any existing animation
-    if (animationTimeoutRef.current) {
-      clearTimeout(animationTimeoutRef.current);
+  /**
+   * キューから1件取り出して表示し、終了後に次のアイテムを処理する
+   * Process one item from the queue, then recursively process the next.
+   * 再帰呼び出しはprocessQueueRef経由で行い、useCallbackのクロージャが
+   * 古いバージョンを参照する問題を回避する
+   */
+  const processQueue = useCallback(async () => {
+    const next = queueRef.current.shift();
+    if (!next) {
+      isDisplayingRef.current = false;
+      return;
     }
+    isDisplayingRef.current = true;
 
     // 画像のアスペクト比をチェック（autoPortraitモード用）
-    // 画像ロードが完了するまで待機してから表示を開始
-    await checkImageAspectRatio(data.card.image_url);
+    await checkImageAspectRatio(next.card.image_url);
 
-    // Generate sparkle positions
     setSparklePositions(generateSparklePositions());
-    setResult(data);
+    setResult(next);
     setShowCard(false);
 
     // Show card after brief delay
     animationTimeoutRef.current = setTimeout(() => {
       setShowCard(true);
-
-      // 効果音を再生（カード表示と同時）
-      // OBSブラウザソースでは自動再生制限があるため、
-      // 再生に失敗しても処理は継続
       playGachaSound();
 
-      // Hide after display
-      // 表示時間はoptions.displayDurationで設定（秒をミリ秒に変換）
-      // Display duration is configurable via options.displayDuration (converted from seconds to ms)
+      // Hide after display, then process next queued item
       animationTimeoutRef.current = setTimeout(() => {
         setShowCard(false);
         animationTimeoutRef.current = setTimeout(() => {
           setResult(null);
+          // ref経由で最新のprocessQueueを呼び出し（再帰）
+          processQueueRef.current();
         }, 500);
       }, options.displayDuration * 1000);
     }, 100);
   }, [checkImageAspectRatio, playGachaSound, options.displayDuration]);
 
+  // processQueueRefを最新のcallbackで更新
+  useEffect(() => {
+    processQueueRef.current = processQueue;
+  }, [processQueue]);
+
+  /**
+   * 新しいガチャ結果をキューに追加し、未再生なら再生を開始する
+   * Enqueue a new gacha result; start playback if idle
+   */
+  const enqueueResult = useCallback((data: GachaResult) => {
+    queueRef.current.push(data);
+    if (!isDisplayingRef.current) {
+      processQueue();
+    }
+  }, [processQueue]);
+
   // refを最新のcallbackで更新（useEffectの依存配列に含めずに最新の関数を参照するため）
   useEffect(() => {
-    displayResultRef.current = displayResult;
-  }, [displayResult]);
+    displayResultRef.current = enqueueResult;
+  }, [enqueueResult]);
 
   // デバッグログを追加するヘルパー関数
   // OBSブラウザソースでの接続問題を調査するために使用
@@ -414,6 +437,9 @@ export default function OverlayPage() {
     cleanupRef.current = cleanup;
 
     return () => {
+      // キューをクリアして未再生アイテムを破棄
+      queueRef.current = [];
+      isDisplayingRef.current = false;
       if (connectionTimeoutRef.current) {
         clearTimeout(connectionTimeoutRef.current);
       }
@@ -443,12 +469,12 @@ export default function OverlayPage() {
 
       if (response.ok) {
         const data = await response.json();
-        displayResult(data);
+        enqueueResult(data);
       }
     } catch (error) {
       logger.error("Demo gacha error:", error);
     }
-  }, [displayResult, streamerId]);
+  }, [enqueueResult, streamerId]);
 
   // Check URL for demo param and optional cardId
   // URLパラメータでdemo=trueの場合にデモを実行、cardIdが指定されていればそのカードを表示

--- a/src/components/GachaHistorySection.tsx
+++ b/src/components/GachaHistorySection.tsx
@@ -37,10 +37,15 @@ export default function GachaHistorySection({
   const tCard = useTranslations("cardManager");
   const tCommon = useTranslations("common");
   const [history, setHistory] = useState<GachaHistoryWithCard[]>(recentGacha);
+  // 削除処理中のアイテムIDを保持し、連続クリックを防止
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const handleDelete = async (historyId: string) => {
+    // 別の削除処理が進行中の場合はスキップ
+    if (deletingId) return;
     if (!confirm(tCard("confirmations.deleteCard"))) return;
 
+    setDeletingId(historyId);
     try {
       const response = await fetch(`/api/gacha-history/${historyId}`, {
         method: "DELETE",
@@ -52,9 +57,14 @@ export default function GachaHistorySection({
         const errorData = await response.json();
         alert(tCard("messages.operationFailed", { msg: errorData.error || tCard("messages.rateLimit") }));
         logger.error("Rate limit exceeded:", errorData);
+      } else {
+        alert(tCard("messages.operationFailed", { msg: `HTTP ${response.status}` }));
       }
     } catch (error) {
       logger.error("Failed to delete gacha history:", error);
+      alert(tCard("messages.operationFailed", { msg: String(error) }));
+    } finally {
+      setDeletingId(null);
     }
   };
 
@@ -100,9 +110,10 @@ export default function GachaHistorySection({
                  {isStreamer && (
                    <button
                      onClick={() => handleDelete(entry.id)}
-                     className="rounded bg-red-500 px-3 py-1 text-xs text-white hover:bg-red-600 transition-colors"
+                     disabled={deletingId !== null}
+                     className="rounded bg-red-500 px-3 py-1 text-xs text-white hover:bg-red-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                    >
-                     {tCommon("delete")}
+                     {deletingId === entry.id ? "..." : tCommon("delete")}
                    </button>
                 )}
               </div>

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -3,6 +3,7 @@ import { selectWeightedCard } from '@/lib/gacha'
 import { normalizeDropRate } from '@/lib/card-utils'
 import { Result, ok, err } from '@/types/result'
 import { logger } from '@/lib/logger'
+import { reportError } from '@/lib/sentry/error-handler'
 
 export interface GachaCard {
   id: string
@@ -59,78 +60,41 @@ export class GachaService {
         return err('Failed to select card')
       }
 
-      // Execute gacha history recording and user check in parallel to reduce CPU time
-      // CPU時間削減のため、ガチャ履歴記録とユーザー確認を並列実行
-      const [historyResult, userCheckResult] = await Promise.all([
-        // Record gacha history (with idempotency using upsert)
-        // ガチャ履歴を記録（冪等性のためupsertを使用）
-        this.supabase
-          .from('gacha_history')
-          .upsert({
-            event_id: eventId || null,
-            user_twitch_id: userTwitchId,
-            user_twitch_username: userTwitchUsername,
-            card_id: selectedCard.id,
-            streamer_id: streamerId,
-          }, {
-            onConflict: 'event_id',
-            ignoreDuplicates: true,
-          }),
-        // Check if user exists (SELECT only, no UPDATE)
-        // ユーザーの存在確認（SELECTのみ、UPDATEなし）
-        this.supabase
-          .from('users')
-          .select('id')
-          .eq('twitch_user_id', userTwitchId)
-          .maybeSingle()
-      ])
+      // gacha_history, users, user_cards を1トランザクションでアトミックに実行
+      // 従来は3回の個別DB操作で中間状態（履歴あり・カード未付与）が発生しえた
+      const { data: rpcResult, error: rpcError } = await this.supabase
+        .rpc('execute_gacha_transaction', {
+          p_event_id: eventId || null,
+          p_user_twitch_id: userTwitchId,
+          p_user_twitch_username: userTwitchUsername,
+          p_card_id: selectedCard.id,
+          p_streamer_id: streamerId,
+        })
 
-      if (historyResult.error) {
-        return err(`Failed to record history: ${historyResult.error.message}`)
+      if (rpcError) {
+        // RPC関数が未デプロイの場合（マイグレーション前）は旧ロジックにフォールバック
+        // 無停止デプロイ時にアプリコードが先にデプロイされても、
+        // ユーザーのチャンネルポイントが消費されカード未付与になることを防ぐ
+        // TODO: マイグレーション適用確認後にフォールバックを削除
+        if (rpcError.code === '42883') {
+          logger.warn('execute_gacha_transaction not found, falling back to legacy operations', {
+            streamerId, userTwitchId, eventId,
+          })
+          return this.executeGachaLegacy(streamerId, userTwitchId, userTwitchUsername, selectedCard, eventId)
+        }
+
+        await reportError(new Error(`Gacha RPC failed: ${rpcError.message}`), {
+          context: 'gacha:executeGacha:rpc',
+          streamerId,
+          userTwitchId,
+          eventId,
+        })
+        return err(`Failed to execute gacha transaction: ${rpcError.message}`)
       }
 
-      // If user doesn't exist, create one
-      // ユーザーが存在しない場合は作成
-      // twitch_display_nameはNOT NULL制約があるため、usernameをデフォルト値として使用
-      // （EventSubからはuser_nameとして表示名が渡されるが、通常のガチャではユーザー名のみ）
-      let user = userCheckResult.data
-      if (!user) {
-        const { data: newUser, error: createError } = await this.supabase
-          .from('users')
-          .upsert({
-            twitch_user_id: userTwitchId,
-            twitch_username: userTwitchUsername,
-            twitch_display_name: userTwitchUsername,
-          }, {
-            onConflict: 'twitch_user_id',
-            ignoreDuplicates: true,
-          })
-          .select('id')
-          .maybeSingle()
-
-        if (createError) {
-          logger.warn('Failed to create user:', createError.message)
-        } else {
-          user = newUser
-        }
-      }
-
-      if (user) {
-        // Use insert instead of upsert - upsert with composite key doesn't work correctly
-        // upsertではなくinsertを使用 - 複合キーでのupsertは正しく動作しない
-        const { error: collectionError } = await this.supabase
-          .from('user_cards')
-          .insert({
-            user_id: user.id,
-            card_id: selectedCard.id,
-            obtained_at: new Date().toISOString(),
-          })
-
-        // Ignore duplicate key error (23505)
-        // 重複キーエラー（23505）は無視
-        if (collectionError && collectionError.code !== '23505') {
-          logger.warn('Failed to add to collection:', collectionError.message)
-        }
+      // EventSub重複通知の場合（event_idが既に処理済み）
+      if (rpcResult?.is_duplicate) {
+        return err('Duplicate event')
       }
 
       return ok({
@@ -140,6 +104,66 @@ export class GachaService {
     } catch (error) {
       return err(`Unexpected error: ${error}`)
     }
+  }
+
+  /**
+   * RPC関数未デプロイ時のフォールバック: 旧ロジック（個別DB操作）でガチャを実行
+   * マイグレーション適用前のデプロイ中間状態でユーザーへのカード未付与を防ぐ
+   * アトミック性は保証されないが、カード付与されないよりは良い
+   * TODO: マイグレーション適用確認後にこのメソッドを削除
+   */
+  private async executeGachaLegacy(
+    streamerId: string, userTwitchId: string, userTwitchUsername: string,
+    selectedCard: GachaCard, eventId?: string
+  ): Promise<Result<GachaResult>> {
+    // gacha_history upsert（冪等性のためevent_idで重複チェック）
+    const { error: historyError } = await this.supabase
+      .from('gacha_history')
+      .upsert({
+        event_id: eventId || null,
+        user_twitch_id: userTwitchId,
+        user_twitch_username: userTwitchUsername,
+        card_id: selectedCard.id,
+        streamer_id: streamerId,
+      }, {
+        onConflict: 'event_id',
+        ignoreDuplicates: true,
+      })
+
+    if (historyError) {
+      return err(`Failed to record history: ${historyError.message}`)
+    }
+
+    // users upsert
+    const { data: user } = await this.supabase
+      .from('users')
+      .upsert({
+        twitch_user_id: userTwitchId,
+        twitch_username: userTwitchUsername,
+        twitch_display_name: userTwitchUsername,
+      }, {
+        onConflict: 'twitch_user_id',
+        ignoreDuplicates: true,
+      })
+      .select('id')
+      .maybeSingle()
+
+    // user_cards insert
+    if (user) {
+      const { error: collectionError } = await this.supabase
+        .from('user_cards')
+        .insert({
+          user_id: user.id,
+          card_id: selectedCard.id,
+          obtained_at: new Date().toISOString(),
+        })
+
+      if (collectionError && collectionError.code !== '23505') {
+        logger.warn('Legacy fallback: Failed to add to collection:', collectionError.message)
+      }
+    }
+
+    return ok({ card: selectedCard, userTwitchUsername })
   }
 
   /**

--- a/supabase/migrations/00015_add_execute_gacha_transaction.sql
+++ b/supabase/migrations/00015_add_execute_gacha_transaction.sql
@@ -1,0 +1,60 @@
+-- Migration: Add execute_gacha_transaction RPC function
+-- ガチャのDB操作（gacha_history, users, user_cards）を1トランザクションで実行するRPC関数
+--
+-- 目的:
+-- - gacha_history INSERT と user_cards INSERT が別々のDB操作だったため、
+--   履歴だけ残りカード未付与の中間状態が発生しうる問題を解消
+-- - EventSub重複通知によるカード二重付与を防止（event_id UNIQUE制約を活用）
+-- - 3回のDB往復（gacha_history upsert → users upsert → user_cards insert）を1回に削減
+
+CREATE OR REPLACE FUNCTION execute_gacha_transaction(
+  p_event_id TEXT,
+  p_user_twitch_id TEXT,
+  p_user_twitch_username TEXT,
+  p_card_id UUID,
+  p_streamer_id UUID
+) RETURNS JSONB AS $$
+DECLARE
+  v_user_id UUID;
+  v_history_id UUID;
+BEGIN
+  -- 1. gacha_history INSERT（event_id UNIQUE制約で重複を検知）
+  -- event_idがNULLの場合はUNIQUE制約が効かないため常にINSERT成功
+  -- event_idが既存の場合はDO NOTHINGで何もせず、v_history_idはNULLのまま
+  INSERT INTO gacha_history (event_id, user_twitch_id, user_twitch_username, card_id, streamer_id)
+  VALUES (p_event_id, p_user_twitch_id, p_user_twitch_username, p_card_id, p_streamer_id)
+  ON CONFLICT (event_id) DO NOTHING
+  RETURNING id INTO v_history_id;
+
+  -- 重複イベントの場合は早期リターン（カード付与をスキップ）
+  IF v_history_id IS NULL AND p_event_id IS NOT NULL THEN
+    RETURN jsonb_build_object('is_duplicate', true);
+  END IF;
+
+  -- 2. users UPSERT（存在しなければ作成、既存なら何もしない）
+  -- twitch_display_nameはNOT NULL制約があるためusernameをデフォルト値として使用
+  INSERT INTO users (twitch_user_id, twitch_username, twitch_display_name)
+  VALUES (p_user_twitch_id, p_user_twitch_username, p_user_twitch_username)
+  ON CONFLICT (twitch_user_id) DO NOTHING;
+
+  -- ユーザーIDを取得（upsertでRETURNINGが効かない場合があるためSELECT）
+  SELECT id INTO v_user_id FROM users WHERE twitch_user_id = p_user_twitch_id;
+
+  -- 3. user_cards INSERT（カードをユーザーに付与）
+  -- 同じカードの複数枚所持を許可（00010_allow_multiple_cardsでUNIQUE制約は削除済み）
+  IF v_user_id IS NOT NULL THEN
+    INSERT INTO user_cards (user_id, card_id, obtained_at)
+    VALUES (v_user_id, p_card_id, NOW());
+  END IF;
+
+  RETURN jsonb_build_object('is_duplicate', false, 'history_id', v_history_id);
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION execute_gacha_transaction IS
+  'ガチャのDB操作（履歴記録・ユーザー作成・カード付与）を1トランザクションでアトミックに実行。event_id重複時はカード付与をスキップ';
+
+-- 実行権限をservice_roleのみに限定
+-- デフォルトではpublicロールにEXECUTEが付与されるため、明示的に剥奪
+REVOKE ALL ON FUNCTION execute_gacha_transaction(TEXT, TEXT, TEXT, UUID, UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION execute_gacha_transaction(TEXT, TEXT, TEXT, UUID, UUID) TO service_role;

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { GachaService } from '@/lib/services/gacha'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { createMockQueryBuilder } from '../utils/supabase-mock'
+
+vi.mock('@/lib/supabase/admin', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/supabase/admin')>()
+  return { ...actual, getSupabaseAdmin: vi.fn() }
+})
+vi.mock('@/lib/sentry/error-handler', () => ({
+  reportError: vi.fn(),
+  reportApiError: vi.fn(),
+  logErrorFromLogger: vi.fn(),
+}))
+
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin)
+
+// テスト用カードデータ
+const testCards = [
+  { id: 'card-1', name: 'Test Card', description: 'desc', image_url: null, rarity: 'common', drop_rate: 1.0 },
+]
+
+/** cardsクエリの共通モック生成。thenableにしてawait対応 */
+function createCardsQuery(cards: typeof testCards | []) {
+  const q = createMockQueryBuilder()
+  ;(q as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
+    resolve({ data: cards, error: null })
+    return q
+  }
+  return q
+}
+
+describe('GachaService.executeGacha', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('正常系: RPC成功でカード結果を返す', async () => {
+    const cardsQuery = createCardsQuery(testCards)
+    const mockRpc = vi.fn().mockResolvedValue({
+      data: { is_duplicate: false, history_id: 'h-1' },
+      error: null,
+    })
+
+    // モック設定後にサービスを生成（コンストラクタでgetSupabaseAdminを呼ぶため）
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'cards') return cardsQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGacha('streamer-1', 'user-1', 'testuser', 'event-1')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.card.id).toBe('card-1')
+      expect(result.data.userTwitchUsername).toBe('testuser')
+    }
+    expect(mockRpc).toHaveBeenCalledWith('execute_gacha_transaction', {
+      p_event_id: 'event-1',
+      p_user_twitch_id: 'user-1',
+      p_user_twitch_username: 'testuser',
+      p_card_id: 'card-1',
+      p_streamer_id: 'streamer-1',
+    })
+  })
+
+  it('重複イベント: is_duplicate=true で Duplicate event エラーを返す', async () => {
+    const cardsQuery = createCardsQuery(testCards)
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn(() => cardsQuery),
+      rpc: vi.fn().mockResolvedValue({
+        data: { is_duplicate: true },
+        error: null,
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGacha('streamer-1', 'user-1', 'testuser', 'event-dup')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('Duplicate event')
+    }
+  })
+
+  it('RPC未デプロイ(42883): レガシーフォールバックで成功する', async () => {
+    const cardsQuery = createCardsQuery(testCards)
+    // フォールバック時のDB操作用モック（upsert → select → insert チェーン）
+    const legacyQuery = createMockQueryBuilder()
+    ;(legacyQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: 'user-1-uuid' }, error: null,
+    })
+    // insert (user_cards) のawait用thenable
+    const insertQuery = createMockQueryBuilder()
+    ;(insertQuery as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
+      resolve({ data: null, error: null })
+      return insertQuery
+    }
+    // upsert (gacha_history) のawait用thenable
+    const upsertQuery = createMockQueryBuilder()
+    ;(upsertQuery as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
+      resolve({ data: null, error: null })
+      return upsertQuery
+    }
+
+    const fromMock = vi.fn((table: string) => {
+      if (table === 'cards') return cardsQuery
+      if (table === 'gacha_history') return upsertQuery
+      if (table === 'users') return legacyQuery
+      if (table === 'user_cards') return insertQuery
+      return createMockQueryBuilder()
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: fromMock,
+      rpc: vi.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'function execute_gacha_transaction does not exist', code: '42883' },
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGacha('streamer-1', 'user-1', 'testuser', 'event-fallback')
+
+    // フォールバックが成功してカードが返る
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.card.id).toBe('card-1')
+    }
+    // フォールバック時のDB操作が呼ばれている
+    expect(fromMock).toHaveBeenCalledWith('gacha_history')
+    expect(fromMock).toHaveBeenCalledWith('users')
+  })
+
+  it('RPCエラー(42883以外): reportErrorを呼びエラー結果を返す', async () => {
+    const { reportError } = await import('@/lib/sentry/error-handler')
+    const mockReportError = vi.mocked(reportError)
+    const cardsQuery = createCardsQuery(testCards)
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn(() => cardsQuery),
+      rpc: vi.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'connection refused', code: '08006' },
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGacha('streamer-1', 'user-1', 'testuser', 'event-err')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toContain('connection refused')
+    }
+    expect(mockReportError).toHaveBeenCalled()
+  })
+
+  it('カード未登録: カードがない場合はエラーを返す', async () => {
+    const cardsQuery = createCardsQuery([])
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn(() => cardsQuery),
+      rpc: vi.fn(),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGacha('streamer-1', 'user-1', 'testuser')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toContain('No cards available')
+    }
+  })
+
+  it('eventId未指定: p_event_idにnullが渡される', async () => {
+    const cardsQuery = createCardsQuery(testCards)
+    const mockRpc = vi.fn().mockResolvedValue({
+      data: { is_duplicate: false, history_id: 'h-2' },
+      error: null,
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn(() => cardsQuery),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    await service.executeGacha('streamer-1', 'user-1', 'testuser')
+
+    expect(mockRpc).toHaveBeenCalledWith('execute_gacha_transaction', expect.objectContaining({
+      p_event_id: null,
+    }))
+  })
+})


### PR DESCRIPTION
- Add result queue to overlay to prevent animation overlap when multiple gacha results arrive in quick succession
- Create execute_gacha_transaction PostgreSQL function to atomically execute gacha_history, users, and user_cards operations in a single transaction, preventing partial state (history recorded but card not granted)
- Handle EventSub duplicate notifications as expected behavior (skip error reporting)
- Add delete button double-click prevention in GachaHistorySection
- Include legacy fallback (error code 42883) for zero-downtime deploy when migration hasn't been applied yet