### PR TITLE
feat: add card title search

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -46,6 +46,10 @@
     "newCard": "New Card",
     "importFromEmotes": "Import from Emotes",
     "editCardNumbers": "Edit Numbers",
+    "search": {
+      "titleLabel": "Search card titles",
+      "titlePlaceholder": "Search by title"
+    },
     "form": {
       "name": "Card Name",
       "namePlaceholder": "Card name",
@@ -92,6 +96,7 @@
       "networkErrorDelete": "A network error occurred. Deletion cancelled.",
       "operationFailed": "Operation failed: {msg}",
       "emptyCards": "No cards yet. Start by adding a new card.",
+      "noMatchingCards": "No cards match the current filters.",
       "probability": "Probability:",
       "errorOccurred": "An error occurred ({status})",
       "uploadLimited": "Upload feature is limited",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -46,6 +46,10 @@
     "newCard": "新規カード",
     "importFromEmotes": "エモートからインポート",
     "editCardNumbers": "番号をまとめて編集",
+    "search": {
+      "titleLabel": "カードタイトル検索",
+      "titlePlaceholder": "タイトルで検索"
+    },
     "form": {
       "name": "カード名",
       "namePlaceholder": "カード名",
@@ -92,6 +96,7 @@
       "networkErrorDelete": "ネットワークエラーが発生しました。削除をキャンセルしました。",
       "operationFailed": "操作に失敗しました: {msg}",
       "emptyCards": "まだカードがありません。「新規カード追加」から始めましょう。",
+      "noMatchingCards": "条件に一致するカードがありません。",
       "probability": "確率:",
       "errorOccurred": "エラーが発生しました ({status})",
       "uploadLimited": "アップロード機能が制限されています",

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -134,6 +134,7 @@ export default function CardManager({
   const [sortField, setSortField] = useState<SortField>("created_at");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [titleSearchQuery, setTitleSearchQuery] = useState("");
   // Track if this is the first render to skip initial reload
   // 初回レンダリングかどうかを追跡して初期リロードをスキップ
   const isFirstRender = useRef(true);
@@ -203,17 +204,23 @@ export default function CardManager({
    * サーバーがソートを処理、クライアントは即時UIフィードバックのためフィルタリングのみ
    */
   const filteredAndSortedCards = useMemo(() => {
+    const normalizedQuery = titleSearchQuery.trim().toLowerCase();
     // Only apply client-side filter for optimistic updates (toggle active)
     // 楽観的更新（アクティブ切り替え）用にクライアントサイドフィルターのみ適用
+    let nextCards = cards;
     if (statusFilter === "active") {
-      return cards.filter(card => card.is_active);
+      nextCards = nextCards.filter(card => card.is_active);
     } else if (statusFilter === "inactive") {
-      return cards.filter(card => !card.is_active);
+      nextCards = nextCards.filter(card => !card.is_active);
     }
+    if (normalizedQuery) {
+      nextCards = nextCards.filter(card => card.name.toLowerCase().includes(normalizedQuery));
+    }
+
     // Cards are already sorted by server, just return as-is
     // カードは既にサーバーでソートされているのでそのまま返す
-    return cards;
-  }, [cards, statusFilter]);
+    return nextCards;
+  }, [cards, statusFilter, titleSearchQuery]);
   const [showForm, setShowForm] = useState(false);
   const [editingCard, setEditingCard] = useState<Card | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -1760,6 +1767,17 @@ export default function CardManager({
           {/* Sorting and filtering controls */}
           {/* 並び替えとフィルタリングコントロール */}
           <div className="flex flex-wrap items-center gap-2">
+            {/* Title search */}
+            {/* タイトル検索 */}
+            <input
+              type="search"
+              value={titleSearchQuery}
+              onChange={(e) => setTitleSearchQuery(e.target.value)}
+              placeholder={t("search.titlePlaceholder")}
+              aria-label={t("search.titleLabel")}
+              className="min-w-[14rem] rounded-lg border border-gray-600 bg-gray-700 px-3 py-1.5 text-sm text-white placeholder:text-gray-400"
+            />
+
             {/* Sort field selector */}
             {/* 並び替えフィールド選択 */}
             <select
@@ -1852,9 +1870,11 @@ export default function CardManager({
 
         return (
           <>
-            {/* List view */}
-            {/* リスト表示 */}
-            {currentViewMode === "list" ? (
+            {displayCards.length === 0 ? (
+              <p className="rounded-lg border border-gray-700 bg-gray-800 px-4 py-8 text-center text-gray-400">
+                {t("messages.noMatchingCards")}
+              </p>
+            ) : currentViewMode === "list" ? (
               <CardList
                 cards={displayCards}
                 totalActiveWeight={totalActiveWeight}

--- a/tests/unit/components/card-manager-search.test.tsx
+++ b/tests/unit/components/card-manager-search.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import CardManager from '@/components/CardManager'
+import jaMessages from '../../../messages/ja.json'
+import type { Card } from '@/types/database'
+
+vi.mock('@/lib/logger')
+
+const baseCard = (overrides: Partial<Card>): Card => ({
+  id: 'card-1',
+  streamer_id: 'streamer-1',
+  name: 'カードA',
+  description: '',
+  image_url: null,
+  rarity: 'common',
+  card_number: null,
+  drop_rate: 0.25,
+  intra_rarity_weight: 1,
+  is_active: true,
+  hp: 10,
+  atk: 5,
+  def: 5,
+  spd: 5,
+  skill_type: 'attack',
+  skill_name: 'たいあたり',
+  skill_power: 10,
+  created_at: '2026-05-01T00:00:00Z',
+  updated_at: '2026-05-01T00:00:00Z',
+  ...overrides,
+})
+
+const renderCardManager = (cards: Card[]) => {
+  return render(
+    <NextIntlClientProvider locale="ja" messages={jaMessages}>
+      <CardManager streamerId="streamer-1" initialCards={cards} initialRarityWeights={{}} />
+    </NextIntlClientProvider>
+  )
+}
+
+describe('CardManager title search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+  })
+
+  it('filters the card management list by card title', () => {
+    renderCardManager([
+      baseCard({ id: 'alpha', name: 'Alpha Dragon' }),
+      baseCard({ id: 'beta', name: 'Beta Wizard' }),
+      baseCard({ id: 'gamma', name: 'Gamma Dragon' }),
+    ])
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'カードタイトル検索' }), {
+      target: { value: 'dragon' },
+    })
+
+    expect(screen.getByText('Alpha Dragon')).toBeInTheDocument()
+    expect(screen.getByText('Gamma Dragon')).toBeInTheDocument()
+    expect(screen.queryByText('Beta Wizard')).not.toBeInTheDocument()
+    expect(screen.getByText('2 件のカード')).toBeInTheDocument()
+  })
+
+  it('shows a filtered empty state without replacing the no-cards message', () => {
+    renderCardManager([
+      baseCard({ id: 'alpha', name: 'Alpha Dragon' }),
+    ])
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'カードタイトル検索' }), {
+      target: { value: 'missing' },
+    })
+
+    expect(screen.getByText('条件に一致するカードがありません。')).toBeInTheDocument()
+    expect(screen.queryByText('まだカードがありません。「新規カード追加」から始めましょう。')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add a title search box to the card management controls
- filter the current card list client-side by card title while preserving status filter and server sort order
- add localized empty-state copy and component coverage for search results

Closes #440

## Validation
- npm_config_cache=/private/tmp/twica-npm-cache npx vitest run tests/unit/components/card-manager-search.test.tsx --no-watch --pool=forks --poolOptions.forks.singleFork=true
- npm_config_cache=/private/tmp/twica-npm-cache npm run lint
- npm_config_cache=/private/tmp/twica-npm-cache npm run build
- npm_config_cache=/private/tmp/twica-npm-cache npm run workers:build
