### PR TITLE
fix: retry collection completion reads

### DIFF
--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -1136,12 +1136,15 @@ export const getCollectionCompletions = cache(async (
   const cachedFetch = unstable_cache(
     async () => {
       const supabaseAdmin = getSupabaseAdmin();
-      const { data, error } = await supabaseAdmin
-        .from("collection_completions")
-        .select("total_cards, completed_at")
-        .eq("twitch_user_id", twitchUserId)
-        .eq("streamer_id", streamerId)
-        .order("completed_at", { ascending: false });
+      const { data, error } = await withRetry(
+        () => supabaseAdmin
+          .from("collection_completions")
+          .select("total_cards, completed_at")
+          .eq("twitch_user_id", twitchUserId)
+          .eq("streamer_id", streamerId)
+          .order("completed_at", { ascending: false }),
+        "dashboard:getCollectionCompletions",
+      );
       if (error) {
         logger.error(`Failed to fetch collection completions: ${error.message}`);
         return [];

--- a/tests/unit/collection-completions.test.ts
+++ b/tests/unit/collection-completions.test.ts
@@ -3,8 +3,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Supabase admin モック
 const mockUpsert = vi.fn();
 const mockSelect = vi.fn();
-const mockEq = vi.fn();
-const mockOrder = vi.fn();
 
 vi.mock('@/lib/supabase/admin', () => ({
   getSupabaseAdmin: () => ({
@@ -109,6 +107,28 @@ describe('collection-completions', () => {
       const result = await getCollectionCompletions('user1', 'streamer1');
 
       expect(result).toEqual([]);
+    });
+
+    it('一時的な502エラーをリトライして復旧する', async () => {
+      const mockData = [
+        { total_cards: 8, completed_at: '2026-03-01T00:00:00Z' },
+      ];
+      const mockOrder = vi.fn()
+        .mockResolvedValueOnce({ data: null, error: { message: 'error code: 502' } })
+        .mockResolvedValueOnce({ data: mockData, error: null });
+      mockSelect.mockImplementation(() => ({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: mockOrder,
+          }),
+        }),
+      }));
+
+      const { getCollectionCompletions } = await import('@/lib/dashboard-data');
+      const result = await getCollectionCompletions('user1', 'streamer1');
+
+      expect(result).toEqual(mockData);
+      expect(mockOrder).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
## Summary
- wrap collection completion history reads in the shared Supabase retry helper
- add regression coverage for recovery after a transient 502 response

Issues: Closes #373

## Validation
- npm_config_cache=/private/tmp/twica-maker-npm-cache npx vitest run tests/unit/collection-completions.test.ts tests/unit/supabase-retry.test.ts
- npm run lint (passes with existing warnings)
- npm run build
- npm run workers:build (after npm_config_cache=/private/tmp/twica-maker-npm-cache npm ci to avoid nested-worktree Turbopack root inference)