### PR TITLE
fix: avoid redirect mismatch for linked account auth

### DIFF
--- a/src/app/api/auth/bot/callback/route.ts
+++ b/src/app/api/auth/bot/callback/route.ts
@@ -1,14 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 
-import { getSession, canUseStreamerFeatures } from '@/lib/session'
-import { getSupabaseAdmin } from '@/lib/supabase/admin'
-import { exchangeCodeForTokens, getTwitchUser, isInvalidAuthorizationCodeError } from '@/lib/twitch/auth'
-import { ADDITIONAL_SCOPES } from '@/lib/twitch/scopes'
 import { COOKIE_NAMES, ERROR_MESSAGES } from '@/lib/constants'
 import { checkRateLimit, getClientIp, rateLimits } from '@/lib/rate-limit'
-import { logger } from '@/lib/logger'
 import { getBaseUrl } from '@/lib/url-utils'
+import { handleLinkedAccountCallback } from '@/lib/twitch/linked-account-auth'
 
 function redirectToSettings(baseUrl: string, params: Record<string, string>) {
   const searchParams = new URLSearchParams(params)
@@ -39,134 +35,14 @@ export async function GET(request: NextRequest) {
 
   const cookieStore = await cookies()
   const storedState = cookieStore.get(COOKIE_NAMES.BOT_AUTH_STATE)?.value
+
   if (!storedState || state !== storedState) {
     return redirectToSettings(baseUrl, { bot_error: 'invalid_state' })
   }
 
-  const session = await getSession()
-  if (!session || !canUseStreamerFeatures(session)) {
-    return redirectToSettings(baseUrl, { bot_error: ERROR_MESSAGES.UNAUTHORIZED })
-  }
-
-  const redirectUri = `${baseUrl}/api/auth/bot/callback`
-  const response = redirectToSettings(baseUrl, { bot: 'connected' })
-
-  try {
-    const tokens = await exchangeCodeForTokens(code, redirectUri)
-    if (!tokens.scope?.includes(ADDITIONAL_SCOPES.CHAT_WRITE)) {
-      return redirectToSettings(baseUrl, { bot_error: 'missing_chat_scope' })
-    }
-
-    const botUser = await getTwitchUser(tokens.access_token)
-    if (botUser.id === session.twitchUserId) {
-      return redirectToSettings(baseUrl, { bot_error: 'same_account' })
-    }
-
-    const expiresAt = new Date(Date.now() + tokens.expires_in * 1000)
-    const supabaseAdmin = getSupabaseAdmin()
-
-    const { data: streamer, error: streamerError } = await supabaseAdmin
-      .from('streamers')
-      .select('id')
-      .eq('twitch_user_id', session.twitchUserId)
-      .maybeSingle()
-
-    if (streamerError || !streamer) {
-      logger.error('BOT auth callback: failed to find streamer', {
-        twitchUserId: session.twitchUserId,
-        botTwitchUserId: botUser.id,
-        error: streamerError,
-      })
-      return redirectToSettings(baseUrl, { bot_error: 'database_error' })
-    }
-
-    const botAccountFields = {
-      twitch_user_id: botUser.id,
-      twitch_username: botUser.login,
-      twitch_display_name: botUser.display_name,
-      twitch_access_token: tokens.access_token,
-      twitch_refresh_token: tokens.refresh_token,
-      twitch_token_expires_at: expiresAt.toISOString(),
-      scopes: tokens.scope ?? [],
-      status: 'active',
-      last_error: null,
-    }
-
-    const { data: existingBotAccount, error: existingBotError } = await supabaseAdmin
-      .from('twitch_bot_accounts')
-      .select('id')
-      .eq('owner_type', 'streamer')
-      .eq('streamer_id', streamer.id)
-      .maybeSingle()
-
-    if (existingBotError) {
-      logger.error('BOT auth callback: failed to fetch existing BOT account', {
-        twitchUserId: session.twitchUserId,
-        botTwitchUserId: botUser.id,
-        error: existingBotError,
-      })
-      return redirectToSettings(baseUrl, { bot_error: 'database_error' })
-    }
-
-    const botAccountResult = existingBotAccount
-      ? await supabaseAdmin
-          .from('twitch_bot_accounts')
-          .update(botAccountFields)
-          .eq('id', existingBotAccount.id)
-          .select('id')
-          .single()
-      : await supabaseAdmin
-          .from('twitch_bot_accounts')
-          .insert({
-            ...botAccountFields,
-            owner_type: 'streamer',
-            streamer_id: streamer.id,
-          })
-          .select('id')
-          .single()
-
-    if (botAccountResult.error) {
-      logger.error('BOT auth callback: failed to save BOT account', {
-        twitchUserId: session.twitchUserId,
-        botTwitchUserId: botUser.id,
-        error: botAccountResult.error,
-      })
-      return redirectToSettings(baseUrl, { bot_error: 'database_error' })
-    }
-
-    const { error: senderSettingsError } = await supabaseAdmin
-      .from('streamer_chat_sender_settings')
-      .upsert({
-        streamer_id: streamer.id,
-        sender_mode: 'custom_bot',
-        custom_bot_account_id: botAccountResult.data.id,
-      })
-
-    if (senderSettingsError) {
-      logger.error('BOT auth callback: failed to save chat sender settings', {
-        twitchUserId: session.twitchUserId,
-        botTwitchUserId: botUser.id,
-        error: senderSettingsError,
-      })
-      return redirectToSettings(baseUrl, { bot_error: 'database_error' })
-    }
-
-    logger.info('BOT account connected for chat announcements', {
-      twitchUserId: session.twitchUserId,
-      botTwitchUserId: botUser.id,
-    })
-
-    response.cookies.delete(COOKIE_NAMES.BOT_AUTH_STATE)
-    return response
-  } catch (error) {
-    const errorType = isInvalidAuthorizationCodeError(error)
-      ? 'invalid_authorization_code'
-      : 'bot_auth_failed'
-    logger.error('BOT auth callback failed', {
-      twitchUserId: session.twitchUserId,
-      errorType,
-      error,
-    })
-    return redirectToSettings(baseUrl, { bot_error: errorType })
-  }
+  return handleLinkedAccountCallback({
+    baseUrl,
+    code,
+    redirectUri: `${baseUrl}/api/auth/bot/callback`,
+  })
 }

--- a/src/app/api/auth/bot/connect/route.ts
+++ b/src/app/api/auth/bot/connect/route.ts
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
 
     const state = randomBytesHex(32)
     const baseUrl = getBaseUrl(request)
-    const redirectUri = `${baseUrl}${API_ROUTES.AUTH_BOT_CALLBACK}`
+    const redirectUri = `${baseUrl}${API_ROUTES.AUTH_TWITCH_CALLBACK}`
     const loginUrl = getTwitchAuthUrl(redirectUri, state, [ADDITIONAL_SCOPES.CHAT_WRITE])
 
     const response = NextResponse.json({ success: true, loginUrl })

--- a/src/app/api/auth/twitch/callback/route.ts
+++ b/src/app/api/auth/twitch/callback/route.ts
@@ -10,6 +10,7 @@ import { checkRateLimit, rateLimits, getClientIp } from '@/lib/rate-limit'
 import { logger } from '@/lib/logger'
 import { getBaseUrl } from '@/lib/url-utils'
 import { signSession } from '@/lib/session'
+import { handleLinkedAccountCallback } from '@/lib/twitch/linked-account-auth'
 
 export async function GET(request: NextRequest) {
   // 開発環境ではリクエストのホストから動的にベースURLを取得
@@ -47,6 +48,16 @@ export async function GET(request: NextRequest) {
 
   // Verify state
   const cookieStore = await cookies()
+  const storedBotState = cookieStore.get(COOKIE_NAMES.BOT_AUTH_STATE)?.value
+  if (storedBotState && state === storedBotState) {
+    const redirectUri = `${baseUrl}/api/auth/twitch/callback`
+    return handleLinkedAccountCallback({
+      baseUrl,
+      code,
+      redirectUri,
+    })
+  }
+
   const storedState = cookieStore.get(COOKIE_NAMES.AUTH_STATE)?.value
 
   if (!storedState || state !== storedState) {

--- a/src/lib/twitch/linked-account-auth.ts
+++ b/src/lib/twitch/linked-account-auth.ts
@@ -1,0 +1,149 @@
+import { NextResponse } from 'next/server'
+
+import { getSession, canUseStreamerFeatures } from '@/lib/session'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { exchangeCodeForTokens, getTwitchUser, isInvalidAuthorizationCodeError } from '@/lib/twitch/auth'
+import { ADDITIONAL_SCOPES } from '@/lib/twitch/scopes'
+import { COOKIE_NAMES, ERROR_MESSAGES } from '@/lib/constants'
+import { logger } from '@/lib/logger'
+
+function redirectToSettings(baseUrl: string, params: Record<string, string>) {
+  const searchParams = new URLSearchParams(params)
+  return NextResponse.redirect(`${baseUrl}/dashboard/settings?${searchParams.toString()}`)
+}
+
+export async function handleLinkedAccountCallback({
+  baseUrl,
+  code,
+  redirectUri,
+}: {
+  baseUrl: string
+  code: string
+  redirectUri: string
+}) {
+  const session = await getSession()
+  if (!session || !canUseStreamerFeatures(session)) {
+    return redirectToSettings(baseUrl, { bot_error: ERROR_MESSAGES.UNAUTHORIZED })
+  }
+
+  const response = redirectToSettings(baseUrl, { bot: 'connected' })
+
+  try {
+    const tokens = await exchangeCodeForTokens(code, redirectUri)
+    if (!tokens.scope?.includes(ADDITIONAL_SCOPES.CHAT_WRITE)) {
+      return redirectToSettings(baseUrl, { bot_error: 'missing_chat_scope' })
+    }
+
+    const botUser = await getTwitchUser(tokens.access_token)
+    if (botUser.id === session.twitchUserId) {
+      return redirectToSettings(baseUrl, { bot_error: 'same_account' })
+    }
+
+    const expiresAt = new Date(Date.now() + tokens.expires_in * 1000)
+    const supabaseAdmin = getSupabaseAdmin()
+
+    const { data: streamer, error: streamerError } = await supabaseAdmin
+      .from('streamers')
+      .select('id')
+      .eq('twitch_user_id', session.twitchUserId)
+      .maybeSingle()
+
+    if (streamerError || !streamer) {
+      logger.error('Linked account callback: failed to find streamer', {
+        twitchUserId: session.twitchUserId,
+        linkedTwitchUserId: botUser.id,
+        error: streamerError,
+      })
+      return redirectToSettings(baseUrl, { bot_error: 'database_error' })
+    }
+
+    const botAccountFields = {
+      twitch_user_id: botUser.id,
+      twitch_username: botUser.login,
+      twitch_display_name: botUser.display_name,
+      twitch_access_token: tokens.access_token,
+      twitch_refresh_token: tokens.refresh_token,
+      twitch_token_expires_at: expiresAt.toISOString(),
+      scopes: tokens.scope ?? [],
+      status: 'active',
+      last_error: null,
+    }
+
+    const { data: existingBotAccount, error: existingBotError } = await supabaseAdmin
+      .from('twitch_bot_accounts')
+      .select('id')
+      .eq('owner_type', 'streamer')
+      .eq('streamer_id', streamer.id)
+      .maybeSingle()
+
+    if (existingBotError) {
+      logger.error('Linked account callback: failed to fetch existing linked account', {
+        twitchUserId: session.twitchUserId,
+        linkedTwitchUserId: botUser.id,
+        error: existingBotError,
+      })
+      return redirectToSettings(baseUrl, { bot_error: 'database_error' })
+    }
+
+    const botAccountResult = existingBotAccount
+      ? await supabaseAdmin
+          .from('twitch_bot_accounts')
+          .update(botAccountFields)
+          .eq('id', existingBotAccount.id)
+          .select('id')
+          .single()
+      : await supabaseAdmin
+          .from('twitch_bot_accounts')
+          .insert({
+            ...botAccountFields,
+            owner_type: 'streamer',
+            streamer_id: streamer.id,
+          })
+          .select('id')
+          .single()
+
+    if (botAccountResult.error) {
+      logger.error('Linked account callback: failed to save linked account', {
+        twitchUserId: session.twitchUserId,
+        linkedTwitchUserId: botUser.id,
+        error: botAccountResult.error,
+      })
+      return redirectToSettings(baseUrl, { bot_error: 'database_error' })
+    }
+
+    const { error: senderSettingsError } = await supabaseAdmin
+      .from('streamer_chat_sender_settings')
+      .upsert({
+        streamer_id: streamer.id,
+        sender_mode: 'custom_bot',
+        custom_bot_account_id: botAccountResult.data.id,
+      })
+
+    if (senderSettingsError) {
+      logger.error('Linked account callback: failed to save chat sender settings', {
+        twitchUserId: session.twitchUserId,
+        linkedTwitchUserId: botUser.id,
+        error: senderSettingsError,
+      })
+      return redirectToSettings(baseUrl, { bot_error: 'database_error' })
+    }
+
+    logger.info('Linked account connected for chat announcements', {
+      twitchUserId: session.twitchUserId,
+      linkedTwitchUserId: botUser.id,
+    })
+
+    response.cookies.delete(COOKIE_NAMES.BOT_AUTH_STATE)
+    return response
+  } catch (error) {
+    const errorType = isInvalidAuthorizationCodeError(error)
+      ? 'invalid_authorization_code'
+      : 'bot_auth_failed'
+    logger.error('Linked account callback failed', {
+      twitchUserId: session.twitchUserId,
+      errorType,
+      error,
+    })
+    return redirectToSettings(baseUrl, { bot_error: errorType })
+  }
+}


### PR DESCRIPTION
## Summary
- route linked-account OAuth through the existing Twitch callback URL so it matches the registered redirect URI
- detect linked-account state in the normal Twitch callback and hand off to the linked-account save flow
- keep the legacy /api/auth/bot/callback route working for environments that registered it manually

## Validation
- npm run lint
- npm run workers:build