### PR TITLE
fix: ミドルウェアの期限切れCookie削除によるチャット通知権限消失を修正 (#306)

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -29,8 +29,15 @@ export const API_ROUTES = {
 }
 
 export const SESSION_CONFIG = {
-  MAX_AGE_SECONDS: 7 * 24 * 60 * 60,  // 7 days
+  MAX_AGE_SECONDS: 7 * 24 * 60 * 60,  // 7 days (session validity)
   MAX_AGE_MS: 7 * 24 * 60 * 60 * 1000, // 7 days in milliseconds
+  // CookieのmaxAgeはセッション有効期限より長く設定する。
+  // ログインルートのparseSession()が期限切れCookieからtwitchUserIdを抽出して
+  // 追加スコープ（user:write:chat等）を保持するために、この猶予期間が必要。
+  // Cookie maxAge is intentionally longer than session validity.
+  // The login route's parseSession() relies on the expired cookie to extract twitchUserId
+  // and preserve additional scopes (e.g., user:write:chat) during re-login.
+  COOKIE_MAX_AGE_SECONDS: 30 * 24 * 60 * 60,  // 30 days (cookie lifetime for scope preservation)
   COOKIE_PATH: '/',
 }
 
@@ -99,7 +106,13 @@ export function getSessionCookieOptions(): {
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'lax' as const,
     path: '/',
-    maxAge: SESSION_CONFIG.MAX_AGE_SECONDS,
+    // セッション有効期限(7日)より長いmaxAge(30日)を使用。
+    // getSession()はexpiresAtで有効期限を判定するため、Cookieが長く残っても安全。
+    // 期限切れCookieはログイン時のスコープ保持にのみ使用される。
+    // Use COOKIE_MAX_AGE_SECONDS (30d) instead of MAX_AGE_SECONDS (7d).
+    // getSession() checks expiresAt for session validity, so a longer cookie is safe.
+    // Expired cookies are only used for scope preservation during re-login.
+    maxAge: SESSION_CONFIG.COOKIE_MAX_AGE_SECONDS,
     ...(domain && { domain }),
   }
 }
@@ -125,15 +138,6 @@ export function getDeleteCookieOptions(): {
     ...(domain && { domain }),
   }
 }
