### PR TITLE
fix: retry transient failures in Twitch chat send (#389)

### DIFF
--- a/src/lib/twitch/chat-service.ts
+++ b/src/lib/twitch/chat-service.ts
@@ -8,6 +8,19 @@ import { TWITCH_CHAT_MESSAGE_MAX_CHARACTERS } from '@/lib/constants'
 
 const TWITCH_API_URL = 'https://api.twitch.tv/helix'
 
+// 一時的な障害（Twitch API 5xx, 429 Rate Limit, ネットワーク例外）に対してのみリトライ。
+// 4xx (401/403/404) は永続的失敗として即座に返す。
+// 過剰なリトライは EventSub の DO CPU time を圧迫するため、最大2回（合計3試行）に抑える。
+// Retry only on transient failures (Twitch API 5xx / 429 / network exceptions).
+// 4xx (401/403/404) is treated as terminal failure. Capped at 2 retries (3 attempts total)
+// to avoid excessive DO CPU time on the EventSub path. See Issue #389.
+const CHAT_SEND_MAX_ATTEMPTS = 3
+// 250ms, 500ms。ジッターは付けない（並列度が低く herd 効果が小さいため）。
+const CHAT_SEND_RETRY_DELAYS_MS = [250, 500]
+const RETRYABLE_HTTP_STATUSES = new Set([429, 500, 502, 503, 504])
+
+const sleep = (ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms))
+
 /**
  * チャット通知のプレースホルダー型
  * Placeholders available for chat announcement templates
@@ -75,106 +88,156 @@ export class TwitchChatService {
    * @returns 成功した場合はtrue、失敗した場合はfalse
    */
   async sendChatMessage(broadcasterTwitchUserId: string, message: string): Promise<boolean> {
-    try {
-      // 送信前にDBのスコープを確認（無駄なAPI呼び出し抑止）
-      // Check DB scope before sending to avoid unnecessary API calls (e.g., repeated 401s from EventSub)
-      const hasChatScope = await hasScope(broadcasterTwitchUserId, ADDITIONAL_SCOPES.CHAT_WRITE)
-      if (!hasChatScope) {
-        logger.info('Skipping chat message - user:write:chat scope not granted', { broadcasterTwitchUserId })
-        return false
-      }
+    // 送信前にDBのスコープを確認（無駄なAPI呼び出し抑止）
+    // Check DB scope before sending to avoid unnecessary API calls (e.g., repeated 401s from EventSub)
+    const hasChatScope = await hasScope(broadcasterTwitchUserId, ADDITIONAL_SCOPES.CHAT_WRITE)
+    if (!hasChatScope) {
+      logger.info('Skipping chat message - user:write:chat scope not granted', { broadcasterTwitchUserId })
+      return false
+    }
 
-      // 配信者本人のアクセストークンを取得（user:write:chatスコープが必要）
-      // Get the broadcaster's access token (requires user:write:chat scope)
-      const accessToken = await getTwitchAccessToken(broadcasterTwitchUserId)
+    // 配信者本人のアクセストークンを取得（user:write:chatスコープが必要）
+    // Get the broadcaster's access token (requires user:write:chat scope)
+    const accessToken = await getTwitchAccessToken(broadcasterTwitchUserId)
 
-      if (!accessToken) {
-        logger.warn('No access token available for broadcaster', { broadcasterTwitchUserId })
-        return false
-      }
+    if (!accessToken) {
+      logger.warn('No access token available for broadcaster', { broadcasterTwitchUserId })
+      return false
+    }
 
-      // メッセージを500文字に制限（Twitch APIの制限）
-      // Truncate message to 500 characters (Twitch API limit)
-      const truncatedMessage = countCharacters(message) > TWITCH_CHAT_MESSAGE_MAX_CHARACTERS
-        ? `${truncateCharacters(message, TWITCH_CHAT_MESSAGE_MAX_CHARACTERS - 3)}...`
-        : message
+    // メッセージを500文字に制限（Twitch APIの制限）
+    // Truncate message to 500 characters (Twitch API limit)
+    const truncatedMessage = countCharacters(message) > TWITCH_CHAT_MESSAGE_MAX_CHARACTERS
+      ? `${truncateCharacters(message, TWITCH_CHAT_MESSAGE_MAX_CHARACTERS - 3)}...`
+      : message
 
-      // Twitch Helix API: POST /helix/chat/messages
-      // sender_id と broadcaster_id を同じにすることで、配信者として投稿
-      const response = await fetch(`${TWITCH_API_URL}/chat/messages`, {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${accessToken}`,
-          'Client-Id': this.clientId,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          broadcaster_id: broadcasterTwitchUserId,
-          sender_id: broadcasterTwitchUserId,
-          message: truncatedMessage,
-        }),
-      })
+    const requestInit: RequestInit = {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Client-Id': this.clientId,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        broadcaster_id: broadcasterTwitchUserId,
+        sender_id: broadcasterTwitchUserId,
+        message: truncatedMessage,
+      }),
+    }
 
-      if (!response.ok) {
-        const errorBody: TwitchApiError = await response.json().catch(() => ({}))
+    // 一時的な障害（5xx / 429 / ネットワーク例外）に対してのみ最大2回リトライ。
+    // 各試行の最終的な「エラーの素」を保持し、全試行失敗時に1度だけ報告する。
+    // Retry only on transient failures; record the last error to report once after exhaustion.
+    let lastResponse: Response | null = null
+    let lastResponseErrorBody: TwitchApiError | null = null
+    let lastException: unknown = null
 
-        // 401かつスコープ不足の場合、ログのみ出力しDBは変更しない
-        // sub-check.tsと同じ方針: 401/403でのスコープ除去は行わず、スコープ除去はユーザーの手動確認APIでのみ行う
-        // 別端末ログイン等でトークンにスコープがない場合、再認証で復旧するためDB保護が重要
-        // On 401 with missing scope, only log a warning without modifying DB.
-        // Follows sub-check.ts pattern: scope removal only via user-initiated verification API.
-        // When token lacks scope (e.g., login from another device), DB preservation allows recovery via re-auth.
-        if (response.status === 401 && (
-          errorBody.message?.includes('user:write:chat') ||
-          errorBody.message?.includes('Insufficient authorization')
-        )) {
-          logger.warn('Twitch API returned 401 for chat scope - token/DB mismatch detected (DB preserved)', {
-            broadcasterTwitchUserId,
-            twitchError: errorBody.message,
-          })
-        }
-
-        // Supabase に記録し、Cron Worker 経由で GitHub Issue を自動作成する
-        // Report to Supabase so the Cron Worker can create a GitHub Issue
-        // 自己修復の後に配置（自己修復が確実に実行されるようにするため）
-        // Placed after self-healing to ensure healing runs regardless of reporting outcome
-        // try-catch で囲む: reportApiError の失敗が return false をブロックしないようにする
-        // Wrapped in try-catch so reportApiError failure doesn't prevent return false
-        try {
-          await reportApiError('/helix/chat/messages', 'POST',
-            new Error(`Twitch API ${response.status}: ${errorBody.message || 'Unknown error'}`),
-            { broadcasterTwitchUserId, status: response.status, twitchError: errorBody.error }
-          )
-        } catch {
-          // reportApiError 自体の失敗はベストエフォート — メインフローをブロックしない
-          // reportApiError failure is best-effort — must not block main flow
-        }
-
-        return false
-      }
-
-        logger.info('Chat message sent successfully', {
-          broadcasterTwitchUserId,
-          messageLength: countCharacters(truncatedMessage),
-        })
-
-      return true
-    } catch (error) {
-      // ネットワークエラーなど予期しない例外をSupabaseに記録
-      // reportError 内部で console.error も出力される
-      // try-catch で囲む: reportError の失敗で例外が sendChatMessage 外に漏れないようにする
-      // Wrapped in try-catch so reportError failure doesn't leak exceptions to callers
+    for (let attempt = 1; attempt <= CHAT_SEND_MAX_ATTEMPTS; attempt++) {
       try {
-        await reportError(error, {
-          context: 'chat-service:sendChatMessage',
+        // Twitch Helix API: POST /helix/chat/messages
+        // sender_id と broadcaster_id を同じにすることで、配信者として投稿
+        const response = await fetch(`${TWITCH_API_URL}/chat/messages`, requestInit)
+
+        if (response.ok) {
+          logger.info('Chat message sent successfully', {
+            broadcasterTwitchUserId,
+            messageLength: countCharacters(truncatedMessage),
+            attempt,
+          })
+          return true
+        }
+
+        const errorBody: TwitchApiError = await response.json().catch(() => ({}))
+        lastResponse = response
+        lastResponseErrorBody = errorBody
+        lastException = null
+
+        // 4xx は永続的失敗とみなしリトライしない（401 スコープ・403 禁止・404 not found 等）。
+        // 429 と 5xx のみリトライ対象。
+        // 4xx is terminal (not retryable). Only 429 and 5xx are retried.
+        const isRetryable = RETRYABLE_HTTP_STATUSES.has(response.status) && attempt < CHAT_SEND_MAX_ATTEMPTS
+        if (!isRetryable) {
+          break
+        }
+
+        logger.warn('Twitch chat message transient failure - retrying', {
           broadcasterTwitchUserId,
+          status: response.status,
+          attempt,
+          nextDelayMs: CHAT_SEND_RETRY_DELAYS_MS[attempt - 1],
         })
+        await sleep(CHAT_SEND_RETRY_DELAYS_MS[attempt - 1])
+      } catch (error) {
+        // ネットワーク例外（fetch reject）はリトライ対象。最終試行のみ外で報告する。
+        // Network exception (fetch reject) is retryable; only the final one will be reported.
+        lastException = error
+        lastResponse = null
+        lastResponseErrorBody = null
+
+        if (attempt >= CHAT_SEND_MAX_ATTEMPTS) {
+          break
+        }
+
+        logger.warn('Twitch chat message network error - retrying', {
+          broadcasterTwitchUserId,
+          attempt,
+          nextDelayMs: CHAT_SEND_RETRY_DELAYS_MS[attempt - 1],
+          error: error instanceof Error ? error.message : String(error),
+        })
+        await sleep(CHAT_SEND_RETRY_DELAYS_MS[attempt - 1])
+      }
+    }
+
+    // 全試行が失敗。HTTPエラー or ネットワーク例外のいずれかを1度だけ報告する。
+    // All attempts exhausted. Report exactly once.
+    if (lastResponse !== null) {
+      const errorBody = lastResponseErrorBody ?? {}
+
+      // 401かつスコープ不足の場合、ログのみ出力しDBは変更しない
+      // sub-check.tsと同じ方針: 401/403でのスコープ除去は行わず、スコープ除去はユーザーの手動確認APIでのみ行う
+      // 別端末ログイン等でトークンにスコープがない場合、再認証で復旧するためDB保護が重要
+      // On 401 with missing scope, only log a warning without modifying DB.
+      // Follows sub-check.ts pattern: scope removal only via user-initiated verification API.
+      // When token lacks scope (e.g., login from another device), DB preservation allows recovery via re-auth.
+      if (lastResponse.status === 401 && (
+        errorBody.message?.includes('user:write:chat') ||
+        errorBody.message?.includes('Insufficient authorization')
+      )) {
+        logger.warn('Twitch API returned 401 for chat scope - token/DB mismatch detected (DB preserved)', {
+          broadcasterTwitchUserId,
+          twitchError: errorBody.message,
+        })
+      }
+
+      // Supabase に記録し、Cron Worker 経由で GitHub Issue を自動作成する
+      // Report to Supabase so the Cron Worker can create a GitHub Issue
+      // try-catch で囲む: reportApiError の失敗が return false をブロックしないようにする
+      // Wrapped in try-catch so reportApiError failure doesn't prevent return false
+      try {
+        await reportApiError('/helix/chat/messages', 'POST',
+          new Error(`Twitch API ${lastResponse.status}: ${errorBody.message || 'Unknown error'}`),
+          { broadcasterTwitchUserId, status: lastResponse.status, twitchError: errorBody.error }
+        )
       } catch {
-        // reportError 自体の失敗はベストエフォート — 必ず return false に到達させる
-        // reportError failure is best-effort — must always reach return false
+        // reportApiError 自体の失敗はベストエフォート — メインフローをブロックしない
+        // reportApiError failure is best-effort — must not block main flow
       }
       return false
     }
+
+    // ネットワーク例外パス。reportError 内部で console.error も出力される
+    // try-catch で囲む: reportError の失敗で例外が sendChatMessage 外に漏れないようにする
+    // Network exception path. Wrapped in try-catch so reportError failure doesn't leak.
+    try {
+      await reportError(lastException, {
+        context: 'chat-service:sendChatMessage',
+        broadcasterTwitchUserId,
+      })
+    } catch {
+      // reportError 自体の失敗はベストエフォート — 必ず return false に到達させる
+      // reportError failure is best-effort — must always reach return false
+    }
+    return false
   }
 
   /**

--- a/tests/unit/chat-service.test.ts
+++ b/tests/unit/chat-service.test.ts
@@ -16,11 +16,18 @@ vi.mock('@/lib/sentry/error-handler', () => ({
 describe('TwitchChatService', () => {
   let service: TwitchChatService;
   const originalFetch = global.fetch;
+  // リトライの指数バックオフ遅延をテスト時のみ即時解決し、テスト時間を短縮する。
+  // describe スコープ内で上書き／復元することで他テストファイルへの副作用を防ぐ。
+  // Stub setTimeout to immediate-fire only inside this describe; restored in afterEach
+  // so other test files are unaffected.
+  const originalSetTimeout = globalThis.setTimeout;
 
   beforeEach(() => {
     vi.clearAllMocks();
     // 各テストの独立性を保つため fetch mock を初期化
     global.fetch = vi.fn();
+    // @ts-expect-error - test-only stub: delay引数を無視してコールバックを即時実行
+    globalThis.setTimeout = (cb: () => void) => { cb(); return 0; };
     // デフォルトではスコープあり（個別テストでオーバーライド可能）
     vi.mocked(hasScope).mockResolvedValue(true);
     service = new TwitchChatService();
@@ -28,6 +35,7 @@ describe('TwitchChatService', () => {
 
   afterEach(() => {
     global.fetch = originalFetch;
+    globalThis.setTimeout = originalSetTimeout;
   });
 
   describe('sendChatMessage - hasScope事前チェック', () => {
@@ -258,6 +266,154 @@ describe('TwitchChatService', () => {
 
       // 外側 catch 内の reportError が失敗しても例外が漏れず false を返す
       expect(result).toBe(false);
+    });
+  });
+
+  describe('sendChatMessage - 一時的失敗のリトライ (Issue #389)', () => {
+    it('500エラーでリトライし、2回目で成功した場合は true を返す', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          json: () => Promise.resolve({ error: 'Internal Server Error', message: 'Unknown error' }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ data: [{ message_id: 'msg-123' }] }),
+        } as Response);
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      expect(result).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      // リトライ成功時は reportApiError は呼ばれない
+      expect(reportApiError).not.toHaveBeenCalled();
+    });
+
+    it('500エラーが連続で起きた場合は最大3回試行し reportApiError が1度だけ呼ばれる', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: 'Internal Server Error', message: 'Unknown error' }),
+      } as Response);
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      expect(result).toBe(false);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+      // すべて失敗した時のみ1回だけ通報
+      expect(reportApiError).toHaveBeenCalledTimes(1);
+      expect(reportApiError).toHaveBeenCalledWith(
+        '/helix/chat/messages',
+        'POST',
+        expect.any(Error),
+        expect.objectContaining({ broadcasterTwitchUserId: '123456789', status: 500 }),
+      );
+    });
+
+    it('502/503/504/429 でも同様にリトライ対象', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+
+      for (const status of [502, 503, 504, 429]) {
+        vi.clearAllMocks();
+        vi.mocked(hasScope).mockResolvedValue(true);
+        vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+
+        vi.mocked(global.fetch)
+          .mockResolvedValueOnce({
+            ok: false,
+            status,
+            json: () => Promise.resolve({ error: 'Service Unavailable' }),
+          } as Response)
+          .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ data: [{ message_id: 'msg-123' }] }),
+          } as Response);
+
+        const result = await service.sendChatMessage('123456789', 'test message');
+
+        expect(result).toBe(true);
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+      }
+    });
+
+    it('401はリトライしない（永続的失敗）', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({
+          error: 'Unauthorized',
+          status: 401,
+          message: 'User access token requires the user:write:chat scope.',
+        }),
+      } as Response);
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      expect(result).toBe(false);
+      // 401は1回で終わる（リトライしない）
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(reportApiError).toHaveBeenCalledTimes(1);
+    });
+
+    it('404もリトライしない（永続的失敗）', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({ error: 'Not Found' }),
+      } as Response);
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      expect(result).toBe(false);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('ネットワーク例外もリトライ対象、最終的に reportError が1度だけ呼ばれる', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+
+      vi.mocked(global.fetch).mockRejectedValue(new Error('ECONNRESET'));
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      expect(result).toBe(false);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+      expect(reportError).toHaveBeenCalledTimes(1);
+      expect(reportApiError).not.toHaveBeenCalled();
+    });
+
+    it('ネットワーク例外→500→200 のように混在しても最終的に成功すれば true', async () => {
+      vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');
+
+      vi.mocked(global.fetch)
+        .mockRejectedValueOnce(new Error('ECONNRESET'))
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          json: () => Promise.resolve({ error: 'Internal Server Error' }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ data: [{ message_id: 'msg-123' }] }),
+        } as Response);
+
+      const result = await service.sendChatMessage('123456789', 'test message');
+
+      expect(result).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+      expect(reportApiError).not.toHaveBeenCalled();
+      expect(reportError).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #389.

`POST /helix/chat/messages` が `Twitch API 500: Unknown error` を返すたびに `sendChatMessage` がリトライせず即座に失敗→ `reportApiError` で auto-generated issue が再発する状況だった。一時的な 5xx / 429 / ネットワーク例外に対してのみ短いリトライを追加し、ノイズを抑える。

## Changes

- `src/lib/twitch/chat-service.ts`: `sendChatMessage` に最大2回（合計3試行）のリトライを追加
  - リトライ対象: HTTP 500 / 502 / 503 / 504 / 429、および fetch reject (ネットワーク例外)
  - 非リトライ対象: 401 / 403 / 404 などの 4xx は永続的失敗として即終了（既存挙動を維持）
  - バックオフ: 250ms → 500ms（固定遅延、ジッタなし）
  - 報告は最終失敗時に1度だけ。`reportApiError` / `reportError` のいずれか
- `tests/unit/chat-service.test.ts`: リトライのテストケース7件追加
  - 500 → 200 でリトライ成功
  - 500 が3回連続で失敗時に `reportApiError` が1度だけ呼ばれる
  - 502 / 503 / 504 / 429 がリトライ対象
  - 401 / 404 はリトライしない
  - ネットワーク例外もリトライ対象、最終的に `reportError` が1度だけ
  - ネットワーク例外 → 500 → 200 の混在で最終的に成功
- リトライ遅延を即時解決するための `setTimeout` スタブは `describe` スコープに閉じ、他テストファイルへ副作用が漏れないように `afterEach` で復元

## Design notes

- リトライ予算は意図的に小さく抑えている（EventSub ハンドラの追加レイテンシを最小化）
- `Retry-After` ヘッダ対応・full jitter は YAGNI で見送り（429 は実際には issue 化していない）
- 既存の 401 スコープ警告ロジック（DB 保護）は変更なし

## Acceptance criteria

- [x] Twitch Helix の一時的な 5xx で即時に GitHub issue が立たない
- [x] 4xx は引き続き即時失敗（無駄なリトライをしない）
- [x] 全試行失敗時のみ Supabase に1度だけ報告

## Test plan

- [x] `npm run test:all` — 666/666 passed (chat-service.test.ts は 25/25 passed)
- [x] `npm run lint` — 0 errors
- [ ] manual: 本番 Twitch API で 5xx 発生時にリトライで吸収されることを wrangler tail で確認

---
Generated by Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWBDcubHfoc486ihHpWito)_