### PR TITLE
feat: streamer toggle for showing unowned cards to viewers (#395)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -385,6 +385,31 @@
       "close": "Close"
     }
   },
+  "cardVisibilitySettings": {
+    "title": "Unowned Card Visibility",
+    "description": "Choose whether viewers can see cards they haven't collected yet on your collection page.",
+    "status": {
+      "enabled": "Visible",
+      "disabled": "Hidden"
+    },
+    "form": {
+      "showUnowned": "Show unowned cards to viewers",
+      "showUnownedHelp": "When off, viewers see only cards they have collected (default).",
+      "showDetails": "Reveal image and description of unowned cards",
+      "showDetailsHelp": "When off, unowned cards show only their rarity; the image, name, and description are masked as placeholders.",
+      "requiresShowUnowned": "requires \"Show unowned cards\""
+    },
+    "messages": {
+      "shownEnabled": "Unowned cards will be shown to viewers",
+      "shownDisabled": "Unowned cards are hidden from viewers",
+      "detailsEnabled": "Unowned card details are now visible",
+      "detailsDisabled": "Unowned card details are now hidden",
+      "saving": "Saving..."
+    },
+    "errors": {
+      "saveFailed": "Failed to save settings"
+    }
+  },
   "channelPointSettings": {
     "title": "Card Redemption Settings",
     "status": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -385,6 +385,31 @@
       "close": "閉じる"
     }
   },
