### PR TITLE
fix: R2リトライ対象にUnspecified errorを追加 (#349, #348)

### DIFF
--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -272,7 +272,8 @@ export async function uploadToR2WithRetry(
       const errorMessage = error instanceof Error ? error.message : String(error);
 
       // 一時的なエラーかどうかを判定
-      const transientErrors = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'service unavailable', '503', 'NetworkingError'];
+      // "Unspecified error" はR2ネイティブバインディングの一時障害 (Issue #349/#348)
+      const transientErrors = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'service unavailable', '503', 'NetworkingError', 'Unspecified error'];
       const isTransient = transientErrors.some(err =>
         errorMessage.toLowerCase().includes(err.toLowerCase())
       );
@@ -315,7 +316,8 @@ export async function uploadSoundToR2WithRetry(
       const errorMessage = error instanceof Error ? error.message : String(error);
 
       // 一時的なエラーかどうかを判定
-      const transientErrors = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'service unavailable', '503', 'NetworkingError'];
+      // "Unspecified error" はR2ネイティブバインディングの一時障害 (Issue #349/#348)
+      const transientErrors = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'service unavailable', '503', 'NetworkingError', 'Unspecified error'];
       const isTransient = transientErrors.some(err =>
         errorMessage.toLowerCase().includes(err.toLowerCase())
       );


### PR DESCRIPTION
## Summary
- R2ネイティブバインディングの一時障害 "Unspecified error (0)" をリトライ対象エラーに追加
- 画像・効果音両方のアップロードリトライロジックに適用

Fixes #349
Fixes #348

## Test plan
- [ ] "Unspecified error" を含むエラーがリトライされることを確認
- [ ] 既存のリトライ対象エラー（ECONNRESET等）が引き続き正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)