### PR TITLE
copy: describe chat sender as linked account

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -392,7 +392,7 @@
       "saveTemplate": "Save Template",
       "saving": "Saving...",
       "chatDemo": "Chat Demo",
-      "connectBot": "Connect Another Account",
+      "connectBot": "Connect Another Twitch Account",
       "connectingBot": "Connecting...",
       "disconnectBot": "Disconnect Account",
       "disconnectingBot": "Disconnecting..."
@@ -416,7 +416,7 @@
     },
     "bot": {
       "title": "Sender Account",
-      "description": "Without another account connected, messages are sent from your streamer account. Connect Twitch to send from a different account.",
+      "description": "Without another account connected, messages are sent from your streamer account. When you start linking, Twitch opens authorization with the account currently signed in on Twitch. To send from a different account, switch accounts on Twitch before linking.",
       "connectedAs": "Sending as {name}"
     }
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -371,7 +371,7 @@
   },
   "chatAnnouncementSettings": {
     "title": "Chat Announcement Settings",
-    "description": "Automatically post gacha results to Twitch chat. Connect a BOT account to send messages from that account.",
+    "description": "Automatically post gacha results to Twitch chat. Connect another Twitch account to send messages from that account.",
     "status": {
       "enabled": "Enabled",
       "disabled": "Disabled"
@@ -392,22 +392,22 @@
       "saveTemplate": "Save Template",
       "saving": "Saving...",
       "chatDemo": "Chat Demo",
-      "connectBot": "Connect BOT",
+      "connectBot": "Connect Another Account",
       "connectingBot": "Connecting...",
-      "disconnectBot": "Disconnect BOT",
+      "disconnectBot": "Disconnect Account",
       "disconnectingBot": "Disconnecting..."
     },
     "messages": {
       "checkingScope": "Checking permissions...",
       "saved": "Settings saved",
       "lengthWarning": "If the card description or URL is long, the outgoing message may reach about {estimated} characters. Anything over {max} characters will be truncated when sent.",
-      "botDisconnected": "BOT account disconnected"
+      "botDisconnected": "Linked account disconnected"
     },
     "errors": {
       "saveFailed": "Failed to save settings",
       "reauthorizeFailed": "Re-authorization failed",
-      "botConnectFailed": "Failed to start BOT connection",
-      "botDisconnectFailed": "Failed to disconnect BOT account"
+      "botConnectFailed": "Failed to start account connection",
+      "botDisconnectFailed": "Failed to disconnect linked account"
     },
     "demo": {
       "title": "Chat Message Preview",
@@ -416,7 +416,7 @@
     },
     "bot": {
       "title": "Sender Account",
-      "description": "Without a BOT connection, messages are sent from your streamer account. Connect Twitch to send from a dedicated BOT.",
+      "description": "Without another account connected, messages are sent from your streamer account. Connect Twitch to send from a different account.",
       "connectedAs": "Sending as {name}"
     }
   },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -392,7 +392,7 @@
       "saveTemplate": "テンプレートを保存",
       "saving": "保存中...",
       "chatDemo": "チャットデモ",
-      "connectBot": "別アカウントを連携",
+      "connectBot": "Twitchで別アカウントを連携",
       "connectingBot": "連携中...",
       "disconnectBot": "別アカウント連携を解除",
       "disconnectingBot": "解除中..."
@@ -416,7 +416,7 @@
     },
     "bot": {
       "title": "送信アカウント",
-      "description": "未連携の場合は配信者アカウントから送信します。別のTwitchアカウントから送る場合は連携してください。",
+      "description": "未連携の場合は配信者アカウントから送信します。連携を始めると、現在Twitchにログインしているアカウントで認証が開きます。別のアカウントから送る場合は、先にTwitch側でそのアカウントに切り替えてから連携してください。",
       "connectedAs": "{name} から送信します"
     }
   },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -371,7 +371,7 @@
   },
   "chatAnnouncementSettings": {
     "title": "チャット通知設定",
-    "description": "ガチャ結果をTwitchチャットに自動投稿します。BOTアカウントを連携すると、そのアカウントからメッセージが送信されます。",
+    "description": "ガチャ結果をTwitchチャットに自動投稿します。別のTwitchアカウントを連携すると、そのアカウントからメッセージが送信されます。",
     "status": {
       "enabled": "有効",
       "disabled": "無効"
@@ -392,22 +392,22 @@
       "saveTemplate": "テンプレートを保存",
       "saving": "保存中...",
       "chatDemo": "チャットデモ",
-      "connectBot": "BOTを連携",
+      "connectBot": "別アカウントを連携",
       "connectingBot": "連携中...",
-      "disconnectBot": "BOT連携を解除",
+      "disconnectBot": "別アカウント連携を解除",
       "disconnectingBot": "解除中..."
     },
     "messages": {
       "checkingScope": "権限を確認中...",
       "saved": "設定を保存しました",
       "lengthWarning": "カード説明やURLが長い場合、送信メッセージが最大 {estimated} 文字程度になる可能性があります。{max}文字を超えた分は送信時に切り詰められます。",
-      "botDisconnected": "BOT連携を解除しました"
+      "botDisconnected": "別アカウント連携を解除しました"
     },
     "errors": {
       "saveFailed": "設定の保存に失敗しました",
       "reauthorizeFailed": "再認証に失敗しました",
-      "botConnectFailed": "BOT連携の開始に失敗しました",
-      "botDisconnectFailed": "BOT連携の解除に失敗しました"
+      "botConnectFailed": "別アカウント連携の開始に失敗しました",
+      "botDisconnectFailed": "別アカウント連携の解除に失敗しました"
     },
     "demo": {
       "title": "チャットメッセージプレビュー",
@@ -416,7 +416,7 @@
     },
     "bot": {
       "title": "送信アカウント",
-      "description": "未連携の場合は配信者アカウントから送信します。専用BOTから送る場合はTwitchで連携してください。",
+      "description": "未連携の場合は配信者アカウントから送信します。別のTwitchアカウントから送る場合は連携してください。",
       "connectedAs": "{name} から送信します"
     }
   },

--- a/src/components/ChatAnnouncementSettings.tsx
+++ b/src/components/ChatAnnouncementSettings.tsx
@@ -230,7 +230,7 @@ export default function ChatAnnouncementSettings({
       setMessage(errorData.error || t("errors.botConnectFailed"));
       setIsError(true);
     } catch (error) {
-      logger.error("BOT connect error:", error);
+      logger.error("Alternate account connect error:", error);
       setMessage(t("errors.botConnectFailed"));
       setIsError(true);
     } finally {
@@ -268,7 +268,7 @@ export default function ChatAnnouncementSettings({
       setMessage(t("messages.botDisconnected"));
       setIsError(false);
     } catch (error) {
-      logger.error("BOT disconnect error:", error);
+      logger.error("Alternate account disconnect error:", error);
       setMessage(t("errors.botDisconnectFailed"));
       setIsError(true);
     } finally {


### PR DESCRIPTION
## Summary
- replace user-facing BOT account wording with linked/alternate Twitch account wording
- update connect/disconnect button labels, success/error messages, and sender account help text
- keep internal BOT table/API naming unchanged for future official BOT support

## Validation
- npx vitest run tests/unit/bot-account-migration.test.ts
- npm run lint (passes with existing warnings)
