### PR TITLE
feat: add card collection numbering

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -252,6 +252,12 @@
     "cardTypes": "{count} types",
     "totalCount": "{count} cards",
     "cardCount": "x{count}",
+    "cardNumber": "#{number}",
+    "sort": {
+      "label": "Sort",
+      "number": "Number",
+      "rarity": "Rarity"
+    },
     "viewCollection": "View Collection",
     "unownedCard": "???"
   },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -252,6 +252,12 @@
     "cardTypes": "{count}種類",
     "totalCount": "{count}枚",
     "cardCount": "x{count}",
+    "cardNumber": "#{number}",
+    "sort": {
+      "label": "並び替え",
+      "number": "番号順",
+      "rarity": "レアリティ順"
+    },
     "viewCollection": "コレクションを見る",
     "unownedCard": "???"
   },

--- a/src/app/collection/[streamerId]/page.tsx
+++ b/src/app/collection/[streamerId]/page.tsx
@@ -7,7 +7,11 @@ import {
   getCollectionCompletions,
   recordCollectionCompletion,
 } from "@/lib/dashboard-data";
-import { countOwnedActiveCardTypes, sortCollectedCards } from "@/lib/collection-utils";
+import {
+  countOwnedActiveCardTypes,
+  createCollectionNumberMap,
+  sortCollectedCards,
+} from "@/lib/collection-utils";
 import StreamerCollection from "@/components/StreamerCollection";
 import type { StreamerCollectionCard } from "@/components/StreamerCollection";
 
@@ -53,10 +57,12 @@ export default async function StreamerCollectionPage({
   ]);
 
   const activeCardIds = new Set(activeCards.map((card) => card.id));
+  const collectionNumberMap = createCollectionNumberMap([...activeCards, ...userCards]);
   const ownedCards: StreamerCollectionCard[] = sortCollectedCards(userCards).map((card) => ({
     ...card,
     count: card.count,
     isOwned: true,
+    collectionNumber: collectionNumberMap.get(card.id),
   }));
 
   // 未所持カードの視聴者向け表示（Issue #395）
@@ -73,6 +79,7 @@ export default async function StreamerCollectionPage({
         ...card,
         count: 0,
         isOwned: false,
+        collectionNumber: collectionNumberMap.get(card.id),
       }))
     : [];
 

--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -25,6 +25,9 @@ interface CollectionCardProps {
     label: string;
     color: string;
   };
+  // Stable collection number for encyclopedia-style display
+  // 図鑑表示用の固定カード番号
+  collectionNumberLabel?: string;
   // Number of copies the user owns (optional, shown if > 1)
   // ユーザーが所有する枚数（任意、1より大きい場合に表示）
   count?: number;
