### PR TITLE
fix: keep additional reward controls within panel

### DIFF
--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -964,11 +964,11 @@ export default function ChannelPointSettings({
 
                {/* Add new additional reward */}
                {/* 新しい追加報酬を追加 */}
-               <div className="flex items-center gap-2">
+               <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
                  <select
                    value={selectedAdditionalRewardId}
                    onChange={(e) => setSelectedAdditionalRewardId(e.target.value)}
-                   className="flex-1 rounded-lg bg-gray-600 px-3 py-2 text-sm text-gray-200"
+                   className="w-full min-w-0 rounded-lg bg-gray-600 px-3 py-2 text-sm text-gray-200"
                  >
                    <option value="">{t("additionalRewards.selectToAdd")}</option>
                    {rewards
@@ -988,7 +988,7 @@ export default function ChannelPointSettings({
                  <button
                    onClick={handleAddAdditionalReward}
                    disabled={addingAdditional || !selectedAdditionalRewardId}
-                   className="rounded-lg bg-purple-600 px-4 py-2 text-sm text-white hover:bg-purple-700 disabled:opacity-50"
+                   className="w-full rounded-lg bg-purple-600 px-4 py-2 text-sm text-white hover:bg-purple-700 disabled:opacity-50 sm:w-auto"
                  >
                    {addingAdditional ? tCommon("loading") : tCommon("add")}
                  </button>

--- a/tests/unit/channel-point-settings-layout.test.ts
+++ b/tests/unit/channel-point-settings-layout.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+function readSource(path: string) {
+  return readFileSync(join(process.cwd(), path), "utf8");
+}
+
+describe("ChannelPointSettings layout", () => {
+  it("keeps the additional reward selector and add button inside the settings panel", () => {
+    const source = readSource("src/components/ChannelPointSettings.tsx");
+
+    expect(source).toContain("grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center");
+    expect(source).toContain("w-full min-w-0 rounded-lg bg-gray-600 px-3 py-2 text-sm text-gray-200");
+    expect(source).toContain("w-full rounded-lg bg-purple-600 px-4 py-2 text-sm text-white hover:bg-purple-700 disabled:opacity-50 sm:w-auto");
+  });
+});


### PR DESCRIPTION
## Summary
- Fix the additional channel-point reward row so the select can shrink inside the settings panel
- Stack the select and add button on narrow widths while keeping the desktop button auto-sized
- Add a focused layout regression test for the control classes

Issues: Closes #461

## Validation
- `npm_config_cache=/private/tmp/twica-maker-npm-cache npm ci`
- `npm_config_cache=/private/tmp/twica-maker-npm-cache npx vitest run tests/unit/channel-point-settings-layout.test.ts`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npm run workers:build`
