### PR TITLE
fix: prevent card form pane overflow

### DIFF
--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -1332,10 +1332,10 @@ export default function CardManager({
                   </svg>
                 </button>
               </div>
-              <div className="grid gap-4 md:grid-cols-2">
+              <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
                 {/* 左カラム: カード名 + レアリティを縦積み（右の画像ペーンと高さを揃える） */}
-                <div className="flex flex-col justify-between">
-                  <div>
+                <div className="flex min-w-0 flex-col justify-between gap-4">
+                  <div className="min-w-0">
                     <label className="mb-1 block text-sm text-gray-300">
                       {t("form.name")} *
                     </label>
@@ -1348,12 +1348,12 @@ export default function CardManager({
                       onChange={(e) =>
                         setFormData({ ...formData, name: e.target.value })
                       }
-                      className="w-full rounded-lg bg-gray-600 px-4 py-2 text-white"
+                      className="w-full min-w-0 rounded-lg bg-gray-600 px-4 py-2 text-white"
                     />
                   </div>
-                  <div>
-                    <div className="grid gap-3 sm:grid-cols-2">
-                      <div>
+                  <div className="min-w-0">
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                      <div className="min-w-0">
                         <label className="mb-1 block text-sm text-gray-300">
                           {t("form.rarity")}
                         </label>
@@ -1363,7 +1363,7 @@ export default function CardManager({
                           onChange={(e) =>
                             setFormData({ ...formData, rarity: e.target.value as Rarity })
                           }
-                          className="w-full appearance-none rounded-lg bg-gray-600 px-4 py-2 pr-10 text-white"
+                          className="w-full min-w-0 appearance-none rounded-lg bg-gray-600 px-4 py-2 pr-10 text-white"
                           style={SELECT_ARROW_STYLE}
                         >
                           {RARITIES.map((r) => (
@@ -1373,7 +1373,7 @@ export default function CardManager({
                           ))}
                         </select>
                       </div>
-                      <div>
+                      <div className="min-w-0">
                         <label className="mb-1 block text-sm text-gray-300">
                           {t("form.cardNumber")}
                         </label>
@@ -1388,7 +1388,7 @@ export default function CardManager({
                           onChange={(e) =>
                             setFormData({ ...formData, cardNumber: e.target.value })
                           }
-                          className="w-full rounded-lg bg-gray-600 px-4 py-2 text-white placeholder:text-gray-300"
+                          className="w-full min-w-0 rounded-lg bg-gray-600 px-4 py-2 text-white placeholder:text-gray-300"
                         />
                         <p className="mt-1 text-xs text-gray-300">
                           {t("form.cardNumberHelp")}
@@ -1398,7 +1398,7 @@ export default function CardManager({
                   </div>
                 </div>
                 {/* 右カラム: 画像 */}
-                <div>
+                <div className="min-w-0">
               <label className="mb-1 block text-sm text-gray-300">
                 {t("form.image")}
               </label>
@@ -1425,7 +1425,7 @@ export default function CardManager({
                       className="rounded object-cover"
                       unoptimized
                     />
-                    <div className="flex-1">
+                    <div className="min-w-0 flex-1">
                       <p className="text-sm text-gray-300">{t("form.currentImage")}</p>
                       <p className="text-xs text-gray-500 truncate max-w-[200px]">
                         {confirmedImageUrl.split('/').pop()}
@@ -1451,7 +1451,7 @@ export default function CardManager({
                       alt={t("form.croppedImage")}
                       className={`rounded object-cover ${selectedCropMode === "portrait" ? "h-[84px] w-[60px]" : "h-[60px] w-[60px]"}`}
                     />
-                    <div className="flex-1">
+                    <div className="min-w-0 flex-1">
                       <p className="text-sm text-green-300">{t("form.croppedImage")}</p>
                       <p className="text-xs text-gray-400">
                         {planCropModes[selectedCropMode].dimensions}px ({planCropModes[selectedCropMode].label})
@@ -1486,7 +1486,7 @@ export default function CardManager({
                       ref={fileInputRef}
                       onChange={handleFileChange}
                       disabled={storageStatus?.uploadDisabled}
-                      className={`w-full text-sm text-gray-400 file:mr-4 file:rounded-lg file:border-0 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white ${
+                      className={`w-full min-w-0 text-sm text-gray-400 file:mr-4 file:rounded-lg file:border-0 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white ${
                         storageStatus?.uploadDisabled
                           ? 'opacity-50 cursor-not-allowed file:bg-gray-500'
                           : 'file:bg-purple-600 hover:file:bg-purple-700'
@@ -1514,7 +1514,7 @@ export default function CardManager({
                         setUserModifiedImage(true);
                       }}
                       disabled={imageUrlValidating}
-                      className="w-full rounded-lg bg-gray-600 px-4 py-2 text-white disabled:opacity-50"
+                      className="w-full min-w-0 rounded-lg bg-gray-600 px-4 py-2 text-white disabled:opacity-50"
                     />
                     {/* Show validating indicator when checking image URL */}
                     {/* 画像URL検証中の表示 */}

--- a/tests/unit/card-manager-form-layout.test.ts
+++ b/tests/unit/card-manager-form-layout.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readSource(path: string) {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+describe("CardManager form layout", () => {
+  it("keeps the two-pane card form from overflowing narrow modal columns", () => {
+    const source = readSource("src/components/CardManager.tsx");
+
+    expect(source).toContain("md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]");
+    expect(source).toContain("flex min-w-0 flex-col justify-between gap-4");
+    expect(source).toContain("grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]");
+    expect(source).toContain("w-full min-w-0 appearance-none rounded-lg");
+    expect(source).toContain("w-full min-w-0 rounded-lg bg-gray-600");
+  });
+});


### PR DESCRIPTION
Summary
- Keep the card form modal columns shrinkable with minmax(0,1fr) and min-w-0 so controls stay inside each pane.
- Add regression coverage for the CardManager form layout utilities.

Closes #444

Validation
- npm_config_cache=/private/tmp/twica-maker-npm-cache npx vitest run tests/unit/card-manager-form-layout.test.ts
- npm_config_cache=/private/tmp/twica-maker-npm-cache npm run lint
- npm_config_cache=/private/tmp/twica-maker-npm-cache npm run build
- npm_config_cache=/private/tmp/twica-maker-npm-cache npm run workers:build