### PR TITLE
fix: retry transient Twitch token DB reads

### DIFF
--- a/src/lib/twitch/token-manager.ts
+++ b/src/lib/twitch/token-manager.ts
@@ -17,11 +17,14 @@ export class TwitchTokenError extends Error {
 export async function getTwitchAccessToken(twitchUserId: string): Promise<string | null> {
   const supabaseAdmin = getSupabaseAdmin();
 
-  const { data: user, error: dbError } = await supabaseAdmin
-    .from('users')
-    .select('twitch_access_token, twitch_refresh_token, twitch_token_expires_at')
-    .eq('twitch_user_id', twitchUserId)
-    .maybeSingle();
+  const { data: user, error: dbError } = await withRetry(
+    () => supabaseAdmin
+      .from('users')
+      .select('twitch_access_token, twitch_refresh_token, twitch_token_expires_at')
+      .eq('twitch_user_id', twitchUserId)
+      .maybeSingle(),
+    'twitch token fetch',
+  );
 
   if (dbError) {
     // PGRST204 means column not found - token columns may not exist in schema
@@ -540,11 +543,14 @@ export async function validateTokenScopes(twitchUserId: string): Promise<string[
     // check-scope GET must be read-only; getTwitchAccessToken() would refresh expired
     // tokens and write to DB, violating the read-only contract.
     const supabaseAdmin = getSupabaseAdmin();
-    const { data: user, error: dbError } = await supabaseAdmin
-      .from('users')
-      .select('twitch_access_token, twitch_token_expires_at')
-      .eq('twitch_user_id', twitchUserId)
-      .maybeSingle();
+    const { data: user, error: dbError } = await withRetry(
+      () => supabaseAdmin
+        .from('users')
+        .select('twitch_access_token, twitch_token_expires_at')
+        .eq('twitch_user_id', twitchUserId)
+        .maybeSingle(),
+      'twitch token scope validation fetch',
+    );
 
     if (dbError || !user?.twitch_access_token) return null;
 

--- a/tests/unit/twitch-token-manager.test.ts
+++ b/tests/unit/twitch-token-manager.test.ts
@@ -102,6 +102,35 @@ describe('Twitch Token Manager', () => {
       await expect(getTwitchAccessToken('123456789')).rejects.toThrow('Failed to fetch user tokens from database');
     });
 
+    it('一時的な502の後にトークン取得をリトライする', async () => {
+      const mockSupabaseAdmin: MockSupabaseAdmin = {
+        from: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn()
+          .mockResolvedValueOnce({
+            status: 502,
+            error: { code: '502', message: 'error code: 502' },
+          })
+          .mockResolvedValueOnce({
+            data: {
+              twitch_access_token: 'valid-token-after-retry',
+              twitch_refresh_token: 'refresh-token',
+              twitch_token_expires_at: new Date(Date.now() + 3600000).toISOString(),
+            },
+            error: null,
+          }),
+        update: vi.fn().mockReturnThis(),
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabaseAdmin as never);
+
+      const token = await getTwitchAccessToken('123456789');
+      expect(token).toBe('valid-token-after-retry');
+      expect(mockSupabaseAdmin.maybeSingle).toHaveBeenCalledTimes(2);
+    });
+
     it('期限切れのトークンを更新する', async () => {
       const mockSupabaseAdmin: MockSupabaseAdmin = {
         from: vi.fn().mockReturnThis(),


### PR DESCRIPTION
## Summary
- Retry transient Supabase/PostgREST 502/503 failures when fetching Twitch user tokens
- Apply the same retry behavior to DB-backed Twitch scope checks and read-only token scope validation
- Add regression coverage for token fetch and scope check recovery after a 502 response

Closes #388
Closes #387

## Validation
- `npm_config_cache=/private/tmp/twica-maker-npm-cache npx vitest run tests/unit/twitch-token-manager.test.ts tests/unit/supabase-retry.test.ts`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npm run workers:build`
