### PR TITLE
copy: shorten linked account button label

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -392,9 +392,9 @@
       "saveTemplate": "Save Template",
       "saving": "Saving...",
       "chatDemo": "Chat Demo",
-      "connectBot": "Connect Another Twitch Account",
+      "connectBot": "Connect",
       "connectingBot": "Connecting...",
-      "disconnectBot": "Disconnect Account",
+      "disconnectBot": "Disconnect",
       "disconnectingBot": "Disconnecting..."
     },
     "messages": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -392,9 +392,9 @@
       "saveTemplate": "テンプレートを保存",
       "saving": "保存中...",
       "chatDemo": "チャットデモ",
-      "connectBot": "Twitchで別アカウントを連携",
+      "connectBot": "連携する",
       "connectingBot": "連携中...",
-      "disconnectBot": "別アカウント連携を解除",
+      "disconnectBot": "解除する",
       "disconnectingBot": "解除中..."
     },
     "messages": {

--- a/src/components/ChatAnnouncementSettings.tsx
+++ b/src/components/ChatAnnouncementSettings.tsx
@@ -426,7 +426,7 @@ export default function ChatAnnouncementSettings({
             <button
               onClick={handleDisconnectBot}
               disabled={botDisconnecting}
-              className="rounded-lg bg-gray-600 px-4 py-2 text-sm text-white hover:bg-gray-500 disabled:opacity-50"
+              className="shrink-0 whitespace-nowrap rounded-lg bg-gray-600 px-4 py-2 text-sm text-white hover:bg-gray-500 disabled:opacity-50"
             >
               {botDisconnecting ? t("buttons.disconnectingBot") : t("buttons.disconnectBot")}
             </button>
@@ -434,7 +434,7 @@ export default function ChatAnnouncementSettings({
             <button
               onClick={handleConnectBot}
               disabled={botConnecting}
-              className="rounded-lg bg-purple-600 px-4 py-2 text-sm text-white hover:bg-purple-700 disabled:opacity-50"
+              className="shrink-0 whitespace-nowrap rounded-lg bg-purple-600 px-4 py-2 text-sm text-white hover:bg-purple-700 disabled:opacity-50"
             >
               {botConnecting ? t("buttons.connectingBot") : t("buttons.connectBot")}
             </button>


### PR DESCRIPTION
## Summary
- shorten the linked account connect/disconnect button labels so they do not wrap awkwardly
- keep the detailed Twitch account-switching guidance in the description text
- add nowrap/shrink styling to sender account action buttons

## Validation
- npm run lint (passes with existing warnings)
