### PR TITLE
[codex] Show channel point ranking only on tab

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -908,9 +908,10 @@
   "gachaStatsPage": {
     "title": "Gacha Stats",
     "description": "View card drop rates and statistics.",
-    "period": {
+    "tabs": {
       "7d": "7 Days",
-      "30d": "30 Days"
+      "30d": "30 Days",
+      "channelPoints": "Channel Points"
     },
     "totalDraws": "Total Draws",
     "draws": "draws",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -905,9 +905,10 @@
   "gachaStatsPage": {
     "title": "ガチャ統計",
     "description": "カードの排出率と統計情報を確認できます。",
-    "period": {
+    "tabs": {
       "7d": "7日間",
-      "30d": "30日間"
+      "30d": "30日間",
+      "channelPoints": "チャネルポイント"
     },
     "totalDraws": "総ガチャ回数",
     "draws": "回",

--- a/src/components/DropRateTable.tsx
+++ b/src/components/DropRateTable.tsx
@@ -39,6 +39,8 @@ interface GachaStatsData {
   rarityStats: RarityStat[];
 }
 
+type StatsTab = "7d" | "30d" | "channelPoints";
+
 /**
  * Drop rate comparison table for streamer statistics page
  * Shows configured vs actual drop rates with deviation highlighting
@@ -49,9 +51,10 @@ export default function DropRateTable() {
   const t = useTranslations("gachaStatsPage");
   const tRarity = useTranslations("rarity");
 
-  const [period, setPeriod] = useState<"7d" | "30d">("7d");
+  const [activeTab, setActiveTab] = useState<StatsTab>("7d");
   const [stats, setStats] = useState<GachaStatsData | null>(null);
   const [loading, setLoading] = useState(true);
+  const period = activeTab === "30d" ? "30d" : "7d";
 
   useEffect(() => {
     const fetchStats = async () => {
@@ -261,18 +264,18 @@ export default function DropRateTable() {
   return (
     <div>
       {/* Period tabs / 期間タブ */}
-      <div className="mb-6 flex gap-2">
-        {(["7d", "30d"] as const).map((p) => (
+      <div className="mb-6 flex flex-wrap gap-2">
+        {(["7d", "30d", "channelPoints"] as const).map((tab) => (
           <button
-            key={p}
-            onClick={() => setPeriod(p)}
+            key={tab}
+            onClick={() => setActiveTab(tab)}
             className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
-              period === p
+              activeTab === tab
                 ? "bg-purple-600 text-white"
                 : "border border-gray-600 text-gray-300 hover:bg-gray-700"
             }`}
           >
-            {t(`period.${p}`)}
+            {t(`tabs.${tab}`)}
           </button>
         ))}
       </div>
@@ -283,11 +286,10 @@ export default function DropRateTable() {
         </div>
       ) : !stats ? (
         <div className="py-12 text-center text-gray-400">{t("noData")}</div>
+      ) : activeTab === "channelPoints" ? (
+        renderChannelPointRanking()
       ) : (
-        <>
-          {renderChannelPointRanking()}
-          {renderPeriodStats()}
-        </>
+        renderPeriodStats()
       )}
 
       {/* Full period stats notice / 全期間統計についてのお知らせ */}

--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -567,6 +567,53 @@ interface ChannelPointUsageStatsRpcRow {
   last_redeemed_at: string | null;
 }
 
+interface GachaDropStatsRpcCardRow {
+  card_id: string;
+  card_name: string;
+  rarity: string;
+  image_url: string | null;
+  configured_rate: number | string;
+  actual_count: number | string;
+  actual_rate: number | string;
+}
+
+interface GachaDropStatsRpcRarityRow {
+  rarity: string;
+  count: number | string;
+  rate: number | string;
+}
+
+function parseGachaDropStatsRpc(rpcResult: unknown): Omit<GachaStatsResult, "channelPointStats"> | null {
+  if (!rpcResult || typeof rpcResult !== "object") return null;
+
+  const payload = rpcResult as {
+    total_draws?: number | string | null;
+    card_stats?: GachaDropStatsRpcCardRow[] | null;
+    rarity_stats?: GachaDropStatsRpcRarityRow[] | null;
+  };
+  if (!Array.isArray(payload.card_stats) || !Array.isArray(payload.rarity_stats)) {
+    return null;
+  }
+
+  return {
+    totalDraws: Number(payload.total_draws || 0),
+    cardStats: payload.card_stats.map((row) => ({
+      cardId: row.card_id,
+      cardName: row.card_name,
+      rarity: row.rarity,
+      imageUrl: row.image_url,
+      configuredRate: Number(row.configured_rate || 0),
+      actualCount: Number(row.actual_count || 0),
+      actualRate: Number(row.actual_rate || 0),
+    })),
+    rarityStats: payload.rarity_stats.map((row) => ({
+      rarity: row.rarity,
+      count: Number(row.count || 0),
+      rate: Number(row.rate || 0),
+    })),
+  };
+}
+
 function parseChannelPointUsageStatsRpc(rpcResult: unknown): GachaStatsResult["channelPointStats"] | null {
   if (!rpcResult || typeof rpcResult !== "object") return null;
 
@@ -611,33 +658,12 @@ export async function getGachaStats(
   const daysAgo = period === "7d" ? 7 : 30;
   const fromDate = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000);
 
-  // Run independent queries in parallel to reduce latency
-  // 独立したクエリを並列実行してレイテンシを削減
-  const [countResult, historyResult, cardsResult, channelPointResult] = await Promise.all([
-    // 1. Get total draw count using count-only query (avoids 1000-row limit)
-    // count-onlyクエリで正確な総ガチャ回数を取得（1000行制限を回避）
+  const [dropStatsResult, channelPointResult] = await Promise.all([
     supabaseAdmin
-      .from("gacha_history")
-      .select("id", { count: "exact", head: true })
-      .eq("streamer_id", streamerId)
-      .gte("redeemed_at", fromDate.toISOString()),
-    // 2. Fetch history with card_id to count draws per card
-    // card_idのみ取得してカードごとの排出回数を集計
-    // For very active streamers (>10000 draws/period), counts may be approximate.
-    // 非常にアクティブな配信者（期間内10000回超）の場合、カウントは近似値になる可能性がある。
-    supabaseAdmin
-      .from("gacha_history")
-      .select("card_id, cards(rarity)")
-      .eq("streamer_id", streamerId)
-      .gte("redeemed_at", fromDate.toISOString())
-      .limit(10000),
-    // 3. Fetch all active cards to include cards with 0 draws
-    // 排出0回のカードも含めるため、配信者の全アクティブカードを取得
-    supabaseAdmin
-      .from("cards")
-      .select("id, name, rarity, image_url, drop_rate")
-      .eq("streamer_id", streamerId)
-      .eq("is_active", true),
+      .rpc("get_gacha_drop_stats", {
+        p_streamer_id: streamerId,
+        p_from_date: fromDate.toISOString(),
+      }),
     supabaseAdmin
       .rpc("get_channel_point_usage_stats", {
         p_streamer_id: streamerId,
@@ -646,68 +672,20 @@ export async function getGachaStats(
       }),
   ]);
 
-  const totalDraws = countResult.count;
-  const history = historyResult.data;
-  const allCards = cardsResult.data;
-
-  const safeTotal = totalDraws || 0;
+  const dropStats = parseGachaDropStatsRpc(dropStatsResult.data) || {
+    totalDraws: 0,
+    cardStats: [],
+    rarityStats: ["legendary", "epic", "rare", "common"].map((rarity) => ({
+      rarity,
+      count: 0,
+      rate: 0,
+    })),
+  };
   const channelPointStats =
     parseChannelPointUsageStatsRpc(channelPointResult.data) ||
     EMPTY_CHANNEL_POINT_STATS;
 
-  // Count draws per card
-  // カードごとの排出回数を集計
-  const drawCounts = new Map<string, number>();
-  for (const h of history || []) {
-    drawCounts.set(h.card_id, (drawCounts.get(h.card_id) || 0) + 1);
-  }
-
-  // Calculate total configured weight for percentage calculation
-  // パーセンテージ計算用に設定重みの合計を算出
-  const totalWeight = (allCards || []).reduce(
-    (sum, c) => sum + (c.drop_rate || 0),
-    0
-  );
-
-  // Build per-card stats
-  // カードごとの統計を構築
-  const cardStats = (allCards || []).map((card) => {
-    const actualCount = drawCounts.get(card.id) || 0;
-    return {
-      cardId: card.id,
-      cardName: card.name,
-      rarity: card.rarity,
-      imageUrl: card.image_url,
-      // Configured rate as percentage of total weight
-      // 全体の重みに対する設定率（パーセンテージ）
-      configuredRate: totalWeight > 0 ? (card.drop_rate / totalWeight) * 100 : 0,
-      actualCount,
-      actualRate: safeTotal > 0 ? (actualCount / safeTotal) * 100 : 0,
-    };
-  });
-
-  // Build rarity-level stats
-  // レアリティレベルの統計を構築
-  const rarityMap = new Map<string, number>();
-  for (const h of history || []) {
-    const card = h.cards as unknown as { rarity: string } | null;
-    if (card) {
-      rarityMap.set(card.rarity, (rarityMap.get(card.rarity) || 0) + 1);
-    }
-  }
-
-  const rarityStats = ["legendary", "epic", "rare", "common"].map(
-    (rarity) => {
-      const count = rarityMap.get(rarity) || 0;
-      return {
-        rarity,
-        count,
-        rate: safeTotal > 0 ? (count / safeTotal) * 100 : 0,
-      };
-    }
-  );
-
-  return { totalDraws: safeTotal, channelPointStats, cardStats, rarityStats };
+  return { ...dropStats, channelPointStats };
 }
 
 /**

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -546,7 +546,21 @@ export interface Database {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      get_gacha_drop_stats: {
+        Args: {
+          p_streamer_id: string
+          p_from_date: string
+        }
+        Returns: Json
+      }
+      get_channel_point_usage_stats: {
+        Args: {
+          p_streamer_id: string
+          p_from_date?: string | null
+          p_limit?: number
+        }
+        Returns: Json
+      }
     }
     Enums: {
       [_ in never]: never

--- a/supabase/migrations/00038_add_gacha_drop_stats_rpc.sql
+++ b/supabase/migrations/00038_add_gacha_drop_stats_rpc.sql
@@ -1,0 +1,106 @@
+-- RPC: 配信者の期間内ガチャ排出統計をDB側で正確に集約して返す
+-- PostgREST/Supabase client の行取得上限に左右されないよう、履歴行を
+-- アプリに返さず、DB内で COUNT/GROUP BY した結果だけを返却する。
+CREATE OR REPLACE FUNCTION get_gacha_drop_stats(
+  p_streamer_id UUID,
+  p_from_date TIMESTAMPTZ
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_total_draws BIGINT;
+  v_total_weight NUMERIC;
+  v_card_stats JSONB;
+  v_rarity_stats JSONB;
+BEGIN
+  SELECT COUNT(*)::BIGINT
+  INTO v_total_draws
+  FROM gacha_history
+  WHERE streamer_id = p_streamer_id
+    AND redeemed_at >= p_from_date;
+
+  SELECT COALESCE(SUM(drop_rate), 0)::NUMERIC
+  INTO v_total_weight
+  FROM cards
+  WHERE streamer_id = p_streamer_id
+    AND is_active = TRUE;
+
+  WITH draw_counts AS (
+    SELECT card_id, COUNT(*)::BIGINT AS draw_count
+    FROM gacha_history
+    WHERE streamer_id = p_streamer_id
+      AND redeemed_at >= p_from_date
+    GROUP BY card_id
+  )
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'card_id', c.id,
+      'card_name', c.name,
+      'rarity', c.rarity,
+      'image_url', c.image_url,
+      'configured_rate', CASE
+        WHEN v_total_weight > 0 THEN (c.drop_rate / v_total_weight) * 100
+        ELSE 0
+      END,
+      'actual_count', COALESCE(dc.draw_count, 0),
+      'actual_rate', CASE
+        WHEN v_total_draws > 0 THEN (COALESCE(dc.draw_count, 0)::NUMERIC / v_total_draws) * 100
+        ELSE 0
+      END
+    )
+    ORDER BY c.rarity_order ASC, c.created_at DESC
+  ), '[]'::JSONB)
+  INTO v_card_stats
+  FROM cards c
+  LEFT JOIN draw_counts dc ON dc.card_id = c.id
+  WHERE c.streamer_id = p_streamer_id
+    AND c.is_active = TRUE;
+
+  WITH rarity_counts AS (
+    SELECT c.rarity, COUNT(*)::BIGINT AS draw_count
+    FROM gacha_history gh
+    JOIN cards c ON c.id = gh.card_id
+    WHERE gh.streamer_id = p_streamer_id
+      AND gh.redeemed_at >= p_from_date
+    GROUP BY c.rarity
+  ),
+  rarity_order AS (
+    SELECT *
+    FROM (VALUES
+      ('legendary'::TEXT, 1),
+      ('epic'::TEXT, 2),
+      ('rare'::TEXT, 3),
+      ('common'::TEXT, 4)
+    ) AS r(rarity, sort_order)
+  )
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'rarity', ro.rarity,
+      'count', COALESCE(rc.draw_count, 0),
+      'rate', CASE
+        WHEN v_total_draws > 0 THEN (COALESCE(rc.draw_count, 0)::NUMERIC / v_total_draws) * 100
+        ELSE 0
+      END
+    )
+    ORDER BY ro.sort_order
+  )
+  INTO v_rarity_stats
+  FROM rarity_order ro
+  LEFT JOIN rarity_counts rc ON rc.rarity = ro.rarity;
+
+  RETURN jsonb_build_object(
+    'total_draws', v_total_draws,
+    'card_stats', v_card_stats,
+    'rarity_stats', v_rarity_stats
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION get_gacha_drop_stats(UUID, TIMESTAMPTZ) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_gacha_drop_stats(UUID, TIMESTAMPTZ) TO service_role;
+
+CREATE INDEX IF NOT EXISTS idx_gacha_history_streamer_redeemed_card
+  ON gacha_history(streamer_id, redeemed_at DESC, card_id);

--- a/tests/unit/gacha-stats-api.test.ts
+++ b/tests/unit/gacha-stats-api.test.ts
@@ -112,86 +112,53 @@ describe("GET /api/gacha-stats", () => {
       createMockResponse({ id: "streamer-id-1" })
     );
 
-    // getGachaStats accesses gacha_history twice:
-    // 1st: count-only query (select("id", { count: "exact", head: true }))
-    // 2nd: data query (draw/card data for drop-rate aggregation)
-    // getGachaStats は gacha_history に2回アクセスする:
-    // 1回目: count-only クエリ、2回目: データ取得クエリ
-    const countQuery = createMockQueryBuilder();
-    const countResponse = { data: null, error: null, count: 1 };
-    (countQuery as unknown as Record<string, unknown>).then = (
-      resolve: (value: unknown) => void
-    ) => {
-      resolve(countResponse);
-      return countQuery;
-    };
-
-    const historyQuery = createMockQueryBuilder();
-    const historyResponse = {
-      data: [
-        {
-          card_id: "c1",
-          cards: { rarity: "common" },
-        },
-      ],
-      error: null,
-    };
-    (historyQuery as unknown as Record<string, unknown>).then = (
-      resolve: (value: unknown) => void
-    ) => {
-      resolve(historyResponse);
-      return historyQuery;
-    };
-
-    // Cards query (for allCards in getGachaStats)
-    // カードクエリ（getGachaStats内のallCards用）
-    const cardsQuery = createMockQueryBuilder();
-    const cardsResponse = {
-      data: [
-        {
-          id: "c1",
-          name: "Card1",
-          rarity: "common",
-          image_url: null,
-          drop_rate: 100,
-        },
-      ],
-      error: null,
-    };
-    (cardsQuery as unknown as Record<string, unknown>).then = (
-      resolve: (value: unknown) => void
-    ) => {
-      resolve(cardsResponse);
-      return cardsQuery;
-    };
-
-    const rpc = vi.fn().mockResolvedValue({
-      data: {
-        total_points: 250,
-        ranking: [
-          {
-            user_twitch_id: "viewer1",
-            username: "ViewerOne",
-            total_points: 250,
-            redemption_count: 2,
-            last_redeemed_at: "2026-01-01T00:00:00Z",
+    const rpc = vi.fn((functionName: string) => {
+      if (functionName === "get_gacha_drop_stats") {
+        return Promise.resolve({
+          data: {
+            total_draws: 1001,
+            card_stats: [
+              {
+                card_id: "c1",
+                card_name: "Card1",
+                rarity: "common",
+                image_url: null,
+                configured_rate: 100,
+                actual_count: 1001,
+                actual_rate: 100,
+              },
+            ],
+            rarity_stats: [
+              { rarity: "legendary", count: 0, rate: 0 },
+              { rarity: "epic", count: 0, rate: 0 },
+              { rarity: "rare", count: 0, rate: 0 },
+              { rarity: "common", count: 1001, rate: 100 },
+            ],
           },
-        ],
-      },
-      error: null,
+          error: null,
+        });
+      }
+
+      return Promise.resolve({
+        data: {
+          total_points: 250,
+          ranking: [
+            {
+              user_twitch_id: "viewer1",
+              username: "ViewerOne",
+              total_points: 250,
+              redemption_count: 2,
+              last_redeemed_at: "2026-01-01T00:00:00Z",
+            },
+          ],
+        },
+        error: null,
+      });
     });
 
-    // Track gacha_history call order to return count query first, then data query
-    // gacha_history の呼び出し順を追跡し、最初にcountクエリ、次にデータクエリを返す
-    let gachaHistoryCallCount = 0;
     mockGetSupabaseAdmin.mockReturnValue({
       from: vi.fn((table: string) => {
         if (table === "streamers") return streamerQuery;
-        if (table === "gacha_history") {
-          gachaHistoryCallCount++;
-          return gachaHistoryCallCount === 1 ? countQuery : historyQuery;
-        }
-        if (table === "cards") return cardsQuery;
         return createMockQueryBuilder();
       }),
       rpc,
@@ -201,10 +168,10 @@ describe("GET /api/gacha-stats", () => {
     expect(res.status).toBe(200);
 
     const body = await res.json();
-    expect(body.totalDraws).toBe(1);
+    expect(body.totalDraws).toBe(1001);
     expect(body.cardStats).toHaveLength(1);
     expect(body.cardStats[0].cardName).toBe("Card1");
-    expect(body.cardStats[0].actualCount).toBe(1);
+    expect(body.cardStats[0].actualCount).toBe(1001);
     expect(body.cardStats[0].actualRate).toBe(100);
     expect(body.rarityStats).toHaveLength(4);
     expect(body.channelPointStats.totalPoints).toBe(250);
@@ -221,6 +188,10 @@ describe("GET /api/gacha-stats", () => {
       p_streamer_id: "streamer-id-1",
       p_from_date: null,
       p_limit: 10,
+    });
+    expect(rpc).toHaveBeenCalledWith("get_gacha_drop_stats", {
+      p_streamer_id: "streamer-id-1",
+      p_from_date: expect.any(String),
     });
   });
 
@@ -242,73 +213,9 @@ describe("GET /api/gacha-stats", () => {
       createMockResponse({ id: "streamer-id-1" })
     );
 
-    const countQuery = createMockQueryBuilder();
-    (countQuery as unknown as Record<string, unknown>).then = (
-      resolve: (value: unknown) => void
-    ) => {
-      resolve({ data: null, error: null, count: 3 });
-      return countQuery;
-    };
-
-    const historyQuery = createMockQueryBuilder();
-    (historyQuery as unknown as Record<string, unknown>).then = (
-      resolve: (value: unknown) => void
-    ) => {
-      resolve({
-        data: [
-          {
-            card_id: "c1",
-            cards: { rarity: "common" },
-          },
-          {
-            card_id: "c1",
-            cards: { rarity: "common" },
-          },
-          {
-            card_id: "c2",
-            cards: { rarity: "rare" },
-          },
-        ],
-        error: null,
-      });
-      return historyQuery;
-    };
-
-    const cardsQuery = createMockQueryBuilder();
-    (cardsQuery as unknown as Record<string, unknown>).then = (
-      resolve: (value: unknown) => void
-    ) => {
-      resolve({
-        data: [
-          {
-            id: "c1",
-            name: "Card1",
-            rarity: "common",
-            image_url: null,
-            drop_rate: 50,
-          },
-          {
-            id: "c2",
-            name: "Card2",
-            rarity: "rare",
-            image_url: null,
-            drop_rate: 50,
-          },
-        ],
-        error: null,
-      });
-      return cardsQuery;
-    };
-
-    let gachaHistoryCallCount = 0;
     mockGetSupabaseAdmin.mockReturnValue({
       from: vi.fn((table: string) => {
         if (table === "streamers") return streamerQuery;
-        if (table === "gacha_history") {
-          gachaHistoryCallCount++;
-          return gachaHistoryCallCount === 1 ? countQuery : historyQuery;
-        }
-        if (table === "cards") return cardsQuery;
         return createMockQueryBuilder();
       }),
       rpc: vi.fn().mockResolvedValue({
@@ -321,6 +228,8 @@ describe("GET /api/gacha-stats", () => {
     expect(res.status).toBe(200);
 
     const body = await res.json();
+    expect(body.totalDraws).toBe(0);
+    expect(body.cardStats).toEqual([]);
     expect(body.channelPointStats).toEqual({
       totalPoints: 0,
       ranking: [],


### PR DESCRIPTION
## Summary
- add a Channel Points tab to the streamer stats view
- show the all-time channel point ranking only when that tab is selected
- move period drop-rate stats to a DB-side RPC so counts do not depend on Supabase row fetch limits

## Impact
- the 7d/30d tabs stay focused on period-based drop-rate stats
- channel point ranking stays hidden until the Channel Points tab is selected
- total draws, per-card counts, and rarity counts are aggregated in SQL instead of reading capped history rows into the app

## Validation
- npm_config_cache=/private/tmp/twica-maker-npm-cache npx vitest run tests/unit/gacha-stats-api.test.ts
- npm run lint
- npm run build