### PR TITLE
chore: migrate OpenNext config helper

### DIFF
--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -1,40 +1,5 @@
-import type { OpenNextConfig } from "@opennextjs/cloudflare";
+import { defineCloudflareConfig } from "@opennextjs/cloudflare";
 
-/**
- * OpenNext configuration for Cloudflare Workers
- * Cloudflare Workers用のOpenNext設定
- *
- * This configuration file controls how the Next.js app is deployed
- * to Cloudflare Workers using OpenNext.
- *
- * この設定ファイルはOpenNextを使用してNext.jsアプリを
- * Cloudflare Workersにデプロイする方法を制御します。
- */
-const config: OpenNextConfig = {
-  default: {
-    override: {
-      wrapper: "cloudflare-node",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-      incrementalCache: "dummy",
-      tagCache: "dummy",
-      queue: "direct",
-    },
-  },
-  // Allow Node.js crypto in edge runtime
-  // EdgeランタイムでNode.js cryptoを許可
-  edgeExternals: ["node:crypto"],
-  middleware: {
-    external: true,
-    override: {
-      wrapper: "cloudflare-edge",
-      converter: "edge",
-      proxyExternalRequest: "fetch",
-      incrementalCache: "dummy",
-      tagCache: "dummy",
-      queue: "direct",
-    },
-  },
-};
-
-export default config;
+export default defineCloudflareConfig({
+  queue: "direct",
+});

--- a/tests/unit/open-next-config.test.ts
+++ b/tests/unit/open-next-config.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import config from "../../open-next.config";
+
+describe("open-next.config", () => {
+  it("uses the Cloudflare config helper while preserving existing runtime overrides", () => {
+    expect(config.default.override.wrapper).toBe("cloudflare-node");
+    expect(config.default.override.converter).toBe("edge");
+    expect(config.default.override.proxyExternalRequest).toBe("fetch");
+    expect(config.default.override.incrementalCache).toBe("dummy");
+    expect(config.default.override.tagCache).toBe("dummy");
+    expect(config.default.override.queue).toBe("direct");
+
+    expect(config.edgeExternals).toContain("node:crypto");
+    expect(config.middleware?.external).toBe(true);
+    expect(config.middleware?.override?.wrapper).toBe("cloudflare-edge");
+    expect(config.middleware?.override?.queue).toBe("direct");
+    expect(config.cloudflare?.useWorkerdCondition).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- migrate `open-next.config.ts` to `defineCloudflareConfig()`
- preserve the existing direct revalidation queue setting
- add a unit test that locks the generated Cloudflare runtime overrides

Closes #238

## Verification
- `npx vitest run tests/unit/open-next-config.test.ts`
- `npm run lint`
- `npm run test:unit`
- `npm run workers:build`
