### PR TITLE
fix: RPC unique_card_idsにDISTINCTを追加し重複カードIDを排除

### DIFF
--- a/supabase/migrations/00032_add_get_gacha_users_for_streamer.sql
+++ b/supabase/migrations/00032_add_get_gacha_users_for_streamer.sql
@@ -56,7 +56,7 @@ BEGIN
   ) ud
   -- LEFT JOIN: user_cardsにレコードがないユーザー（旧データ）も含める
   LEFT JOIN LATERAL (
-    SELECT COALESCE(jsonb_agg(uc.card_id), '[]'::JSONB) AS card_ids
+    SELECT COALESCE(jsonb_agg(DISTINCT uc.card_id), '[]'::JSONB) AS card_ids
     FROM user_cards uc
     JOIN users u ON u.id = uc.user_id
     JOIN cards c ON c.id = uc.card_id


### PR DESCRIPTION
user_cardsテーブルに同一カードが複数枚存在するため、
jsonb_aggにDISTINCTがないとカード枚数がユニーク種類数として返されていた。