### PR TITLE
fix: improve card number editing

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -45,6 +45,7 @@
     "editCard": "Edit Card",
     "newCard": "New Card",
     "importFromEmotes": "Import from Emotes",
+    "editCardNumbers": "Edit Numbers",
     "form": {
       "name": "Card Name",
       "namePlaceholder": "Card name",
@@ -102,6 +103,18 @@
       "imageUrlResolutionExceeded": "Image URL resolution exceeds limit. Max width: {maxWidth}px, max height: {maxHeight}px (current: {width}x{height})",
       "imageUrlLoadFailed": "Failed to load image URL. Please check the URL.",
       "imageUrlValidating": "Validating image..."
+    },
+    "cardNumberEditor": {
+      "title": "Edit Card Numbers",
+      "description": "Update card numbers in one place. Leave blank to use auto-numbering.",
+      "save": "Save Numbers",
+      "saving": "Saving...",
+      "duplicate": "The same number is assigned to multiple cards: {number}",
+      "invalid": "Card number must be a positive integer.",
+      "noChanges": "No changes.",
+      "saved": "Card numbers saved.",
+      "auto": "Auto",
+      "numberLabel": "Number"
     },
     "sort": {
       "createdAt": "Date Created",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -45,6 +45,7 @@
     "editCard": "カードを編集",
     "newCard": "新規カード",
     "importFromEmotes": "エモートからインポート",
+    "editCardNumbers": "番号をまとめて編集",
     "form": {
       "name": "カード名",
       "namePlaceholder": "カード名",
@@ -102,6 +103,18 @@
       "imageUrlResolutionExceeded": "画像URLの解像度が制限を超えています。横幅{maxWidth}px、縦幅{maxHeight}pxまでです（現在: {width}x{height}）",
       "imageUrlLoadFailed": "画像URLの読み込みに失敗しました。URLを確認してください。",
       "imageUrlValidating": "画像を検証中..."
+    },
+    "cardNumberEditor": {
+      "title": "カード番号をまとめて編集",
+      "description": "番号だけをまとめて変更できます。空欄にすると自動採番になります。",
+      "save": "番号を保存",
+      "saving": "保存中...",
+      "duplicate": "同じ番号が複数のカードに指定されています: {number}",
+      "invalid": "カード番号は1以上の整数で入力してください。",
+      "noChanges": "変更はありません。",
+      "saved": "カード番号を保存しました。",
+      "auto": "自動",
+      "numberLabel": "番号"
     },
     "sort": {
       "createdAt": "設定日",

--- a/src/app/api/cards/[id]/route.ts
+++ b/src/app/api/cards/[id]/route.ts
@@ -17,6 +17,7 @@ import { deleteFromR2 } from "@/lib/r2-client";
 import { removeBlobFile } from "@/lib/storage-db";
 import { isR2Url, isVercelBlobUrl, isStorageUrl, getR2KeyFromUrl } from "@/lib/storage-utils";
 import { recalculateIfAutoMode } from "@/lib/recalculate-drop-rates";
+import { CARD_NUMBER_MESSAGES, isCardNumberConflictError } from "@/lib/card-number-errors";
 import type { ApiRateLimitResponse } from "@/types/api";
 
 function extractRarityWeights(streamers: unknown): Record<string, number> | null {
@@ -134,7 +135,7 @@ export async function PUT(
       (!Number.isInteger(cardNumber) || cardNumber <= 0)
     ) {
       return NextResponse.json(
-        { error: "Card number must be a positive integer" },
+        { error: CARD_NUMBER_MESSAGES.invalid },
         { status: 400 }
       );
     }
@@ -231,6 +232,12 @@ export async function PUT(
       .maybeSingle();
 
     if (error) {
+      if (isCardNumberConflictError(error)) {
+        return NextResponse.json(
+          { error: CARD_NUMBER_MESSAGES.duplicate },
+          { status: 409 }
+        );
+      }
       return handleDatabaseError(error, "Failed to update card");
     }
 

--- a/src/app/api/cards/route.ts
+++ b/src/app/api/cards/route.ts
@@ -18,6 +18,7 @@ import { getStorageUsage } from "@/lib/storage-usage";
 import { sha256Prefix } from "@/lib/crypto-utils";
 import { logger } from "@/lib/logger";
 import { recalculateIfAutoMode } from "@/lib/recalculate-drop-rates";
+import { CARD_NUMBER_MESSAGES, isCardNumberConflictError } from "@/lib/card-number-errors";
 import type { ApiRateLimitResponse } from "@/types/api";
 
 // Cache TTL for cards list (30 seconds to balance freshness and CPU usage)
@@ -126,7 +127,7 @@ export async function POST(request: NextRequest) {
       (!Number.isInteger(cardNumber) || cardNumber <= 0)
     ) {
       return NextResponse.json(
-        { error: "Card number must be a positive integer" },
+        { error: CARD_NUMBER_MESSAGES.invalid },
         { status: 400 }
       );
     }
@@ -180,6 +181,12 @@ export async function POST(request: NextRequest) {
       .maybeSingle();
 
     if (error) {
+      if (isCardNumberConflictError(error)) {
+        return NextResponse.json(
+          { error: CARD_NUMBER_MESSAGES.duplicate },
+          { status: 409 }
+        );
+      }
       return handleDatabaseError(error, "Cards API: Failed to create card");
     }
 

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -316,6 +316,13 @@ export default function CardManager({
   // Default drop rate for emote cards
   // エモートカードのデフォルト出現確率
   const [emoteDefaultDropRate, setEmoteDefaultDropRate] = useState(0.25);
+  const [showCardNumberEditor, setShowCardNumberEditor] = useState(false);
+  const [cardNumberDrafts, setCardNumberDrafts] = useState<Record<string, string>>({});
+  const [savingCardNumbers, setSavingCardNumbers] = useState(false);
+  const [cardNumberEditorMessage, setCardNumberEditorMessage] = useState<{
+    type: "error" | "success" | "info";
+    text: string;
+  } | null>(null);
 
   // Fetch storage status
   // ストレージ状態を取得
@@ -535,6 +542,125 @@ export default function CardManager({
     setSelectedEmotes(new Set());
     setEmoteError(null);
     fetchEmotes();
+  };
+
+  const cardNumberEditorCards = useMemo(() => {
+    return [...cards].sort((a, b) => {
+      const numberDiff = (a.card_number ?? Number.MAX_SAFE_INTEGER) - (b.card_number ?? Number.MAX_SAFE_INTEGER);
+      if (numberDiff !== 0) return numberDiff;
+      const createdAtDiff = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+      if (createdAtDiff !== 0) return createdAtDiff;
+      return a.id.localeCompare(b.id);
+    });
+  }, [cards]);
+
+  const openCardNumberEditor = () => {
+    setCardNumberDrafts(
+      Object.fromEntries(cards.map((card) => [card.id, card.card_number ? String(card.card_number) : ""]))
+    );
+    setCardNumberEditorMessage(null);
+    setShowCardNumberEditor(true);
+  };
+
+  const parseCardNumberDraft = (value: string): number | null | "invalid" => {
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    if (!/^\d+$/.test(trimmed)) return "invalid";
+    const parsed = Number(trimmed);
+    if (!Number.isSafeInteger(parsed) || parsed <= 0) return "invalid";
+    return parsed;
+  };
+
+  const validateCardNumberDrafts = (): Array<{ card: Card; cardNumber: number | null }> | null => {
+    const seen = new Map<number, string>();
+    const updates: Array<{ card: Card; cardNumber: number | null }> = [];
+
+    for (const card of cards) {
+      const parsed = parseCardNumberDraft(cardNumberDrafts[card.id] ?? "");
+      if (parsed === "invalid") {
+        setCardNumberEditorMessage({ type: "error", text: t("cardNumberEditor.invalid") });
+        return null;
+      }
+      if (parsed !== null) {
+        if (seen.has(parsed)) {
+          setCardNumberEditorMessage({
+            type: "error",
+            text: t("cardNumberEditor.duplicate", { number: parsed }),
+          });
+          return null;
+        }
+        seen.set(parsed, card.id);
+      }
+      if ((card.card_number ?? null) !== parsed) {
+        updates.push({ card, cardNumber: parsed });
+      }
+    }
+
+    return updates;
+  };
+
+  const saveCardNumbers = async () => {
+    const updates = validateCardNumberDrafts();
+    if (!updates) return;
+    if (updates.length === 0) {
+      setCardNumberEditorMessage({ type: "info", text: t("cardNumberEditor.noChanges") });
+      return;
+    }
+
+    setSavingCardNumbers(true);
+    setCardNumberEditorMessage(null);
+    try {
+      const updateCardNumber = async (card: Card, cardNumber: number | null): Promise<Card> => {
+        const response = await fetch(`/api/cards/${card.id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ cardNumber }),
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({ error: "Unknown error" }));
+          throw new Error(errorData.error || t("messages.errorOccurred", { status: response.status }));
+        }
+
+        const responseData = await response.json();
+        const savedCardData = { ...(responseData as Record<string, unknown>) };
+        delete savedCardData.recalculatedCards;
+        return savedCardData as unknown as Card;
+      };
+
+      const updatedCards: Card[] = [];
+      for (const update of updates) {
+        if (update.card.card_number !== null) {
+          await updateCardNumber(update.card, null);
+        }
+      }
+      for (const update of updates) {
+        if (update.cardNumber === null) {
+          updatedCards.push({ ...update.card, card_number: null });
+        } else {
+          updatedCards.push(await updateCardNumber(update.card, update.cardNumber));
+        }
+      }
+
+      handleBatchDropRateSave(updatedCards);
+      setCardNumberDrafts((prevDrafts) => {
+        const nextDrafts = { ...prevDrafts };
+        for (const card of updatedCards) {
+          nextDrafts[card.id] = card.card_number ? String(card.card_number) : "";
+        }
+        return nextDrafts;
+      });
+      setCardNumberEditorMessage({ type: "success", text: t("cardNumberEditor.saved") });
+    } catch (error) {
+      logger.error("Failed to save card numbers:", error);
+      setCardNumberEditorMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : t("messages.errorOccurred", { status: 500 }),
+      });
+    } finally {
+      setSavingCardNumbers(false);
+    }
   };
 
   /**
@@ -1111,6 +1237,12 @@ export default function CardManager({
             {t("importFromEmotes")}
           </button>
           <button
+            onClick={openCardNumberEditor}
+            className="rounded-lg border border-purple-600 px-4 py-2 text-purple-400 hover:bg-purple-600 hover:text-white transition whitespace-nowrap"
+          >
+            {t("editCardNumbers")}
+          </button>
+          <button
             onClick={() => setShowForm(true)}
             className="rounded-lg bg-purple-600 px-4 py-2 text-white hover:bg-purple-700 whitespace-nowrap"
           >
@@ -1523,6 +1655,100 @@ export default function CardManager({
                 </button>
               </div>
             </form>
+          </div>
+        </div>
+      )}
+
+      {/* Card number bulk editor modal */}
+      {/* カード番号の一括編集モーダル */}
+      {showCardNumberEditor && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+          <div className="max-h-[90vh] w-full max-w-3xl overflow-hidden rounded-xl bg-gray-800 shadow-2xl">
+            <div className="flex items-center justify-between border-b border-gray-700 p-4 sm:p-6">
+              <div>
+                <h3 className="text-lg font-semibold text-white">{t("cardNumberEditor.title")}</h3>
+                <p className="mt-1 text-sm text-gray-300">{t("cardNumberEditor.description")}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setShowCardNumberEditor(false)}
+                className="text-gray-400 hover:text-white"
+                aria-label={tCommon("cancel")}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            <div className="max-h-[60vh] overflow-y-auto p-4 sm:p-6">
+              {cardNumberEditorMessage && (
+                <div
+                  className={`mb-4 rounded-lg border px-3 py-2 text-sm ${
+                    cardNumberEditorMessage.type === "error"
+                      ? "border-red-500/40 bg-red-500/10 text-red-300"
+                      : cardNumberEditorMessage.type === "success"
+                        ? "border-green-500/40 bg-green-500/10 text-green-300"
+                        : "border-gray-500/40 bg-gray-700 text-gray-300"
+                  }`}
+                >
+                  {cardNumberEditorMessage.text}
+                </div>
+              )}
+
+              <div className="space-y-2">
+                {cardNumberEditorCards.map((card) => (
+                  <div
+                    key={card.id}
+                    className="grid grid-cols-[minmax(0,1fr)_7rem] items-center gap-3 rounded-lg bg-gray-700/70 p-3"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-white">{card.name}</p>
+                      <p className="text-xs text-gray-400">
+                        {card.card_number ? `#${card.card_number}` : t("cardNumberEditor.auto")}
+                      </p>
+                    </div>
+                    <div>
+                      <label className="sr-only" htmlFor={`card-number-${card.id}`}>
+                        {t("cardNumberEditor.numberLabel")}
+                      </label>
+                      <input
+                        id={`card-number-${card.id}`}
+                        type="number"
+                        min="1"
+                        step="1"
+                        inputMode="numeric"
+                        placeholder={t("cardNumberEditor.auto")}
+                        value={cardNumberDrafts[card.id] ?? ""}
+                        onChange={(e) => {
+                          setCardNumberDrafts((drafts) => ({ ...drafts, [card.id]: e.target.value }));
+                          setCardNumberEditorMessage(null);
+                        }}
+                        className="w-full rounded-lg bg-gray-600 px-3 py-2 text-white placeholder:text-gray-300"
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-3 border-t border-gray-700 p-4 sm:p-6">
+              <button
+                type="button"
+                onClick={() => setShowCardNumberEditor(false)}
+                className="rounded-lg border border-gray-600 px-4 py-2 text-gray-300 hover:bg-gray-700"
+              >
+                {tCommon("cancel")}
+              </button>
+              <button
+                type="button"
+                onClick={saveCardNumbers}
+                disabled={savingCardNumbers}
+                className="rounded-lg bg-purple-600 px-4 py-2 text-white hover:bg-purple-700 disabled:opacity-50"
+              >
+                {savingCardNumbers ? t("cardNumberEditor.saving") : t("cardNumberEditor.save")}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/src/lib/card-number-errors.ts
+++ b/src/lib/card-number-errors.ts
@@ -1,0 +1,13 @@
+export const CARD_NUMBER_MESSAGES = {
+  duplicate: "このカード番号はすでに別のカードで使われています。",
+  invalid: "カード番号は1以上の整数で入力してください。",
+} as const;
+
+export function isCardNumberConflictError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const err = error as { code?: unknown; message?: unknown; details?: unknown };
+  if (err.code !== "23505") return false;
+
+  const text = `${String(err.message || "")} ${String(err.details || "")}`;
+  return text.includes("cards_streamer_card_number_unique") || text.includes("card_number");
+}

--- a/tests/unit/card-number-errors.test.ts
+++ b/tests/unit/card-number-errors.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { isCardNumberConflictError } from "@/lib/card-number-errors";
+
+describe("card-number-errors", () => {
+  it("detects card number unique constraint violations", () => {
+    expect(isCardNumberConflictError({
+      code: "23505",
+      message: "duplicate key value violates unique constraint \"cards_streamer_card_number_unique\"",
+    })).toBe(true);
+  });
+
+  it("ignores unrelated database errors", () => {
+    expect(isCardNumberConflictError({
+      code: "23505",
+      message: "duplicate key value violates unique constraint \"other_constraint\"",
+    })).toBe(false);
+    expect(isCardNumberConflictError({ code: "42P01", message: "relation missing" })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- return a clear message when a manual card number conflicts with another card
- add a bulk card-number editor so streamers can edit numbers without opening each card form
- validate duplicate/invalid numbers before save and handle number swaps by clearing changed numbers before applying final values

## Validation
- npm_config_cache=/private/tmp/twica-maker-npm-cache npx vitest run tests/unit/card-number-errors.test.ts tests/unit/collection-utils.test.ts tests/unit/cards-get-api.test.ts tests/unit/components/sorted-card-grid.test.tsx
- npm_config_cache=/private/tmp/twica-maker-npm-cache npm run lint
- npm_config_cache=/private/tmp/twica-maker-npm-cache npm run build
- npm_config_cache=/private/tmp/twica-maker-npm-cache npm run workers:build