-
-// 後方互換性のために残す（使用箇所は順次 getSessionCookieOptions() に置き換え）
-export const SESSION_COOKIE_OPTIONS = {
-  httpOnly: true,
-  secure: process.env.NODE_ENV === 'production',
-  sameSite: 'lax' as const,
-  path: '/',
-  maxAge: SESSION_CONFIG.MAX_AGE_SECONDS,
-} as const
 
 export const STATE_COOKIE_OPTIONS = {
   httpOnly: true,

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -99,9 +99,12 @@ export const getSession = cache(async (): Promise<Session | null> => {
 
     if (session.expiresAt && Date.now() > session.expiresAt) {
       logger.warn('[Session] Session expired')
-      // Cookie cleanup is handled by middleware (updateSession)
-      // ミドルウェア（updateSession）でCookieクリアを処理するため、ここではCookie操作しない
-      // Server ComponentからのCookie書き込みはNext.jsで禁止されている
+      // 期限切れセッションCookieはミドルウェアで削除しない（スコープ保持のため）。
+      // Cookie自体はCOOKIE_MAX_AGE_SECONDSの期限でブラウザが自動削除する。
+      // Server ComponentからのCookie書き込みはNext.jsで禁止されている。
+      // Expired session cookies are NOT deleted by middleware (preserved for scope restoration).
+      // The cookie is automatically cleaned up by the browser when COOKIE_MAX_AGE_SECONDS expires.
+      // Server Components cannot write cookies in Next.js.
       logger.info(`[Perf] getSession (expired): ${Date.now() - start}ms`);
       return null;
     }

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -12,14 +12,23 @@ import { COOKIE_NAMES, getDeleteCookieOptions } from '@/lib/constants'
  * 以前のsupabase.auth.getUser()呼び出しは、ページ遷移ごとにSupabaseへの
  * 不要なAPIリクエストを発生させ、大幅な遅延（1リクエストあたり約100-500ms）の原因となっていた。
  *
- * Additionally, expired session cookies are cleared here in middleware because
- * Server Components (layout/page) cannot modify cookies. clearSession() in
- * getSession() was causing "Cookies can only be modified in a Server Action
- * or Route Handler" errors.
+ * IMPORTANT: Expired session cookies are NOT deleted here.
+ * The login route's parseSession() fallback relies on the expired cookie
+ * to extract twitchUserId and preserve additional scopes (e.g., user:write:chat)
+ * during re-login. Deleting the expired cookie here would cause the login route
+ * to lose the twitchUserId, resulting in silent scope loss.
+ * The cookie's maxAge (COOKIE_MAX_AGE_SECONDS) is intentionally set longer than
+ * the session validity (MAX_AGE_SECONDS) to provide a grace period for scope preservation.
+ * getSession() already returns null for expired sessions, so keeping the cookie
+ * is safe — it only serves as a twitchUserId source for the login route.
  *
- * 期限切れセッションCookieのクリアもここで行う。Server Component（layout/page）では
- * Cookieの書き込みが禁止されているため、getSession()内のclearSession()呼び出しが
- * エラーを引き起こしていた。
+ * 重要: 期限切れセッションCookieはここで削除しない。
+ * ログインルートのparseSession()フォールバックが期限切れCookieからtwitchUserIdを
+ * 抽出し、追加スコープ（user:write:chat等）を保持するために使用する。
+ * ここで削除するとログインルートがtwitchUserIdを取得できず、スコープが暗黙的に消失する。
+ * CookieのmaxAge（COOKIE_MAX_AGE_SECONDS）はセッション有効期限（MAX_AGE_SECONDS）より
+ * 意図的に長く設定されており、スコープ保持のための猶予期間を提供する。
+ * getSession()は期限切れセッションにnullを返すため、Cookieを残しても安全。
  */
 export async function updateSession(request: NextRequest) {
   const response = NextResponse.next({ request })
@@ -29,15 +38,18 @@ export async function updateSession(request: NextRequest) {
     try {
       const parsed = JSON.parse(sessionCookie)
       if (typeof parsed.expiresAt === 'number' && Date.now() > parsed.expiresAt) {
-        // Clear expired session and CSRF cookies via middleware response
-        // ミドルウェアのレスポンス経由で期限切れセッション・CSRFのCookieをクリア
+        // セッション期限切れ時: CSRFトークンのみ削除。セッションCookieは保持する。
+        // セッションCookieを削除するとログイン時のスコープ保持ができなくなるため。
+        // On session expiry: only clear CSRF token. Keep session cookie for scope preservation.
+        // Deleting session cookie here would prevent scope preservation during re-login.
         const deleteOptions = getDeleteCookieOptions()
-        response.cookies.set(COOKIE_NAMES.SESSION, '', deleteOptions)
         response.cookies.set(COOKIE_NAMES.CSRF_TOKEN, '', deleteOptions)
       }
     } catch {
-      // Clear unparseable session and CSRF cookies
-      // パースできないセッションCookie・CSRFトークンもクリア
+      // パースできないCookieは改ざん/破損の可能性があるため両方削除（セキュリティ対策）
+      // スコープ保持にも使えないため、削除しても問題ない
+      // Clear unparseable cookies (both session and CSRF) as they may be tampered/corrupted
+      // They can't be used for scope preservation anyway
       const deleteOptions = getDeleteCookieOptions()
       response.cookies.set(COOKIE_NAMES.SESSION, '', deleteOptions)
       response.cookies.set(COOKIE_NAMES.CSRF_TOKEN, '', deleteOptions)

--- a/tests/unit/session-middleware.test.ts
+++ b/tests/unit/session-middleware.test.ts
@@ -5,12 +5,18 @@ import { COOKIE_NAMES } from '@/lib/constants'
 
 /**
  * Tests for middleware session cleanup logic.
- * Expired or malformed session cookies should be cleared in middleware,
- * because Server Components cannot modify cookies (Next.js restriction).
+ *
+ * Key behavior:
+ * - Expired session cookies are NOT deleted (preserved for scope restoration during re-login)
+ * - CSRF cookies ARE deleted when session expires (no longer needed)
+ * - Unparseable (corrupted/tampered) session cookies are deleted (security)
  *
  * ミドルウェアでのセッションクリーンアップロジックのテスト。
- * 期限切れまたは不正なセッションCookieはミドルウェアでクリアする必要がある。
- * Server ComponentではCookieの変更がNext.jsにより禁止されているため。
+ *
+ * 主な動作:
+ * - 期限切れセッションCookieは削除しない（再ログイン時のスコープ保持に必要）
+ * - CSRFトークンはセッション期限切れ時に削除する（不要のため）
+ * - パースできないCookieは削除する（セキュリティ対策）
  */
 describe('updateSession middleware', () => {
   const validSession = {
@@ -54,7 +60,11 @@ describe('updateSession middleware', () => {
     expect(setCookieHeader).toBeNull()
   })
 
-  it('should clear session and CSRF cookies when session is expired', async () => {
+  it('should preserve expired session cookie and only clear CSRF cookie', async () => {
+    // 期限切れセッションCookieはスコープ保持のために残す
+    // ログインルートのparseSession()がtwitchUserIdを抽出して追加スコープを保持するため
+    // Expired session cookie is preserved for scope preservation during re-login
+    // The login route's parseSession() extracts twitchUserId to preserve additional scopes
     const expiredSession = {
       ...validSession,
       expiresAt: Date.now() - 1000, // expired 1 second ago
@@ -64,11 +74,15 @@ describe('updateSession middleware', () => {
     })
     const response = await updateSession(request)
 
-    // Verify session cookie is cleared (maxAge=0)
+    // レスポンスにセッションCookieのSet-Cookieヘッダーが含まれない
+    // = ミドルウェアがCookieを書き換えない = ブラウザの既存Cookieがそのまま保持される
+    // response.cookies.get() returns undefined means no Set-Cookie header for this cookie
+    // = middleware doesn't modify it = browser's existing cookie is preserved
     const sessionCookie = response.cookies.get(COOKIE_NAMES.SESSION)
-    expect(sessionCookie?.value).toBe('')
+    expect(sessionCookie).toBeUndefined()
 
-    // Verify CSRF cookie is also cleared
+    // CSRFトークンは削除される（期限切れセッションでは不要）
+    // CSRF cookie should be cleared (not needed for expired session)
     const csrfCookie = response.cookies.get(COOKIE_NAMES.CSRF_TOKEN)
     expect(csrfCookie?.value).toBe('')
   })
@@ -100,5 +114,28 @@ describe('updateSession middleware', () => {
     // No Set-Cookie headers should be added
     const setCookieHeader = response.headers.get('set-cookie')
     expect(setCookieHeader).toBeNull()
+  })
+
+  it('should preserve session cookie even when expired for a long time', async () => {
+    // 長期間経過した期限切れセッションもスコープ保持のために残す
+    // Even long-expired sessions are preserved for scope preservation
+    const longExpiredSession = {
+      ...validSession,
+      expiresAt: Date.now() - 20 * 24 * 60 * 60 * 1000, // expired 20 days ago
+    }
+    const request = createRequest({
+      [COOKIE_NAMES.SESSION]: JSON.stringify(longExpiredSession),
+    })
+    const response = await updateSession(request)
+
+    // レスポンスにSet-Cookieなし = ミドルウェアが書き換えない = 既存Cookie保持
+    // No Set-Cookie in response = middleware doesn't modify = existing cookie preserved
+    const sessionCookie = response.cookies.get(COOKIE_NAMES.SESSION)
+    expect(sessionCookie).toBeUndefined()
+
+    // CSRFトークンのみ削除される
+    // Only CSRF cookie should be cleared
+    const csrfCookie = response.cookies.get(COOKIE_NAMES.CSRF_TOKEN)
+    expect(csrfCookie?.value).toBe('')
   })
 })


### PR DESCRIPTION
ミドルウェアがセッション期限切れ時にCookieを即座に削除するため、
再ログイン時にloginルートのparseSession()がtwitchUserIdを取得できず、 追加スコープ(user:write:chat)がOAuthリクエストに含まれなかった。
callbackの全置換でスコープが暗黙的に消失していた。

修正内容:
- ミドルウェア: 期限切れセッションCookieを削除しない(CSRFのみ削除)
- Cookie maxAge: セッション有効期限(7日)より長い30日に変更
- session.ts: コメントをミドルウェア変更に合わせて更新
- デッドコードSESSION_COOKIE_OPTIONSを削除
- テスト: 新しいミドルウェア動作に合わせて更新・追加

https://claude.ai/code/session_01Rhd69aUVAtmD5gxPSX7XZd