### PR TITLE
fix: EventSubユーザー起因revocationのエラーレベル分離 (#285)

### DIFF
--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -174,21 +174,30 @@ export async function POST(request: NextRequest) {
     const subscriptionType = subscription?.type || "unknown";
     const broadcasterId = subscription?.condition?.broadcaster_user_id || "unknown";
 
-    logger.warn(
-      `EventSub revocation received: reason=${revocationReason}, type=${subscriptionType}, broadcaster=${broadcasterId}`,
-      { subscription }
-    );
-
-    // Supabaseに記録してGitHub Issue化する（awaitしないとWorkers打ち切りで記録されない）
-    // Must await — Cloudflare Workers terminates background promises after response
-    await reportError(new Error(`EventSub revocation: ${revocationReason}`), {
-      context: "eventsub:revocation",
-      type: "eventsub",
-      revocationReason,
-      subscriptionType,
-      broadcasterId,
-      subscriptionId: subscription?.id,
-    });
+    // ユーザー起因のrevocationはGitHub Issue化せずログのみ (Issue #285)
+    // User-initiated revocations are expected behavior, not bugs
+    const EXPECTED_REVOCATIONS = ['authorization_revoked', 'user_removed'];
+    if (EXPECTED_REVOCATIONS.includes(revocationReason)) {
+      logger.info(
+        `EventSub revocation (user-initiated): reason=${revocationReason}, type=${subscriptionType}, broadcaster=${broadcasterId}`,
+        { subscription }
+      );
+    } else {
+      // インフラ問題等の予期しないrevocationはreportErrorでGitHub Issue化
+      // Unexpected revocations (e.g. notification_failures_exceeded) indicate infrastructure issues
+      logger.warn(
+        `EventSub revocation (unexpected): reason=${revocationReason}, type=${subscriptionType}, broadcaster=${broadcasterId}`,
+        { subscription }
+      );
+      await reportError(new Error(`EventSub revocation: ${revocationReason}`), {
+        context: "eventsub:revocation",
+        type: "eventsub",
+        revocationReason,
+        subscriptionType,
+        broadcasterId,
+        subscriptionId: subscription?.id,
+      });
+    }
 
     return NextResponse.json({ received: true });
   }


### PR DESCRIPTION
## Summary
- `authorization_revoked` / `user_removed` を `reportError()` から `logger.info()` に格下げ
- ユーザーがTwitch連携を解除した際の正常動作であり、GitHub Issue自動作成のノイズを削減
- `notification_failures_exceeded` 等のインフラ問題は引き続き `reportError()` でGitHub Issue化

Fixes #285

## Test plan
- [ ] authorization_revokedイベント受信時にGitHub Issueが作成されないことを確認
- [ ] notification_failures_exceededイベント受信時にGitHub Issueが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)