### PR TITLE
feat: preserve animated GIF card uploads

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -72,16 +72,19 @@
       "descriptionCount": "{current} / {max} characters",
       "currentImage": "Current image",
       "croppedImage": "Cropped image",
+      "originalAnimatedImage": "Animated image",
+      "originalAnimatedImageHelp": "GIF files are saved unchanged to preserve animation",
       "selectCropMode": "Select Crop Size",
       "cropModeDescription": "For Square images, name and description can be shown in the card frame on display. You can toggle this in overlay settings. Portrait images are displayed as-is.",
       "cropNoteWithOptions": "(Crop to Square {square} or Portrait {portrait})",
+      "animatedGifNote": ". GIF files are saved without cropping to preserve animation",
       "selectResolution": "Select Resolution",
       "resolutionStandard": "Standard (800px)",
       "resolutionFullHd": "Full HD (1920px)",
       "resolution4k": "4K (3840px)"
     },
     "fileUpload": {
-      "formats": "Supported: JPEG, PNG | ",
+      "formats": "Supported: JPEG, PNG, GIF, WebP | ",
       "maxSize": "Max size: {mb}MB"
     },
     "buttons": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -78,6 +78,7 @@
       "cropModeDescription": "For Square images, name and description can be shown in the card frame on display. You can toggle this in overlay settings. Portrait images are displayed as-is.",
       "cropNoteWithOptions": "(Crop to Square {square} or Portrait {portrait})",
       "animatedGifNote": ". GIF files are saved without cropping to preserve animation",
+      "animatedGifSizeLimit": "GIF files are uploaded as-is. Please keep them under {maxMb}MB.",
       "selectResolution": "Select Resolution",
       "resolutionStandard": "Standard (800px)",
       "resolutionFullHd": "Full HD (1920px)",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -78,6 +78,7 @@
       "cropModeDescription": "正方形の場合、表示時に名前・説明をカード枠に表示できます。オーバーレイ設定で表示非表示を選択できます。ポートレイトはそのまま表示されます。",
       "cropNoteWithOptions": "（正方形{square}またはポートレイト{portrait}にトリミング）",
       "animatedGifNote": "。GIFはアニメーション保持のためトリミングせず保存します",
+      "animatedGifSizeLimit": "GIFはそのまま送信されるため、{maxMb}MB以下にしてください",
       "selectResolution": "解像度を選択",
       "resolutionStandard": "標準 (800px)",
       "resolutionFullHd": "Full HD (1920px)",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -72,16 +72,19 @@
       "descriptionCount": "{current} / {max}文字",
       "currentImage": "現在の画像",
       "croppedImage": "トリミング済み画像",
+      "originalAnimatedImage": "アニメーション画像",
+      "originalAnimatedImageHelp": "GIFはアニメーションを保つため元ファイルのまま保存されます",
       "selectCropMode": "トリミングサイズを選択",
       "cropModeDescription": "正方形の場合、表示時に名前・説明をカード枠に表示できます。オーバーレイ設定で表示非表示を選択できます。ポートレイトはそのまま表示されます。",
       "cropNoteWithOptions": "（正方形{square}またはポートレイト{portrait}にトリミング）",
