### PR TITLE
fix: retry transient scope checks

### DIFF
--- a/src/lib/supabase/retry.ts
+++ b/src/lib/supabase/retry.ts
@@ -16,12 +16,12 @@ interface RetryOptions {
 
 const DEFAULT_DELAYS = [100, 300, 1000]
 
-// 502/503 はインフラ一時障害のためリトライ対象
-const RETRYABLE_STATUS_CODES = [502, 503]
+// 500/502/503 はインフラ一時障害のためリトライ対象
+const RETRYABLE_STATUS_CODES = [500, 502, 503]
 
 // Supabase/PostgREST が返すエラーメッセージのテキストパターン
 // ステータスコード数字が含まれない場合（"Bad Gateway" 等）にも対応
-const RETRYABLE_MESSAGE_PATTERNS = ['bad gateway', 'service unavailable']
+const RETRYABLE_MESSAGE_PATTERNS = ['internal server error', 'bad gateway', 'service unavailable']
 
 /**
  * Supabase クエリ結果に対するリトライラッパー

--- a/src/lib/twitch/token-manager.ts
+++ b/src/lib/twitch/token-manager.ts
@@ -1,4 +1,5 @@
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
+import { withRetry } from '@/lib/supabase/retry';
 import { refreshTwitchToken, type TwitchTokens } from './auth';
 import { logger } from '@/lib/logger';
 
@@ -407,11 +408,14 @@ export async function deleteTwitchTokens(twitchUserId: string): Promise<void> {
 export async function hasScope(twitchUserId: string, scope: string): Promise<boolean> {
   const supabaseAdmin = getSupabaseAdmin();
 
-  const { data: user, error } = await supabaseAdmin
-    .from('users')
-    .select('twitch_scopes')
-    .eq('twitch_user_id', twitchUserId)
-    .maybeSingle();
+  const { data: user, error } = await withRetry(
+    () => supabaseAdmin
+      .from('users')
+      .select('twitch_scopes')
+      .eq('twitch_user_id', twitchUserId)
+      .maybeSingle(),
+    'Twitch scope check',
+  );
 
   if (error) {
     // PGRST204 means column not found - twitch_scopes column may not exist

--- a/tests/unit/supabase-retry.test.ts
+++ b/tests/unit/supabase-retry.test.ts
@@ -45,6 +45,25 @@ describe('withRetry', () => {
     expect(queryFn).toHaveBeenCalledTimes(2)
   })
 
+  it('Cloudflare HTML 500 の場合リトライする', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        status: 500,
+        statusText: 'Internal Server Error',
+        error: {
+          message: '<html><head><title>500 Internal Server Error</title></head><body>cloudflare</body></html>',
+        },
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: 'ok',
+        error: null,
+      })
+    const result = await withRetry(queryFn, 'test', { delays: [0, 0, 0] })
+    expect(result.error).toBeNull()
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+
   it('result.status が 503 の場合リトライする', async () => {
     const queryFn = vi.fn()
       .mockResolvedValueOnce({

--- a/tests/unit/twitch-token-manager.test.ts
+++ b/tests/unit/twitch-token-manager.test.ts
@@ -357,6 +357,36 @@ describe('Twitch Token Manager', () => {
       expect(result).toBe(true);
     });
 
+    it('scope確認のDB読み取りがCloudflare 500から復旧した場合はリトライしてtrueを返す', async () => {
+      const mockSupabaseAdmin: MockSupabaseAdmin = {
+        from: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn()
+          .mockResolvedValueOnce({
+            status: 500,
+            error: {
+              message: '<html><head><title>500 Internal Server Error</title></head><body>cloudflare</body></html>',
+            },
+          })
+          .mockResolvedValueOnce({
+            status: 200,
+            data: {
+              twitch_scopes: ['user:read:email', 'user:write:chat'],
+            },
+            error: null,
+          }),
+        update: vi.fn().mockReturnThis(),
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabaseAdmin as never);
+
+      const result = await hasScope('123456789', 'user:write:chat');
+      expect(result).toBe(true);
+      expect(mockSupabaseAdmin.maybeSingle).toHaveBeenCalledTimes(2);
+    });
+
     it('ユーザーがスコープを持っていない場合はfalseを返す', async () => {
       const mockSupabaseAdmin: MockSupabaseAdmin = {
         from: vi.fn().mockReturnThis(),


### PR DESCRIPTION
## Summary
- retry Supabase/PostgREST scope checks when Cloudflare/Supabase returns transient 500 HTML responses
- extend the shared Supabase retry helper to classify 500/Internal Server Error as retryable
- add regression coverage for `hasScope` recovering from the production-style Cloudflare 500 body

Closes #382

## Validation
- `npm_config_cache=/private/tmp/twica-maker-npm-cache npx vitest run tests/unit/supabase-retry.test.ts tests/unit/twitch-token-manager.test.ts`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npm run workers:build`
