### PR TITLE
feat: add channel point usage ranking

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -915,6 +915,15 @@
     "totalDraws": "Total Draws",
     "draws": "draws",
     "noData": "No gacha data for this period.",
+    "channelPointRanking": {
+      "title": "Channel Point Usage Ranking",
+      "total": "Period total: {points} points",
+      "noData": "No channel point usage data for this period.",
+      "rank": "Rank",
+      "user": "User",
+      "points": "Points Used",
+      "redemptions": "Redemptions"
+    },
     "dropRateTable": {
       "cardName": "Card Name",
       "rarity": "Rarity",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -912,6 +912,15 @@
     "totalDraws": "総ガチャ回数",
     "draws": "回",
     "noData": "この期間にはガチャデータがありません。",
+    "channelPointRanking": {
+      "title": "チャネルポイント使用ランキング",
+      "total": "期間内合計: {points} ポイント",
+      "noData": "この期間にはチャネルポイント使用データがありません。",
+      "rank": "順位",
+      "user": "ユーザー",
+      "points": "使用ポイント",
+      "redemptions": "回数"
+    },
     "dropRateTable": {
       "cardName": "カード名",
       "rarity": "レアリティ",

--- a/src/components/DropRateTable.tsx
+++ b/src/components/DropRateTable.tsx
@@ -25,6 +25,16 @@ interface RarityStat {
 
 interface GachaStatsData {
   totalDraws: number;
+  channelPointStats: {
+    totalPoints: number;
+    ranking: Array<{
+      userTwitchId: string;
+      username: string;
+      totalPoints: number;
+      redemptionCount: number;
+      lastRedeemedAt: string | null;
+    }>;
+  };
   cardStats: CardStat[];
   rarityStats: RarityStat[];
 }
@@ -107,6 +117,58 @@ export default function DropRateTable() {
             <div className="text-sm text-gray-400">
               {t("totalDraws")} ({t(`period.${period}`)})
             </div>
+          </div>
+
+          {/* Channel point usage ranking / チャネルポイント使用ランキング */}
+          <div className="mb-6 overflow-hidden rounded-xl bg-gray-800">
+            <div className="border-b border-gray-700 p-4">
+              <h3 className="text-lg font-semibold text-white">
+                {t("channelPointRanking.title")}
+              </h3>
+              <p className="mt-1 text-sm text-gray-400">
+                {t("channelPointRanking.total", {
+                  points: stats.channelPointStats.totalPoints.toLocaleString(),
+                })}
+              </p>
+            </div>
+            {stats.channelPointStats.ranking.length === 0 ? (
+              <div className="p-4 text-sm text-gray-400">
+                {t("channelPointRanking.noData")}
+              </div>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-700 text-left text-gray-400">
+                    <th className="w-14 p-3 text-right">
+                      {t("channelPointRanking.rank")}
+                    </th>
+                    <th className="p-3">{t("channelPointRanking.user")}</th>
+                    <th className="p-3 text-right">
+                      {t("channelPointRanking.points")}
+                    </th>
+                    <th className="p-3 text-right">
+                      {t("channelPointRanking.redemptions")}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-700">
+                  {stats.channelPointStats.ranking.map((row, index) => (
+                    <tr key={row.userTwitchId}>
+                      <td className="p-3 text-right font-medium text-gray-300">
+                        {index + 1}
+                      </td>
+                      <td className="p-3 text-white">{row.username}</td>
+                      <td className="p-3 text-right font-medium text-white">
+                        {row.totalPoints.toLocaleString()}
+                      </td>
+                      <td className="p-3 text-right text-gray-300">
+                        {row.redemptionCount}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
           </div>
 
           {/* Rarity summary / レアリティ別サマリー */}

--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -533,6 +533,16 @@ export async function getGachaUsersForStreamer(
  */
 export interface GachaStatsResult {
   totalDraws: number;
+  channelPointStats: {
+    totalPoints: number;
+    ranking: Array<{
+      userTwitchId: string;
+      username: string;
+      totalPoints: number;
+      redemptionCount: number;
+      lastRedeemedAt: string | null;
+    }>;
+  };
   cardStats: Array<{
     cardId: string;
     cardName: string;
@@ -547,6 +557,85 @@ export interface GachaStatsResult {
     count: number;
     rate: number;
   }>;
+}
+
+interface ChannelPointUsageStatsRpcRow {
+  user_twitch_id: string;
+  username: string | null;
+  total_points: number | string;
+  redemption_count: number;
+  last_redeemed_at: string | null;
+}
+
+function parseChannelPointUsageStatsRpc(rpcResult: unknown): GachaStatsResult["channelPointStats"] | null {
+  if (!rpcResult || typeof rpcResult !== "object") return null;
+
+  const payload = rpcResult as {
+    total_points?: number | string | null;
+    ranking?: ChannelPointUsageStatsRpcRow[] | null;
+  };
+  if (!Array.isArray(payload.ranking)) return null;
+
+  return {
+    totalPoints: Number(payload.total_points || 0),
+    ranking: payload.ranking.map((row) => ({
+      userTwitchId: row.user_twitch_id,
+      username: row.username || row.user_twitch_id,
+      totalPoints: Number(row.total_points || 0),
+      redemptionCount: row.redemption_count,
+      lastRedeemedAt: row.last_redeemed_at,
+    })),
+  };
+}
+
+function buildChannelPointUsageStatsFromHistory(
+  history: Array<{
+    user_twitch_id: string;
+    user_twitch_username: string | null;
+    reward_cost: number | null;
+    redeemed_at: string;
+  }>
+): GachaStatsResult["channelPointStats"] {
+  const userMap = new Map<string, {
+    username: string;
+    totalPoints: number;
+    redemptionCount: number;
+    lastRedeemedAt: string | null;
+  }>();
+  let totalPoints = 0;
+
+  for (const entry of history) {
+    const rewardCost = entry.reward_cost || 0;
+    if (rewardCost <= 0) continue;
+
+    totalPoints += rewardCost;
+    const existing = userMap.get(entry.user_twitch_id);
+    if (existing) {
+      existing.totalPoints += rewardCost;
+      existing.redemptionCount += 1;
+      if (!existing.lastRedeemedAt || entry.redeemed_at > existing.lastRedeemedAt) {
+        existing.lastRedeemedAt = entry.redeemed_at;
+      }
+    } else {
+      userMap.set(entry.user_twitch_id, {
+        username: entry.user_twitch_username || entry.user_twitch_id,
+        totalPoints: rewardCost,
+        redemptionCount: 1,
+        lastRedeemedAt: entry.redeemed_at,
+      });
+    }
+  }
+
+  const ranking = Array.from(userMap.entries())
+    .map(([userTwitchId, entry]) => ({ userTwitchId, ...entry }))
+    .sort((a, b) => {
+      if (b.totalPoints !== a.totalPoints) return b.totalPoints - a.totalPoints;
+      if (b.redemptionCount !== a.redemptionCount) return b.redemptionCount - a.redemptionCount;
+      return (b.lastRedeemedAt || "").localeCompare(a.lastRedeemedAt || "");
+    })
+    .slice(0, 10);
+
+  return { totalPoints, ranking };
 }
 
 /**
@@ -566,9 +655,9 @@ export async function getGachaStats(
   const daysAgo = period === "7d" ? 7 : 30;
   const fromDate = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000);
 
-  // Run all 3 independent queries in parallel to reduce latency
-  // 3つの独立したクエリを並列実行してレイテンシを削減
-  const [countResult, historyResult, cardsResult] = await Promise.all([
+  // Run independent queries in parallel to reduce latency
+  // 独立したクエリを並列実行してレイテンシを削減
+  const [countResult, historyResult, cardsResult, channelPointResult] = await Promise.all([
     // 1. Get total draw count using count-only query (avoids 1000-row limit)
     // count-onlyクエリで正確な総ガチャ回数を取得（1000行制限を回避）
     supabaseAdmin
@@ -582,7 +671,7 @@ export async function getGachaStats(
     // 非常にアクティブな配信者（期間内10000回超）の場合、カウントは近似値になる可能性がある。
     supabaseAdmin
       .from("gacha_history")
-      .select("card_id, cards(rarity)")
+      .select("card_id, user_twitch_id, user_twitch_username, reward_cost, redeemed_at, cards(rarity)")
       .eq("streamer_id", streamerId)
       .gte("redeemed_at", fromDate.toISOString())
       .limit(10000),
@@ -593,6 +682,12 @@ export async function getGachaStats(
       .select("id, name, rarity, image_url, drop_rate")
       .eq("streamer_id", streamerId)
       .eq("is_active", true),
+    supabaseAdmin
+      .rpc("get_channel_point_usage_stats", {
+        p_streamer_id: streamerId,
+        p_from_date: fromDate.toISOString(),
+        p_limit: 10,
+      }),
   ]);
 
   const totalDraws = countResult.count;
@@ -600,6 +695,9 @@ export async function getGachaStats(
   const allCards = cardsResult.data;
 
   const safeTotal = totalDraws || 0;
+  const channelPointStats =
+    parseChannelPointUsageStatsRpc(channelPointResult.data) ||
+    buildChannelPointUsageStatsFromHistory(history || []);
 
   // Count draws per card
   // カードごとの排出回数を集計
@@ -653,7 +751,7 @@ export async function getGachaStats(
     }
   );
 
-  return { totalDraws: safeTotal, cardStats, rarityStats };
+  return { totalDraws: safeTotal, channelPointStats, cardStats, rarityStats };
 }
 
 /**

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -216,26 +216,32 @@ export interface Database {
       gacha_history: {
         Row: {
           id: string
+          event_id: string | null
           user_twitch_id: string
           user_twitch_username: string | null
           card_id: string
           streamer_id: string
+          reward_cost: number | null
           redeemed_at: string
         }
         Insert: {
           id?: string
+          event_id?: string | null
           user_twitch_id: string
           user_twitch_username?: string | null
           card_id: string
           streamer_id: string
+          reward_cost?: number | null
           redeemed_at?: string
         }
         Update: {
           id?: string
+          event_id?: string | null
           user_twitch_id?: string
           user_twitch_username?: string | null
           card_id?: string
           streamer_id?: string
+          reward_cost?: number | null
           redeemed_at?: string
         }
       }

--- a/supabase/migrations/00036_add_channel_point_usage_stats.sql
+++ b/supabase/migrations/00036_add_channel_point_usage_stats.sql
@@ -1,0 +1,66 @@
+-- RPC: 配信者の期間内チャネルポイント使用ランキングをDB側で集約して返す
+-- gacha_history.reward_cost は EventSub のチャネルポイント引き換えでのみ入るため、
+-- NULL/0 以下の履歴はランキング対象外にする。
+CREATE OR REPLACE FUNCTION get_channel_point_usage_stats(
+  p_streamer_id UUID,
+  p_from_date TIMESTAMPTZ,
+  p_limit INTEGER DEFAULT 10
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_total_points BIGINT;
+  v_ranking JSONB;
+BEGIN
+  SELECT COALESCE(SUM(reward_cost), 0)::BIGINT
+  INTO v_total_points
+  FROM gacha_history
+  WHERE streamer_id = p_streamer_id
+    AND redeemed_at >= p_from_date
+    AND reward_cost IS NOT NULL
+    AND reward_cost > 0;
+
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'user_twitch_id', ranked.user_twitch_id,
+      'username', ranked.username,
+      'total_points', ranked.total_points,
+      'redemption_count', ranked.redemption_count,
+      'last_redeemed_at', ranked.last_redeemed_at
+    )
+    ORDER BY ranked.total_points DESC, ranked.redemption_count DESC, ranked.last_redeemed_at DESC
+  ), '[]'::JSONB)
+  INTO v_ranking
+  FROM (
+    SELECT
+      user_twitch_id,
+      COALESCE(MAX(user_twitch_username), user_twitch_id) AS username,
+      SUM(reward_cost)::BIGINT AS total_points,
+      COUNT(*)::INTEGER AS redemption_count,
+      MAX(redeemed_at)::TEXT AS last_redeemed_at
+    FROM gacha_history
+    WHERE streamer_id = p_streamer_id
+      AND redeemed_at >= p_from_date
+      AND reward_cost IS NOT NULL
+      AND reward_cost > 0
+    GROUP BY user_twitch_id
+    ORDER BY total_points DESC, redemption_count DESC, last_redeemed_at DESC
+    LIMIT GREATEST(1, p_limit)
+  ) ranked;
+
+  RETURN jsonb_build_object(
+    'total_points', v_total_points,
+    'ranking', v_ranking
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION get_channel_point_usage_stats(UUID, TIMESTAMPTZ, INTEGER) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_channel_point_usage_stats(UUID, TIMESTAMPTZ, INTEGER) TO service_role;
+
+CREATE INDEX IF NOT EXISTS idx_gacha_history_streamer_redeemed_reward
+  ON gacha_history(streamer_id, redeemed_at DESC)
+  WHERE reward_cost IS NOT NULL AND reward_cost > 0;

--- a/tests/unit/gacha-stats-api.test.ts
+++ b/tests/unit/gacha-stats-api.test.ts
@@ -114,7 +114,7 @@ describe("GET /api/gacha-stats", () => {
 
     // getGachaStats accesses gacha_history twice:
     // 1st: count-only query (select("id", { count: "exact", head: true }))
-    // 2nd: data query (select("card_id, cards(rarity)"))
+    // 2nd: data query (draw/card/point data for aggregation)
     // getGachaStats は gacha_history に2回アクセスする:
     // 1回目: count-only クエリ、2回目: データ取得クエリ
     const countQuery = createMockQueryBuilder();
@@ -131,6 +131,10 @@ describe("GET /api/gacha-stats", () => {
       data: [
         {
           card_id: "c1",
+          user_twitch_id: "viewer1",
+          user_twitch_username: "ViewerOne",
+          reward_cost: 100,
+          redeemed_at: "2026-01-01T00:00:00Z",
           cards: { rarity: "common" },
         },
       ],
@@ -165,6 +169,22 @@ describe("GET /api/gacha-stats", () => {
       return cardsQuery;
     };
 
+    const rpc = vi.fn().mockResolvedValue({
+      data: {
+        total_points: 250,
+        ranking: [
+          {
+            user_twitch_id: "viewer1",
+            username: "ViewerOne",
+            total_points: 250,
+            redemption_count: 2,
+            last_redeemed_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      },
+      error: null,
+    });
+
     // Track gacha_history call order to return count query first, then data query
     // gacha_history の呼び出し順を追跡し、最初にcountクエリ、次にデータクエリを返す
     let gachaHistoryCallCount = 0;
@@ -178,6 +198,7 @@ describe("GET /api/gacha-stats", () => {
         if (table === "cards") return cardsQuery;
         return createMockQueryBuilder();
       }),
+      rpc,
     } as unknown as ReturnType<typeof getSupabaseAdmin>);
 
     const res = await GET(createRequest({ period: "7d" }));
@@ -190,5 +211,148 @@ describe("GET /api/gacha-stats", () => {
     expect(body.cardStats[0].actualCount).toBe(1);
     expect(body.cardStats[0].actualRate).toBe(100);
     expect(body.rarityStats).toHaveLength(4);
+    expect(body.channelPointStats.totalPoints).toBe(250);
+    expect(body.channelPointStats.ranking).toEqual([
+      {
+        userTwitchId: "viewer1",
+        username: "ViewerOne",
+        totalPoints: 250,
+        redemptionCount: 2,
+        lastRedeemedAt: "2026-01-01T00:00:00Z",
+      },
+    ]);
+    expect(rpc).toHaveBeenCalledWith("get_channel_point_usage_stats", {
+      p_streamer_id: "streamer-id-1",
+      p_from_date: expect.any(String),
+      p_limit: 10,
+    });
+  });
+
+  it("falls back to history rows when channel point stats RPC is not deployed", async () => {
+    const session = {
+      twitchUserId: "streamer1",
+      twitchUsername: "streamer1",
+      twitchDisplayName: "Streamer 1",
+      twitchProfileImageUrl: "",
+      broadcasterType: "affiliate",
+      expiresAt: Date.now() + 100000,
+      version: 1,
+    };
+    mockGetSession.mockResolvedValue(session);
+    mockCanUseStreamerFeatures.mockReturnValue(true);
+
+    const streamerQuery = createMockQueryBuilder();
+    (streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue(
+      createMockResponse({ id: "streamer-id-1" })
+    );
+
+    const countQuery = createMockQueryBuilder();
+    (countQuery as unknown as Record<string, unknown>).then = (
+      resolve: (value: unknown) => void
+    ) => {
+      resolve({ data: null, error: null, count: 3 });
+      return countQuery;
+    };
+
+    const historyQuery = createMockQueryBuilder();
+    (historyQuery as unknown as Record<string, unknown>).then = (
+      resolve: (value: unknown) => void
+    ) => {
+      resolve({
+        data: [
+          {
+            card_id: "c1",
+            user_twitch_id: "viewer1",
+            user_twitch_username: "ViewerOne",
+            reward_cost: 100,
+            redeemed_at: "2026-01-01T00:00:00Z",
+            cards: { rarity: "common" },
+          },
+          {
+            card_id: "c1",
+            user_twitch_id: "viewer1",
+            user_twitch_username: "ViewerOne",
+            reward_cost: 200,
+            redeemed_at: "2026-01-02T00:00:00Z",
+            cards: { rarity: "common" },
+          },
+          {
+            card_id: "c2",
+            user_twitch_id: "viewer2",
+            user_twitch_username: "ViewerTwo",
+            reward_cost: 250,
+            redeemed_at: "2026-01-03T00:00:00Z",
+            cards: { rarity: "rare" },
+          },
+        ],
+        error: null,
+      });
+      return historyQuery;
+    };
+
+    const cardsQuery = createMockQueryBuilder();
+    (cardsQuery as unknown as Record<string, unknown>).then = (
+      resolve: (value: unknown) => void
+    ) => {
+      resolve({
+        data: [
+          {
+            id: "c1",
+            name: "Card1",
+            rarity: "common",
+            image_url: null,
+            drop_rate: 50,
+          },
+          {
+            id: "c2",
+            name: "Card2",
+            rarity: "rare",
+            image_url: null,
+            drop_rate: 50,
+          },
+        ],
+        error: null,
+      });
+      return cardsQuery;
+    };
+
+    let gachaHistoryCallCount = 0;
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "streamers") return streamerQuery;
+        if (table === "gacha_history") {
+          gachaHistoryCallCount++;
+          return gachaHistoryCallCount === 1 ? countQuery : historyQuery;
+        }
+        if (table === "cards") return cardsQuery;
+        return createMockQueryBuilder();
+      }),
+      rpc: vi.fn().mockResolvedValue({
+        data: null,
+        error: { code: "42883", message: "function not found" },
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await GET(createRequest({ period: "30d" }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.channelPointStats.totalPoints).toBe(550);
+    expect(body.channelPointStats.ranking).toEqual([
+      {
+        userTwitchId: "viewer1",
+        username: "ViewerOne",
+        totalPoints: 300,
+        redemptionCount: 2,
+        lastRedeemedAt: "2026-01-02T00:00:00Z",
+      },
+      {
+        userTwitchId: "viewer2",
+        username: "ViewerTwo",
+        totalPoints: 250,
+        redemptionCount: 1,
+        lastRedeemedAt: "2026-01-03T00:00:00Z",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- add DB-side channel point usage stats aggregation for gacha history
- return channel point totals and top-user ranking from `/api/gacha-stats`
- display the ranking on the streamer stats page with ja/en labels

Issues: Closes #383

## Validation
- npm_config_cache=/private/tmp/twica-maker-npm-cache npx vitest run tests/unit/gacha-stats-api.test.ts tests/unit/gacha-service.test.ts
- npm run lint
- npm run workers:build
