### PR TITLE
fix: ガチャ履歴ユーザービューのカード内訳不正をDB側RPC集約で修正

### DIFF
--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -394,7 +394,8 @@ export interface GachaUserEntry {
 
 /**
  * Get aggregated user list for a streamer's gacha history
- * JS側で集約: ユニークユーザー一覧、各ユーザーのユニークカード数、ガチャ回数、最終日時
+ * RPC get_gacha_users_for_streamer でDB側集計を行い、件数制限なしで正確なカード所有状況を返す
+ * RPC未デプロイ時はクライアント側集約にフォールバック（10,000件制限付き）
  * 配信者向け: ガチャを引いたユーザー一覧を集約して返す
  */
 export async function getGachaUsersForStreamer(
@@ -403,11 +404,45 @@ export async function getGachaUsersForStreamer(
 ): Promise<{ users: GachaUserEntry[]; pagination: { page: number; perPage: number; total: number; totalPages: number } }> {
   const { page = 1, perPage = 20 } = options;
   const supabaseAdmin = getSupabaseAdmin();
+  const offset = (page - 1) * perPage;
 
-  // Fetch gacha history and active card IDs in parallel
-  // ガチャ履歴とアクティブカードIDを並列取得
-  // Note: 10,000件上限は getGachaStats と同じパターン。
-  // 超過する配信者では集計が近似値となる。
+  // RPC: DB側でGROUP BY集約 + ページネーション（件数制限なし）
+  const { data: rpcResult, error: rpcError } = await supabaseAdmin
+    .rpc("get_gacha_users_for_streamer", {
+      p_streamer_id: streamerId,
+      p_limit: perPage,
+      p_offset: offset,
+    });
+
+  if (!rpcError && rpcResult) {
+    // RPC成功: DB側集約結果をGachaUserEntry[]に変換
+    // asキャストだが、SQL側でCOALESCEにより users/unique_card_ids は必ず配列を返す
+    const rpcData = rpcResult as { users: Array<{ user_twitch_id: string; username: string; draw_count: number; last_draw_at: string; unique_card_ids: string[] }>; total: number };
+    const rpcUsers = rpcData.users || [];
+    const users: GachaUserEntry[] = rpcUsers.map((u) => ({
+      userTwitchId: u.user_twitch_id,
+      username: u.username || "",
+      drawCount: u.draw_count,
+      uniqueCards: (u.unique_card_ids || []).length,
+      uniqueCardIds: u.unique_card_ids || [],
+      lastDrawAt: u.last_draw_at,
+    }));
+    const total = rpcData.total || 0;
+    return {
+      users,
+      pagination: { page, perPage, total, totalPages: Math.ceil(total / perPage) },
+    };
+  }
+
+  // RPCエラー時はクライアント側集約にフォールバック（マイグレーション未適用時の互換性維持）
+  // TODO: マイグレーション適用確認後にフォールバックを削除
+  if (rpcError?.code === "42883") {
+    logger.warn("get_gacha_users_for_streamer not deployed, falling back to client-side aggregation");
+  } else if (rpcError) {
+    reportError(new Error(`get_gacha_users_for_streamer RPC failed: ${rpcError.message}`));
+  }
+
+  // フォールバック: 既存のクライアント側集約ロジック（10,000件制限あり）
   const [historyResult, activeCardsResult] = await Promise.all([
     supabaseAdmin
       .from("gacha_history")
@@ -422,6 +457,11 @@ export async function getGachaUsersForStreamer(
       .eq("is_active", true),
   ]);
 
+  // フォールバックDBエラー時はreportErrorで検知可能にする
+  if (historyResult.error) {
+    reportError(new Error(`gacha_history fallback query failed: ${historyResult.error.message}`));
+  }
+
   const data = historyResult.data;
   if (!data || data.length === 0) {
     return {
@@ -430,11 +470,9 @@ export async function getGachaUsersForStreamer(
     };
   }
 
-  // Build active card ID set for filtering uniqueCards
-  // uniqueCards のフィルタリング用にアクティブカードIDセットを構築
   const activeCardIds = new Set((activeCardsResult.data || []).map((c) => c.id));
 
-  // Aggregate by user / ユーザーごとに集約
+  // ユーザーごとに集約
   const userMap = new Map<string, {
     username: string;
     drawCount: number;
@@ -446,8 +484,6 @@ export async function getGachaUsersForStreamer(
     const existing = userMap.get(row.user_twitch_id);
     if (existing) {
       existing.drawCount++;
-      // Only count active cards for collection progress
-      // コレクション進捗にはアクティブカードのみカウント
       if (activeCardIds.has(row.card_id)) {
         existing.cardIds.add(row.card_id);
       }
@@ -465,8 +501,6 @@ export async function getGachaUsersForStreamer(
     }
   }
 
-  // Convert to sorted array (by draw count descending)
-  // ガチャ回数の降順でソート
   const allUsers: GachaUserEntry[] = Array.from(userMap.entries())
     .map(([userTwitchId, info]) => ({
       userTwitchId,
@@ -478,10 +512,9 @@ export async function getGachaUsersForStreamer(
     }))
     .sort((a, b) => b.drawCount - a.drawCount);
 
-  // Client-side pagination / クライアント側ページネーション
   const total = allUsers.length;
-  const offset = (page - 1) * perPage;
-  const paginatedUsers = allUsers.slice(offset, offset + perPage);
+  const fallbackOffset = (page - 1) * perPage;
+  const paginatedUsers = allUsers.slice(fallbackOffset, fallbackOffset + perPage);
 
   return {
     users: paginatedUsers,

--- a/supabase/migrations/00032_add_get_gacha_users_for_streamer.sql
+++ b/supabase/migrations/00032_add_get_gacha_users_for_streamer.sql
@@ -1,0 +1,81 @@
+-- RPC: 配信者のガチャユーザー一覧をDB側で集約して返す
+-- gacha_historyの件数制限（10,000件）を回避し、全ユーザーの正確なカード所有状況を返却する
+-- user_cardsテーブルからアクティブカードのみを集約するため、
+-- execute_gacha_transaction (00015) 導入前のデータでも正しく動作する
+CREATE OR REPLACE FUNCTION get_gacha_users_for_streamer(
+  p_streamer_id UUID,
+  p_limit INTEGER DEFAULT 20,
+  p_offset INTEGER DEFAULT 0
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_result JSONB;
+  v_total INTEGER;
+BEGIN
+  -- 総ユニークユーザー数を取得（ページネーション用）
+  SELECT COUNT(DISTINCT user_twitch_id) INTO v_total
+  FROM gacha_history
+  WHERE streamer_id = p_streamer_id;
+
+  IF v_total = 0 THEN
+    RETURN jsonb_build_object('users', '[]'::JSONB, 'total', 0);
+  END IF;
+
+  -- ユーザーごとの抽選回数・最終抽選日時を集約し、
+  -- user_cardsからアクティブカードIDを取得して結合
+  SELECT jsonb_build_object(
+    'users', COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'user_twitch_id', ud.user_twitch_id,
+        'username', ud.username,
+        'draw_count', ud.draw_count,
+        'last_draw_at', ud.last_draw_at,
+        'unique_card_ids', COALESCE(uc_agg.card_ids, '[]'::JSONB)
+      )
+      ORDER BY ud.draw_count DESC
+    ), '[]'::JSONB),
+    'total', v_total
+  )
+  INTO v_result
+  FROM (
+    -- gacha_historyからユーザーごとの抽選統計を集約
+    SELECT
+      gh.user_twitch_id,
+      MAX(gh.user_twitch_username) AS username,
+      COUNT(*)::INTEGER AS draw_count,
+      MAX(gh.redeemed_at)::TEXT AS last_draw_at
+    FROM gacha_history gh
+    WHERE gh.streamer_id = p_streamer_id
+    GROUP BY gh.user_twitch_id
+    ORDER BY draw_count DESC
+    LIMIT p_limit OFFSET p_offset
+  ) ud
+  -- LEFT JOIN: user_cardsにレコードがないユーザー（旧データ）も含める
+  LEFT JOIN LATERAL (
+    SELECT COALESCE(jsonb_agg(uc.card_id), '[]'::JSONB) AS card_ids
+    FROM user_cards uc
+    JOIN users u ON u.id = uc.user_id
+    JOIN cards c ON c.id = uc.card_id
+    WHERE u.twitch_user_id = ud.user_twitch_id
+      AND c.streamer_id = p_streamer_id
+      AND c.is_active = true
+  ) uc_agg ON true;
+
+  RETURN v_result;
+END;
+$$;
+
+-- service_role のみ実行可能（00031と同じ権限モデル）
+REVOKE ALL ON FUNCTION get_gacha_users_for_streamer(UUID, INTEGER, INTEGER) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_gacha_users_for_streamer(UUID, INTEGER, INTEGER) TO service_role;
+
+-- GROUP BY + COUNT(DISTINCT) のパフォーマンス確保用複合インデックス
+-- 大量ガチャ履歴（10,000件超）環境でRPCがフルスキャンを回避するために必須
+-- Note: CONCURRENTLY はトランザクション内で使用不可のため通常の CREATE INDEX を使用
+-- 大規模テーブルでの本番適用時は手動で CREATE INDEX CONCURRENTLY を検討すること
+CREATE INDEX IF NOT EXISTS idx_gacha_history_streamer_user
+  ON gacha_history(streamer_id, user_twitch_id);

--- a/tests/unit/gacha-users-rpc.test.ts
+++ b/tests/unit/gacha-users-rpc.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { getGachaUsersForStreamer } from "@/lib/dashboard-data";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { reportError } from "@/lib/sentry/error-handler";
+
+vi.mock("@/lib/supabase/admin", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/supabase/admin")>();
+  return { ...actual, getSupabaseAdmin: vi.fn() };
+});
+vi.mock("@/lib/sentry/error-handler", () => ({
+  reportError: vi.fn(),
+  reportApiError: vi.fn(),
+  logErrorFromLogger: vi.fn(),
+}));
+vi.mock("next/cache", () => ({
+  unstable_cache: (fn: () => Promise<unknown>) => fn,
+}));
+
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin);
+const mockReportError = vi.mocked(reportError);
+
+const STREAMER_ID = "streamer-uuid-123";
+
+/** RPC成功時のモッククライアントを作成 */
+function createRpcSuccessClient(rpcData: unknown) {
+  return {
+    rpc: vi.fn().mockResolvedValue({ data: rpcData, error: null }),
+    from: vi.fn(),
+  };
+}
+
+/** RPCエラー時のモッククライアントを作成（フォールバック用のfromも設定） */
+function createRpcErrorClient(
+  errorCode: string,
+  errorMessage: string,
+  historyData: unknown[] | null = [],
+  cardsData: unknown[] | null = []
+) {
+  // fromのチェーンメソッドをモック
+  const historyQuery = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue({ data: historyData, error: null }),
+  };
+  const cardsQuery = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ data: cardsData, error: null }),
+    }),
+  };
+
+  return {
+    rpc: vi.fn().mockResolvedValue({
+      data: null,
+      error: { code: errorCode, message: errorMessage },
+    }),
+    from: vi.fn((table: string) => {
+      if (table === "gacha_history") return historyQuery;
+      if (table === "cards") return cardsQuery;
+      return historyQuery;
+    }),
+  };
+}
+
+describe("getGachaUsersForStreamer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("RPC成功時", () => {
+    it("RPC結果をGachaUserEntry[]に正しく変換する", async () => {
+      const rpcData = {
+        users: [
+          {
+            user_twitch_id: "user1",
+            username: "Alice",
+            draw_count: 50,
+            last_draw_at: "2025-01-01T00:00:00Z",
+            unique_card_ids: ["card-a", "card-b"],
+          },
+          {
+            user_twitch_id: "user2",
+            username: "Bob",
+            draw_count: 30,
+            last_draw_at: "2025-01-02T00:00:00Z",
+            unique_card_ids: ["card-a"],
+          },
+        ],
+        total: 2,
+      };
+      mockGetSupabaseAdmin.mockReturnValue(
+        createRpcSuccessClient(rpcData) as any
+      );
+
+      const result = await getGachaUsersForStreamer(STREAMER_ID, {
+        page: 1,
+        perPage: 20,
+      });
+
+      expect(result.users).toHaveLength(2);
+      expect(result.users[0]).toEqual({
+        userTwitchId: "user1",
+        username: "Alice",
+        drawCount: 50,
+        uniqueCards: 2,
+        uniqueCardIds: ["card-a", "card-b"],
+        lastDrawAt: "2025-01-01T00:00:00Z",
+      });
+      expect(result.users[1]).toEqual({
+        userTwitchId: "user2",
+        username: "Bob",
+        drawCount: 30,
+        uniqueCards: 1,
+        uniqueCardIds: ["card-a"],
+        lastDrawAt: "2025-01-02T00:00:00Z",
+      });
+      expect(result.pagination).toEqual({
+        page: 1,
+        perPage: 20,
+        total: 2,
+        totalPages: 1,
+      });
+    });
+
+    it("RPCにp_limit/p_offsetを正しく渡す", async () => {
+      const rpcData = { users: [], total: 0 };
+      const client = createRpcSuccessClient(rpcData);
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+
+      await getGachaUsersForStreamer(STREAMER_ID, { page: 3, perPage: 10 });
+
+      expect(client.rpc).toHaveBeenCalledWith(
+        "get_gacha_users_for_streamer",
+        { p_streamer_id: STREAMER_ID, p_limit: 10, p_offset: 20 }
+      );
+    });
+
+    it("ユーザーが0件の場合、空配列を返す", async () => {
+      const rpcData = { users: [], total: 0 };
+      mockGetSupabaseAdmin.mockReturnValue(
+        createRpcSuccessClient(rpcData) as any
+      );
+
+      const result = await getGachaUsersForStreamer(STREAMER_ID);
+
+      expect(result.users).toEqual([]);
+      expect(result.pagination.total).toBe(0);
+      expect(result.pagination.totalPages).toBe(0);
+    });
+
+    it("usernameがnullの場合、空文字に変換する", async () => {
+      const rpcData = {
+        users: [
+          {
+            user_twitch_id: "user1",
+            username: null,
+            draw_count: 5,
+            last_draw_at: "2025-01-01T00:00:00Z",
+            unique_card_ids: [],
+          },
+        ],
+        total: 1,
+      };
+      mockGetSupabaseAdmin.mockReturnValue(
+        createRpcSuccessClient(rpcData) as any
+      );
+
+      const result = await getGachaUsersForStreamer(STREAMER_ID);
+
+      expect(result.users[0].username).toBe("");
+    });
+
+    it("totalPagesが正しく切り上げ計算される", async () => {
+      const rpcData = { users: [{ user_twitch_id: "u1", username: "A", draw_count: 1, last_draw_at: "2025-01-01T00:00:00Z", unique_card_ids: [] }], total: 21 };
+      mockGetSupabaseAdmin.mockReturnValue(
+        createRpcSuccessClient(rpcData) as any
+      );
+
+      const result = await getGachaUsersForStreamer(STREAMER_ID, { perPage: 10 });
+
+      expect(result.pagination.totalPages).toBe(3);
+    });
+
+    it("RPC結果がnull（エラーなし）の場合、フォールバックする", async () => {
+      // rpcResultがnullの場合はフォールバック（from経由のクエリが走る）
+      const client = createRpcErrorClient("42883", "n/a", [], []);
+      // rpcをnull返却に上書き
+      client.rpc = vi.fn().mockResolvedValue({ data: null, error: null });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+
+      const result = await getGachaUsersForStreamer(STREAMER_ID);
+
+      // フォールバックで空結果
+      expect(result.users).toEqual([]);
+    });
+  });
+
+  describe("RPC未デプロイ時（42883エラー）のフォールバック", () => {
+    it("クライアント側集約にフォールバックする", async () => {
+      const historyData = [
+        {
+          user_twitch_id: "user1",
+          user_twitch_username: "Alice",
+          card_id: "card-a",
+          redeemed_at: "2025-01-01T00:00:00Z",
+        },
+        {
+          user_twitch_id: "user1",
+          user_twitch_username: "Alice",
+          card_id: "card-b",
+          redeemed_at: "2025-01-02T00:00:00Z",
+        },
+      ];
+      const cardsData = [{ id: "card-a" }, { id: "card-b" }];
+
+      mockGetSupabaseAdmin.mockReturnValue(
+        createRpcErrorClient(
+          "42883",
+          "function not found",
+          historyData,
+          cardsData
+        ) as any
+      );
+
+      const result = await getGachaUsersForStreamer(STREAMER_ID);
+
+      expect(result.users).toHaveLength(1);
+      expect(result.users[0].userTwitchId).toBe("user1");
+      expect(result.users[0].drawCount).toBe(2);
+      expect(result.users[0].uniqueCardIds).toEqual(
+        expect.arrayContaining(["card-a", "card-b"])
+      );
+      // reportErrorは42883では呼ばれない
+      expect(mockReportError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("RPCその他エラー時のフォールバック", () => {
+    it("reportErrorを呼びつつフォールバックする", async () => {
+      mockGetSupabaseAdmin.mockReturnValue(
+        createRpcErrorClient("PGRST202", "some db error", [], []) as any
+      );
+
+      const result = await getGachaUsersForStreamer(STREAMER_ID);
+
+      // フォールバックで空結果（履歴データなし）
+      expect(result.users).toEqual([]);
+      // reportErrorが呼ばれている
+      expect(mockReportError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            "get_gacha_users_for_streamer RPC failed"
+          ),
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
gacha_historyの10,000件制限により一部ユーザーの所有カードが不完全になるバグを、
DB側RPC (get_gacha_users_for_streamer) で件数制限なしの集約を行うことで解決。 RPC未デプロイ時は既存のクライアント側集約にフォールバックし段階的移行を可能にする。