### PR TITLE
feat: show card owners in gacha stats

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -954,7 +954,10 @@
       "rarity": "Rarity",
       "configuredRate": "Configured Rate",
       "actualRate": "Actual Rate",
-      "drawCount": "Draw Count"
+      "drawCount": "Draw Count",
+      "owners": "Owners",
+      "ownerCount": "{count} users",
+      "noOwners": "No owners"
     },
     "raritySummary": "Rarity Summary",
     "fullPeriodStats": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -951,7 +951,10 @@
       "rarity": "レアリティ",
       "configuredRate": "設定排出率",
       "actualRate": "実際の排出率",
-      "drawCount": "排出回数"
+      "drawCount": "排出回数",
+      "owners": "所持ユーザー",
+      "ownerCount": "{count}人",
+      "noOwners": "所持ユーザーなし"
     },
     "raritySummary": "レアリティ別サマリー",
     "fullPeriodStats": {

--- a/src/components/DropRateTable.tsx
+++ b/src/components/DropRateTable.tsx
@@ -15,6 +15,14 @@ interface CardStat {
   configuredRate: number;
   actualCount: number;
   actualRate: number;
+  ownerCount: number;
+  owners: Array<{
+    userTwitchId: string;
+    username: string;
+    displayName: string;
+    ownedCount: number;
+    lastObtainedAt: string;
+  }>;
 }
 
 interface RarityStat {
@@ -205,6 +213,7 @@ export default function DropRateTable() {
                 <th className="p-3 text-right">
                   {t("dropRateTable.drawCount")}
                 </th>
+                <th className="p-3">{t("dropRateTable.owners")}</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-700">
@@ -254,6 +263,35 @@ export default function DropRateTable() {
                   </td>
                   <td className="p-3 text-right text-gray-300">
                     {card.actualCount}
+                  </td>
+                  <td className="p-3">
+                    <div className="min-w-48 max-w-xs">
+                      <div className="text-sm font-medium text-white">
+                        {t("dropRateTable.ownerCount", {
+                          count: card.ownerCount,
+                        })}
+                      </div>
+                      {card.owners.length > 0 ? (
+                        <div className="mt-1 flex flex-wrap gap-1">
+                          {card.owners.map((owner) => (
+                            <span
+                              key={owner.userTwitchId}
+                              className="rounded bg-gray-700 px-2 py-0.5 text-xs text-gray-200"
+                              title={owner.userTwitchId}
+                            >
+                              {owner.displayName || owner.username}
+                              {owner.ownedCount > 1
+                                ? ` x${owner.ownedCount}`
+                                : ""}
+                            </span>
+                          ))}
+                        </div>
+                      ) : (
+                        <div className="mt-1 text-xs text-gray-500">
+                          {t("dropRateTable.noOwners")}
+                        </div>
+                      )}
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -551,6 +551,14 @@ export interface GachaStatsResult {
     configuredRate: number;
     actualCount: number;
     actualRate: number;
+    ownerCount: number;
+    owners: Array<{
+      userTwitchId: string;
+      username: string;
+      displayName: string;
+      ownedCount: number;
+      lastObtainedAt: string;
+    }>;
   }>;
   rarityStats: Array<{
     rarity: string;
@@ -590,6 +598,25 @@ interface GachaDropStatsRpcRarityRow {
   rate: number | string;
 }
 
+type GachaStatsOwner = GachaStatsResult["cardStats"][number]["owners"][number];
+
+type GachaStatsOwnerRow = {
+  card_id: string;
+  obtained_at: string;
+  users:
+    | {
+        twitch_user_id: string;
+        twitch_username: string | null;
+        twitch_display_name: string | null;
+      }
+    | Array<{
+        twitch_user_id: string;
+        twitch_username: string | null;
+        twitch_display_name: string | null;
+      }>
+    | null;
+};
+
 function parseGachaDropStatsRpc(rpcResult: unknown): Omit<GachaStatsResult, "channelPointStats"> | null {
   if (!rpcResult || typeof rpcResult !== "object") return null;
 
@@ -612,6 +639,8 @@ function parseGachaDropStatsRpc(rpcResult: unknown): Omit<GachaStatsResult, "cha
       configuredRate: Number(row.configured_rate || 0),
       actualCount: Number(row.actual_count || 0),
       actualRate: Number(row.actual_rate || 0),
+      ownerCount: 0,
+      owners: [],
     })),
     rarityStats: payload.rarity_stats.map((row) => ({
       rarity: row.rarity,
@@ -732,12 +761,23 @@ export async function getGachaStats(
   const daysAgo = period === "7d" ? 7 : 30;
   const fromDate = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000);
 
-  const [dropStatsResult, channelPointResult] = await Promise.all([
+  const [dropStatsResult, ownerResult, channelPointResult] = await Promise.all([
     supabaseAdmin
       .rpc("get_gacha_drop_stats", {
         p_streamer_id: streamerId,
         p_from_date: fromDate.toISOString(),
       }),
+    supabaseAdmin
+      .from("user_cards")
+      .select(`
+        card_id,
+        obtained_at,
+        users!inner(twitch_user_id, twitch_username, twitch_display_name),
+        cards!inner(streamer_id, is_active)
+      `)
+      .eq("cards.streamer_id", streamerId)
+      .eq("cards.is_active", true)
+      .range(0, 9999),
     supabaseAdmin
       .rpc("get_channel_point_usage_stats", {
         p_streamer_id: streamerId,
@@ -767,7 +807,45 @@ export async function getGachaStats(
     }
   }
 
-  return { ...dropStats, channelPointStats };
+  const ownersByCard = new Map<string, Map<string, GachaStatsOwner>>();
+
+  for (const row of (ownerResult.data || []) as GachaStatsOwnerRow[]) {
+    const user = Array.isArray(row.users) ? row.users[0] : row.users;
+    if (!user) continue;
+
+    const cardOwners = ownersByCard.get(row.card_id) || new Map();
+    const existing = cardOwners.get(user.twitch_user_id);
+    if (existing) {
+      existing.ownedCount += 1;
+      if (row.obtained_at > existing.lastObtainedAt) {
+        existing.lastObtainedAt = row.obtained_at;
+      }
+    } else {
+      cardOwners.set(user.twitch_user_id, {
+        userTwitchId: user.twitch_user_id,
+        username: user.twitch_username || "",
+        displayName: user.twitch_display_name || user.twitch_username || "",
+        ownedCount: 1,
+        lastObtainedAt: row.obtained_at,
+      });
+    }
+    ownersByCard.set(row.card_id, cardOwners);
+  }
+
+  const cardStats = dropStats.cardStats.map((card) => {
+    const owners = Array.from(ownersByCard.get(card.cardId)?.values() || []).sort(
+      (a, b) =>
+        b.ownedCount - a.ownedCount ||
+        new Date(b.lastObtainedAt).getTime() - new Date(a.lastObtainedAt).getTime()
+    );
+    return {
+      ...card,
+      ownerCount: owners.length,
+      owners,
+    };
+  });
+
+  return { ...dropStats, cardStats, channelPointStats };
 }
 
 /**

--- a/tests/unit/gacha-stats-api.test.ts
+++ b/tests/unit/gacha-stats-api.test.ts
@@ -156,9 +156,41 @@ describe("GET /api/gacha-stats", () => {
       });
     });
 
+    const ownersQuery = createMockQueryBuilder();
+    const ownersResponse = {
+      data: [
+        {
+          card_id: "c1",
+          obtained_at: "2026-01-01T00:00:00Z",
+          users: {
+            twitch_user_id: "viewer1",
+            twitch_username: "alice",
+            twitch_display_name: "Alice",
+          },
+        },
+        {
+          card_id: "c1",
+          obtained_at: "2026-01-02T00:00:00Z",
+          users: {
+            twitch_user_id: "viewer1",
+            twitch_username: "alice",
+            twitch_display_name: "Alice",
+          },
+        },
+      ],
+      error: null,
+    };
+    (ownersQuery as unknown as Record<string, unknown>).then = (
+      resolve: (value: unknown) => void
+    ) => {
+      resolve(ownersResponse);
+      return ownersQuery;
+    };
+
     mockGetSupabaseAdmin.mockReturnValue({
       from: vi.fn((table: string) => {
         if (table === "streamers") return streamerQuery;
+        if (table === "user_cards") return ownersQuery;
         return createMockQueryBuilder();
       }),
       rpc,
@@ -173,6 +205,16 @@ describe("GET /api/gacha-stats", () => {
     expect(body.cardStats[0].cardName).toBe("Card1");
     expect(body.cardStats[0].actualCount).toBe(1001);
     expect(body.cardStats[0].actualRate).toBe(100);
+    expect(body.cardStats[0].ownerCount).toBe(1);
+    expect(body.cardStats[0].owners).toEqual([
+      {
+        userTwitchId: "viewer1",
+        username: "alice",
+        displayName: "Alice",
+        ownedCount: 2,
+        lastObtainedAt: "2026-01-02T00:00:00Z",
+      },
+    ]);
     expect(body.rarityStats).toHaveLength(4);
     expect(body.channelPointStats.totalPoints).toBe(250);
     expect(body.channelPointStats.ranking).toEqual([


### PR DESCRIPTION
## Summary
- add current card-owner aggregation to the gacha stats API using `user_cards`
- show owner counts and owner name chips in the dashboard stats card table
- cover duplicate card ownership aggregation in the gacha stats API test

## Issues
Closes #391

## Validation
- `npx vitest run tests/unit/gacha-stats-api.test.ts`
- `npm run lint` (passes with existing warnings)
- `npm run workers:build` (passes with existing middleware-to-proxy warning)