@@ -62,6 +65,7 @@ export default function CollectionCard({
   name,
   imageUrl,
   rarityInfo,
+  collectionNumberLabel,
   count,
   countLabel,
   priority = false,
@@ -82,6 +86,11 @@ export default function CollectionCard({
       <div className="p-3 pb-2">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0">
+            {collectionNumberLabel && (
+              <div className="mb-1 text-xs font-semibold text-purple-300">
+                {collectionNumberLabel}
+              </div>
+            )}
             <h3 className={`font-semibold truncate text-base ${isOwned ? "text-white" : "text-white/70"}`}>
               {name}
             </h3>

--- a/src/components/SortedCardGrid.tsx
+++ b/src/components/SortedCardGrid.tsx
@@ -1,7 +1,11 @@
+"use client";
+
+import { useMemo, useState } from "react";
 import CollectionCard from "./CollectionCard";
 import ExpandableDescription from "./ExpandableDescription";
 import type { Rarity, Card } from "@/types/database";
 import { RARITIES } from "@/lib/constants";
+import { sortCollectedCards, type CollectionSortMode } from "@/lib/collection-utils";
 
 /**
  * Get rarity information (label and color) for a given rarity value
@@ -13,6 +17,7 @@ const getRarityInfo = (rarity: Rarity) =>
 interface CardWithDetails extends Card {
   count: number;
   isOwned?: boolean;
+  collectionNumber?: number;
 }
 
 interface SortedCardGridProps {
@@ -34,6 +39,10 @@ interface SortedCardGridProps {
     noImage: string;
     unownedCard: string;
     inactiveStatus: string;
+    cardNumberTemplate: string;
+    sortLabel: string;
+    sortByNumber: string;
+    sortByRarity: string;
   };
 }
 
@@ -48,64 +57,98 @@ export default function SortedCardGrid({
   hideUnownedDetails = false,
   translations,
 }: SortedCardGridProps) {
+  const [sortMode, setSortMode] = useState<CollectionSortMode>("number");
+  const sortedCards = useMemo(
+    () => sortCollectedCards(cards, sortMode),
+    [cards, sortMode]
+  );
+
   return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-      {cards.map((card, index) => {
-        const isOwned = card.isOwned ?? true;
-        const rarityInfo = getRarityInfo(card.rarity);
-        // First 4 cards get priority for LCP optimization
-        // 最初の4枚のカードはLCP最適化のためpriority設定
-        const isPriority = index < 4;
+    <>
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        <span className="text-sm text-gray-400">{translations.sortLabel}</span>
+        {([
+          ["number", translations.sortByNumber],
+          ["rarity", translations.sortByRarity],
+        ] as const).map(([mode, label]) => (
+          <button
+            key={mode}
+            type="button"
+            onClick={() => setSortMode(mode)}
+            className={`rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+              sortMode === mode
+                ? "bg-purple-600 text-white"
+                : "border border-gray-600 text-gray-300 hover:bg-gray-700"
+            }`}
+            aria-pressed={sortMode === mode}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {sortedCards.map((card, index) => {
+          const isOwned = card.isOwned ?? true;
+          const rarityInfo = getRarityInfo(card.rarity);
+          // First 4 cards get priority for LCP optimization
+          // 最初の4枚のカードはLCP最適化のためpriority設定
+          const isPriority = index < 4;
 
-        // 未所持カードの「詳細マスク」モード:
-        //   show_unowned_card_details=false (=hideUnownedDetails=true) のときに有効。
-        //   名前/画像/説明をプレースホルダーに置き換え、レアリティバッジのみ残す。
-        //
-        // 「詳細公開」モード (hideUnownedDetails=false) のときは未所持カードでも
-        //   名前・画像・説明を本来のまま表示する。所持済カードとの違いはロック表示と
-        //   グレースケール、所有数の非表示のみ。
-        //
-        // Issue #395 の要求:
-        //   - 視聴者は所持していないカードを「⑤???」のような形で見られる (placeholder)
-        //   - もしくは公開モードでは画像と説明まで含めて見られる
-        const maskUnownedDetails = !isOwned && hideUnownedDetails;
-        const displayName = maskUnownedDetails ? translations.unownedCard : card.name;
-        const displayImageUrl = maskUnownedDetails ? null : card.image_url;
-        const showDescription =
-          (isOwned || !hideUnownedDetails) && Boolean(card.description);
+          // 未所持カードの「詳細マスク」モード:
+          //   show_unowned_card_details=false (=hideUnownedDetails=true) のときに有効。
+          //   名前/画像/説明をプレースホルダーに置き換え、レアリティバッジのみ残す。
+          //
+          // 「詳細公開」モード (hideUnownedDetails=false) のときは未所持カードでも
+          //   名前・画像・説明を本来のまま表示する。所持済カードとの違いはロック表示と
+          //   グレースケール、所有数の非表示のみ。
+          //
+          // Issue #395 の要求:
+          //   - 視聴者は所持していないカードを「⑤???」のような形で見られる (placeholder)
+          //   - もしくは公開モードでは画像と説明まで含めて見られる
+          const maskUnownedDetails = !isOwned && hideUnownedDetails;
+          const displayName = maskUnownedDetails ? translations.unownedCard : card.name;
+          const displayImageUrl = maskUnownedDetails ? null : card.image_url;
+          const showDescription =
+            (isOwned || !hideUnownedDetails) && Boolean(card.description);
 
-        return (
-          <CollectionCard
-            key={card.id}
-            id={card.id}
-            streamerId={streamerId}
-            name={displayName}
-            imageUrl={displayImageUrl}
-            rarityInfo={{
-              label: rarityInfo.label,
-              color: rarityInfo.color,
-            }}
-            count={isOwned ? card.count : undefined}
-            countLabel={
-              isOwned
-                ? translations.cardCountTemplate.replace("{count}", String(card.count))
-                : undefined
-            }
-            priority={isPriority}
-            noImageText={
-              maskUnownedDetails ? translations.unownedCard : translations.noImage
-            }
-            isOwned={isOwned}
-            isInactive={isOwned && !card.is_active}
-            inactiveLabel={translations.inactiveStatus}
-            descriptionComponent={
-              showDescription ? (
-                <ExpandableDescription description={card.description as string} />
-              ) : undefined
-            }
-          />
-        );
-      })}
-    </div>
+          return (
+            <CollectionCard
+              key={card.id}
+              id={card.id}
+              streamerId={streamerId}
+              name={displayName}
+              imageUrl={displayImageUrl}
+              rarityInfo={{
+                label: rarityInfo.label,
+                color: rarityInfo.color,
+              }}
+              collectionNumberLabel={
+                card.collectionNumber
+                  ? translations.cardNumberTemplate.replace("{number}", String(card.collectionNumber))
+                  : undefined
+              }
+              count={isOwned ? card.count : undefined}
+              countLabel={
+                isOwned
+                  ? translations.cardCountTemplate.replace("{count}", String(card.count))
+                  : undefined
+              }
+              priority={isPriority}
+              noImageText={
+                maskUnownedDetails ? translations.unownedCard : translations.noImage
+              }
+              isOwned={isOwned}
+              isInactive={isOwned && !card.is_active}
+              inactiveLabel={translations.inactiveStatus}
+              descriptionComponent={
+                showDescription ? (
+                  <ExpandableDescription description={card.description as string} />
+                ) : undefined
+              }
+            />
+          );
+        })}
+      </div>
+    </>
   );
 }

--- a/src/components/StreamerCollection.tsx
+++ b/src/components/StreamerCollection.tsx
@@ -9,6 +9,7 @@ import type { Streamer, Card } from "@/types/database";
 export interface StreamerCollectionCard extends Card {
   count: number;
   isOwned: boolean;
+  collectionNumber?: number;
 }
 
 interface StreamerCollectionProps {
@@ -110,6 +111,10 @@ export default async function StreamerCollection({
               noImage: tCommon("noImage"),
               unownedCard: t("unownedCard"),
               inactiveStatus: tCardManager("status.paused"),
+              cardNumberTemplate: t("cardNumber"),
+              sortLabel: t("sort.label"),
+              sortByNumber: t("sort.number"),
+              sortByRarity: t("sort.rarity"),
             }}
           />
         )}

--- a/src/lib/collection-utils.ts
+++ b/src/lib/collection-utils.ts
@@ -1,19 +1,66 @@
 import { RARITY_ORDER } from "@/lib/constants";
 import type { Card } from "@/types/database";
 
-type SortableCollectionCard = Pick<Card, "rarity" | "created_at">;
+export type CollectionSortMode = "rarity" | "number";
+
+type SortableCollectionCard = Pick<Card, "id" | "rarity" | "created_at"> & {
+  collectionNumber?: number;
+};
+
+type NumberableCollectionCard = Pick<Card, "id" | "created_at">;
 
 /**
  * Sort owned cards for collection views.
- * Rarity is primary (legendary first), then newest first within the same rarity.
+ * Defaults to rarity first (legendary first), with optional encyclopedia number order.
  */
-export function sortCollectedCards<T extends SortableCollectionCard>(cards: T[]): T[] {
+export function sortCollectedCards<T extends SortableCollectionCard>(
+  cards: T[],
+  mode: CollectionSortMode = "rarity"
+): T[] {
   return [...cards].sort((a, b) => {
+    if (mode === "number") {
+      const numberDiff =
+        (a.collectionNumber ?? Number.MAX_SAFE_INTEGER) -
+        (b.collectionNumber ?? Number.MAX_SAFE_INTEGER);
+      if (numberDiff !== 0) return numberDiff;
+    }
+
     const rarityDiff = RARITY_ORDER.indexOf(a.rarity) - RARITY_ORDER.indexOf(b.rarity);
     if (rarityDiff !== 0) return rarityDiff;
 
-    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    const createdAtDiff = new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    if (createdAtDiff !== 0) return createdAtDiff;
+
+    return a.id.localeCompare(b.id);
   });
+}
+
+/**
+ * Build stable encyclopedia-style card numbers for a streamer's cards.
+ * Older cards receive smaller numbers, and duplicate owned-card rows are ignored.
+ */
+export function createCollectionNumberMap<T extends NumberableCollectionCard>(
+  cards: T[]
+): Map<string, number> {
+  const uniqueCards = new Map<string, T>();
+  for (const card of cards) {
+    const existing = uniqueCards.get(card.id);
+    if (
+      !existing ||
+      new Date(card.created_at).getTime() < new Date(existing.created_at).getTime()
+    ) {
+      uniqueCards.set(card.id, card);
+    }
+  }
+
+  const sortedCards = [...uniqueCards.values()].sort((a, b) => {
+    const createdAtDiff = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+    if (createdAtDiff !== 0) return createdAtDiff;
+
+    return a.id.localeCompare(b.id);
+  });
+
+  return new Map(sortedCards.map((card, index) => [card.id, index + 1]));
 }
 
 /**

--- a/tests/unit/collection-utils.test.ts
+++ b/tests/unit/collection-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { countOwnedActiveCardTypes, sortCollectedCards } from "@/lib/collection-utils";
+import {
+  countOwnedActiveCardTypes,
+  createCollectionNumberMap,
+  sortCollectedCards,
+} from "@/lib/collection-utils";
 
 describe("collection-utils", () => {
   describe("sortCollectedCards", () => {
@@ -17,6 +21,49 @@ describe("collection-utils", () => {
         "rare-new",
         "common-new",
       ]);
+    });
+
+    it("sorts by collection number when requested", () => {
+      const cards = [
+        { id: "third", rarity: "legendary" as const, created_at: "2026-03-03T00:00:00Z", collectionNumber: 3 },
+        { id: "first", rarity: "common" as const, created_at: "2026-03-01T00:00:00Z", collectionNumber: 1 },
+        { id: "second", rarity: "rare" as const, created_at: "2026-03-02T00:00:00Z", collectionNumber: 2 },
+      ];
+
+      expect(sortCollectedCards(cards, "number").map((card) => card.id)).toEqual([
+        "first",
+        "second",
+        "third",
+      ]);
+    });
+  });
+
+  describe("createCollectionNumberMap", () => {
+    it("assigns stable card numbers by oldest created_at first", () => {
+      const cards = [
+        { id: "card-b", created_at: "2026-03-02T00:00:00Z" },
+        { id: "card-a", created_at: "2026-03-01T00:00:00Z" },
+        { id: "card-c", created_at: "2026-03-03T00:00:00Z" },
+      ];
+
+      expect(Object.fromEntries(createCollectionNumberMap(cards))).toEqual({
+        "card-a": 1,
+        "card-b": 2,
+        "card-c": 3,
+      });
+    });
+
+    it("deduplicates repeated cards before numbering", () => {
+      const cards = [
+        { id: "card-a", created_at: "2026-03-01T00:00:00Z" },
+        { id: "card-a", created_at: "2026-03-01T00:00:00Z" },
+        { id: "card-b", created_at: "2026-03-02T00:00:00Z" },
+      ];
+
+      expect(Object.fromEntries(createCollectionNumberMap(cards))).toEqual({
+        "card-a": 1,
+        "card-b": 2,
+      });
     });
   });
 

--- a/tests/unit/components/sorted-card-grid.test.tsx
+++ b/tests/unit/components/sorted-card-grid.test.tsx
@@ -37,9 +37,32 @@ const baseTranslations = {
   noImage: 'NoImage',
   unownedCard: '???',
   inactiveStatus: 'PAUSED',
+  cardNumberTemplate: '#{number}',
+  sortLabel: '並び替え',
+  sortByNumber: '番号順',
+  sortByRarity: 'レアリティ順',
 }
 
 describe('SortedCardGrid - unowned card visibility (Issue #395)', () => {
+  it('renders encyclopedia numbers and defaults to number order', () => {
+    const cards = [
+      { ...baseCard({ id: 'card-2', name: 'SecondCard', created_at: '2026-04-02T00:00:00Z' }), count: 1, isOwned: true, collectionNumber: 2 },
+      { ...baseCard({ id: 'card-1', name: 'FirstCard', created_at: '2026-04-01T00:00:00Z' }), count: 1, isOwned: true, collectionNumber: 1 },
+    ]
+    render(
+      <SortedCardGrid
+        cards={cards}
+        streamerId="streamer-1"
+        translations={baseTranslations}
+      />
+    )
+
+    expect(screen.getByText('#1')).toBeInTheDocument()
+    expect(screen.getByText('#2')).toBeInTheDocument()
+    const names = screen.getAllByRole('heading', { level: 3 }).map((heading) => heading.textContent)
+    expect(names).toEqual(['FirstCard', 'SecondCard'])
+  })
+
   it('renders owned card with its name and image', () => {
     const cards = [
       { ...baseCard({ id: 'owned-1', name: 'OwnedCard' }), count: 2, isOwned: true },


### PR DESCRIPTION
## Summary
- add stable encyclopedia-style card numbers for streamer collection pages
- default the collection grid to number order and add a number/rarity sort toggle
- show card numbers on collection cards, including masked unowned cards

Closes #394

## Validation
- npm_config_cache=/tmp/twica-npm-cache npx vitest run tests/unit/collection-utils.test.ts tests/unit/components/sorted-card-grid.test.tsx
- npm_config_cache=/tmp/twica-npm-cache npm run lint (passes with existing warnings)
- npm_config_cache=/tmp/twica-npm-cache npm run build
- npm_config_cache=/tmp/twica-npm-cache npm run workers:build