### PR TITLE
fix: Realtime broadcastのdeprecation警告を解消 (#222)

### DIFF
--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -97,11 +97,13 @@ export async function broadcastGachaResult(
     let attemptCount = 0
     while (attemptCount <= maxRetries) {
       try {
-        await channel.send({
-          type: 'broadcast',
-          event: 'gacha_result',
-          payload,
-        })
+        // httpSend() を明示的に使用し REST API 経由で送信 (Issue #222)
+        // サーバーサイド(Cloudflare Workers)ではWebSocket不要のため、
+        // send() の自動フォールバック（deprecated）を回避する
+        const result = await channel.httpSend('gacha_result', payload)
+        if (!result.success) {
+          throw new Error(`Broadcast HTTP send failed: ${result.status} ${result.error}`)
+        }
         return
       } catch (error) {
         attemptCount++


### PR DESCRIPTION
## Summary
- `broadcastGachaResult()` で `channel.send()` (deprecated REST fallback) → `channel.httpSend()` (明示的REST送信) に変更
- サーバーサイド(Cloudflare Workers)からの送信ではWebSocket不要のため、REST APIを明示使用
- `httpSend()` は型安全な戻り値 (`{ success: true } | { success: false; status; error }`) を提供

## Test plan
- [x] 全553テスト通過
- [ ] preview環境でガチャ実行時にブロードキャストが正常に動作することを確認
- [ ] Cloudflare Workers ログで deprecation warning が消えていることを確認

Fixes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)