### PR TITLE
fix: Supabase SSR cookie書き込み失敗のログ可視化 (#271)

### DIFF
--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 import type { Database } from '@/types/database'
+import { logger } from '@/lib/logger'
 
 export async function createClient() {
   const cookieStore = await cookies()
@@ -20,8 +21,14 @@ export async function createClient() {
             cookiesToSet.forEach(({ name, value, options }) =>
               cookieStore.set(name, value, options)
             )
-          } catch {
-            // Server Component から呼ばれた場合は無視
+          } catch (error) {
+            // Server Component からの cookie 書き込みは Next.js で禁止されている (Issue #271)
+            // Supabase SSR がトークンリフレッシュ時に setAll() を呼ぶが、
+            // Server Component コンテキストでは失敗する。ログで可視化する。
+            logger.warn('[Supabase] Cookie set failed (likely Server Component context)', {
+              cookieNames: cookiesToSet.map(c => c.name),
+              error: error instanceof Error ? error.message : String(error),
+            });
           }
         },
       },


### PR DESCRIPTION
## Summary
- `src/lib/supabase/server.ts` の `setAll()` catch ブロックで完全にサイレント化されていたエラーを `logger.warn()` で可視化
- Server Component コンテキストでの Supabase トークンリフレッシュ失敗の原因特定を容易にする

Fixes #271

## Test plan
- [ ] Server Component から createClient() を呼び出した際にログが出力されることを確認
- [ ] Route Handler からの正常な cookie 書き込みに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)