### PR TITLE
perf: lazy-load dashboard client components

### DIFF
--- a/src/app/dashboard/cards/page.tsx
+++ b/src/app/dashboard/cards/page.tsx
@@ -1,9 +1,17 @@
 import { redirect } from "next/navigation";
+import dynamic from "next/dynamic";
 import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { getStreamerData } from "@/lib/dashboard-data";
 import { getUserPlan, PLAN_MAX_IMAGE_WIDTH, PLAN_AVAILABLE_WIDTHS } from "@/lib/plan";
-import CardManager from "@/components/CardManager";
 import type { Card } from "@/types/database";
+
+const CardManager = dynamic(() => import("@/components/CardManager"), {
+  loading: () => (
+    <div className="rounded-lg border border-gray-700 bg-gray-800 p-6 text-sm text-gray-400">
+      Loading cards...
+    </div>
+  ),
+});
 
 // Note: Page is automatically dynamic due to cookies() usage in getSession()
 // cookies()使用により自動的に動的ページになるため、force-dynamicは不要

--- a/src/app/dashboard/history/page.tsx
+++ b/src/app/dashboard/history/page.tsx
@@ -1,4 +1,5 @@
 import { getTranslations } from "next-intl/server";
+import dynamic from "next/dynamic";
 import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { getSupabaseAdmin } from "@/lib/supabase/admin";
 import {
@@ -6,7 +7,14 @@ import {
   getGachaHistoryForUser,
   getActiveCardsForStreamer,
 } from "@/lib/dashboard-data";
-import GachaHistoryTable from "@/components/GachaHistoryTable";
+
+const GachaHistoryTable = dynamic(() => import("@/components/GachaHistoryTable"), {
+  loading: () => (
+    <div className="rounded-lg border border-gray-700 bg-gray-800 p-6 text-sm text-gray-400">
+      Loading history...
+    </div>
+  ),
+});
 
 /**
  * Gacha History page

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,15 +1,41 @@
 import { redirect } from "next/navigation";
+import dynamic from "next/dynamic";
 import { getTranslations } from "next-intl/server";
 import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { getStreamerData } from "@/lib/dashboard-data";
 import { shouldShowVoteCampaign } from "@/lib/storage-db";
 import { VOTE_CAMPAIGN_CONFIG } from "@/lib/constants";
-import ChannelPointSettings from "@/components/ChannelPointSettings";
-import OverlayPreview from "@/components/OverlayPreview";
-import GachaSoundSettings from "@/components/GachaSoundSettings";
-import ChatAnnouncementSettings from "@/components/ChatAnnouncementSettings";
-import CardVisibilitySettings from "@/components/CardVisibilitySettings";
 import VoteCampaignButton from "@/components/VoteCampaignButton";
+
+const OverlayPreview = dynamic(() => import("@/components/OverlayPreview"), {
+  loading: () => (
+    <div className="rounded-lg border border-gray-700 bg-gray-800 p-6 text-sm text-gray-400">
+      Loading overlay preview...
+    </div>
+  ),
+});
+
+const ChannelPointSettings = dynamic(() => import("@/components/ChannelPointSettings"), {
+  loading: () => <SettingsPanelSkeleton />,
+});
+const GachaSoundSettings = dynamic(() => import("@/components/GachaSoundSettings"), {
+  loading: () => <SettingsPanelSkeleton />,
+});
+const ChatAnnouncementSettings = dynamic(() => import("@/components/ChatAnnouncementSettings"), {
+  loading: () => <SettingsPanelSkeleton />,
+});
+const CardVisibilitySettings = dynamic(() => import("@/components/CardVisibilitySettings"), {
+  loading: () => <SettingsPanelSkeleton />,
+});
+
+function SettingsPanelSkeleton() {
+  return (
+    <div className="rounded-lg border border-gray-700 bg-gray-800 p-4">
+      <div className="h-4 w-1/3 rounded bg-gray-700" />
+      <div className="mt-3 h-3 w-2/3 rounded bg-gray-700" />
+    </div>
+  );
+}
 
 // Note: Page is automatically dynamic due to cookies() usage in getSession()
 // cookies()使用により自動的に動的ページになるため、force-dynamicは不要

--- a/tests/unit/dynamic-imports.test.ts
+++ b/tests/unit/dynamic-imports.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readSource(path: string) {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+describe("dashboard dynamic imports", () => {
+  it("lazy-loads the large card manager client component", () => {
+    const source = readSource("src/app/dashboard/cards/page.tsx");
+
+    expect(source).toContain('import dynamic from "next/dynamic"');
+    expect(source).toContain('dynamic(() => import("@/components/CardManager")');
+    expect(source).not.toContain('import CardManager from "@/components/CardManager"');
+  });
+
+  it("lazy-loads the gacha history table client component", () => {
+    const source = readSource("src/app/dashboard/history/page.tsx");
+
+    expect(source).toContain('import dynamic from "next/dynamic"');
+    expect(source).toContain('dynamic(() => import("@/components/GachaHistoryTable")');
+    expect(source).not.toContain('import GachaHistoryTable from "@/components/GachaHistoryTable"');
+  });
+
+  it("lazy-loads streamer settings panels", () => {
+    const source = readSource("src/app/dashboard/settings/page.tsx");
+
+    expect(source).toContain('dynamic(() => import("@/components/OverlayPreview")');
+    expect(source).toContain('dynamic(() => import("@/components/ChannelPointSettings")');
+    expect(source).toContain('dynamic(() => import("@/components/GachaSoundSettings")');
+    expect(source).toContain('dynamic(() => import("@/components/ChatAnnouncementSettings")');
+    expect(source).toContain('dynamic(() => import("@/components/CardVisibilitySettings")');
+  });
+});


### PR DESCRIPTION
## Summary
- Lazy-load large dashboard client components with `next/dynamic`
- Add loading fallbacks for card management, gacha history, overlay preview, and streamer settings panels
- Add a unit test that guards the dynamic import boundaries

Issues: Closes #237

## Validation
- `npx vitest run tests/unit/dynamic-imports.test.ts`
- `npm run lint` (passes with existing warnings)
- `npm run workers:build` (passes; existing Next.js middleware deprecation warning remains tracked by #417)
