### PR TITLE
Fix logout when CSRF cookie is missing

### DIFF
--- a/src/app/api/session/route.ts
+++ b/src/app/api/session/route.ts
@@ -2,6 +2,8 @@ import { getSession } from '@/lib/session'
 import { NextResponse } from 'next/server'
 import { handleApiError } from '@/lib/error-handler'
 import { ERROR_MESSAGES } from '@/lib/constants'
+import { setCSRFToken } from '@/lib/csrf'
+import { logger } from '@/lib/logger'
 
 export async function GET() {
   try {
@@ -11,7 +13,18 @@ export async function GET() {
       return NextResponse.json({ error: ERROR_MESSAGES.NOT_AUTHENTICATED }, { status: 401 })
     }
 
-    return NextResponse.json(session)
+    const response = NextResponse.json(session)
+
+    try {
+      const csrfToken = await setCSRFToken()
+      response.headers.set('x-csrf-token', csrfToken)
+    } catch (error) {
+      logger.warn('Session API: failed to refresh CSRF token', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      })
+    }
+
+    return response
   } catch (error) {
     return handleApiError(error, "Session API: GET")
   }

--- a/src/components/LogoutButton.tsx
+++ b/src/components/LogoutButton.tsx
@@ -17,13 +17,36 @@ interface LogoutButtonProps {
 export function LogoutButton({ className, label, children }: LogoutButtonProps) {
   const [isPending, startTransition] = useTransition()
 
+  const tryLogout = async (): Promise<Response> => {
+    return fetch('/api/auth/logout', {
+      method: 'POST',
+      credentials: 'include',
+    })
+  }
+
+  const refreshCsrfToken = async (): Promise<boolean> => {
+    try {
+      const response = await fetch('/api/session', {
+        credentials: 'include',
+        cache: 'no-store',
+      })
+
+      return response.ok
+    } catch {
+      return false
+    }
+  }
+
   const handleLogout = () => {
     startTransition(async () => {
       try {
-        const response = await fetch('/api/auth/logout', {
-          method: 'POST',
-          credentials: 'include',
-        })
+        let response = await tryLogout()
+
+        // CSRF cookie だけが欠けている不整合セッションでは、/api/session で
+        // トークンを再発行してから一度だけ logout を再試行する。
+        if (response.status === 403 && await refreshCsrfToken()) {
+          response = await tryLogout()
+        }
 
         // 正常リダイレクト時のみ指定 URL へ遷移し、それ以外は reload で
         // サーバー側のセッション状態を真実として再評価する（403/429 でログアウト失敗時に

--- a/tests/unit/components/logout-button.test.tsx
+++ b/tests/unit/components/logout-button.test.tsx
@@ -1,0 +1,49 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { LogoutButton } from '@/components/LogoutButton'
+
+describe('LogoutButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('logout が 403 のとき /api/session で CSRF を再発行してから 1 回だけ再試行する', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const locationSpy = vi.spyOn(window.location, 'reload').mockImplementation(() => undefined)
+
+    render(
+      <LogoutButton label="logout">
+        <span>Logout</span>
+      </LogoutButton>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /logout/i }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        '/api/auth/logout',
+        expect.objectContaining({ method: 'POST', credentials: 'include' })
+      )
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        '/api/session',
+        expect.objectContaining({ credentials: 'include', cache: 'no-store' })
+      )
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        3,
+        '/api/auth/logout',
+        expect.objectContaining({ method: 'POST', credentials: 'include' })
+      )
+      expect(locationSpy).toHaveBeenCalled()
+    })
+
+    locationSpy.mockRestore()
+  })
+})

--- a/tests/unit/session-api.test.ts
+++ b/tests/unit/session-api.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GET } from '@/app/api/session/route'
+import { getSession } from '@/lib/session'
+import { setCSRFToken } from '@/lib/csrf'
+import { ERROR_MESSAGES } from '@/lib/constants'
+
+vi.mock('@/lib/session', () => ({
+  getSession: vi.fn(),
+}))
+
+vi.mock('@/lib/csrf', () => ({
+  setCSRFToken: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const mockGetSession = vi.mocked(getSession)
+const mockSetCSRFToken = vi.mocked(setCSRFToken)
+
+describe('GET /api/session', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('認証済みセッションでは CSRF トークンを再発行してレスポンスヘッダーに載せる', async () => {
+    mockGetSession.mockResolvedValue({
+      twitchUserId: '123',
+      twitchUsername: 'user',
+      twitchDisplayName: 'User',
+      twitchProfileImageUrl: 'https://example.com/avatar.png',
+      broadcasterType: 'affiliate',
+      expiresAt: Date.now() + 60_000,
+      version: 1,
+    })
+    mockSetCSRFToken.mockResolvedValue('fresh-csrf-token')
+
+    const response = await GET()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-csrf-token')).toBe('fresh-csrf-token')
+    await expect(response.json()).resolves.toMatchObject({
+      twitchUserId: '123',
+    })
+  })
+
+  it('未認証時は 401 を返す', async () => {
+    mockGetSession.mockResolvedValue(null)
+
+    const response = await GET()
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      error: ERROR_MESSAGES.NOT_AUTHENTICATED,
+    })
+    expect(mockSetCSRFToken).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- retry logout once after refreshing the CSRF cookie through the session API
- have the session API eagerly issue a CSRF token for authenticated sessions
- add unit coverage for the retry flow and the session header behavior

## Testing
- npx vitest run tests/unit/session-api.test.ts
- npx vitest run tests/unit/components/logout-button.test.tsx
- npx next build --webpack
