### PR TITLE
fix: degrade sound settings API failures

### DIFF
--- a/src/app/api/streamer/[streamerId]/sound-settings/route.ts
+++ b/src/app/api/streamer/[streamerId]/sound-settings/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin } from "@/lib/supabase/admin";
 import { withRetry } from "@/lib/supabase/retry";
-import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
+import { handleApiError } from "@/lib/error-handler";
 import { ERROR_MESSAGES } from "@/lib/constants";
+import { logger } from "@/lib/logger";
 
 interface RouteParams {
   params: Promise<{ streamerId: string }>;
@@ -32,7 +33,7 @@ export async function GET(
     // 配信者の効果音設定のみを取得
     // パブリックエンドポイントなので必要最小限の情報のみ返す
     // 502 一時障害に対するリトライ (Issue #325)
-    const { data: streamer, error } = await withRetry(
+    const { data: streamer, error, status } = await withRetry(
       () => supabaseAdmin
         .from("streamers")
         .select("gacha_sound_url, gacha_sound_enabled")
@@ -42,7 +43,15 @@ export async function GET(
     );
 
     if (error) {
-      return handleDatabaseError(error, "Streamer Sound Settings API");
+      logger.warn("Streamer Sound Settings API: falling back to disabled sound settings", {
+        streamerId,
+        status,
+        error: error.message,
+      });
+      return NextResponse.json({
+        soundUrl: null,
+        soundEnabled: false,
+      });
     }
 
     if (!streamer) {

--- a/tests/unit/sound-settings-api.test.ts
+++ b/tests/unit/sound-settings-api.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/streamer/[streamerId]/sound-settings/route";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+vi.mock("@/lib/supabase/admin", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/supabase/admin")>();
+  return {
+    ...actual,
+    getSupabaseAdmin: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+function createSoundSettingsClient(response: {
+  data: { gacha_sound_url: string | null; gacha_sound_enabled: boolean | null } | null;
+  error: { message: string; code?: string } | null;
+  status?: number;
+}) {
+  const query = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(response),
+  };
+
+  return {
+    from: vi.fn(() => query),
+    query,
+  };
+}
+
+function request() {
+  return new NextRequest("http://localhost:3000/api/streamer/streamer-1/sound-settings");
+}
+
+describe("GET /api/streamer/[streamerId]/sound-settings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the configured sound settings", async () => {
+    const mockSupabase = createSoundSettingsClient({
+      data: {
+        gacha_sound_url: "https://cdn.example.com/sound.mp3",
+        gacha_sound_enabled: true,
+      },
+      error: null,
+      status: 200,
+    });
+    vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const response = await GET(request(), {
+      params: Promise.resolve({ streamerId: "streamer-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      soundUrl: "https://cdn.example.com/sound.mp3",
+      soundEnabled: true,
+    });
+    expect(mockSupabase.from).toHaveBeenCalledWith("streamers");
+    expect(mockSupabase.query.select).toHaveBeenCalledWith("gacha_sound_url, gacha_sound_enabled");
+    expect(mockSupabase.query.eq).toHaveBeenCalledWith("id", "streamer-1");
+  });
+
+  it("keeps streamer-not-found as a 404", async () => {
+    const mockSupabase = createSoundSettingsClient({
+      data: null,
+      error: null,
+      status: 200,
+    });
+    vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const response = await GET(request(), {
+      params: Promise.resolve({ streamerId: "missing-streamer" }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Streamer not found" });
+  });
+
+  it("falls back to disabled sound settings when the database returns a transient 520", async () => {
+    const mockSupabase = createSoundSettingsClient({
+      data: null,
+      error: { message: "error code: 520" },
+      status: 520,
+    });
+    vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const response = await GET(request(), {
+      params: Promise.resolve({ streamerId: "streamer-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      soundUrl: null,
+      soundEnabled: false,
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Streamer Sound Settings API: falling back to disabled sound settings",
+      {
+        streamerId: "streamer-1",
+        status: 520,
+        error: "error code: 520",
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- keep the public sound-settings API available when Supabase returns transient 520/DB errors
- fall back to disabled sound settings so overlays can continue rendering without creating a production error issue
- add unit coverage for configured, missing-streamer, and 520 fallback responses

Issues: Closes #396

## Validation
- npm_config_cache=/private/tmp/twica-maker-npm-cache npm ci
- npx vitest run tests/unit/sound-settings-api.test.ts tests/unit/supabase-retry.test.ts
- npm run lint
- npm run build
- npm run workers:build
