### PR TITLE
docs: document Cloudflare proxy migration blocker

### DIFF
--- a/docs/cloudflare-proxy-migration.md
+++ b/docs/cloudflare-proxy-migration.md
@@ -1,0 +1,33 @@
+# Cloudflare Proxy Migration Policy
+
+Next.js 16 reports the `middleware.ts` convention as deprecated and recommends
+renaming it to `proxy.ts`. TwiCa intentionally keeps `src/middleware.ts` for
+now because the current Cloudflare deployment path cannot build a Next.js Proxy.
+
+## Current Decision
+
+- Keep `src/middleware.ts` on `preview` until the OpenNext Cloudflare adapter
+  supports Next.js Proxy output.
+- Do not add `src/proxy.ts` yet.
+- Accept the Next.js deprecated convention warning as the smaller operational
+  risk while Cloudflare builds still require Edge Middleware output.
+
+## Verification
+
+A direct migration from `src/middleware.ts` to `src/proxy.ts` removes the
+Next.js warning, but `npm run workers:build` fails with:
+
+```text
+ERROR Node.js middleware is not currently supported. Consider switching to Edge Middleware.
+```
+
+Next.js 16 rejects forcing Proxy back to Edge runtime, so the blocker is in the
+deployment compatibility layer rather than in TwiCa's middleware logic.
+
+## Revisit Conditions
+
+Revisit this decision when either of these is true:
+
+- OpenNext Cloudflare documents support for Next.js Proxy / Node.js middleware.
+- TwiCa changes deployment architecture so request interception no longer needs
+  to run in Cloudflare Workers middleware.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,11 @@ import { setSecurityHeaders } from '@/lib/security-headers'
 import { ERROR_MESSAGES } from '@/lib/constants'
 import { defaultLocale, locales, LOCALE_COOKIE_NAME, type Locale } from '@/i18n/config'
 
+// Next.js 16 recommends proxy.ts, but Proxy always builds as Node.js runtime.
+// OpenNext Cloudflare 1.16.1 cannot deploy Node.js middleware, so this file
+// intentionally stays on the deprecated middleware.ts convention until the
+// Cloudflare adapter supports Proxy or an equivalent deploy path.
+
 /**
  * Detect locale from request (cookie or Accept-Language header)
  * リクエストからロケールを検出（CookieまたはAccept-Languageヘッダー）

--- a/tests/unit/cloudflare-proxy-migration.test.ts
+++ b/tests/unit/cloudflare-proxy-migration.test.ts
@@ -1,0 +1,26 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readSource(path: string) {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+describe("Cloudflare proxy migration policy", () => {
+  it("keeps Edge Middleware until OpenNext Cloudflare supports Next.js Proxy", () => {
+    expect(existsSync(join(process.cwd(), "src/middleware.ts"))).toBe(true);
+    expect(existsSync(join(process.cwd(), "src/proxy.ts"))).toBe(false);
+  });
+
+  it("documents the deploy blocker and revisit condition", () => {
+    const doc = readSource("docs/cloudflare-proxy-migration.md");
+    const middleware = readSource("src/middleware.ts");
+
+    expect(doc).toContain("Node.js middleware is not currently supported");
+    expect(doc).toContain("Do not add `src/proxy.ts` yet");
+    expect(doc).toContain("OpenNext Cloudflare");
+    expect(middleware).toContain("export async function middleware");
+    expect(middleware).not.toContain("export async function proxy");
+    expect(middleware).toContain("intentionally stays on the deprecated middleware.ts convention");
+  });
+});


### PR DESCRIPTION
## Summary
- Document the current Cloudflare/OpenNext blocker for migrating `src/middleware.ts` to Next.js 16 `src/proxy.ts`
- Keep `src/middleware.ts` intentionally in place until OpenNext Cloudflare supports Next.js Proxy / Node.js middleware output
- Add a regression test that prevents accidentally adding `src/proxy.ts` or dropping the documented deployment policy

Closes #420.
Refs #417.

## Validation
- `npx vitest run tests/unit/cloudflare-proxy-migration.test.ts tests/unit/session-middleware.test.ts`
- `npm run workers:build` (passes; expected Next.js middleware deprecation warning remains)
