### PR TITLE
feat: チャット通知に {unique} / {all} プレースホルダを追加 (#350)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -360,7 +360,7 @@
       "enableAnnouncement": "Enable chat announcements",
       "customTemplate": "Custom Template (optional)",
       "templatePlaceholder": "@'{'user'}' got a ['{'rarity'}'] '{'card'}'!",
-      "placeholderHelp": "Available placeholders: '{'user'}'=username, '{'card'}'=card name, '{'rarity'}'=rarity, '{'num'}'=owned count, '{'detail'}'=card description, '{'url'}'=collection URL",
+      "placeholderHelp": "Available placeholders: '{'user'}'=username, '{'card'}'=card name, '{'rarity'}'=rarity, '{'num'}'=owned count, '{'unique'}'=unique types owned, '{'all'}'=total types, '{'detail'}'=card description, '{'url'}'=collection URL",
       "previewLength": "Preview length: {current} / {max} characters"
     },
     "buttons": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -360,7 +360,7 @@
       "enableAnnouncement": "チャット通知を有効にする",
       "customTemplate": "カスタムテンプレート（任意）",
       "templatePlaceholder": "@'{'user'}' が【'{'rarity'}'】'{'card'}' を獲得しました！",
-      "placeholderHelp": "使用可能なプレースホルダー: '{'user'}'=ユーザー名, '{'card'}'=カード名, '{'rarity'}'=レアリティ, '{'num'}'=所持枚数, '{'detail'}'=カード説明, '{'url'}'=コレクションURL",
+      "placeholderHelp": "使用可能なプレースホルダー: '{'user'}'=ユーザー名, '{'card'}'=カード名, '{'rarity'}'=レアリティ, '{'num'}'=所持枚数, '{'unique'}'=所持種類数, '{'all'}'=全種類数, '{'detail'}'=カード説明, '{'url'}'=コレクションURL",
       "previewLength": "プレビュー文字数: {current} / {max}文字"
     },
     "buttons": {

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -430,31 +430,92 @@ async function sendChatAnnouncement(
     legendary: 'レジェンダリー',
   };
 
-  // テンプレートに {num} プレースホルダーが含まれる場合のみカード所持枚数を取得
-  // waitUntil内のwall time短縮のため、不要なDBクエリ（users + user_cards）をスキップ
-  // Skip card count queries when template doesn't use {num} to reduce wall time in waitUntil
+  // テンプレートに含まれるプレースホルダーに応じてのみDBクエリを実行
+  // waitUntil内のwall time短縮のため、不要なDBクエリをスキップ
+  // Run DB queries only for placeholders that appear in the template to keep waitUntil wall-time short
   const effectiveTemplate = streamer.chat_announcement_template || DEFAULT_CHAT_TEMPLATE;
+  const needsCardCount = /\{num\}/.test(effectiveTemplate);
+  const needsUniqueCount = /\{unique\}/.test(effectiveTemplate);
+  const needsAllCount = /\{all\}/.test(effectiveTemplate);
+
   let cardCount: number | undefined;
-  if (effectiveTemplate.includes('{num}')) {
+  let uniqueCount: number | undefined;
+  let allCount: number | undefined;
+
+  if (needsCardCount || needsUniqueCount || needsAllCount) {
     const supabaseAdminNoCache = getSupabaseAdminNoCache();
-    try {
-      const { data: user } = await supabaseAdminNoCache
-        .from('users')
-        .select('id')
-        .eq('twitch_user_id', userId)
-        .maybeSingle();
 
-      if (user) {
-        const { count } = await supabaseAdminNoCache
-          .from('user_cards')
+    // {all} は配信者のアクティブカード総数のため、直接 cards テーブルを count クエリ
+    // {all}: count active cards for this streamer (user-independent)
+    const allCountPromise = needsAllCount
+      ? supabaseAdminNoCache
+          .from('cards')
           .select('id', { count: 'exact', head: true })
-          .eq('user_id', user.id)
-          .eq('card_id', card.id);
+          .eq('streamer_id', streamer.id)
+          .eq('is_active', true)
+      : null;
 
-        cardCount = count ?? undefined;
+    // {num} / {unique} は RPC `get_user_card_counts` で DB 側 GROUP BY 済みの
+    // ユーザー所持カード一覧を取得して求める（PostgREST の行数制限を根本的に回避）
+    // is_active フィルタは RPC が行わないため、ここでは JS 側で行う
+    // {num} / {unique}: use RPC returning pre-aggregated per-card counts.
+    // The RPC handles GROUP BY server-side, avoiding PostgREST 1000-row cap.
+    // RPC does not filter by is_active, so we filter on the client.
+    const userCardCountsPromise = (needsCardCount || needsUniqueCount)
+      ? supabaseAdminNoCache.rpc('get_user_card_counts', {
+          p_twitch_user_id: userId,
+          p_streamer_id: streamer.id,
+        })
+      : null;
+
+    const [allCountResult, userCardCountsResult] = await Promise.all([
+      allCountPromise,
+      userCardCountsPromise,
+    ]);
+
+    if (needsAllCount) {
+      if (allCountResult?.error) {
+        logger.warn('Failed to fetch {all} card count for chat announcement', {
+          streamerId: streamer.id,
+          error: allCountResult.error.message,
+        });
+      } else {
+        allCount = allCountResult?.count ?? 0;
       }
-    } catch {
-      // カウント取得失敗は無視
+    }
+
+    if (needsCardCount || needsUniqueCount) {
+      if (userCardCountsResult?.error) {
+        logger.warn('Failed to fetch user card counts for chat announcement', {
+          streamerId: streamer.id,
+          userTwitchId: userId,
+          error: userCardCountsResult.error.message,
+        });
+        if (needsUniqueCount) {
+          // RPC 失敗時は 0 にフォールバックせず、未定義のままプレースホルダを空文字化
+          // On RPC failure, leave placeholders undefined so buildMessage strips them
+        }
+      } else {
+        // RPC は JSONB 配列を返し、各要素は { count, card: {..., is_active, id}, streamer }
+        // RPC returns a JSONB array; each row holds { count, card: {...}, streamer }
+        const rows = (userCardCountsResult?.data ?? []) as Array<{
+          count: number;
+          card: { id: string; is_active: boolean };
+        }>;
+
+        if (needsCardCount) {
+          // 現在当選したカードの所持数を検索
+          // Find the count for the card that just dropped
+          const currentCardRow = rows.find((row) => row.card?.id === card.id);
+          cardCount = currentCardRow?.count ?? 0;
+        }
+
+        if (needsUniqueCount) {
+          // アクティブカードのみ数えてコンプ進捗を算出
+          // Count only active cards to match the progress definition in dashboard UI
+          uniqueCount = rows.filter((row) => row.card?.is_active === true).length;
+        }
+      }
     }
   }
 
@@ -471,6 +532,8 @@ async function sendChatAnnouncement(
     rarity: rarityMap[card.rarity] || card.rarity,
     detail: card.description || undefined,
     num: cardCount,
+    unique: uniqueCount,
+    all: allCount,
     url: collectionUrl,
   };
 

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -468,54 +468,69 @@ async function sendChatAnnouncement(
         })
       : null;
 
-    const [allCountResult, userCardCountsResult] = await Promise.all([
-      allCountPromise,
-      userCardCountsPromise,
-    ]);
+    // transient な transport / runtime 例外が throw されるとチャット通知全体が
+    // 飛んでしまうため、Promise.all を try/catch で囲みフォールバック挙動を担保する。
+    // PostgREST の `error` payload は下の if で個別にハンドリングする。
+    // Wrap the Promise.all so transient transport/runtime rejections don't abort
+    // the whole chat announcement. PostgREST `error` payloads are still handled below.
+    try {
+      const [allCountResult, userCardCountsResult] = await Promise.all([
+        allCountPromise,
+        userCardCountsPromise,
+      ]);
 
-    if (needsAllCount) {
-      if (allCountResult?.error) {
-        logger.warn('Failed to fetch {all} card count for chat announcement', {
-          streamerId: streamer.id,
-          error: allCountResult.error.message,
-        });
-      } else {
-        allCount = allCountResult?.count ?? 0;
-      }
-    }
-
-    if (needsCardCount || needsUniqueCount) {
-      if (userCardCountsResult?.error) {
-        logger.warn('Failed to fetch user card counts for chat announcement', {
-          streamerId: streamer.id,
-          userTwitchId: userId,
-          error: userCardCountsResult.error.message,
-        });
-        if (needsUniqueCount) {
-          // RPC 失敗時は 0 にフォールバックせず、未定義のままプレースホルダを空文字化
-          // On RPC failure, leave placeholders undefined so buildMessage strips them
-        }
-      } else {
-        // RPC は JSONB 配列を返し、各要素は { count, card: {..., is_active, id}, streamer }
-        // RPC returns a JSONB array; each row holds { count, card: {...}, streamer }
-        const rows = (userCardCountsResult?.data ?? []) as Array<{
-          count: number;
-          card: { id: string; is_active: boolean };
-        }>;
-
-        if (needsCardCount) {
-          // 現在当選したカードの所持数を検索
-          // Find the count for the card that just dropped
-          const currentCardRow = rows.find((row) => row.card?.id === card.id);
-          cardCount = currentCardRow?.count ?? 0;
-        }
-
-        if (needsUniqueCount) {
-          // アクティブカードのみ数えてコンプ進捗を算出
-          // Count only active cards to match the progress definition in dashboard UI
-          uniqueCount = rows.filter((row) => row.card?.is_active === true).length;
+      if (needsAllCount) {
+        if (allCountResult?.error) {
+          logger.warn('Failed to fetch {all} card count for chat announcement', {
+            streamerId: streamer.id,
+            error: allCountResult.error.message,
+          });
+        } else {
+          allCount = allCountResult?.count ?? 0;
         }
       }
+
+      if (needsCardCount || needsUniqueCount) {
+        if (userCardCountsResult?.error) {
+          logger.warn('Failed to fetch user card counts for chat announcement', {
+            streamerId: streamer.id,
+            userTwitchId: userId,
+            error: userCardCountsResult.error.message,
+          });
+          if (needsUniqueCount) {
+            // RPC 失敗時は 0 にフォールバックせず、未定義のままプレースホルダを空文字化
+            // On RPC failure, leave placeholders undefined so buildMessage strips them
+          }
+        } else {
+          // RPC は JSONB 配列を返し、各要素は { count, card: {..., is_active, id}, streamer }
+          // RPC returns a JSONB array; each row holds { count, card: {...}, streamer }
+          const rows = (userCardCountsResult?.data ?? []) as Array<{
+            count: number;
+            card: { id: string; is_active: boolean };
+          }>;
+
+          if (needsCardCount) {
+            // 現在当選したカードの所持数を検索
+            // Find the count for the card that just dropped
+            const currentCardRow = rows.find((row) => row.card?.id === card.id);
+            cardCount = currentCardRow?.count ?? 0;
+          }
+
+          if (needsUniqueCount) {
+            // アクティブカードのみ数えてコンプ進捗を算出
+            // Count only active cards to match the progress definition in dashboard UI
+            uniqueCount = rows.filter((row) => row.card?.is_active === true).length;
+          }
+        }
+      }
+    } catch (err) {
+      // transient 失敗時はプレースホルダを未定義のまま残し、通知は送信する
+      // On transient failure, leave placeholders undefined and still send the announcement
+      logger.warn('Chat announcement count queries threw; falling back to empty placeholders', {
+        streamerId: streamer.id,
+        userTwitchId: userId,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/src/components/ChatAnnouncementSettings.tsx
+++ b/src/components/ChatAnnouncementSettings.tsx
@@ -23,6 +23,10 @@ const MAX_TEMPLATE_PLACEHOLDER_LENGTHS = {
   card: 100,
   rarity: 12,
   num: 10,
+  // コンプ進捗のユニーク/全種類数は現実的に4桁で十分
+  // Collection progress counts realistically fit in 4 digits
+  unique: 4,
+  all: 4,
   detail: CARD_DESCRIPTION_MAX_CHARACTERS,
 } as const;
 
@@ -33,6 +37,8 @@ function buildChatPreviewMessage(
     card: string;
     rarity: string;
     num: string;
+    unique: string;
+    all: string;
     detail: string;
     url: string;
   }
@@ -42,6 +48,8 @@ function buildChatPreviewMessage(
     .replace(/\{card\}/g, placeholders.card)
     .replace(/\{rarity\}/g, placeholders.rarity)
     .replace(/\{num\}/g, placeholders.num)
+    .replace(/\{unique\}/g, placeholders.unique)
+    .replace(/\{all\}/g, placeholders.all)
     .replace(/\{detail\}/g, placeholders.detail)
     .replace(/\{url\}/g, placeholders.url)
     .replace(/\s+/g, " ")
@@ -96,6 +104,8 @@ export default function ChatAnnouncementSettings({
       card: "レジェンダリーカード",
       rarity: "レジェンダリー",
       num: "3",
+      unique: "5",
+      all: "10",
       detail: "特別なカードの説明文です",
       url: `https://twica.live/collection/${streamerId}`,
     });
@@ -113,6 +123,8 @@ export default function ChatAnnouncementSettings({
         card: "カ".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.card),
         rarity: "レ".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.rarity),
         num: "9".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.num),
+        unique: "9".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.unique),
+        all: "9".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.all),
         detail: "説".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.detail),
         url: `https://twica.live/collection/${streamerId}`,
       })

--- a/src/lib/twitch/chat-service.ts
+++ b/src/lib/twitch/chat-service.ts
@@ -31,6 +31,12 @@ export interface ChatMessagePlaceholders {
   // ユーザーがこのカードを何枚目に獲得したか（オプション）
   // How many of this card the user now owns (optional)
   num?: number
+  // コンプ進捗用: 配信者のアクティブカードのうちユーザーが所持しているユニーク種類数（オプション）
+  // Collection progress: number of unique active card types the user owns for this streamer (optional)
+  unique?: number
+  // コンプ進捗用: 配信者のアクティブカードの総種類数（オプション）
+  // Collection progress: total number of active card types for this streamer (optional)
+  all?: number
 }
 
 /**
@@ -210,6 +216,20 @@ export class TwitchChatService {
       message = message.replace(/\{num\}/g, String(placeholders.num))
     } else {
       message = message.replace(/\{num\}/g, '')
+    }
+
+    // コンプ進捗プレースホルダー: 値が渡された場合のみ置換、未指定時は削除
+    // Collection progress placeholders: substitute only when provided, otherwise strip
+    if (placeholders.unique !== undefined) {
+      message = message.replace(/\{unique\}/g, String(placeholders.unique))
+    } else {
+      message = message.replace(/\{unique\}/g, '')
+    }
+
+    if (placeholders.all !== undefined) {
+      message = message.replace(/\{all\}/g, String(placeholders.all))
+    } else {
+      message = message.replace(/\{all\}/g, '')
     }
 
     // 連続する空白を1つにまとめ、前後の空白を削除

--- a/tests/unit/chat-service.test.ts
+++ b/tests/unit/chat-service.test.ts
@@ -260,4 +260,53 @@ describe('TwitchChatService', () => {
       expect(result).toBe(false);
     });
   });
+
+  describe('buildMessage - コンプ進捗プレースホルダー ({unique}/{all})', () => {
+    const basePlaceholders = {
+      user: 'SampleUser',
+      card: 'Legendary Card',
+      rarity: 'レジェンダリー',
+    };
+
+    it('{unique} と {all} が値に置換される', () => {
+      const message = service.buildMessage(
+        'コンプ進捗: {unique}/{all}種類ゲット！',
+        { ...basePlaceholders, unique: 5, all: 10 }
+      );
+      expect(message).toBe('コンプ進捗: 5/10種類ゲット！');
+    });
+
+    it('unique=0 でも "0" として置換される（未所持状態）', () => {
+      const message = service.buildMessage(
+        '{user} は {unique}/{all}種類を所持しています',
+        { ...basePlaceholders, unique: 0, all: 10 }
+      );
+      expect(message).toBe('SampleUser は 0/10種類を所持しています');
+    });
+
+    it('unique/all 未指定時はプレースホルダーが空文字に置換される', () => {
+      const message = service.buildMessage(
+        '{user} が {card} を獲得！{unique}{all}',
+        basePlaceholders
+      );
+      // 末尾の空文字置換後、空白正規化で末尾スペースが落ちる
+      expect(message).toBe('SampleUser が Legendary Card を獲得！');
+    });
+
+    it('all のみ指定された場合でも {unique} は空文字に置換される', () => {
+      const message = service.buildMessage(
+        'カード総数: {all}種類',
+        { ...basePlaceholders, all: 10 }
+      );
+      expect(message).toBe('カード総数: 10種類');
+    });
+
+    it('既存プレースホルダーと併用できる', () => {
+      const message = service.buildMessage(
+        '@{user} が【{rarity}】{card}（{num}枚目 / コンプ {unique}/{all}）を獲得！',
+        { ...basePlaceholders, num: 3, unique: 5, all: 10 }
+      );
+      expect(message).toBe('@SampleUser が【レジェンダリー】Legendary Card（3枚目 / コンプ 5/10）を獲得！');
+    });
+  });
 });


### PR DESCRIPTION
## 概要

Closes #350

ガチャ結果のチャット通知にコンプ進捗を表示できるよう、2 つのプレースホルダを追加します。

| プレースホルダ | 意味 |
|---|---|
| `{unique}` | 配信者のアクティブカードのうち、そのユーザーが所持しているユニーク種類数 |
| `{all}` | 配信者のアクティブカードの総種類数 |

テンプレート例:
```
@{user} が【{rarity}】{card} を獲得！ コンプ進捗: {unique}/{all}種類
```

## 設計上のポイント

- **不要なクエリを回さない**: テンプレート文字列に `{unique}` / `{all}` が含まれるときだけ DB を叩く。`{num}` の既存パターンに揃えた。
- **DB 側集計**: `{unique}` と `{num}` は既存 RPC `get_user_card_counts(p_twitch_user_id, p_streamer_id)` を使用して GROUP BY 済みの per-card count を取得。PostgREST の行数制限を根本回避しつつ users 事前ルックアップも統合。
- **アクティブカードのみ集計**: `{unique}` はダッシュボードのコンプ進捗表示と整合するため、`is_active = true` のカードのみカウント。
- **並列化**: `{all}`（配信者のアクティブカード数）は ユーザー情報に依存しないため、RPC と `Promise.all` で並列取得。
- **エラー時の挙動**: DB 失敗時は `logger.warn` でログを残し、プレースホルダーは空文字に置換（既存 `{num}` と同等のフォールバック方針）。

## 変更ファイル

- `src/lib/twitch/chat-service.ts` — `ChatMessagePlaceholders` に `unique?` / `all?` を追加し `buildMessage` で置換
- `src/app/api/twitch/eventsub/route.ts` — テンプレート分岐と RPC 利用の条件付きクエリを実装
- `src/components/ChatAnnouncementSettings.tsx` — 設定画面のプレビュー / 文字数上限試算に反映
- `messages/ja.json` / `messages/en.json` — `placeholderHelp` に新プレースホルダーを追記
- `tests/unit/chat-service.test.ts` — `buildMessage` に 5 ケースのユニットテストを追加（置換・0 値・未指定・既存プレースホルダー併用）

## 動作確認

- [x] `npx vitest run tests/unit/chat-service.test.ts` — 18 tests passed
- [x] `npx vitest run tests/unit/` — 604 tests passed（全単体テストに回帰なし）
- [x] `npx eslint` — 変更ファイルで警告なし
- [x] `npx tsc --noEmit` — 変更ファイルで新規エラーなし（既存エラー数 7 から変わらず）
- [ ] 手動確認（preview デプロイ後に実機で確認予定）
  - [ ] テンプレートに `{unique}` / `{all}` を含めて保存
  - [ ] 実際のガチャでチャット通知が期待通りに置換されることを確認
  - [ ] テンプレート未使用時に余計な DB クエリが発行されないことを Logs で確認

## 後方互換性

`ChatMessagePlaceholders` の新フィールドは optional のため既存呼び出しコードに影響はありません。既存テンプレートに `{unique}` / `{all}` が含まれなければ、DB クエリパスも分岐しません。

https://claude.ai/code/session_01CNt5XSZCfTaZfrB1T136pR

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNt5XSZCfTaZfrB1T136pR)_