### PR TITLE
fix: retry transient gacha database errors

### DIFF
--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -4,6 +4,7 @@ import { normalizeDropRate } from '@/lib/card-utils'
 import { Result, ok, err } from '@/types/result'
 import { logger } from '@/lib/logger'
 import { reportError } from '@/lib/sentry/error-handler'
+import { withRetry } from '@/lib/supabase/retry'
 
 export interface GachaCard {
   id: string
@@ -38,11 +39,14 @@ export class GachaService {
     try {
       // Get active cards for this streamer
       // このストリーマーの有効なカードを取得
-      const { data: cards, error: cardsError } = await this.supabase
-        .from('cards')
-        .select('id, name, description, image_url, rarity, drop_rate')
-        .eq('streamer_id', streamerId)
-        .eq('is_active', true)
+      const { data: cards, error: cardsError } = await withRetry(
+        () => this.supabase
+          .from('cards')
+          .select('id, name, description, image_url, rarity, drop_rate')
+          .eq('streamer_id', streamerId)
+          .eq('is_active', true),
+        'gacha:executeGacha:cards',
+      )
 
       if (cardsError) {
         return err(`Database error: ${cardsError.message}`)
@@ -62,15 +66,17 @@ export class GachaService {
 
       // gacha_history, users, user_cards を1トランザクションでアトミックに実行
       // 従来は3回の個別DB操作で中間状態（履歴あり・カード未付与）が発生しえた
-      const { data: rpcResult, error: rpcError } = await this.supabase
-        .rpc('execute_gacha_transaction', {
+      const { data: rpcResult, error: rpcError } = await withRetry(
+        () => this.supabase.rpc('execute_gacha_transaction', {
           p_event_id: eventId || null,
           p_user_twitch_id: userTwitchId,
           p_user_twitch_username: userTwitchUsername,
           p_card_id: selectedCard.id,
           p_streamer_id: streamerId,
           p_reward_cost: rewardCost ?? null,
-        })
+        }),
+        'gacha:executeGacha:rpc',
+      )
 
       if (rpcError) {
         // RPC関数が未デプロイの場合（マイグレーション前）は旧ロジックにフォールバック

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -89,6 +89,64 @@ describe('GachaService.executeGacha', () => {
     }
   })
 
+  it('カード取得の一時的な502エラーをリトライして成功する', async () => {
+    const failingCardsQuery = createMockQueryBuilder()
+    ;(failingCardsQuery as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
+      resolve({ data: null, error: { message: 'Database error: error code: 502', code: '502' } })
+      return failingCardsQuery
+    }
+    const cardsQuery = createCardsQuery(testCards)
+    const mockRpc = vi.fn().mockResolvedValue({
+      data: { is_duplicate: false, history_id: 'h-retry-cards' },
+      error: null,
+    })
+    const fromMock = vi.fn((table: string) => {
+      if (table === 'cards') {
+        return fromMock.mock.calls.filter(([name]) => name === 'cards').length === 1
+          ? failingCardsQuery
+          : cardsQuery
+      }
+      return createMockQueryBuilder()
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: fromMock,
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGacha('streamer-1', 'user-1', 'testuser', 'event-card-retry')
+
+    expect(result.success).toBe(true)
+    expect(fromMock).toHaveBeenCalledWith('cards')
+    expect(fromMock).toHaveBeenCalledTimes(2)
+    expect(mockRpc).toHaveBeenCalledTimes(1)
+  })
+
+  it('RPCの一時的な502エラーをリトライして成功する', async () => {
+    const cardsQuery = createCardsQuery(testCards)
+    const mockRpc = vi.fn()
+      .mockResolvedValueOnce({
+        data: null,
+        error: { message: 'Gacha RPC failed: error code: 502', code: '502' },
+      })
+      .mockResolvedValueOnce({
+        data: { is_duplicate: false, history_id: 'h-retry-rpc' },
+        error: null,
+      })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn(() => cardsQuery),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGacha('streamer-1', 'user-1', 'testuser', 'event-rpc-retry')
+
+    expect(result.success).toBe(true)
+    expect(mockRpc).toHaveBeenCalledTimes(2)
+  })
+
   it('RPC未デプロイ(42883): レガシーフォールバックで成功する', async () => {
     const cardsQuery = createCardsQuery(testCards)
     // フォールバック時のDB操作用モック（upsert → select → insert チェーン）


### PR DESCRIPTION
## Summary
- retries transient Supabase/PostgREST failures when loading active gacha cards
- retries transient `execute_gacha_transaction` RPC failures before reporting gacha execution errors
- adds regressions for card-query and RPC 502 recovery paths

Issues: Closes #378, closes #379, closes #380

## Validation
- `npx vitest run tests/unit/gacha-service.test.ts tests/unit/supabase-retry.test.ts`
- `npm run lint` (existing warnings only)
- `npm run build`
- `npm run workers:build`
