### PR TITLE
fix: Cookie消失時のスコープ乖離による401無限ループを修正

### DIFF
--- a/src/app/api/auth/twitch/callback/route.ts
+++ b/src/app/api/auth/twitch/callback/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
-import { exchangeCodeForTokens, getTwitchUser, isInvalidAuthorizationCodeError, ADDITIONAL_SCOPES } from '@/lib/twitch/auth'
+import { exchangeCodeForTokens, getTwitchUser, isInvalidAuthorizationCodeError, ADDITIONAL_SCOPES, getTwitchAuthUrl } from '@/lib/twitch/auth'
 import { saveTwitchScopes } from '@/lib/twitch/token-manager'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { handleAuthError } from '@/lib/auth-error-handler'
-import { COOKIE_NAMES, SESSION_CONFIG, ERROR_MESSAGES, getSessionCookieOptions, getDeleteCookieOptions } from '@/lib/constants'
+import { COOKIE_NAMES, SESSION_CONFIG, ERROR_MESSAGES, getSessionCookieOptions, getDeleteCookieOptions, STATE_COOKIE_OPTIONS } from '@/lib/constants'
 import { checkRateLimit, rateLimits, getClientIp } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
 import { getBaseUrl } from '@/lib/url-utils'
@@ -105,6 +105,85 @@ export async function GET(request: NextRequest) {
     // Re-auth flow marker cookie (set by reauth API)
     const reauthState = cookieStore.get(COOKIE_NAMES.REAUTH_STATE)?.value
     const isReauthFlow = reauthState === state
+    // スコープ自動復元リダイレクト判定Cookie（1回目callbackで設定される）
+    // Auto scope recovery marker cookie (set by first callback when redirecting)
+    const scopeRecoveryState = cookieStore.get(COOKIE_NAMES.SCOPE_RECOVERY)?.value
+    const isScopeRecovery = scopeRecoveryState === state
+
+    // --- スコープ乖離チェック（upsert前） ---
+    // Cookie消失等でloginルートがスコープ復元できなかった場合、トークンにDBの追加スコープが
+    // 含まれていない可能性がある。upsert前に検出し、不足スコープを含むOAuthフローに
+    // 自動リダイレクトする。DB未変更のため、2回目OAuthが失敗/中断しても安全。
+    //
+    // Scope divergence check BEFORE upsert.
+    // When login route couldn't restore scopes (cookie loss), the token may lack DB's additional
+    // scopes. Detect before upsert and auto-redirect to OAuth with missing scopes.
+    // DB is unchanged, so if the 2nd OAuth fails/is interrupted, previous state is preserved.
+    let skipScopeSave = false
+    if (!isReauthFlow && !scopeRestoreFailed && !isScopeRecovery) {
+      try {
+        const { data: existingUser, error: existingScopeError } = await supabaseAdmin
+          .from('users')
+          .select('twitch_scopes')
+          .eq('twitch_user_id', twitchUser.id)
+          .maybeSingle()
+
+        if (existingScopeError) {
+          // DB読み取り失敗: fail-safe(スキップ)で保護。リダイレクトできない（スコープ不明）
+          // DB read failure: fail-safe skip. Cannot redirect (unknown scopes).
+          skipScopeSave = true
+          logger.warn('Auth callback: Skipping scope save due to existing scope read failure', {
+            twitchUserId: twitchUser.id,
+            error: existingScopeError.message,
+          })
+        } else if (existingUser?.twitch_scopes) {
+          const validAdditionalScopes = Object.values(ADDITIONAL_SCOPES) as string[]
+          const existingAdditional = (existingUser.twitch_scopes as string[]).filter(
+            (s: string) => validAdditionalScopes.includes(s)
+          )
+
+          if (existingAdditional.length > 0) {
+            const missingScopes = existingAdditional.filter(
+              (s: string) => !tokens.scope.includes(s)
+            )
+            if (missingScopes.length > 0) {
+              // トークンにDB追加スコープが不足 → 不足スコープを含むOAuthフローに自動リダイレクト
+              // DBに何も書かずreturnするため、2回目OAuthが失敗しても旧状態が維持される。
+              // forceVerify: falseでユーザーが既に許可済みならTwitch同意画面を非表示。
+              // SCOPE_RECOVERYを設定し、2回目callbackで乖離チェックをスキップ（無限ループ防止）。
+              //
+              // Token missing DB additional scopes → auto-redirect to OAuth with missing scopes.
+              // No DB writes before return, so previous state is preserved if 2nd OAuth fails.
+              // forceVerify: false skips consent screen if user already authorized these scopes.
+              // SCOPE_RECOVERY cookie prevents infinite loop on 2nd callback.
+              logger.info('Auth callback: Auto-redirecting to restore missing scopes', {
+                twitchUserId: twitchUser.id,
+                missingScopes,
+                existingAdditional,
+                tokenScopes: tokens.scope,
+              })
+
+              const newState = crypto.randomUUID()
+              const redirectUri = `${baseUrl}/api/auth/twitch/callback`
+              const authUrl = getTwitchAuthUrl(redirectUri, newState, existingAdditional, { forceVerify: false })
+
+              const redirectResponse = NextResponse.redirect(authUrl)
+              redirectResponse.cookies.set(COOKIE_NAMES.AUTH_STATE, newState, STATE_COOKIE_OPTIONS)
+              redirectResponse.cookies.set(COOKIE_NAMES.SCOPE_RECOVERY, newState, STATE_COOKIE_OPTIONS)
+              return redirectResponse
+            }
+          }
+        }
+      } catch (error) {
+        // 予期しない例外: fail-safe(スキップ)。リダイレクトせずupsertに進む
+        // Unexpected exception: fail-safe skip. Proceed to upsert without redirect.
+        skipScopeSave = true
+        logger.warn('Auth callback: Skipping scope save due to unexpected error', {
+          twitchUserId: twitchUser.id,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
 
     try {
       // upsertのエラーを明示的にチェック（Supabase JSはエラー時にthrowせずerrorオブジェクトを返す）
@@ -135,67 +214,6 @@ export async function GET(request: NextRequest) {
         throw upsertError
       }
 
-      // 既存追加スコープの保護（別端末ログイン対策）
-      // 通常ログイン（非reauth）でDBに追加スコープがあるが、
-      // トークンにそれら全てが含まれていない場合 → スコープ保存をスキップしてDB状態を保護。
-      // 別端末からのログインではCookieが無く、loginルートでスコープ復元されないため、
-      // 全置換すると追加スコープ（chat/sub等）がDBから消失してしまう。
-      //
-      // Protect existing additional scopes (cross-device login guard).
-      // On normal login (non-reauth), if DB has additional scopes but token doesn't include
-      // all of them, skip scope save to preserve DB state. On a different device, no cookies
-      // exist, so login route can't restore scopes → full replace would wipe additional scopes.
-      //
-      // DB/トークン乖離リスク: スキップ時、DBにスコープがあるがトークンには無い状態が残る。
-      // chat: check-scope APIでトークン検証し乖離検出 → 再認証誘導 (check-scope/route.ts)
-      // sub: ユーザーの手動確認APIで401/403時にremoveScope() (check-subscription/route.ts)
-      let skipScopeSave = false
-      if (!isReauthFlow && !scopeRestoreFailed) {
-        try {
-          const { data: existingUser, error: existingScopeError } = await supabaseAdmin
-            .from('users')
-            .select('twitch_scopes')
-            .eq('twitch_user_id', twitchUser.id)
-            .maybeSingle()
-
-          if (existingScopeError) {
-            // DB読み取り失敗: scopeRestoreFailedと同じくfail-safe(スキップ)で保護
-            skipScopeSave = true
-            logger.warn('Auth callback: Skipping scope save due to existing scope read failure', {
-              twitchUserId: twitchUser.id,
-              error: existingScopeError.message,
-            })
-          } else if (existingUser?.twitch_scopes) {
-            const validAdditionalScopes = Object.values(ADDITIONAL_SCOPES) as string[]
-            const existingAdditional = (existingUser.twitch_scopes as string[]).filter(
-              (s: string) => validAdditionalScopes.includes(s)
-            )
-
-            if (existingAdditional.length > 0) {
-              const missingScopes = existingAdditional.filter(
-                (s: string) => !tokens.scope.includes(s)
-              )
-              if (missingScopes.length > 0) {
-                skipScopeSave = true
-                logger.warn('Auth callback: Skipping scope save to protect existing additional scopes', {
-                  twitchUserId: twitchUser.id,
-                  missingScopes,
-                  existingAdditional,
-                  tokenScopes: tokens.scope,
-                })
-              }
-            }
-          }
-        } catch (error) {
-          // 予期しない例外: fail-safe(スキップ)
-          skipScopeSave = true
-          logger.warn('Auth callback: Skipping scope save due to unexpected error', {
-            twitchUserId: twitchUser.id,
-            error: error instanceof Error ? error.message : String(error),
-          })
-        }
-      }
-
       // トークン交換時に付与されたスコープをDBに全置換で保存する。
       // loginルートがOAuthリクエストに既存スコープ（user:write:chat等）を含めるため、
       // ユーザーのTwitch Grantにスコープが存在すれば新トークンにも含まれ保持される。
@@ -216,8 +234,9 @@ export async function GET(request: NextRequest) {
             tokenScopes: tokens.scope,
           })
         } else if (skipScopeSave) {
-          // 別端末ログイン保護: DB既存の追加スコープがトークンに含まれていないためスキップ
-          logger.warn('Auth callback: Scope save skipped to protect existing additional scopes', {
+          // DB読み取りエラー等のfail-safe: DB既存スコープを保護するためスキップ
+          // Fail-safe for DB read errors: skip to protect existing DB scopes
+          logger.warn('Auth callback: Scope save skipped due to fail-safe guard', {
             twitchUserId: twitchUser.id,
             tokenScopes: tokens.scope,
           })
@@ -228,6 +247,7 @@ export async function GET(request: NextRequest) {
             scopeCount: tokens.scope.length,
             scopes: tokens.scope,
             isReauthFlow,
+            isScopeRecovery,
           })
         }
       }
@@ -376,6 +396,12 @@ export async function GET(request: NextRequest) {
     // 並行フロー保護のため、state一致時のみ削除する
     if (isReauthFlow) {
       response.cookies.set(COOKIE_NAMES.REAUTH_STATE, '', getDeleteCookieOptions())
+    }
+
+    // Clear scope recovery marker cookie only when state matches this flow
+    // スコープ自動復元リダイレクトのマーカーCookieを削除（state一致時のみ）
+    if (isScopeRecovery) {
+      response.cookies.set(COOKIE_NAMES.SCOPE_RECOVERY, '', getDeleteCookieOptions())
     }
 
     // スコープ復元用Cookie（ログアウト後のtwitchUserId保持用）を削除

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -29,6 +29,13 @@ export const COOKIE_NAMES = {
   // Minimal cookie for scope restoration after logout (stores only twitchUserId).
   // Replaces full session cookie to minimize retained data.
   SCOPE_RESTORE_USER_ID: 'twica_scope_restore_uid',
+  // スコープ自動復元リダイレクト用Cookie（値はOAuth state）
+  // Cookie消失等でloginルートがスコープ復元できなかった場合、callbackが不足スコープを含む
+  // OAuthフローに自動リダイレクトする。2回目callbackでこのCookieを検出して乖離チェックをスキップ。
+  // Auto scope recovery redirect marker (value is OAuth state).
+  // When login route cannot restore scopes (cookie loss etc.), callback auto-redirects to
+  // a new OAuth flow with missing scopes. Second callback detects this cookie to skip divergence check.
+  SCOPE_RECOVERY: 'twica_scope_recovery',
 }
 
 export const API_ROUTES = {

--- a/src/lib/twitch/token-manager.ts
+++ b/src/lib/twitch/token-manager.ts
@@ -84,19 +84,20 @@ async function refreshTwitchAccessToken(twitchUserId: string, refreshToken: stri
       throw error;
     }
 
-    // リフレッシュレスポンスにスコープが含まれていればDBとマージ同期（best-effort）
-    // リフレッシュトークンのレスポンスにはデフォルトスコープしか含まれない場合がある
-    // (例: 別端末ログインでuser:write:chatなしでリフレッシュされたトークン)
-    // 全置換するとDBの追加スコープが消失するため、既存スコープとマージする
-    // Best-effort scope merge on token refresh. Refresh response may only contain
-    // default scopes (e.g., token refreshed after login from another device without
-    // user:write:chat). Full replace would wipe additional scopes, so merge with existing.
+    // リフレッシュレスポンスのスコープでDBを全置換する（best-effort）
+    // Twitchのrefreshレスポンスはトークンの実スコープを返す（公式ドキュメント準拠）。
+    // 以前はDBスコープとマージしていたが、トークンにないスコープがDBに残ると
+    // DB/トークン乖離が永続化し401エラーの原因になるため、全置換に変更。
+    // callbackの自動リダイレクト機構により、追加スコープはログイン時に復元される。
+    //
+    // Full replace DB scopes with refresh response scopes (best-effort).
+    // Twitch refresh response returns actual token scopes (per official docs).
+    // Previously merged with DB scopes, but stale DB scopes cause permanent
+    // DB/token divergence and repeated 401 errors. Full replace keeps DB in sync.
+    // Callback's auto-redirect mechanism recovers additional scopes on login.
     if (tokens.scope && tokens.scope.length > 0) {
       try {
-        const existingScopes = await getExistingScopes(twitchUserId);
-        // トークンの実スコープとDBの既存スコープをマージ（重複除去）
-        const mergedScopes = [...new Set([...tokens.scope, ...existingScopes])];
-        await saveTwitchScopes(twitchUserId, mergedScopes);
+        await saveTwitchScopes(twitchUserId, tokens.scope);
       } catch (scopeSaveError) {
         logger.warn('Failed to sync scopes on token refresh (best-effort)', {
           twitchUserId,
@@ -159,23 +160,6 @@ export async function deleteTwitchTokens(twitchUserId: string): Promise<void> {
     }
     throw error;
   }
-}
-
-/**
- * ユーザーの既存Twitchスコープを取得する（内部ヘルパー）
- * refreshTwitchAccessTokenでのマージ同期用
- * Get existing Twitch scopes for a user (internal helper for merge sync on refresh)
- */
-async function getExistingScopes(twitchUserId: string): Promise<string[]> {
-  const supabaseAdmin = getSupabaseAdmin();
-  const { data: user, error } = await supabaseAdmin
-    .from('users')
-    .select('twitch_scopes')
-    .eq('twitch_user_id', twitchUserId)
-    .maybeSingle();
-
-  if (error || !user?.twitch_scopes) return [];
-  return user.twitch_scopes;
 }
 
 /**

--- a/tests/unit/auth-scope-preservation.test.ts
+++ b/tests/unit/auth-scope-preservation.test.ts
@@ -547,9 +547,9 @@ describe('Auth scope preservation: callback route', () => {
     expect(deleteCall).toBeUndefined()
   })
 
-  it('別端末ログイン: DBに追加スコープがあるがトークンにない場合、スコープ保存がスキップされる', async () => {
-    // 別端末: Cookie無し → loginでスコープ復元されない → トークンにはデフォルト3スコープのみ
-    // DBにはuser:write:chatがある → 全置換すると消失 → スキップで保護
+  it('Cookie消失ログイン: DBに追加スコープがあるがトークンにない場合、不足スコープを含むOAuthに自動リダイレクトする', async () => {
+    // Cookie無し → loginでスコープ復元されない → トークンにはデフォルトスコープのみ
+    // DBにuser:write:chatがある → 不足スコープを含むOAuthフローに自動リダイレクト
     mockCookieStore.get.mockImplementation((name: string) => {
       if (name === 'twitch_auth_state') return { value: 'test-state-123' }
       return undefined
@@ -557,14 +557,28 @@ describe('Auth scope preservation: callback route', () => {
     // DBに追加スコープ（user:write:chat）がある
     setCallbackMaybeSingleResults(['user:read:email', 'user:write:chat'])
 
-    const { NextRequest } = await import('next/server')
+    const { NextRequest, NextResponse } = await import('next/server')
     const url = 'http://localhost:3000/api/auth/twitch/callback?code=test-code&state=test-state-123'
     const request = new NextRequest(url)
 
     const { GET } = await import('@/app/api/auth/twitch/callback/route')
-    await GET(request)
+    const response = await GET(request) as ReturnType<typeof NextResponse.redirect>
 
-    // saveTwitchScopesがスキップされることを確認
+    // Twitch OAuthにリダイレクトされること（user:write:chatを含む）
+    expect(response.type).toBe('redirect')
+    expect(response.url).toContain('user:write:chat')
+
+    // SCOPE_RECOVERYとAUTH_STATE cookieが設定されること
+    const cookieSetCalls = (response.cookies.set as ReturnType<typeof vi.fn>).mock.calls
+    const authStateCookie = cookieSetCalls.find((call: unknown[]) => call[0] === 'twitch_auth_state')
+    const scopeRecoveryCookie = cookieSetCalls.find((call: unknown[]) => call[0] === 'twica_scope_recovery')
+    expect(authStateCookie).toBeDefined()
+    expect(scopeRecoveryCookie).toBeDefined()
+    // 両方のcookieが同じstate値を持つこと
+    expect(authStateCookie![1]).toBe(scopeRecoveryCookie![1])
+
+    // DB未変更（upsertもsaveScopesも呼ばれない）
+    expect(mockUpsert).not.toHaveBeenCalled()
     expect(mockSaveTwitchScopes).not.toHaveBeenCalled()
   })
 
@@ -587,8 +601,8 @@ describe('Auth scope preservation: callback route', () => {
     expect(mockSaveTwitchScopes).toHaveBeenCalledWith('user123', ['user:read:email', 'openid'])
   })
 
-  it('部分欠落: DBに2つの追加スコープがあるがトークンに1つだけの場合、スコープ保存がスキップされる', async () => {
-    // DBにchatとsubの両方がある、トークンにはchatのみ → sub欠落 → スキップ
+  it('部分欠落: DBに2つの追加スコープがあるがトークンに1つだけの場合、全追加スコープを含むOAuthに自動リダイレクトする', async () => {
+    // DBにchatとsubの両方がある、トークンにはchatのみ → sub欠落 → リダイレクトで復元
     mockCookieStore.get.mockImplementation((name: string) => {
       if (name === 'twitch_auth_state') return { value: 'test-state-123' }
       return undefined
@@ -605,14 +619,20 @@ describe('Auth scope preservation: callback route', () => {
       scope: ['user:read:email', 'user:write:chat'],
     })
 
-    const { NextRequest } = await import('next/server')
+    const { NextRequest, NextResponse } = await import('next/server')
     const url = 'http://localhost:3000/api/auth/twitch/callback?code=test-code&state=test-state-123'
     const request = new NextRequest(url)
 
     const { GET } = await import('@/app/api/auth/twitch/callback/route')
-    await GET(request)
+    const response = await GET(request) as ReturnType<typeof NextResponse.redirect>
 
-    // sub欠落によりスキップ
+    // 全追加スコープ（chat + sub）を含むOAuthにリダイレクトされること
+    expect(response.type).toBe('redirect')
+    expect(response.url).toContain('user:write:chat')
+    expect(response.url).toContain('user:read:subscriptions')
+
+    // DB未変更
+    expect(mockUpsert).not.toHaveBeenCalled()
     expect(mockSaveTwitchScopes).not.toHaveBeenCalled()
   })
 
@@ -642,6 +662,58 @@ describe('Auth scope preservation: callback route', () => {
 
     // fail-safeによりスキップ
     expect(mockSaveTwitchScopes).not.toHaveBeenCalled()
+  })
+
+  it('スコープ自動復元2回目callback: SCOPE_RECOVERYがstate一致時、乖離チェックをスキップし通常通りスコープ保存する', async () => {
+    // 1回目callbackでSCOPE_RECOVERYを設定してリダイレクトした後の2回目callback
+    // 乖離チェックをスキップし、トークンのスコープを全置換で保存する
+    mockCookieStore.get.mockImplementation((name: string) => {
+      if (name === 'twitch_auth_state') return { value: 'test-state-123' }
+      if (name === 'twica_scope_recovery') return { value: 'test-state-123' }
+      return undefined
+    })
+    // DBに追加スコープがある（通常ログインならリダイレクトされるケース）
+    setCallbackMaybeSingleResults(['user:read:email', 'user:write:chat'])
+
+    const { NextRequest, NextResponse } = await import('next/server')
+    const url = 'http://localhost:3000/api/auth/twitch/callback?code=test-code&state=test-state-123'
+    const request = new NextRequest(url)
+
+    const { GET } = await import('@/app/api/auth/twitch/callback/route')
+    const response = await GET(request) as ReturnType<typeof NextResponse.redirect>
+
+    // リダイレクトではなく通常のcallback完了（dashboardリダイレクト）
+    expect(response.url).toContain('/dashboard')
+    // スコープが全置換で保存される
+    expect(mockSaveTwitchScopes).toHaveBeenCalledWith('user123', ['user:read:email', 'openid'])
+    // SCOPE_RECOVERY cookieが削除される
+    const deleteCall = (response.cookies.set as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call: unknown[]) => call[0] === 'twica_scope_recovery' && call[1] === ''
+    )
+    expect(deleteCall).toBeDefined()
+  })
+
+  it('SCOPE_RECOVERYのstate不一致時は通常の乖離チェックが行われる（並行フロー保護）', async () => {
+    // 別タブのSCOPE_RECOVERY cookieが存在するが、stateが異なる
+    mockCookieStore.get.mockImplementation((name: string) => {
+      if (name === 'twitch_auth_state') return { value: 'test-state-123' }
+      if (name === 'twica_scope_recovery') return { value: 'other-tab-state-456' }
+      return undefined
+    })
+    // DBに追加スコープがある → 乖離検出 → リダイレクト
+    setCallbackMaybeSingleResults(['user:read:email', 'user:write:chat'])
+
+    const { NextRequest, NextResponse } = await import('next/server')
+    const url = 'http://localhost:3000/api/auth/twitch/callback?code=test-code&state=test-state-123'
+    const request = new NextRequest(url)
+
+    const { GET } = await import('@/app/api/auth/twitch/callback/route')
+    const response = await GET(request) as ReturnType<typeof NextResponse.redirect>
+
+    // state不一致なのでSCOPE_RECOVERYは無視され、乖離チェックが実行 → リダイレクト
+    expect(response.type).toBe('redirect')
+    expect(response.url).toContain('user:write:chat')
+    expect(mockUpsert).not.toHaveBeenCalled()
   })
 
   it('reauthフローでは追加スコープ欠落でもスキップしない（全置換）', async () => {

--- a/tests/unit/twitch-token-manager.test.ts
+++ b/tests/unit/twitch-token-manager.test.ts
@@ -686,32 +686,20 @@ describe('Twitch Token Manager', () => {
       expect(token).toBe('new-token');
     });
 
-    it('DBの既存追加スコープとリフレッシュレスポンスのスコープがマージされる', async () => {
+    it('リフレッシュレスポンスのスコープでDBが全置換される（マージではない）', async () => {
       // DBに user:write:chat があるが、リフレッシュレスポンスには含まれないケース
-      // （別端末ログインで基本スコープだけでリフレッシュされた場合）
-      let maybeSingleCallCount = 0;
+      // 全置換により、DBのstaleなスコープが除去されDB/トークン乖離が解消される
       const mockSupabaseAdmin: MockSupabaseAdmin = {
         from: vi.fn().mockReturnThis(),
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
-        maybeSingle: vi.fn().mockImplementation(() => {
-          maybeSingleCallCount++;
-          if (maybeSingleCallCount === 1) {
-            // getTwitchAccessToken: 期限切れトークン
-            return Promise.resolve({
-              data: {
-                twitch_access_token: 'expired-token',
-                twitch_refresh_token: 'refresh-token',
-                twitch_token_expires_at: new Date(Date.now() - 3600000).toISOString(),
-              },
-              error: null,
-            });
-          }
-          // getExistingScopes: DBに既存の追加スコープあり
-          return Promise.resolve({
-            data: { twitch_scopes: ['user:read:email', 'user:write:chat'] },
-            error: null,
-          });
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: {
+            twitch_access_token: 'expired-token',
+            twitch_refresh_token: 'refresh-token',
+            twitch_token_expires_at: new Date(Date.now() - 3600000).toISOString(),
+          },
+          error: null,
         }),
         update: vi.fn().mockReturnThis(),
         insert: vi.fn().mockResolvedValue({ error: null }),
@@ -730,13 +718,9 @@ describe('Twitch Token Manager', () => {
       const token = await getTwitchAccessToken('123456789');
       expect(token).toBe('new-token');
 
-      // マージ結果: リフレッシュスコープ + DBの既存スコープ（user:write:chatが保護される）
+      // 全置換: リフレッシュレスポンスのスコープのみ（DBの既存user:write:chatは含まれない）
       expect(mockSupabaseAdmin.update).toHaveBeenCalledWith({
-        twitch_scopes: expect.arrayContaining([
-          'user:read:email',
-          'channel:read:redemptions',
-          'user:write:chat',
-        ]),
+        twitch_scopes: ['user:read:email', 'channel:read:redemptions'],
       });
     });
 


### PR DESCRIPTION
Cookie消失（30日超過、Safari ITP等）後の再ログインで、login ルートが
twitchUserId を取得できず追加スコープなしで OAuth を実行し、callback が DB保護のためスコープ保存をスキップしていたため、DB/トークン乖離が永続化し
POST /helix/chat/messages で401エラーが頻発していた。

- callback: スコープ乖離チェックをupsert前に移動。乖離検出時はDB未変更で 不足スコープを含むOAuthフローに自動リダイレクト（SCOPE_RECOVERY cookie で無限ループ防止、forceVerify:false で透過的リダイレクト）
- token-manager: refresh時のスコープ保存をunion mergeからfull replaceに変更 し、staleなDBスコープによる乖離の永続化を解消
- getExistingScopes ヘルパー関数を削除（不要化）