### PR TITLE
Handle missing card_number schema cache

### DIFF
--- a/src/app/api/cards/[id]/route.ts
+++ b/src/app/api/cards/[id]/route.ts
@@ -17,7 +17,7 @@ import { deleteFromR2 } from "@/lib/r2-client";
 import { removeBlobFile } from "@/lib/storage-db";
 import { isR2Url, isVercelBlobUrl, isStorageUrl, getR2KeyFromUrl } from "@/lib/storage-utils";
 import { recalculateIfAutoMode } from "@/lib/recalculate-drop-rates";
-import { CARD_NUMBER_MESSAGES, isCardNumberConflictError } from "@/lib/card-number-errors";
+import { CARD_NUMBER_MESSAGES, isCardNumberConflictError, isMissingCardNumberColumnError } from "@/lib/card-number-errors";
 import type { ApiRateLimitResponse } from "@/types/api";
 
 function extractRarityWeights(streamers: unknown): Record<string, number> | null {
@@ -224,12 +224,24 @@ export async function PUT(
       }
     }
 
-    const { data: updatedCard, error } = await supabaseAdmin
+    let { data: updatedCard, error } = await supabaseAdmin
       .from("cards")
       .update(updateData)
       .eq("id", id)
       .select()
       .maybeSingle();
+
+    if (error && isMissingCardNumberColumnError(error) && "card_number" in updateData) {
+      delete updateData.card_number;
+      const retryResult = await supabaseAdmin
+        .from("cards")
+        .update(updateData)
+        .eq("id", id)
+        .select()
+        .maybeSingle();
+      updatedCard = retryResult.data;
+      error = retryResult.error;
+    }
 
     if (error) {
       if (isCardNumberConflictError(error)) {

--- a/src/app/api/cards/route.ts
+++ b/src/app/api/cards/route.ts
@@ -18,7 +18,7 @@ import { getStorageUsage } from "@/lib/storage-usage";
 import { sha256Prefix } from "@/lib/crypto-utils";
 import { logger } from "@/lib/logger";
 import { recalculateIfAutoMode } from "@/lib/recalculate-drop-rates";
-import { CARD_NUMBER_MESSAGES, isCardNumberConflictError } from "@/lib/card-number-errors";
+import { CARD_NUMBER_MESSAGES, isCardNumberConflictError, isMissingCardNumberColumnError } from "@/lib/card-number-errors";
 import type { ApiRateLimitResponse } from "@/types/api";
 
 // Cache TTL for cards list (30 seconds to balance freshness and CPU usage)
@@ -174,11 +174,22 @@ export async function POST(request: NextRequest) {
       insertData.intra_rarity_weight = intraRarityWeight;
     }
 
-    const { data: card, error } = await supabaseAdmin
+    let { data: card, error } = await supabaseAdmin
       .from("cards")
       .insert(insertData)
       .select()
       .maybeSingle();
+
+    if (error && isMissingCardNumberColumnError(error)) {
+      delete insertData.card_number;
+      const retryResult = await supabaseAdmin
+        .from("cards")
+        .insert(insertData)
+        .select()
+        .maybeSingle();
+      card = retryResult.data;
+      error = retryResult.error;
+    }
 
     if (error) {
       if (isCardNumberConflictError(error)) {
@@ -273,7 +284,27 @@ async function fetchCardsFromDB(
   query = query.order(dbSortField, { ascending, nullsFirst: false });
   query = query.range(offset, offset + limit - 1);
 
-  const { data: cards, error, count } = await query;
+  let { data: cards, error, count } = await query;
+  if (error && sortField === "card_number" && isMissingCardNumberColumnError(error)) {
+    const fallbackQuery = supabaseAdmin
+      .from("cards")
+      .select("*", { count: "exact" })
+      .eq("streamer_id", streamerId);
+
+    let filteredFallbackQuery = fallbackQuery;
+    if (statusFilter === "active") {
+      filteredFallbackQuery = filteredFallbackQuery.eq("is_active", true);
+    } else if (statusFilter === "inactive") {
+      filteredFallbackQuery = filteredFallbackQuery.eq("is_active", false);
+    }
+
+    const fallbackResult = await filteredFallbackQuery
+      .order("created_at", { ascending, nullsFirst: false })
+      .range(offset, offset + limit - 1);
+    cards = fallbackResult.data;
+    error = fallbackResult.error;
+    count = fallbackResult.count;
+  }
   if (error) throw error;
 
   logger.info(`[Perf] fetchCardsFromDB: ${Date.now() - start}ms (${cards?.length || 0} cards)`);

--- a/src/lib/card-number-errors.ts
+++ b/src/lib/card-number-errors.ts
@@ -11,3 +11,19 @@ export function isCardNumberConflictError(error: unknown): boolean {
   const text = `${String(err.message || "")} ${String(err.details || "")}`;
   return text.includes("cards_streamer_card_number_unique") || text.includes("card_number");
 }
+
+export function isMissingCardNumberColumnError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const err = error as { code?: unknown; message?: unknown; details?: unknown; hint?: unknown };
+  const text = [
+    err.message,
+    err.details,
+    err.hint,
+  ].map((value) => String(value || "")).join(" ");
+
+  return text.includes("card_number") && (
+    text.includes("schema cache") ||
+    text.includes("column") ||
+    err.code === "PGRST204"
+  );
+}

--- a/tests/unit/card-number-errors.test.ts
+++ b/tests/unit/card-number-errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isCardNumberConflictError } from "@/lib/card-number-errors";
+import { isCardNumberConflictError, isMissingCardNumberColumnError } from "@/lib/card-number-errors";
 
 describe("card-number-errors", () => {
   it("detects card number unique constraint violations", () => {
@@ -15,5 +15,21 @@ describe("card-number-errors", () => {
       message: "duplicate key value violates unique constraint \"other_constraint\"",
     })).toBe(false);
     expect(isCardNumberConflictError({ code: "42P01", message: "relation missing" })).toBe(false);
+  });
+});
+
+describe("isMissingCardNumberColumnError", () => {
+  it("detects PostgREST schema-cache errors for cards.card_number", () => {
+    expect(isMissingCardNumberColumnError({
+      code: "PGRST204",
+      message: "Could not find the 'card_number' column of 'cards' in the schema cache",
+    })).toBe(true);
+  });
+
+  it("ignores unrelated missing-column errors", () => {
+    expect(isMissingCardNumberColumnError({
+      code: "PGRST204",
+      message: "Could not find the 'other_column' column of 'cards' in the schema cache",
+    })).toBe(false);
   });
 });

--- a/tests/unit/cards-get-api.test.ts
+++ b/tests/unit/cards-get-api.test.ts
@@ -83,6 +83,49 @@ function setupCardsMock(options: {
   return { streamerQuery, cardsQuery }
 }
 
+function setupCardsMockWithRetry(options: {
+  streamer?: { id: string } | null
+  firstCardsError: Error
+  retryCards?: Record<string, unknown>[]
+}) {
+  const streamerQuery = createMockQueryBuilder()
+  ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue(
+    createMockResponse(options.streamer ?? null)
+  )
+
+  const firstCardsQuery = createMockQueryBuilder()
+  ;(firstCardsQuery as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
+    resolve({ data: null, error: options.firstCardsError, count: null })
+    return firstCardsQuery
+  }
+
+  const retryCardsQuery = createMockQueryBuilder()
+  ;(retryCardsQuery as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
+    resolve({
+      data: options.retryCards ?? [],
+      error: null,
+      count: options.retryCards?.length ?? 0,
+    })
+    return retryCardsQuery
+  }
+
+  const from = vi.fn((table: string) => {
+    if (table === 'streamers') return streamerQuery
+    if (table === 'cards') {
+      return from.mock.calls.filter(([calledTable]) => calledTable === 'cards').length === 1
+        ? firstCardsQuery
+        : retryCardsQuery
+    }
+    return createMockQueryBuilder()
+  })
+
+  mockGetSupabaseAdmin.mockReturnValue({
+    from,
+  } as ReturnType<typeof getSupabaseAdmin>)
+
+  return { firstCardsQuery, retryCardsQuery }
+}
+
 function createRequest(params: Record<string, string> = {}): NextRequest {
   const url = new URL('http://localhost/api/cards')
   Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value))
@@ -170,6 +213,28 @@ describe('GET /api/cards', () => {
       }))
 
       expect(cardsQuery.order).toHaveBeenCalledWith('card_number', { ascending: true, nullsFirst: false })
+    })
+
+    it('card_number が schema cache にない場合は created_at ソートで再試行する', async () => {
+      const { firstCardsQuery, retryCardsQuery } = setupCardsMockWithRetry({
+        streamer: { id: 'streamer-1' },
+        firstCardsError: Object.assign(new Error("Could not find the 'card_number' column of 'cards' in the schema cache"), {
+          code: 'PGRST204',
+        }),
+        retryCards: [{ id: '1', drop_rate: 0.5 }],
+      })
+
+      const response = await GET(createRequest({
+        streamerId: 'streamer-1',
+        sortField: 'card_number',
+        sortDirection: 'asc',
+      }))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body.cards).toHaveLength(1)
+      expect(firstCardsQuery.order).toHaveBeenCalledWith('card_number', { ascending: true, nullsFirst: false })
+      expect(retryCardsQuery.order).toHaveBeenCalledWith('created_at', { ascending: true, nullsFirst: false })
     })
 
     it('不正なsortFieldはcreated_atにフォールバックする', async () => {


### PR DESCRIPTION
## Summary
- retry card create/update without card_number when Supabase reports the column missing from schema cache
- fallback card_number list sorting to created_at so card management keeps loading while the DB migration/cache catches up
- add regression coverage for the schema-cache error detection and GET fallback

## Validation
- npm run test:unit -- tests/unit/card-number-errors.test.ts tests/unit/cards-get-api.test.ts
- npm run lint
- npm run build