+      "animatedGifNote": "。GIFはアニメーション保持のためトリミングせず保存します",
       "selectResolution": "解像度を選択",
       "resolutionStandard": "標準 (800px)",
       "resolutionFullHd": "Full HD (1920px)",
       "resolution4k": "4K (3840px)"
     },
     "fileUpload": {
-      "formats": "対応形式: JPEG, PNG | ",
+      "formats": "対応形式: JPEG, PNG, GIF, WebP | ",
       "maxSize": "最大サイズ: {mb}MB"
     },
     "buttons": {

--- a/src/app/dashboard/cards/page.tsx
+++ b/src/app/dashboard/cards/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import dynamic from "next/dynamic";
 import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { getStreamerData } from "@/lib/dashboard-data";
-import { getUserPlan, PLAN_MAX_IMAGE_WIDTH, PLAN_AVAILABLE_WIDTHS } from "@/lib/plan";
+import { getUserPlan, PLAN_MAX_IMAGE_WIDTH, PLAN_AVAILABLE_WIDTHS, PLAN_MAX_UPLOAD_SIZE } from "@/lib/plan";
 import type { Card } from "@/types/database";
 
 const CardManager = dynamic(() => import("@/components/CardManager"), {
@@ -57,6 +57,7 @@ export default async function CardsPage() {
   // Issue #269再設計: 新規カードパック名の登録(パック管理モーダルでの追加)
   // にのみプランが必要。既存パックの選択・解除はゲート対象外。
   const isPremium = plan !== "basic";
+  const maxUploadSize = PLAN_MAX_UPLOAD_SIZE[plan];
 
   return (
     <CardManager
@@ -74,6 +75,7 @@ export default async function CardsPage() {
       maxImageWidth={maxImageWidth}
       availableWidths={availableWidths}
       isPremium={isPremium}
+      maxUploadSize={maxUploadSize}
     />
   );
 }

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -75,6 +75,10 @@ interface CardManagerProps {
   // Plan-based available output widths (default: [800])
   // プラン別選択可能な出力幅（デフォルト: [800]）
   availableWidths?: number[];
+  // Plan-based maximum upload size in bytes (default: UPLOAD_CONFIG.MAX_FILE_SIZE)
+  // GIFはトリミング/再圧縮をスキップして原本送信されるため、UI上でユーザーへ上限を案内するのに利用する
+  // プラン別アップロードサイズ上限（バイト）。GIF原本送信モード時の注意文表示にも用いる
+  maxUploadSize?: number;
   // Initial rarity weights: null/undefined = unset (auto mode with defaults), {} = explicit manual mode, {weights} = auto mode
   // レアリティ確率設定: null/undefined=未設定（自動モードデフォルト化）, {}=手動モード明示, {weights}=自動モード
   initialRarityWeights?: Record<string, number> | null;
@@ -139,6 +143,7 @@ export default function CardManager({
   maxCards,
   maxImageWidth = 800,
   availableWidths = [800],
+  maxUploadSize,
   initialRarityWeights = null,
   initialCustomRarities = [],
   initialCardPackNames = [],
@@ -957,6 +962,14 @@ export default function CardManager({
         return;
       }
       if (shouldPreserveOriginalCardUpload(file)) {
+        // GIFはトリミング/再圧縮されず原本のままアップロードされるため、
+        // クライアント側でもプラン上限を事前にチェックし UX を早期化する
+        // （サーバ側 validateUpload でも最終的に弾かれるが、無駄なネットワークを避ける）
+        const validation = validateUpload(file, maxUploadSize);
+        if (!validation.valid) {
+          setUploadError(getUploadErrorMessage(validation.error!));
+          return;
+        }
         imageDimensionRequestId.current++;
         if (croppedPreviewUrl) {
           URL.revokeObjectURL(croppedPreviewUrl);
@@ -1751,6 +1764,13 @@ export default function CardManager({
                       {/* トリミングでJPEGに圧縮されるためファイルサイズ制限を削除 */}
                       {t("fileUpload.formats")}{t("form.cropNoteWithOptions", { square: planCropModes.square.dimensions, portrait: planCropModes.portrait.dimensions })}
                       {t("form.animatedGifNote")}
+                    </p>
+                    {/* GIFはトリミング/再圧縮されず原本のままアップロードされるため、
+                        プラン上限 (basic=1MB, support=5MB, patron/twitch_sub=10MB) を明示する */}
+                    <p className="text-xs text-amber-400">
+                      {t("form.animatedGifSizeLimit", {
+                        maxMb: Math.floor((maxUploadSize ?? 1 * 1024 * 1024) / (1024 * 1024)),
+                      })}
                     </p>
                     <input
                       type="url"

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 import type { Card, Rarity } from "@/types/database";
-import { RARITIES, UPLOAD_CONFIG, DEFAULT_RARITY_WEIGHTS, CARD_DESCRIPTION_MAX_CHARACTERS } from "@/lib/constants";
+import { RARITIES, DEFAULT_RARITY_WEIGHTS, CARD_DESCRIPTION_MAX_CHARACTERS } from "@/lib/constants";
 import { logger } from "@/lib/logger";
 import { formatRarityLabel, getRarityDisplayInfo } from "@/lib/rarity";
 import { getOptimizedImageUrl } from "@/lib/image-utils";
@@ -12,6 +12,7 @@ import { validateUpload, getUploadErrorMessage } from "@/lib/upload-validation";
 import { countCharacters } from "@/lib/text-utils";
 import { DEFAULT_PACK_SENTINEL } from "@/lib/validation/collection-name";
 import { cardMatchesPackKey } from "@/lib/collection-packs";
+import { isAllowedCardUploadFile, shouldPreserveOriginalCardUpload } from "@/lib/card-upload-mode";
 import ImageCropper, { type CropMode, getCropModes } from "./ImageCropper";
 import CardViewToggle, { type ViewMode } from "./CardViewToggle";
 import CardList from "./CardList";
@@ -951,9 +952,22 @@ export default function CardManager({
       // Cropped image will be compressed to JPEG, so original size doesn't matter
       // トリミング前はファイルタイプのみ検証（サイズチェックはスキップ）
       // トリミング後はJPEGに圧縮されるため、元のサイズは問題にならない
-      const allowedTypes = UPLOAD_CONFIG.ALLOWED_TYPES as readonly string[];
-      if (!allowedTypes.includes(file.type)) {
+      if (!isAllowedCardUploadFile(file)) {
         setUploadError(getUploadErrorMessage("INVALID_FILE_TYPE"));
+        return;
+      }
+      if (shouldPreserveOriginalCardUpload(file)) {
+        imageDimensionRequestId.current++;
+        if (croppedPreviewUrl) {
+          URL.revokeObjectURL(croppedPreviewUrl);
+        }
+        setSelectedFileForCrop(null);
+        setSourceImageWidth(null);
+        setCropModeModalOpen(false);
+        setCropModalOpen(false);
+        setSelectedCropMode("square");
+        setCroppedFile(file);
+        setCroppedPreviewUrl(URL.createObjectURL(file));
         return;
       }
       // 画像の実サイズを読み取ってからモーダルを開く
@@ -1675,8 +1689,8 @@ export default function CardManager({
                   </div>
                 )}
 
-                {/* Show cropped image preview when a file has been cropped */}
-                {/* トリミング済みファイルがある場合はプレビュー表示 */}
+                {/* Show selected upload preview when a file is ready */}
+                {/* アップロード準備済みファイルがある場合はプレビュー表示 */}
                 {croppedFile && croppedPreviewUrl && (
                   <div className="flex items-center gap-3 rounded-lg bg-green-900/30 border border-green-600/50 p-3">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -1686,9 +1700,15 @@ export default function CardManager({
                       className={`rounded object-cover ${selectedCropMode === "portrait" ? "h-[84px] w-[60px]" : "h-[60px] w-[60px]"}`}
                     />
                     <div className="min-w-0 flex-1">
-                      <p className="text-sm text-green-300">{t("form.croppedImage")}</p>
+                      <p className="text-sm text-green-300">
+                        {shouldPreserveOriginalCardUpload(croppedFile)
+                          ? t("form.originalAnimatedImage")
+                          : t("form.croppedImage")}
+                      </p>
                       <p className="text-xs text-gray-400">
-                        {planCropModes[selectedCropMode].dimensions}px ({planCropModes[selectedCropMode].label})
+                        {shouldPreserveOriginalCardUpload(croppedFile)
+                          ? t("form.originalAnimatedImageHelp")
+                          : `${planCropModes[selectedCropMode].dimensions}px (${planCropModes[selectedCropMode].label})`}
                       </p>
                     </div>
                     <button
@@ -1730,6 +1750,7 @@ export default function CardManager({
                       {/* File size limit removed since cropping compresses to JPEG */}
                       {/* トリミングでJPEGに圧縮されるためファイルサイズ制限を削除 */}
                       {t("fileUpload.formats")}{t("form.cropNoteWithOptions", { square: planCropModes.square.dimensions, portrait: planCropModes.portrait.dimensions })}
+                      {t("form.animatedGifNote")}
                     </p>
                     <input
                       type="url"

--- a/src/lib/card-upload-mode.ts
+++ b/src/lib/card-upload-mode.ts
@@ -7,10 +7,30 @@ function getUploadExtension(fileName: string): string {
   return lastDotIndex > -1 ? fileName.slice(lastDotIndex + 1).toLowerCase() : ""
 }
 
-export function isAllowedCardUploadFile(file: CardUploadFileLike): boolean {
+/**
+ * カードアップロードで許容するか判定するための共通ヘルパー
+ *
+ * options.allowEmptyMimeWithExtension = true の場合、
+ *   ブラウザによっては File.type が空文字になることがあるため、
+ *   拡張子ベースで補完して許可する（CardManager のクライアント側ファイル選択時に使用）。
+ * デフォルト (false) ではサーバ側 validateUpload など厳密判定が必要な経路で
+ *   拡張子フォールバックを行わず、MIME 型のみで判定する。
+ */
+export interface IsAllowedCardUploadFileOptions {
+  allowEmptyMimeWithExtension?: boolean
+}
+
+export function isAllowedCardUploadFile(
+  file: CardUploadFileLike,
+  options: IsAllowedCardUploadFileOptions = { allowEmptyMimeWithExtension: true },
+): boolean {
   const allowedTypes = UPLOAD_CONFIG.ALLOWED_TYPES as readonly string[]
   if (allowedTypes.includes(file.type)) {
     return true
+  }
+
+  if (!options.allowEmptyMimeWithExtension) {
+    return false
   }
 
   const allowedExtensions = UPLOAD_CONFIG.ALLOWED_EXTENSIONS as readonly string[]

--- a/src/lib/card-upload-mode.ts
+++ b/src/lib/card-upload-mode.ts
@@ -1,0 +1,24 @@
+import { UPLOAD_CONFIG } from "@/lib/constants"
+
+type CardUploadFileLike = Pick<File, "name" | "type">
+
+function getUploadExtension(fileName: string): string {
+  const lastDotIndex = fileName.lastIndexOf(".")
+  return lastDotIndex > -1 ? fileName.slice(lastDotIndex + 1).toLowerCase() : ""
+}
+
+export function isAllowedCardUploadFile(file: CardUploadFileLike): boolean {
+  const allowedTypes = UPLOAD_CONFIG.ALLOWED_TYPES as readonly string[]
+  if (allowedTypes.includes(file.type)) {
+    return true
+  }
+
+  const allowedExtensions = UPLOAD_CONFIG.ALLOWED_EXTENSIONS as readonly string[]
+  return file.type === "" && allowedExtensions.includes(getUploadExtension(file.name))
+}
+
+export function shouldPreserveOriginalCardUpload(file: CardUploadFileLike): boolean {
+  const fileName = file.name.toLowerCase()
+
+  return file.type === "image/gif" || fileName.endsWith(".gif")
+}

--- a/src/lib/file-utils.ts
+++ b/src/lib/file-utils.ts
@@ -20,10 +20,14 @@ export function getFileTypeFromBuffer(buffer: Buffer): string {
     return 'image/png';
   }
 
+  // GIFシグネチャ: "GIF87a" (47 49 46 38 37 61) または "GIF89a" (47 49 46 38 39 61)
+  // バージョンバイト (index 4) が 0x37 ('7') / 0x39 ('9') のいずれかを許容することで、
+  // 一般的に流通するアニメーション GIF (GIF89a) も正しく判定する
   if (buffer.length >= 6 &&
       firstByte === 0x47 && secondByte === 0x49 &&
       buffer[2] === 0x46 && buffer[3] === 0x38 &&
-      buffer[4] === 0x37 && buffer[5] === 0x61) {
+      (buffer[4] === 0x37 || buffer[4] === 0x39) &&
+      buffer[5] === 0x61) {
     return 'image/gif';
   }
 

--- a/src/lib/upload-validation.ts
+++ b/src/lib/upload-validation.ts
@@ -1,4 +1,5 @@
 import { UPLOAD_CONFIG } from '@/lib/constants';
+import { isAllowedCardUploadFile } from '@/lib/card-upload-mode';
 
 export type UploadValidationError =
   | 'FILE_TOO_LARGE'
@@ -35,8 +36,7 @@ export function validateUpload(
     }
   }
 
-  const mimeType = file.type as typeof UPLOAD_CONFIG.ALLOWED_TYPES[number];
-  if (!UPLOAD_CONFIG.ALLOWED_TYPES.includes(mimeType)) {
+  if (!isAllowedCardUploadFile(file)) {
     return {
       valid: false,
       error: 'INVALID_FILE_TYPE',

--- a/src/lib/upload-validation.ts
+++ b/src/lib/upload-validation.ts
@@ -36,7 +36,10 @@ export function validateUpload(
     }
   }
 
-  if (!isAllowedCardUploadFile(file)) {
+  // サーバ側の厳密判定では拡張子による空 MIME フォールバックを行わない。
+  // 拡張子フォールバックはブラウザ依存のフォーム送信で File.type が空になるケースの救済策で、
+  // クライアント側のファイル選択 UI (CardManager) でのみ有効化する。
+  if (!isAllowedCardUploadFile(file, { allowEmptyMimeWithExtension: false })) {
     return {
       valid: false,
       error: 'INVALID_FILE_TYPE',

--- a/tests/unit/card-upload-mode.test.ts
+++ b/tests/unit/card-upload-mode.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+
+import { isAllowedCardUploadFile, shouldPreserveOriginalCardUpload } from "@/lib/card-upload-mode"
+
+describe("shouldPreserveOriginalCardUpload", () => {
+  it("preserves GIF uploads so animation is not flattened by crop canvas", () => {
+    expect(shouldPreserveOriginalCardUpload({
+      name: "card.gif",
+      type: "image/gif",
+    })).toBe(true)
+  })
+
+  it("preserves GIF uploads when the browser omits the MIME type", () => {
+    expect(shouldPreserveOriginalCardUpload({
+      name: "card.GIF",
+      type: "",
+    })).toBe(true)
+  })
+
+  it("uses the crop flow for static image formats", () => {
+    expect(shouldPreserveOriginalCardUpload({
+      name: "card.webp",
+      type: "image/webp",
+    })).toBe(false)
+  })
+})
+
+describe("isAllowedCardUploadFile", () => {
+  it("allows known image MIME types", () => {
+    expect(isAllowedCardUploadFile({
+      name: "card.webp",
+      type: "image/webp",
+    })).toBe(true)
+  })
+
+  it("allows a known extension when the browser omits the MIME type", () => {
+    expect(isAllowedCardUploadFile({
+      name: "card.gif",
+      type: "",
+    })).toBe(true)
+  })
+
+  it("rejects unknown files when the MIME type is missing", () => {
+    expect(isAllowedCardUploadFile({
+      name: "card.txt",
+      type: "",
+    })).toBe(false)
+  })
+})

--- a/tests/unit/card-upload-mode.test.ts
+++ b/tests/unit/card-upload-mode.test.ts
@@ -46,4 +46,28 @@ describe("isAllowedCardUploadFile", () => {
       type: "",
     })).toBe(false)
   })
+
+  it("rejects empty-MIME files when extension fallback is disabled (server path)", () => {
+    expect(
+      isAllowedCardUploadFile(
+        {
+          name: "card.gif",
+          type: "",
+        },
+        { allowEmptyMimeWithExtension: false },
+      ),
+    ).toBe(false)
+  })
+
+  it("still allows known MIME types when extension fallback is disabled", () => {
+    expect(
+      isAllowedCardUploadFile(
+        {
+          name: "card.gif",
+          type: "image/gif",
+        },
+        { allowEmptyMimeWithExtension: false },
+      ),
+    ).toBe(true)
+  })
 })

--- a/tests/unit/upload.test.ts
+++ b/tests/unit/upload.test.ts
@@ -369,6 +369,44 @@ describe('POST /api/upload', () => {
       const body = await response.json()
       expect(body.url).toBe('https://blob.vercel-storage.com/test-image.gif')
     })
+
+    it('GIF89a画像（アニメーションGIF）のアップロードに成功する', async () => {
+      // 回帰テスト: アニメーション GIF の主流バージョンである GIF89a が
+      // マジックナンバー判定で拒否されないことを保証する。
+      mockGetSession.mockResolvedValue({
+        twitchUserId: 'test-user-id',
+        twitchUsername: 'test-user',
+        twitchDisplayName: 'Test User',
+        twitchProfileImageUrl: 'https://example.com/avatar.jpg',
+        broadcasterType: '',
+        expiresAt: Date.now() + 3600000,
+        version: 1,
+      })
+
+      mockUploadToR2WithRetry.mockResolvedValue({
+        url: 'https://blob.vercel-storage.com/test-image-89a.gif',
+      })
+
+      const imageFile = new File([createMinimalGif89aBuffer()], 'test.gif', {
+        type: 'image/gif',
+      })
+
+      const formData = new FormData()
+      formData.append('file', imageFile)
+
+      const request = new NextRequest('http://localhost:3000/api/upload', {
+        method: 'POST',
+        body: formData,
+      })
+
+      const response = await POST(request)
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.url).toBe('https://blob.vercel-storage.com/test-image-89a.gif')
+      expect(mockUploadToR2WithRetry).toHaveBeenCalled()
+      expect(mockUploadToR2WithRetry.mock.calls[0][2]).toBe('image/gif')
+    })
   })
 
   describe('Vercel Blob エラー時', () => {
@@ -424,8 +462,17 @@ function createMinimalPngBuffer(): ArrayBuffer {
 }
 
 function createMinimalGifBuffer(): ArrayBuffer {
+  // GIF87a シグネチャ
   const header = new Uint8Array([
     0x47, 0x49, 0x46, 0x38, 0x37, 0x61
+  ])
+  return header.buffer
+}
+
+function createMinimalGif89aBuffer(): ArrayBuffer {
+  // GIF89a シグネチャ（アニメーション GIF などで一般的に使われるバージョン）
+  const header = new Uint8Array([
+    0x47, 0x49, 0x46, 0x38, 0x39, 0x61
   ])
   return header.buffer
 }
@@ -441,9 +488,23 @@ describe('getFileTypeFromBuffer', () => {
     expect(getFileTypeFromBuffer(pngBuffer)).toBe('image/png')
   })
 
-  it('GIFファイルを正しく識別する', () => {
+  it('GIF87aファイルを正しく識別する', () => {
     const gifBuffer = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x37, 0x61])
     expect(getFileTypeFromBuffer(gifBuffer)).toBe('image/gif')
+  })
+
+  it('GIF89aファイルを正しく識別する（アニメーションGIFで一般的）', () => {
+    // Regression test: 元実装は GIF87a (バイト4=0x37) のみを許容していたため、
+    // 一般的に流通する GIF89a (バイト4=0x39) が application/octet-stream に
+    // 落ちて拒否される致命的バグがあった。両バージョンを許容することを確認する。
+    const gif89aBuffer = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61])
+    expect(getFileTypeFromBuffer(gif89aBuffer)).toBe('image/gif')
+  })
+
+  it('GIFバージョンバイトが不正な場合は拒否する', () => {
+    // 0x37/0x39 以外のバージョン文字は GIF として認めない
+    const invalidGifBuffer = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x30, 0x61])
+    expect(getFileTypeFromBuffer(invalidGifBuffer)).toBe('application/octet-stream')
   })
 
   it('WebPファイルを正しく識別する', () => {


### PR DESCRIPTION
Summary
- Preserve animated GIF card uploads by bypassing the crop-to-JPEG flow for GIF files.
- Share upload type/extension fallback validation between CardManager and the upload validator so GIFs still work when browsers omit MIME type.
- Show GIF-specific ready-to-upload copy and update supported format text for JPEG/PNG/GIF/WebP.

Closes #295

Validation
- npx vitest run tests/unit/card-upload-mode.test.ts tests/unit/upload.test.ts
- npm run lint
- npm run build
- npm run workers:build
