### PR TITLE
Fix chat scope loss after logout and relogin

### DIFF
--- a/src/app/api/auth/reauth/route.ts
+++ b/src/app/api/auth/reauth/route.ts
@@ -4,7 +4,7 @@ import { deleteTwitchTokens } from '@/lib/twitch/token-manager'
 import { handleApiError } from '@/lib/error-handler'
 import { ERROR_MESSAGES } from '@/lib/constants'
 import { getTwitchAuthUrl, ADDITIONAL_SCOPES } from '@/lib/twitch/auth'
-import { API_ROUTES } from '@/lib/constants'
+import { API_ROUTES, COOKIE_NAMES, STATE_COOKIE_OPTIONS } from '@/lib/constants'
 import { logger } from '@/lib/logger'
 import { checkRateLimit, rateLimits, getRateLimitIdentifier } from '@/lib/rate-limit'
 import { randomBytesHex } from '@/lib/crypto-utils'
@@ -65,11 +65,17 @@ export async function POST(request: Request) {
       additionalScopes,
     })
 
-    return NextResponse.json({
+    const response = NextResponse.json({
       success: true,
       loginUrl,
       state, // stateを返してクライアント側でCookieに保存できるようにする
     })
+
+    // callbackで再認証フローを識別するためにstateを保存
+    // Store state marker so callback can identify re-auth flow
+    response.cookies.set(COOKIE_NAMES.REAUTH_STATE, state, STATE_COOKIE_OPTIONS)
+
+    return response
   } catch (error) {
     return handleApiError(error, 'Re-auth API: POST')
   }

--- a/src/app/api/auth/twitch/callback/route.ts
+++ b/src/app/api/auth/twitch/callback/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
-import { exchangeCodeForTokens, getTwitchUser } from '@/lib/twitch/auth'
+import { exchangeCodeForTokens, getTwitchUser, ADDITIONAL_SCOPES } from '@/lib/twitch/auth'
 import { saveTwitchScopes } from '@/lib/twitch/token-manager'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { handleAuthError } from '@/lib/auth-error-handler'
@@ -92,6 +92,10 @@ export async function GET(request: NextRequest) {
     // Check scope restoration guard cookie (set by login route when scope restoration fails)
     const scopeRestoreFailedState = cookieStore.get(COOKIE_NAMES.SCOPE_RESTORE_FAILED)?.value
     const scopeRestoreFailed = scopeRestoreFailedState === state
+    // 再認証フロー判定Cookie（reauth APIで設定）
+    // Re-auth flow marker cookie (set by reauth API)
+    const reauthState = cookieStore.get(COOKIE_NAMES.REAUTH_STATE)?.value
+    const isReauthFlow = reauthState === state
 
     try {
       // upsertのエラーを明示的にチェック（Supabase JSはエラー時にthrowせずerrorオブジェクトを返す）
@@ -122,11 +126,43 @@ export async function GET(request: NextRequest) {
         throw upsertError
       }
 
-      // トークン交換時に付与されたスコープをDBに保存（全置換）
-      // ただし、login側でスコープ復元に失敗していた場合は全置換をスキップし
-      // 既存DBのスコープを保持する（DB障害時の追加スコープ消失を防止）
-      // Save token scopes to DB (full replace), but skip if scope restoration
-      // failed in the login route to prevent silent additional scope loss
+      // 通常ログイン時のみ既存追加スコープを取得してマージに利用する。
+      // 再認証フローはユーザーの明示同意結果を反映するため、マージせず全置換する。
+      // For regular login only, fetch existing additional scopes for merge.
+      // Re-auth flow must reflect explicit user consent, so keep full replace.
+      let existingAdditionalScopes: string[] = []
+      if (!isReauthFlow) {
+        const { data: existingUser, error: existingScopeError } = await supabaseAdmin
+          .from('users')
+          .select('twitch_scopes')
+          .eq('twitch_user_id', twitchUser.id)
+          .maybeSingle()
+
+        if (existingScopeError && existingScopeError.code !== 'PGRST204') {
+          logger.error('Auth callback: Failed to fetch existing scopes for merge', {
+            twitchUserId: twitchUser.id,
+            error: existingScopeError,
+            code: existingScopeError.code,
+            message: existingScopeError.message,
+          })
+          throw existingScopeError
+        }
+
+        if (existingUser?.twitch_scopes) {
+          const validAdditionalScopes = Object.values(ADDITIONAL_SCOPES) as string[]
+          existingAdditionalScopes = existingUser.twitch_scopes.filter(
+            (s: string) => validAdditionalScopes.includes(s)
+          )
+        }
+      }
+
+      // トークン交換時に付与されたスコープをDBに保存。
+      // 通常ログイン時は既存の追加スコープをマージし、ログアウト後ログインでも追加権限を保持する。
+      // ただしlogin側でスコープ復元に失敗していた場合は更新をスキップして既存DBを保持。
+      // Save token scopes to DB.
+      // On regular login, merge with existing additional scopes so relogin after logout
+      // does not drop previously granted optional permissions.
+      // If login-side scope restoration failed, skip update to preserve DB state.
       if (tokens.scope && tokens.scope.length > 0) {
         if (scopeRestoreFailed) {
           // ガード発動: login側でDB障害等によりスコープ復元に失敗しているため、
@@ -138,15 +174,24 @@ export async function GET(request: NextRequest) {
             tokenScopes: tokens.scope,
           })
         } else {
-          // 通常フロー: トークンの実際のスコープで全置換
-          // login側でpreservedScopesがOAuthリクエストに含まれているため、トークンのスコープは正確
-          // Normal flow: full-replace with token's actual scopes
-          // Login route included preservedScopes in the OAuth request, so token scopes are accurate
-          await saveTwitchScopes(twitchUser.id, tokens.scope)
-          logger.info('Auth callback: Saved Twitch scopes (full replace)', {
+          let scopesToSave = tokens.scope
+
+          if (!isReauthFlow && existingAdditionalScopes.length > 0) {
+            scopesToSave = Array.from(new Set([...tokens.scope, ...existingAdditionalScopes]))
+            logger.info('Auth callback: Merged existing additional scopes on regular login', {
+              twitchUserId: twitchUser.id,
+              tokenScopes: tokens.scope,
+              existingAdditionalScopes,
+              mergedScopes: scopesToSave,
+            })
+          }
+
+          await saveTwitchScopes(twitchUser.id, scopesToSave)
+          logger.info('Auth callback: Saved Twitch scopes', {
             twitchUserId: twitchUser.id,
-            scopeCount: tokens.scope.length,
-            scopes: tokens.scope,
+            scopeCount: scopesToSave.length,
+            scopes: scopesToSave,
+            isReauthFlow,
           })
         }
       }
@@ -286,6 +331,12 @@ export async function GET(request: NextRequest) {
     // Only delete this flow's guard cookie to avoid removing another tab's guard
     if (scopeRestoreFailed) {
       response.cookies.set(COOKIE_NAMES.SCOPE_RESTORE_FAILED, '', getDeleteCookieOptions())
+    }
+
+    // Clear re-auth marker cookie only when state matches this flow
+    // 並行フロー保護のため、state一致時のみ削除する
+    if (isReauthFlow) {
+      response.cookies.set(COOKIE_NAMES.REAUTH_STATE, '', getDeleteCookieOptions())
     }
 
     // Clear returnTo cookie if it was used

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -20,6 +20,9 @@ export const COOKIE_NAMES = {
   // スコープ復元失敗時のガード用Cookie（値はOAuth state）
   // Guard cookie for scope restoration failure (value is the OAuth state)
   SCOPE_RESTORE_FAILED: 'twica_scope_restore_failed',
+  // 再認証フロー判定用Cookie（値はOAuth state）
+  // Re-auth flow marker cookie (value is the OAuth state)
+  REAUTH_STATE: 'twica_reauth_state',
 }
 
 export const API_ROUTES = {

--- a/tests/unit/auth-scope-preservation.test.ts
+++ b/tests/unit/auth-scope-preservation.test.ts
@@ -263,6 +263,18 @@ describe('Auth scope preservation: login route', () => {
 describe('Auth scope preservation: callback route', () => {
   let exchangeCodeForTokens: ReturnType<typeof vi.fn>
   let getTwitchUser: ReturnType<typeof vi.fn>
+  const setCallbackMaybeSingleResults = (existingScopes: string[] | null) => {
+    mockMaybeSingle.mockReset()
+    mockMaybeSingle
+      .mockResolvedValueOnce({
+        data: { twitch_scopes: existingScopes },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { tos_accepted_at: '2024-01-01' },
+        error: null,
+      })
+  }
 
   beforeEach(async () => {
     vi.clearAllMocks()
@@ -304,11 +316,8 @@ describe('Auth scope preservation: callback route', () => {
       upsert: mockUpsert,
       update: mockUpdate,
     })
-    // TOS accepted
-    mockMaybeSingle.mockResolvedValue({
-      data: { tos_accepted_at: '2024-01-01' },
-      error: null,
-    })
+    // 1回目: users.twitch_scopes取得, 2回目: users.tos_accepted_at取得
+    setCallbackMaybeSingleResults(null)
   })
 
   it('スコープ復元失敗ガード発動時、saveTwitchScopesがスキップされる', async () => {
@@ -345,6 +354,47 @@ describe('Auth scope preservation: callback route', () => {
     await GET(request)
 
     // saveTwitchScopesが呼ばれることを確認
+    expect(mockSaveTwitchScopes).toHaveBeenCalledWith('user123', ['user:read:email', 'openid'])
+  })
+
+  it('通常ログインでは既存の追加スコープをマージして保存する', async () => {
+    setCallbackMaybeSingleResults(['user:write:chat'])
+
+    mockCookieStore.get.mockImplementation((name: string) => {
+      if (name === 'twitch_auth_state') return { value: 'test-state-123' }
+      return undefined
+    })
+
+    const { NextRequest } = await import('next/server')
+    const url = 'http://localhost:3000/api/auth/twitch/callback?code=test-code&state=test-state-123'
+    const request = new NextRequest(url)
+
+    const { GET } = await import('@/app/api/auth/twitch/callback/route')
+    await GET(request)
+
+    expect(mockSaveTwitchScopes).toHaveBeenCalledWith('user123', [
+      'user:read:email',
+      'openid',
+      'user:write:chat',
+    ])
+  })
+
+  it('再認証フローでは既存追加スコープをマージせず全置換する', async () => {
+    setCallbackMaybeSingleResults(['user:write:chat'])
+
+    mockCookieStore.get.mockImplementation((name: string) => {
+      if (name === 'twitch_auth_state') return { value: 'test-state-123' }
+      if (name === 'twica_reauth_state') return { value: 'test-state-123' }
+      return undefined
+    })
+
+    const { NextRequest } = await import('next/server')
+    const url = 'http://localhost:3000/api/auth/twitch/callback?code=test-code&state=test-state-123'
+    const request = new NextRequest(url)
+
+    const { GET } = await import('@/app/api/auth/twitch/callback/route')
+    await GET(request)
+
     expect(mockSaveTwitchScopes).toHaveBeenCalledWith('user123', ['user:read:email', 'openid'])
   })
 


### PR DESCRIPTION
## Summary
- prevent loss of previously granted optional Twitch scopes on regular login after logout
- keep re-auth behavior as explicit full-replace of scopes
- add callback flow marker cookie for re-auth and clean it up safely by state match
- add unit tests for regular-login merge vs re-auth full-replace behavior

## Problem
After logout and then login, the OAuth request may not include previously granted optional scopes (e.g. user:write:chat) when no valid session is available to restore scopes. Callback then fully replaces DB scopes with token scopes, causing chat permission loss.

## Fix
- Add twica_reauth_state marker cookie in /api/auth/reauth
- In callback:
  - detect re-auth flow by state marker
  - regular login: merge existing additional scopes from DB with token scopes
  - re-auth flow: preserve full-replace semantics

## Test
- updated tests/unit/auth-scope-preservation.test.ts
  - regular login merges existing additional scopes
  - re-auth flow does not merge and keeps full-replace
