### PR TITLE
fix: カード未設定ガチャエラーのreportError除外 (#277)

### DIFF
--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -301,6 +301,15 @@ async function handleRedemption(messageId: string, event: {
         logger.info('[handleRedemption] Skipped - duplicate event (RPC)', { messageId });
         return null;
       }
+      // カード未設定はユーザー設定の問題でありバグではない (Issue #277)
+      // "No cards available" is a streamer setup issue, not a system bug
+      if (result.error === 'No cards available for this streamer') {
+        logger.warn('[handleRedemption] No cards available - streamer setup issue', {
+          messageId,
+          broadcasterUserId: event.broadcaster_user_id,
+        });
+        return null;
+      }
       logger.warn('[handleRedemption] Gacha execution failed', { messageId });
       await reportError(new Error(`Gacha execution failed: ${result.error}`), {
         context: 'eventsub:handleRedemption',


### PR DESCRIPTION
## Summary
- "No cards available for this streamer" エラーを `reportError()` から `logger.warn()` に格下げ
- 配信者の設定ミス（カード未登録でチャンネルポイント報酬を有効化）であり、システムバグではない
- GitHub Issue の自動作成ノイズを削減

Fixes #277

## Test plan
- [ ] カード未設定の配信者でガチャ実行時、GitHub Issueが作成されないことを確認
- [ ] カード未設定以外のガチャエラーは引き続きreportErrorされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)