+  "cardVisibilitySettings": {
+    "title": "未所持カードの表示設定",
+    "description": "視聴者向けコレクションページで、未所持カードを並べて見せるかどうかを設定します。",
+    "status": {
+      "enabled": "表示",
+      "disabled": "非表示"
+    },
+    "form": {
+      "showUnowned": "未所持カードを表示する",
+      "showUnownedHelp": "オフの場合、視聴者には所持済みのカードのみ表示されます（既定）。",
+      "showDetails": "未所持カードの画像・説明を公開する",
+      "showDetailsHelp": "オフの場合、未所持カードはレアリティのみ表示され、画像・名前・説明はプレースホルダーになります。",
+      "requiresShowUnowned": "「未所持カードを表示する」が必要"
+    },
+    "messages": {
+      "shownEnabled": "未所持カードを表示するよう設定しました",
+      "shownDisabled": "未所持カードを非表示にしました",
+      "detailsEnabled": "未所持カードの詳細を公開しました",
+      "detailsDisabled": "未所持カードの詳細を非公開にしました",
+      "saving": "保存中..."
+    },
+    "errors": {
+      "saveFailed": "設定の保存に失敗しました"
+    }
+  },
   "channelPointSettings": {
     "title": "カード引き換え設定",
     "status": {

--- a/src/app/api/streamer/settings/route.ts
+++ b/src/app/api/streamer/settings/route.ts
@@ -94,6 +94,10 @@ export async function POST(request: NextRequest) {
       chatAnnouncementTemplate,
       // レアリティ別自動確率設定（オプション）
       rarityWeights,
+      // 未所持カード表示設定（オプション、Issue #395）
+      // Unowned-card visibility settings (optional, Issue #395)
+      showUnownedCards,
+      showUnownedCardDetails,
     } = body;
 
     if (rarityWeights !== undefined && !validateRarityWeightsInput(rarityWeights)) {
@@ -102,6 +106,15 @@ export async function POST(request: NextRequest) {
 
     if (rarityWeights !== undefined && !hasValidRarityWeightsTotal(rarityWeights)) {
       return NextResponse.json({ error: "Rarity weights total must be 100%" }, { status: 400 });
+    }
+
+    // 視聴者向け未所持カード表示の boolean 検証
+    // Booleans are validated strictly to avoid silent coercion of arbitrary inputs
+    if (showUnownedCards !== undefined && typeof showUnownedCards !== "boolean") {
+      return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
+    }
+    if (showUnownedCardDetails !== undefined && typeof showUnownedCardDetails !== "boolean") {
+      return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
     }
 
     // Verify ownership
@@ -152,6 +165,15 @@ export async function POST(request: NextRequest) {
     // rarityWeights: レアリティ別目標確率（nullで自動モード無効）
     if (rarityWeights !== undefined) {
       updateData.rarity_weights = rarityWeights;
+    }
+
+    // 未所持カードの視聴者向け表示設定
+    // Unowned-card visibility settings for the viewer-facing collection page
+    if (showUnownedCards !== undefined) {
+      updateData.show_unowned_cards = showUnownedCards;
+    }
+    if (showUnownedCardDetails !== undefined) {
+      updateData.show_unowned_card_details = showUnownedCardDetails;
     }
 
     // 更新するフィールドがない場合はエラー

--- a/src/app/collection/[streamerId]/page.tsx
+++ b/src/app/collection/[streamerId]/page.tsx
@@ -53,25 +53,46 @@ export default async function StreamerCollectionPage({
   ]);
 
   const activeCardIds = new Set(activeCards.map((card) => card.id));
-  const cards: StreamerCollectionCard[] = sortCollectedCards(userCards).map((card) => ({
+  const ownedCards: StreamerCollectionCard[] = sortCollectedCards(userCards).map((card) => ({
     ...card,
     count: card.count,
     isOwned: true,
   }));
 
-  // Calculate collection statistics
-  // コレクション統計を計算
+  // 未所持カードの視聴者向け表示（Issue #395）
+  // Unowned-card visibility for viewers (Issue #395):
+  //  - show_unowned_cards=false (default): viewer sees only owned cards (legacy behavior)
+  //  - show_unowned_cards=true: viewer also sees unowned active cards (sorted by rarity, after owned)
+  // 「未所持の詳細を隠す」表示制御は SortedCardGrid の props で行うため、ここではカード自体を含めるかだけを判定する。
+  // The "hide details" toggle is enforced in SortedCardGrid; here we only decide inclusion.
+  const ownedCardIds = new Set(ownedCards.map((card) => card.id));
+  const unownedCards: StreamerCollectionCard[] = streamer.show_unowned_cards
+    ? sortCollectedCards(
+        activeCards.filter((card) => !ownedCardIds.has(card.id))
+      ).map((card) => ({
+        ...card,
+        count: 0,
+        isOwned: false,
+      }))
+    : [];
+
+  // 所持カードを先頭に、未所持カードを後ろに連結
+  // Owned cards first, unowned cards appended after — keeps "your collection" at the top.
+  const cards: StreamerCollectionCard[] = [...ownedCards, ...unownedCards];
+
+  // Calculate collection statistics — 未所持カードはカウントしない（所持実績のみ）
+  // Stats summarize the viewer's actual ownership; unowned cards are excluded.
   const stats = {
-    total: cards.reduce((sum, c) => sum + c.count, 0),
-    unique: cards.length,
-    legendary: cards.filter((c) => c.rarity === "legendary").length,
-    epic: cards.filter((c) => c.rarity === "epic").length,
-    rare: cards.filter((c) => c.rarity === "rare").length,
-    common: cards.filter((c) => c.rarity === "common").length,
+    total: ownedCards.reduce((sum, c) => sum + c.count, 0),
+    unique: ownedCards.length,
+    legendary: ownedCards.filter((c) => c.rarity === "legendary").length,
+    epic: ownedCards.filter((c) => c.rarity === "epic").length,
+    rare: ownedCards.filter((c) => c.rarity === "rare").length,
+    common: ownedCards.filter((c) => c.rarity === "common").length,
   };
 
   const progress = {
-    owned: countOwnedActiveCardTypes(cards, activeCardIds),
+    owned: countOwnedActiveCardTypes(ownedCards, activeCardIds),
     total: activeCards.length,
   };
   const isCurrentComplete = progress.total > 0 && progress.owned >= progress.total;
@@ -94,8 +115,12 @@ export default async function StreamerCollectionPage({
       cards={cards}
       stats={stats}
       progress={progress}
+      // visibleCardTypes は「視聴者がページ上で見ている種類数」(所持 + 表示中の未所持)
+      // visibleCardTypes is the number of card types the viewer sees on this page.
       visibleCardTypes={cards.length}
       completionHistory={completionHistoryForDisplay}
+      // 未所持カードの画像/詳細を隠すかどうか（show_unowned_cards=false の場合は意味を持たない）
+      hideUnownedDetails={!streamer.show_unowned_card_details}
     />
   );
 }

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -8,6 +8,7 @@ import ChannelPointSettings from "@/components/ChannelPointSettings";
 import OverlayPreview from "@/components/OverlayPreview";
 import GachaSoundSettings from "@/components/GachaSoundSettings";
 import ChatAnnouncementSettings from "@/components/ChatAnnouncementSettings";
+import CardVisibilitySettings from "@/components/CardVisibilitySettings";
 import VoteCampaignButton from "@/components/VoteCampaignButton";
 
 // Note: Page is automatically dynamic due to cookies() usage in getSession()
@@ -90,6 +91,15 @@ export default async function SettingsPage() {
               streamerId={streamerData.streamer.id}
               currentEnabled={streamerData.streamer.chat_announcement_enabled ?? false}
               currentTemplate={streamerData.streamer.chat_announcement_template ?? null}
+            />
+            {/* 未所持カード表示設定（Issue #395） */}
+            {/* Unowned-card visibility settings (Issue #395) */}
+            <CardVisibilitySettings
+              streamerId={streamerData.streamer.id}
+              currentShowUnowned={streamerData.streamer.show_unowned_cards ?? false}
+              currentShowUnownedDetails={
+                streamerData.streamer.show_unowned_card_details ?? false
+              }
             />
           </>
         }

--- a/src/components/CardVisibilitySettings.tsx
+++ b/src/components/CardVisibilitySettings.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useTranslations } from "next-intl";
+import { logger } from "@/lib/logger";
+
+interface CardVisibilitySettingsProps {
+  streamerId: string;
+  // 視聴者向けに未所持カードを表示するか（オプトイン、初期値 false）
+  // Whether unowned cards are shown on the viewer collection page (opt-in)
+  currentShowUnowned: boolean;
+  // 未所持カードの画像/説明を露出するか（false=プレースホルダーのみ）
+  // Whether to reveal unowned card image/description (false = placeholder only)
+  currentShowUnownedDetails: boolean;
+}
+
+/**
+ * 未所持カード表示設定コンポーネント (Issue #395)
+ * Settings UI for the viewer-facing visibility of unowned cards.
+ *
+ * - 「未所持カードを表示」 (showUnowned): 視聴者ページに未所持カードを並べるか
+ * - 「未所持カードの詳細を公開」 (showDetails): 表示する場合に画像/説明を出すか
+ *
+ * showDetails は showUnowned=true のときだけ意味を持つ。
+ * showDetails has no effect while showUnowned is false; the UI surfaces this dependency.
+ */
+export default function CardVisibilitySettings({
+  streamerId,
+  currentShowUnowned,
+  currentShowUnownedDetails,
+}: CardVisibilitySettingsProps) {
+  const t = useTranslations("cardVisibilitySettings");
+
+  const [showUnowned, setShowUnowned] = useState(currentShowUnowned);
+  const [showDetails, setShowDetails] = useState(currentShowUnownedDetails);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState("");
+  const [isError, setIsError] = useState(false);
+
+  /**
+   * 設定保存。サーバーは指定したフィールドのみ更新するので、変更したものだけ送る。
+   * Server updates only the keys we send, so include only the toggled field.
+   */
+  const saveSettings = useCallback(
+    async (
+      payload: { showUnownedCards?: boolean; showUnownedCardDetails?: boolean }
+    ): Promise<boolean> => {
+      setSaving(true);
+      try {
+        const response = await fetch("/api/streamer/settings", {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ streamerId, ...payload }),
+        });
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          setMessage(errorData.error || t("errors.saveFailed"));
+          setIsError(true);
+          return false;
+        }
+        setIsError(false);
+        return true;
+      } catch (error) {
+        logger.error("CardVisibilitySettings save failed:", error);
+        setMessage(t("errors.saveFailed"));
+        setIsError(true);
+        return false;
+      } finally {
+        setSaving(false);
+      }
+    },
+    [streamerId, t]
+  );
+
+  const handleToggleShowUnowned = useCallback(async () => {
+    const next = !showUnowned;
+    setShowUnowned(next);
+    const ok = await saveSettings({ showUnownedCards: next });
+    if (ok) {
+      setMessage(next ? t("messages.shownEnabled") : t("messages.shownDisabled"));
+    } else {
+      setShowUnowned(!next);
+    }
+  }, [showUnowned, saveSettings, t]);
+
+  const handleToggleShowDetails = useCallback(async () => {
+    const next = !showDetails;
+    setShowDetails(next);
+    const ok = await saveSettings({ showUnownedCardDetails: next });
+    if (ok) {
+      setMessage(
+        next ? t("messages.detailsEnabled") : t("messages.detailsDisabled")
+      );
+    } else {
+      setShowDetails(!next);
+    }
+  }, [showDetails, saveSettings, t]);
+
+  // showDetails は showUnowned=false の場合は事実上意味を持たないため UI を disable
+  // The details toggle is gated by showUnowned to make the dependency explicit.
+  const detailsDisabled = !showUnowned || saving;
+
+  return (
+    <div className="rounded-xl bg-gray-800 p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-white">{t("title")}</h2>
+        <span
+          className={`inline-flex items-center gap-1 rounded-full px-2 py-1 text-xs ${
+            showUnowned
+              ? "bg-green-500/20 text-green-400"
+              : "bg-gray-500/20 text-gray-400"
+          }`}
+        >
+          <span
+            className={`h-2 w-2 rounded-full ${
+              showUnowned ? "bg-green-500" : "bg-gray-500"
+            }`}
+          />
+          {showUnowned ? t("status.enabled") : t("status.disabled")}
+        </span>
+      </div>
+
+      <p className="mb-4 text-sm text-gray-400">{t("description")}</p>
+
+      <div className="space-y-4">
+        {/* 未所持カードを表示 */}
+        <div className="flex items-center gap-3">
+          <label className="relative inline-flex cursor-pointer items-center">
+            <input
+              type="checkbox"
+              checked={showUnowned}
+              onChange={handleToggleShowUnowned}
+              disabled={saving}
+              className="peer sr-only"
+            />
+            <div className="h-6 w-11 rounded-full bg-gray-600 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-purple-600 peer-checked:after:translate-x-full peer-checked:after:border-white peer-disabled:opacity-50" />
+          </label>
+          <span className="text-sm text-gray-300">
+            {t("form.showUnowned")}
+          </span>
+        </div>
+        <p className="-mt-2 ml-14 text-xs text-gray-500">
+          {t("form.showUnownedHelp")}
+        </p>
+
+        {/* 未所持カードの詳細を公開 */}
+        <div className="flex items-center gap-3">
+          <label className="relative inline-flex cursor-pointer items-center">
+            <input
+              type="checkbox"
+              checked={showDetails}
+              onChange={handleToggleShowDetails}
+              disabled={detailsDisabled}
+              className="peer sr-only"
+            />
+            <div
+              className={`h-6 w-11 rounded-full bg-gray-600 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-purple-600 peer-checked:after:translate-x-full peer-checked:after:border-white peer-disabled:opacity-50 ${
+                !showUnowned ? "opacity-50" : ""
+              }`}
+            />
+          </label>
+          <span
+            className={`text-sm ${
+              showUnowned ? "text-gray-300" : "text-gray-500"
+            }`}
+          >
+            {t("form.showDetails")}
+          </span>
+          {!showUnowned && (
+            <span className="text-xs text-gray-500">
+              ({t("form.requiresShowUnowned")})
+            </span>
+          )}
+        </div>
+        <p className="-mt-2 ml-14 text-xs text-gray-500">
+          {t("form.showDetailsHelp")}
+        </p>
+
+        {message && (
+          <p className={`text-sm ${isError ? "text-red-400" : "text-green-400"}`}>
+            {message}
+          </p>
+        )}
+        {saving && (
+          <p className="text-sm text-gray-400">{t("messages.saving")}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/CardVisibilitySettings.tsx
+++ b/src/components/CardVisibilitySettings.tsx
@@ -76,9 +76,19 @@ export default function CardVisibilitySettings({
   const handleToggleShowUnowned = useCallback(async () => {
     const next = !showUnowned;
     setShowUnowned(next);
-    const ok = await saveSettings({ showUnownedCards: next });
+    // 表示OFFに切り替える際は、詳細公開フラグも同時に false にしておく。
+    // 残しておくと、後で再度ONにした瞬間に意図せず詳細が公開状態になってしまうため。
+    // When turning visibility off, also reset the details flag so a later re-enable
+    // doesn't unexpectedly reveal images/descriptions due to stale DB state.
+    const payload = next
+      ? { showUnownedCards: true }
+      : { showUnownedCards: false, showUnownedCardDetails: false };
+    const ok = await saveSettings(payload);
     if (ok) {
       setMessage(next ? t("messages.shownEnabled") : t("messages.shownDisabled"));
+      if (!next) {
+        setShowDetails(false);
+      }
     } else {
       setShowUnowned(!next);
     }

--- a/src/components/SortedCardGrid.tsx
+++ b/src/components/SortedCardGrid.tsx
@@ -56,18 +56,31 @@ export default function SortedCardGrid({
         // First 4 cards get priority for LCP optimization
         // 最初の4枚のカードはLCP最適化のためpriority設定
         const isPriority = index < 4;
-        // 未所持カードで「詳細を隠す」設定の場合は image_url を null に伏せる。
-        // これにより画像領域は noImageText (例: "未所持") のみ表示される。
-        // When hiding unowned details, mask image_url so the image slot only renders the placeholder text.
-        const shouldMaskImage = !isOwned && hideUnownedDetails;
-        const effectiveImageUrl = shouldMaskImage ? null : card.image_url;
+
+        // 未所持カードの「詳細マスク」モード:
+        //   show_unowned_card_details=false (=hideUnownedDetails=true) のときに有効。
+        //   名前/画像/説明をプレースホルダーに置き換え、レアリティバッジのみ残す。
+        //
+        // 「詳細公開」モード (hideUnownedDetails=false) のときは未所持カードでも
+        //   名前・画像・説明を本来のまま表示する。所持済カードとの違いはロック表示と
+        //   グレースケール、所有数の非表示のみ。
+        //
+        // Issue #395 の要求:
+        //   - 視聴者は所持していないカードを「⑤???」のような形で見られる (placeholder)
+        //   - もしくは公開モードでは画像と説明まで含めて見られる
+        const maskUnownedDetails = !isOwned && hideUnownedDetails;
+        const displayName = maskUnownedDetails ? translations.unownedCard : card.name;
+        const displayImageUrl = maskUnownedDetails ? null : card.image_url;
+        const showDescription =
+          (isOwned || !hideUnownedDetails) && Boolean(card.description);
+
         return (
           <CollectionCard
             key={card.id}
             id={card.id}
             streamerId={streamerId}
-            name={isOwned ? card.name : translations.unownedCard}
-            imageUrl={effectiveImageUrl}
+            name={displayName}
+            imageUrl={displayImageUrl}
             rarityInfo={{
               label: rarityInfo.label,
               color: rarityInfo.color,
@@ -80,14 +93,14 @@ export default function SortedCardGrid({
             }
             priority={isPriority}
             noImageText={
-              shouldMaskImage ? translations.unownedCard : translations.noImage
+              maskUnownedDetails ? translations.unownedCard : translations.noImage
             }
             isOwned={isOwned}
             isInactive={isOwned && !card.is_active}
             inactiveLabel={translations.inactiveStatus}
             descriptionComponent={
-              isOwned && card.description ? (
-                <ExpandableDescription description={card.description} />
+              showDescription ? (
+                <ExpandableDescription description={card.description as string} />
               ) : undefined
             }
           />

--- a/src/components/SortedCardGrid.tsx
+++ b/src/components/SortedCardGrid.tsx
@@ -22,6 +22,9 @@ interface SortedCardGridProps {
   // Streamer ID for linking to card detail pages
   // カード詳細ページへのリンク用配信者ID
   streamerId: string;
+  // 未所持カードの画像/説明を隠すか（プレースホルダー表示）
+  // Issue #395: when true, unowned cards render without image/description (rarity badge + "???" only).
+  hideUnownedDetails?: boolean;
   // Translation strings - must be serializable (no functions)
   // 翻訳文字列 - シリアライズ可能である必要あり（関数不可）
   translations: {
@@ -42,6 +45,7 @@ interface SortedCardGridProps {
 export default function SortedCardGrid({
   cards,
   streamerId,
+  hideUnownedDetails = false,
   translations,
 }: SortedCardGridProps) {
   return (
@@ -52,13 +56,18 @@ export default function SortedCardGrid({
         // First 4 cards get priority for LCP optimization
         // 最初の4枚のカードはLCP最適化のためpriority設定
         const isPriority = index < 4;
+        // 未所持カードで「詳細を隠す」設定の場合は image_url を null に伏せる。
+        // これにより画像領域は noImageText (例: "未所持") のみ表示される。
+        // When hiding unowned details, mask image_url so the image slot only renders the placeholder text.
+        const shouldMaskImage = !isOwned && hideUnownedDetails;
+        const effectiveImageUrl = shouldMaskImage ? null : card.image_url;
         return (
           <CollectionCard
             key={card.id}
             id={card.id}
             streamerId={streamerId}
             name={isOwned ? card.name : translations.unownedCard}
-            imageUrl={card.image_url}
+            imageUrl={effectiveImageUrl}
             rarityInfo={{
               label: rarityInfo.label,
               color: rarityInfo.color,
@@ -70,7 +79,9 @@ export default function SortedCardGrid({
                 : undefined
             }
             priority={isPriority}
-            noImageText={translations.noImage}
+            noImageText={
+              shouldMaskImage ? translations.unownedCard : translations.noImage
+            }
             isOwned={isOwned}
             isInactive={isOwned && !card.is_active}
             inactiveLabel={translations.inactiveStatus}

--- a/src/components/StreamerCollection.tsx
+++ b/src/components/StreamerCollection.tsx
@@ -29,6 +29,10 @@ interface StreamerCollectionProps {
   visibleCardTypes: number;
   // 過去のコンプリート達成履歴（デフォルト空配列で後方互換）
   completionHistory?: { total_cards: number; completed_at: string }[];
+  // 未所持カードの画像/説明を隠すか（プレースホルダー表示にするか）
+  // Issue #395: streamer の show_unowned_card_details=false のときに true。
+  // When true, unowned cards are rendered as placeholders (no image / no description).
+  hideUnownedDetails?: boolean;
 }
 
 /**
@@ -44,6 +48,7 @@ export default async function StreamerCollection({
   progress,
   visibleCardTypes,
   completionHistory = [],
+  hideUnownedDetails = false,
 }: StreamerCollectionProps) {
   const t = await getTranslations("collection");
   const tStreamer = await getTranslations("streamerCollection");
@@ -97,6 +102,7 @@ export default async function StreamerCollection({
           <SortedCardGrid
             cards={cards}
             streamerId={streamer.id}
+            hideUnownedDetails={hideUnownedDetails}
             translations={{
               // Pass template string instead of function (Server -> Client serialization)
               // 関数ではなくテンプレート文字列を渡す（サーバー→クライアントのシリアライズ用）

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -36,6 +36,12 @@ export interface Database {
           // レアリティ名をキーにした目標確率マップ（0-100）
           // Dynamic rarity-to-target-percentage map (0-100)
           rarity_weights: Record<string, number> | null
+          // 視聴者向けコレクションページで未所持カードを表示するか（オプトイン、デフォルトfalse）
+          // Whether unowned cards are visible on the viewer collection page (opt-in, default false)
+          show_unowned_cards: boolean
+          // 未所持カード表示時に画像/説明まで公開するか（false=プレースホルダーのみ）
+          // When unowned cards are shown, whether to reveal card image/description
+          show_unowned_card_details: boolean
           created_at: string
           updated_at: string
         }
@@ -53,6 +59,8 @@ export interface Database {
           chat_announcement_enabled?: boolean
           chat_announcement_template?: string | null
           rarity_weights?: Record<string, number> | null
+          show_unowned_cards?: boolean
+          show_unowned_card_details?: boolean
           created_at?: string
           updated_at?: string
         }
@@ -70,6 +78,8 @@ export interface Database {
           chat_announcement_enabled?: boolean
           chat_announcement_template?: string | null
           rarity_weights?: Record<string, number> | null
+          show_unowned_cards?: boolean
+          show_unowned_card_details?: boolean
           created_at?: string
           updated_at?: string
         }

--- a/supabase/migrations/00035_add_unowned_card_visibility_settings.sql
+++ b/supabase/migrations/00035_add_unowned_card_visibility_settings.sql
@@ -1,0 +1,26 @@
+-- 未所持カードの視聴者向け表示設定を streamers テーブルに追加
+-- Add unowned-card visibility settings (for the viewer-facing collection page) to streamers table.
+--
+-- Issue: #395
+--
+-- 既定値は両方 false。これは追加前の挙動（未所持カードは視聴者には全く見えない）と一致する。
+-- The defaults preserve the pre-feature behavior, where unowned cards are invisible to viewers.
+--
+-- show_unowned_cards:
+--   未所持カードを視聴者向けコレクションページに表示するか。
+--   Whether to display unowned cards on the viewer-facing collection page at all.
+--
+-- show_unowned_card_details:
+--   未所持カードを表示する場合に画像（および説明）まで露出するかどうか。
+--   show_unowned_cards が false の場合は意味を持たない。
+--   When unowned cards are shown, whether to reveal image (and description). No effect when
+--   show_unowned_cards is false.
+
+ALTER TABLE streamers
+  ADD COLUMN IF NOT EXISTS show_unowned_cards BOOLEAN DEFAULT FALSE NOT NULL,
+  ADD COLUMN IF NOT EXISTS show_unowned_card_details BOOLEAN DEFAULT FALSE NOT NULL;
+
+COMMENT ON COLUMN streamers.show_unowned_cards IS
+  'Whether unowned cards are visible on the viewer collection page (default: false, opt-in)';
+COMMENT ON COLUMN streamers.show_unowned_card_details IS
+  'When show_unowned_cards is true, whether to reveal card image/description (false = placeholder only)';

--- a/tests/unit/components/sorted-card-grid.test.tsx
+++ b/tests/unit/components/sorted-card-grid.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import SortedCardGrid from '@/components/SortedCardGrid'
+import type { Card } from '@/types/database'
+
+// Issue #395: 未所持カードを視聴者向けに表示するときの「詳細を隠す」モードを検証する。
+// hideUnownedDetails=true のとき、未所持カードは画像が表示されず、プレースホルダーテキスト ("???")
+// のみが noImageText 経由で表示される。所持カードは常に画像と本来の名前で表示される。
+//
+// hideUnownedDetails=true: unowned cards must mask the image (placeholder text only).
+// Owned cards must always render their actual name and image regardless of the flag.
+
+const baseCard = (overrides: Partial<Card>): Card => ({
+  id: 'card-1',
+  streamer_id: 'streamer-1',
+  name: 'カードA',
+  description: 'カードAの説明',
+  image_url: 'https://example.com/card-a.png',
+  rarity: 'common',
+  drop_rate: 25,
+  intra_rarity_weight: 1,
+  is_active: true,
+  hp: 10,
+  atk: 5,
+  def: 5,
+  spd: 5,
+  skill_type: 'attack',
+  skill_name: 'たいあたり',
+  skill_power: 10,
+  created_at: '2026-04-01T00:00:00Z',
+  updated_at: '2026-04-01T00:00:00Z',
+  ...overrides,
+})
+
+const baseTranslations = {
+  cardCountTemplate: 'x{count}',
+  noImage: 'NoImage',
+  unownedCard: '???',
+  inactiveStatus: 'PAUSED',
+}
+
+describe('SortedCardGrid - unowned card visibility (Issue #395)', () => {
+  it('renders owned card with its name and image', () => {
+    const cards = [
+      { ...baseCard({ id: 'owned-1', name: 'OwnedCard' }), count: 2, isOwned: true },
+    ]
+    render(
+      <SortedCardGrid
+        cards={cards}
+        streamerId="streamer-1"
+        translations={baseTranslations}
+      />
+    )
+    expect(screen.getByText('OwnedCard')).toBeInTheDocument()
+    expect(screen.getAllByRole('img')[0]).toHaveAttribute(
+      'alt',
+      'OwnedCard'
+    )
+  })
+
+  it('renders unowned card with masked name when hideUnownedDetails=false (legacy isOwned=false rendering)', () => {
+    const cards = [
+      { ...baseCard({ id: 'unowned-1', name: 'SecretCard' }), count: 0, isOwned: false },
+    ]
+    render(
+      <SortedCardGrid
+        cards={cards}
+        streamerId="streamer-1"
+        hideUnownedDetails={false}
+        translations={baseTranslations}
+      />
+    )
+    expect(screen.queryByText('SecretCard')).not.toBeInTheDocument()
+    expect(screen.getAllByText('???').length).toBeGreaterThan(0)
+    // 画像 (image_url が指定されているため <img> が描画される)
+    expect(screen.getAllByRole('img').length).toBe(1)
+  })
+
+  it('hides unowned card image when hideUnownedDetails=true (placeholder only)', () => {
+    const cards = [
+      { ...baseCard({ id: 'unowned-1', name: 'SecretCard' }), count: 0, isOwned: false },
+    ]
+    render(
+      <SortedCardGrid
+        cards={cards}
+        streamerId="streamer-1"
+        hideUnownedDetails
+        translations={baseTranslations}
+      />
+    )
+    // 名前は隠される
+    expect(screen.queryByText('SecretCard')).not.toBeInTheDocument()
+    // 画像領域は noImageText (= unownedCard) のプレースホルダーになる
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    // "???" は名前とプレースホルダーの両方で出るため、複数あって良い
+    expect(screen.getAllByText('???').length).toBeGreaterThan(0)
+  })
+
+  it('still shows owned card details even when hideUnownedDetails=true', () => {
+    // 同じグリッドに所持・未所持が混在しても、所持側はマスクされない
+    // Owned cards remain fully visible even when the flag is on.
+    const cards = [
+      { ...baseCard({ id: 'owned-1', name: 'OwnedCard' }), count: 1, isOwned: true },
+      { ...baseCard({ id: 'unowned-1', name: 'SecretCard' }), count: 0, isOwned: false },
+    ]
+    render(
+      <SortedCardGrid
+        cards={cards}
+        streamerId="streamer-1"
+        hideUnownedDetails
+        translations={baseTranslations}
+      />
+    )
+    expect(screen.getByText('OwnedCard')).toBeInTheDocument()
+    expect(screen.queryByText('SecretCard')).not.toBeInTheDocument()
+    // 所持カードの画像のみが描画される（未所持は画像が伏せられる）
+    const imgs = screen.getAllByRole('img')
+    expect(imgs).toHaveLength(1)
+    expect(imgs[0]).toHaveAttribute('alt', 'OwnedCard')
+  })
+})

--- a/tests/unit/components/sorted-card-grid.test.tsx
+++ b/tests/unit/components/sorted-card-grid.test.tsx
@@ -52,15 +52,25 @@ describe('SortedCardGrid - unowned card visibility (Issue #395)', () => {
       />
     )
     expect(screen.getByText('OwnedCard')).toBeInTheDocument()
-    expect(screen.getAllByRole('img')[0]).toHaveAttribute(
-      'alt',
-      'OwnedCard'
-    )
+    expect(screen.getByAltText('OwnedCard')).toBeInTheDocument()
   })
 
-  it('renders unowned card with masked name when hideUnownedDetails=false (legacy isOwned=false rendering)', () => {
+  it('reveals name/image/description for unowned cards when hideUnownedDetails=false (公開モード)', () => {
+    // show_unowned_card_details=true → hideUnownedDetails=false の経路。
+    // i18n ラベル「画像・説明を公開」の契約どおり、未所持カードでも本来の name / image_url
+    // / description が表示される必要がある（所持カードとの差はロックアイコンと所有数の非表示のみ）。
+    // The "reveal details" mode contract: name, image, and description must be visible
+    // even for unowned cards; only ownership-specific UI (count, lock styling) differs.
     const cards = [
-      { ...baseCard({ id: 'unowned-1', name: 'SecretCard' }), count: 0, isOwned: false },
+      {
+        ...baseCard({
+          id: 'unowned-1',
+          name: 'SecretCard',
+          description: 'カード説明テキスト',
+        }),
+        count: 0,
+        isOwned: false,
+      },
     ]
     render(
       <SortedCardGrid
@@ -70,15 +80,25 @@ describe('SortedCardGrid - unowned card visibility (Issue #395)', () => {
         translations={baseTranslations}
       />
     )
-    expect(screen.queryByText('SecretCard')).not.toBeInTheDocument()
-    expect(screen.getAllByText('???').length).toBeGreaterThan(0)
-    // 画像 (image_url が指定されているため <img> が描画される)
-    expect(screen.getAllByRole('img').length).toBe(1)
+    // 名前は本来のものが見える
+    expect(screen.getByText('SecretCard')).toBeInTheDocument()
+    // 画像も描画される（alt は本来の名前）
+    expect(screen.getByAltText('SecretCard')).toBeInTheDocument()
+    // 説明テキストも見える
+    expect(screen.getByText(/カード説明テキスト/)).toBeInTheDocument()
   })
 
-  it('hides unowned card image when hideUnownedDetails=true (placeholder only)', () => {
+  it('hides unowned card image / name / description when hideUnownedDetails=true (placeholder only)', () => {
     const cards = [
-      { ...baseCard({ id: 'unowned-1', name: 'SecretCard' }), count: 0, isOwned: false },
+      {
+        ...baseCard({
+          id: 'unowned-1',
+          name: 'SecretCard',
+          description: 'カード説明テキスト',
+        }),
+        count: 0,
+        isOwned: false,
+      },
     ]
     render(
       <SortedCardGrid
@@ -92,8 +112,30 @@ describe('SortedCardGrid - unowned card visibility (Issue #395)', () => {
     expect(screen.queryByText('SecretCard')).not.toBeInTheDocument()
     // 画像領域は noImageText (= unownedCard) のプレースホルダーになる
     expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    // 説明テキストは漏れない
+    expect(screen.queryByText(/カード説明テキスト/)).not.toBeInTheDocument()
     // "???" は名前とプレースホルダーの両方で出るため、複数あって良い
     expect(screen.getAllByText('???').length).toBeGreaterThan(0)
+  })
+
+  it('always shows the rarity badge regardless of hideUnownedDetails (Issue #395 core requirement)', () => {
+    // Issue 本文の「⑤???」ように、レアリティ（または序列）は常に視聴者に出すのが要点。
+    // The rarity badge must always be visible — that is what makes "placeholder mode"
+    // useful at all (otherwise the placeholder would carry zero information).
+    const cards = [
+      { ...baseCard({ id: 'unowned-1', name: 'SecretCard', rarity: 'legendary' }), count: 0, isOwned: false },
+    ]
+    render(
+      <SortedCardGrid
+        cards={cards}
+        streamerId="streamer-1"
+        hideUnownedDetails
+        translations={baseTranslations}
+      />
+    )
+    // RARITIES のラベルは constants.ts に定義されている (legendary → "レジェンダリー")
+    // The rarity label comes from RARITIES constants, not i18n.
+    expect(screen.getByText("レジェンダリー")).toBeInTheDocument()
   })
 
   it('still shows owned card details even when hideUnownedDetails=true', () => {

--- a/tests/unit/streamer-settings-api.test.ts
+++ b/tests/unit/streamer-settings-api.test.ts
@@ -201,6 +201,110 @@ describe('POST /api/streamer/settings', () => {
     expect(data.error).toBe('Unauthorized')
   })
 
+  // Issue #395: 視聴者向け未所持カード表示設定
+  // The settings API must accept showUnownedCards / showUnownedCardDetails as
+  // independent booleans, validate non-boolean inputs strictly, and persist
+  // them via the existing dynamic updateData pattern.
+  describe('unowned card visibility settings (Issue #395)', () => {
+    it('should accept showUnownedCards/showUnownedCardDetails when both are booleans', async () => {
+      const mockSupabase = createSupabaseMock()
+        .withMaybeSingleResponse({
+          id: 'streamer123',
+          twitch_user_id: 'streamer123',
+        })
+        .build()
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(
+        mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>
+      )
+
+      const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          showUnownedCards: true,
+          showUnownedCardDetails: false,
+        }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.success).toBe(true)
+    })
+
+    it('should reject showUnownedCards when not a boolean', async () => {
+      const mockSupabase = createSupabaseMock().build()
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(
+        mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>
+      )
+
+      const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          // 文字列 "true" は truthy だが boolean ではないので 400 にしたい
+          showUnownedCards: 'true',
+        }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(400)
+    })
+
+    it('should reject showUnownedCardDetails when not a boolean', async () => {
+      const mockSupabase = createSupabaseMock().build()
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(
+        mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>
+      )
+
+      const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          showUnownedCardDetails: 1,
+        }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(400)
+    })
+
+    it('should accept independent showUnownedCardDetails toggle without showUnownedCards', async () => {
+      // 設定UIはトグル単位で部分送信するため、片方だけが届くケースが正常系
+      // The UI may send only one of the two booleans on toggle; both halves must work alone.
+      const mockSupabase = createSupabaseMock()
+        .withMaybeSingleResponse({
+          id: 'streamer123',
+          twitch_user_id: 'streamer123',
+        })
+        .build()
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(
+        mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>
+      )
+
+      const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          showUnownedCardDetails: true,
+        }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(200)
+    })
+  })
+
   it('should return 429 when rate limit exceeded', async () => {
     mockCheckRateLimit.mockResolvedValue({
       success: false,


### PR DESCRIPTION
## Summary

Closes #395.

視聴者向けコレクションページ (`/collection/[streamerId]`) で **配信者が未所持カードの可視性を制御** できるようにした。既定はオフ（既存挙動 = 未所持カードは視聴者に見えない）。

## 設定の意味

| `show_unowned_cards` | `show_unowned_card_details` | 視聴者の見え方 |
| --- | --- | --- |
| false (default) | (任意) | 所持カードのみ（既存挙動） |
| true | true | 未所持カードも表示。名前・画像・説明まで公開（所持/非所持の差はロックアイコンと所有数の有無のみ） |
| true | false | 未所持カードも表示。ただし画像・名前・説明はマスクされ、レアリティバッジ＋「???」プレースホルダーのみ |

## Changes

- **DB migration** `supabase/migrations/00035_add_unowned_card_visibility_settings.sql`
  - `streamers.show_unowned_cards` / `show_unowned_card_details` (`BOOLEAN NOT NULL DEFAULT FALSE`)
- **API** `src/app/api/streamer/settings/route.ts`
  - `showUnownedCards` / `showUnownedCardDetails` を strict boolean 検証で受け付ける
- **Collection page** `src/app/collection/[streamerId]/page.tsx`
  - `show_unowned_cards=true` のとき未所持アクティブカードを末尾に連結
  - **stats / progress / コンプリート判定は所持カードのみ** で集計（既存挙動の互換性）
- **Components**
  - `src/components/SortedCardGrid.tsx`: `hideUnownedDetails` prop 追加。マスクモードで画像/名前/説明をプレースホルダー化、公開モードで未所持でも詳細を露出
  - `src/components/StreamerCollection.tsx`: prop パススルー
  - `src/components/CardVisibilitySettings.tsx` (new): 配信者ダッシュボード用クライアント UI。詳細トグルは「表示」がオフのとき disable。表示をオフに切り替えた際は詳細フラグも同時にリセットして残留状態を防ぐ。
  - `src/app/dashboard/settings/page.tsx`: 新コンポーネントを配線
- **i18n** `messages/{ja,en}.json` に `cardVisibilitySettings.*` を追加
- **Tests**
  - `tests/unit/streamer-settings-api.test.ts`: 新 API フィールド (boolean strict / 単独送信) のテスト 4 件
  - `tests/unit/components/sorted-card-grid.test.tsx` (new): 公開モード / マスクモード / レアリティバッジ常時可視 / 所持カード非影響 5 件

## Acceptance criteria (Issue #395)

- [x] 配信者が「未所持カードを見せるか」を ON/OFF できる
- [x] 配信者が「未所持カードの詳細（画像・説明）を公開するか」を ON/OFF できる
- [x] 詳細を隠した場合は「⑤???」のような形（レアリティ＋プレースホルダー）で見える
- [x] 既定は両方 OFF（既存挙動を破壊しない）

## Self-review notes

セルフレビュー結果を反映済み:

- 詳細公開モードで未所持カードの name/image/description が i18n ラベル通りに表示されること
- 表示OFFに切り替える際は詳細フラグも一緒に false にしてDB残留状態を防ぐこと
- レアリティバッジが常時可視であること

## Test plan

- [x] `npx vitest run` — 677/677 passed
- [x] `npm run lint` — 0 errors（pre-existing warnings のみ）
- [x] tsc 既存エラー数と同数（5 → 5、いずれも他テスト由来の既存エラー）
- [ ] manual: 設定 ON/OFF を切り替えて視聴者ページの見え方が変わることを確認
- [ ] manual: 設定で「表示」をオフにしたあと再度オンにしたとき、詳細フラグが OFF にリセットされていること

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWBDcubHfoc486ihHpWito)_