### PR TITLE
fix: Supabase 502一時障害に対するリトライラッパー導入 (#339, #326, #325)

### DIFF
--- a/src/app/api/streamer/[streamerId]/sound-settings/route.ts
+++ b/src/app/api/streamer/[streamerId]/sound-settings/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { withRetry } from "@/lib/supabase/retry";
 import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
 import { ERROR_MESSAGES } from "@/lib/constants";
 
@@ -30,11 +31,15 @@ export async function GET(
 
     // 配信者の効果音設定のみを取得
     // パブリックエンドポイントなので必要最小限の情報のみ返す
-    const { data: streamer, error } = await supabaseAdmin
-      .from("streamers")
-      .select("gacha_sound_url, gacha_sound_enabled")
-      .eq("id", streamerId)
-      .maybeSingle();
+    // 502 一時障害に対するリトライ (Issue #325)
+    const { data: streamer, error } = await withRetry(
+      () => supabaseAdmin
+        .from("streamers")
+        .select("gacha_sound_url, gacha_sound_enabled")
+        .eq("id", streamerId)
+        .maybeSingle(),
+      'getSoundSettings',
+    );
 
     if (error) {
       return handleDatabaseError(error, "Streamer Sound Settings API");

--- a/src/lib/announcements.ts
+++ b/src/lib/announcements.ts
@@ -8,6 +8,7 @@
 
 import { cache } from 'react'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { withRetry } from '@/lib/supabase/retry'
 import { logger } from './logger'
 
 export interface UnreadAnnouncement {
@@ -103,11 +104,15 @@ export const getUnreadAnnouncements = cache(async (twitchUserId: string): Promis
     const now = new Date()
 
     // 公開済みのお知らせを取得し、トップ表示向けの期限判定はサーバー側で厳密に行う
-    const { data: announcements, error: annError } = await supabase
-      .from('announcements')
-      .select('id, title, body, severity, published_at, expires_at, created_at')
-      .eq('is_published', true)
-      .order('created_at', { ascending: false })
+    // 502 一時障害に対するリトライ (Issue #326)
+    const { data: announcements, error: annError } = await withRetry(
+      () => supabase
+        .from('announcements')
+        .select('id, title, body, severity, published_at, expires_at, created_at')
+        .eq('is_published', true)
+        .order('created_at', { ascending: false }),
+      'getUnreadAnnouncements',
+    )
 
     if (annError) {
       logger.error('Failed to fetch announcements', { error: annError.message })
@@ -170,11 +175,15 @@ export async function getAllAnnouncements(twitchUserId: string): Promise<Announc
     const now = new Date()
 
     // 履歴ページ向けに公開済みのお知らせを取得
-    const { data: announcements, error: annError } = await supabase
-      .from('announcements')
-      .select('id, title, body, severity, is_published, published_at, expires_at, created_at')
-      .eq('is_published', true)
-      .order('created_at', { ascending: false })
+    // 502 一時障害に対するリトライ (Issue #326)
+    const { data: announcements, error: annError } = await withRetry(
+      () => supabase
+        .from('announcements')
+        .select('id, title, body, severity, is_published, published_at, expires_at, created_at')
+        .eq('is_published', true)
+        .order('created_at', { ascending: false }),
+      'getAllAnnouncements',
+    )
 
     if (annError) {
       logger.error('Failed to fetch all announcements', { error: annError.message })

--- a/src/lib/plan.ts
+++ b/src/lib/plan.ts
@@ -14,6 +14,7 @@
 
 import { cache } from 'react'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { withRetry } from '@/lib/supabase/retry'
 import { logger } from '@/lib/logger'
 import { hasTwitchSub } from '@/lib/twitch/sub-check'
 import { PLAN_PRIORITY, PLAN_STORAGE_BONUS } from '@/lib/plan-constants'
@@ -64,11 +65,15 @@ async function getLicensePlan(twitchUserId: string): Promise<PlanType> {
   try {
     const supabaseAdmin = getSupabaseAdmin()
 
-    const { data, error } = await supabaseAdmin
-      .from('user_licenses')
-      .select('plan_type, support_codes!inner(status)')
-      .eq('twitch_user_id', twitchUserId)
-      .in('support_codes.status', ['active', 'rotating'])
+    // 502 一時障害に対するリトライ (Issue #339)
+    const { data, error } = await withRetry(
+      () => supabaseAdmin
+        .from('user_licenses')
+        .select('plan_type, support_codes!inner(status)')
+        .eq('twitch_user_id', twitchUserId)
+        .in('support_codes.status', ['active', 'rotating']),
+      'getLicensePlan',
+    )
 
     if (error) {
       logger.error('[Plan] Failed to get license plan:', error)

--- a/src/lib/supabase/retry.ts
+++ b/src/lib/supabase/retry.ts
@@ -19,9 +19,6 @@ const DEFAULT_DELAYS = [100, 300, 1000]
 // 502/503 はインフラ一時障害のためリトライ対象
 const RETRYABLE_STATUS_CODES = [502, 503]
 
-/** Supabase クエリ結果の最小型（data + error を含む任意の結果に対応） */
-type SupabaseResult<T> = T & { error: { message: string; code?: string } | null }
-
 /**
  * Supabase クエリ結果に対するリトライラッパー
  * { data, error } 形式のレスポンスで error.message に 502/503 が含まれる場合にリトライする。

--- a/src/lib/supabase/retry.ts
+++ b/src/lib/supabase/retry.ts
@@ -32,7 +32,7 @@ const RETRYABLE_MESSAGE_PATTERNS = ['bad gateway', 'service unavailable']
  * @param context - ログ用コンテキスト文字列
  * @param options - リトライオプション
  */
-export async function withRetry<T extends { error: { message: string; code?: string } | null }>(
+export async function withRetry<T extends { status?: number; statusText?: string; error: { message: string; code?: string } | null }>(
   queryFn: () => PromiseLike<T>,
   context: string,
   options?: RetryOptions,
@@ -47,13 +47,16 @@ export async function withRetry<T extends { error: { message: string; code?: str
       return result
     }
 
-    // ステータスコード数字またはテキストパターンでリトライ判定
-    const msg = result.error!.message.toLowerCase()
-    const isRetryable =
+    // HTTPステータスコード（PostgrestResponseBase.status）を最優先でチェック
+    // error.message/code のテキストパターンはフォールバックとして残す
+    const hasRetryableStatus = typeof result.status === 'number' && RETRYABLE_STATUS_CODES.includes(result.status)
+    const msg = result.error.message.toLowerCase()
+    const hasRetryableMessage =
       RETRYABLE_STATUS_CODES.some(code =>
         msg.includes(`${code}`) || result.error!.code === `${code}`
       ) ||
       RETRYABLE_MESSAGE_PATTERNS.some(pattern => msg.includes(pattern))
+    const isRetryable = hasRetryableStatus || hasRetryableMessage
 
     if (!isRetryable || attempt === maxRetries) {
       return result
@@ -61,6 +64,7 @@ export async function withRetry<T extends { error: { message: string; code?: str
 
     const delay = delays[Math.min(attempt, delays.length - 1)]
     logger.warn(`[Supabase Retry] ${context} failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms`, {
+      status: result.status,
       error: result.error.message,
     })
     await new Promise(resolve => setTimeout(resolve, delay))

--- a/src/lib/supabase/retry.ts
+++ b/src/lib/supabase/retry.ts
@@ -19,9 +19,14 @@ const DEFAULT_DELAYS = [100, 300, 1000]
 // 502/503 はインフラ一時障害のためリトライ対象
 const RETRYABLE_STATUS_CODES = [502, 503]
 
+// Supabase/PostgREST が返すエラーメッセージのテキストパターン
+// ステータスコード数字が含まれない場合（"Bad Gateway" 等）にも対応
+const RETRYABLE_MESSAGE_PATTERNS = ['bad gateway', 'service unavailable']
+
 /**
  * Supabase クエリ結果に対するリトライラッパー
- * { data, error } 形式のレスポンスで error.message に 502/503 が含まれる場合にリトライする。
+ * { data, error } 形式のレスポンスで 502/503 相当のエラーの場合にリトライする。
+ * ステータスコード数字・テキストメッセージの両方でマッチする。
  *
  * @param queryFn - Supabase クエリを返す関数（await前のPromiseを返す）
  * @param context - ログ用コンテキスト文字列
@@ -42,11 +47,13 @@ export async function withRetry<T extends { error: { message: string; code?: str
       return result
     }
 
-    // エラーメッセージから HTTP ステータスコードを抽出してリトライ判定
-    const isRetryable = RETRYABLE_STATUS_CODES.some(code =>
-      result.error!.message.includes(`${code}`) ||
-      result.error!.code === `${code}`
-    )
+    // ステータスコード数字またはテキストパターンでリトライ判定
+    const msg = result.error!.message.toLowerCase()
+    const isRetryable =
+      RETRYABLE_STATUS_CODES.some(code =>
+        msg.includes(`${code}`) || result.error!.code === `${code}`
+      ) ||
+      RETRYABLE_MESSAGE_PATTERNS.some(pattern => msg.includes(pattern))
 
     if (!isRetryable || attempt === maxRetries) {
       return result

--- a/src/lib/supabase/retry.ts
+++ b/src/lib/supabase/retry.ts
@@ -1,0 +1,67 @@
+/**
+ * Supabase Query Retry Utility
+ * Supabaseクエリのリトライユーティリティ (Issue #339, #326, #325)
+ *
+ * Supabase PostgREST が一時的に 502/503 を返す場合に指数バックオフでリトライする。
+ * Cloudflare Workers 環境でのネットワーク一時障害に対応。
+ */
+
+import { logger } from '@/lib/logger'
+
+interface RetryOptions {
+  maxRetries?: number
+  /** バックオフ遅延（ミリ秒）: [100, 300, 1000] */
+  delays?: number[]
+}
+
+const DEFAULT_DELAYS = [100, 300, 1000]
+
+// 502/503 はインフラ一時障害のためリトライ対象
+const RETRYABLE_STATUS_CODES = [502, 503]
+
+/** Supabase クエリ結果の最小型（data + error を含む任意の結果に対応） */
+type SupabaseResult<T> = T & { error: { message: string; code?: string } | null }
+
+/**
+ * Supabase クエリ結果に対するリトライラッパー
+ * { data, error } 形式のレスポンスで error.message に 502/503 が含まれる場合にリトライする。
+ *
+ * @param queryFn - Supabase クエリを返す関数（await前のPromiseを返す）
+ * @param context - ログ用コンテキスト文字列
+ * @param options - リトライオプション
+ */
+export async function withRetry<T extends { error: { message: string; code?: string } | null }>(
+  queryFn: () => PromiseLike<T>,
+  context: string,
+  options?: RetryOptions,
+): Promise<T> {
+  const delays = options?.delays ?? DEFAULT_DELAYS
+  const maxRetries = options?.maxRetries ?? delays.length
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const result = await queryFn()
+
+    if (!result.error) {
+      return result
+    }
+
+    // エラーメッセージから HTTP ステータスコードを抽出してリトライ判定
+    const isRetryable = RETRYABLE_STATUS_CODES.some(code =>
+      result.error!.message.includes(`${code}`) ||
+      result.error!.code === `${code}`
+    )
+
+    if (!isRetryable || attempt === maxRetries) {
+      return result
+    }
+
+    const delay = delays[Math.min(attempt, delays.length - 1)]
+    logger.warn(`[Supabase Retry] ${context} failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms`, {
+      error: result.error.message,
+    })
+    await new Promise(resolve => setTimeout(resolve, delay))
+  }
+
+  // 到達しないが型安全のため
+  return queryFn() as Promise<T>
+}

--- a/tests/unit/supabase-retry.test.ts
+++ b/tests/unit/supabase-retry.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { withRetry } from '@/lib/supabase/retry'
+
+// loggerモック
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+
+describe('withRetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('成功時はリトライせずそのまま返す', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ data: 'ok', error: null })
+    const result = await withRetry(queryFn, 'test')
+    expect(result).toEqual({ data: 'ok', error: null })
+    expect(queryFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('リトライ不要なエラーは即座に返す', async () => {
+    const queryFn = vi.fn().mockResolvedValue({
+      status: 400,
+      error: { message: 'Bad request', code: '400' },
+    })
+    const result = await withRetry(queryFn, 'test')
+    expect(result.error!.message).toBe('Bad request')
+    expect(queryFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('result.status が 502 の場合リトライする', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        status: 502,
+        statusText: 'Bad Gateway',
+        error: { message: 'Bad Gateway' },
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: 'ok',
+        error: null,
+      })
+    const result = await withRetry(queryFn, 'test', { delays: [0, 0, 0] })
+    expect(result.error).toBeNull()
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('result.status が 503 の場合リトライする', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        status: 503,
+        error: { message: 'Service Unavailable' },
+      })
+      .mockResolvedValueOnce({ data: 'ok', error: null })
+    const result = await withRetry(queryFn, 'test', { delays: [0, 0, 0] })
+    expect(result.error).toBeNull()
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('error.message にステータスコードが含まれる場合もリトライする（後方互換）', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        error: { message: 'error code: 502' },
+      })
+      .mockResolvedValueOnce({ data: 'ok', error: null })
+    const result = await withRetry(queryFn, 'test', { delays: [0, 0, 0] })
+    expect(result.error).toBeNull()
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('テキストパターン "bad gateway" でもリトライする', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        error: { message: 'Bad Gateway response from upstream' },
+      })
+      .mockResolvedValueOnce({ data: 'ok', error: null })
+    const result = await withRetry(queryFn, 'test', { delays: [0, 0, 0] })
+    expect(result.error).toBeNull()
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('最大リトライ回数を超えたらエラーを返す', async () => {
+    const queryFn = vi.fn().mockResolvedValue({
+      status: 502,
+      error: { message: 'Bad Gateway' },
+    })
+    const result = await withRetry(queryFn, 'test', { maxRetries: 2, delays: [0, 0] })
+    expect(result.error).not.toBeNull()
+    // 初回 + 2回リトライ = 3回呼ばれる
+    expect(queryFn).toHaveBeenCalledTimes(3)
+  })
+
+  it('result.status が 502 でも error.message にコードが無い場合にリトライする（Codex指摘対応）', async () => {
+    // Codexが指摘した: HTTPステータスは502だがメッセージにコード番号なし
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        status: 502,
+        statusText: 'Bad Gateway',
+        error: { message: 'upstream connect error or disconnect/reset before headers' },
+      })
+      .mockResolvedValueOnce({ status: 200, data: 'ok', error: null })
+    const result = await withRetry(queryFn, 'test', { delays: [0, 0, 0] })
+    expect(result.error).toBeNull()
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary
- `src/lib/supabase/retry.ts` に共通リトライユーティリティ `withRetry()` を追加
- 502/503 エラー時に指数バックオフ (100ms → 300ms → 1000ms) で自動リトライ
- 適用箇所:
  - `src/lib/plan.ts` - `getLicensePlan()` (#339)
  - `src/lib/announcements.ts` - `getUnreadAnnouncements()`, `getAllAnnouncements()` (#326)
  - `src/app/api/streamer/[streamerId]/sound-settings/route.ts` (#325)

Fixes #339
Fixes #326
Fixes #325

## Test plan
- [ ] 502エラーが発生した場合にリトライされてリカバリすることを確認
- [ ] 4xxエラー（クライアントエラー）はリトライされないことを確認
- [ ] リトライ上限超過時に既存のフォールバック動作が維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)