### PR TITLE
fix: ignore stale EventSub streamer misses

### DIFF
--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -332,6 +332,15 @@ async function handleRedemption(messageId: string, event: {
         });
         return null;
       }
+      // 削除済み/未登録 broadcaster の古い EventSub 通知は設定起因であり、
+      // production error としてGitHub Issue化しない。
+      if (result.error === 'Streamer not found') {
+        logger.warn('[handleRedemption] Streamer not found - stale or unconfigured EventSub notification', {
+          messageId,
+          broadcasterUserId: event.broadcaster_user_id,
+        });
+        return null;
+      }
       logger.warn('[handleRedemption] Gacha execution failed', { messageId });
       await reportError(new Error(`Gacha execution failed: ${result.error}`), {
         context: 'eventsub:handleRedemption',

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -195,13 +195,20 @@ export class GachaService {
   ): Promise<Result<GachaResult>> {
     try {
       // chat_announcement_enabled/template も同時取得してクエリ統合（CPU時間削減）
-      const { data: streamer, error: streamerError } = await this.supabase
-        .from('streamers')
-        .select('id, channel_point_reward_id, chat_announcement_enabled, chat_announcement_template')
-        .eq('twitch_user_id', event.broadcaster_user_id)
-        .maybeSingle()
+      const { data: streamer, error: streamerError } = await withRetry(
+        () => this.supabase
+          .from('streamers')
+          .select('id, channel_point_reward_id, chat_announcement_enabled, chat_announcement_template')
+          .eq('twitch_user_id', event.broadcaster_user_id)
+          .maybeSingle(),
+        'gacha:executeGachaForEventSub:streamer',
+      )
 
-      if (streamerError || !streamer) {
+      if (streamerError) {
+        return err(`Database error fetching streamer: ${streamerError.message}`)
+      }
+
+      if (!streamer) {
         return err('Streamer not found')
       }
 

--- a/tests/unit/eventsub-redemption.test.ts
+++ b/tests/unit/eventsub-redemption.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/twitch/eventsub/route'
+import { reportError } from '@/lib/sentry/error-handler'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { GachaService } from '@/lib/services/gacha'
+
+const mocks = vi.hoisted(() => ({
+  executeGachaForEventSub: vi.fn(),
+}))
+
+vi.mock('@/lib/services/gacha', () => ({
+  GachaService: vi.fn().mockImplementation(() => ({
+    executeGachaForEventSub: mocks.executeGachaForEventSub,
+  })),
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  getSupabaseAdmin: vi.fn(),
+  getSupabaseAdminNoCache: vi.fn(),
+}))
+
+vi.mock('@/lib/sentry/error-handler', () => ({
+  reportError: vi.fn().mockResolvedValue(undefined),
+  reportApiError: vi.fn(),
+  logErrorFromLogger: vi.fn(),
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn(),
+  getClientIp: vi.fn(() => '127.0.0.1'),
+  rateLimits: { eventsub: {} },
+}))
+
+vi.mock('@/lib/realtime', () => ({
+  broadcastGachaResult: vi.fn(),
+}))
+
+vi.mock('@/lib/twitch/token-manager', () => ({
+  hasScope: vi.fn(),
+}))
+
+vi.mock('@/lib/twitch/chat-service', () => ({
+  DEFAULT_CHAT_TEMPLATE: '{user} got {card}',
+  TwitchChatService: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin)
+const mockReportError = vi.mocked(reportError)
+const MockedGachaService = vi.mocked(GachaService)
+
+async function signEventSubBody(secret: string, messageId: string, timestamp: string, body: string): Promise<string> {
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(messageId + timestamp + body))
+  return `sha256=${Array.from(new Uint8Array(signature))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')}`
+}
+
+async function createNotificationRequest(payload: unknown): Promise<NextRequest> {
+  const secret = 'eventsub-test-secret'
+  process.env.TWITCH_EVENTSUB_SECRET = secret
+  const messageId = 'eventsub-message-1'
+  const timestamp = '2026-05-11T10:00:00Z'
+  const body = JSON.stringify(payload)
+  const signature = await signEventSubBody(secret, messageId, timestamp, body)
+
+  return new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'twitch-eventsub-message-id': messageId,
+      'twitch-eventsub-message-timestamp': timestamp,
+      'twitch-eventsub-message-type': 'notification',
+      'twitch-eventsub-message-signature': signature,
+    },
+    body,
+  })
+}
+
+describe('EventSub redemption handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const historyQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'gacha_history') return historyQuery
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+  })
+
+  it('does not report stale EventSub notifications for missing streamers', async () => {
+    mocks.executeGachaForEventSub.mockResolvedValue({
+      success: false,
+      error: 'Streamer not found',
+    })
+
+    const request = await createNotificationRequest({
+      subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
+      event: {
+        broadcaster_user_id: 'missing-broadcaster',
+        user_id: 'viewer-1',
+        user_login: 'viewer',
+        user_name: 'Viewer',
+        reward: { id: 'reward-1', title: 'Gacha', cost: 100 },
+      },
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ received: true })
+    expect(MockedGachaService).toHaveBeenCalledTimes(1)
+    expect(mockReportError).not.toHaveBeenCalled()
+  })
+
+  it('still reports unexpected gacha failures', async () => {
+    mocks.executeGachaForEventSub.mockResolvedValue({
+      success: false,
+      error: 'Database error fetching streamer: permission denied',
+    })
+
+    const request = await createNotificationRequest({
+      subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
+      event: {
+        broadcaster_user_id: 'broadcaster-1',
+        user_id: 'viewer-1',
+        user_login: 'viewer',
+        user_name: 'Viewer',
+        reward: { id: 'reward-1', title: 'Gacha', cost: 100 },
+      },
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    expect(mockReportError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        context: 'eventsub:handleRedemption',
+        broadcasterUserId: 'broadcaster-1',
+        gachaError: 'Database error fetching streamer: permission denied',
+      }),
+    )
+  })
+})

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -303,6 +303,66 @@ describe('GachaService.executeGachaForEventSub', () => {
     }
   })
 
+  it('streamer未登録: Streamer not foundを返す', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: null,
+      error: null,
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: vi.fn(),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForEventSub({
+      broadcaster_user_id: 'missing-broadcaster',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'reward-1', cost: 100 },
+    }, 'event-missing-streamer')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('Streamer not found')
+    }
+  })
+
+  it('streamer取得DBエラー: 未登録扱いにせずDBエラーを返す', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: null,
+      error: { message: 'permission denied', code: '42501' },
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: vi.fn(),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'reward-1', cost: 100 },
+    }, 'event-streamer-db-error')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('Database error fetching streamer: permission denied')
+    }
+  })
+
   it('未設定のEventSub報酬はReward ID mismatchを返す', async () => {
     const streamerQuery = createMockQueryBuilder()
     ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({


### PR DESCRIPTION
## Summary
- Distinguish EventSub streamer lookup DB errors from missing streamer records
- Treat missing-streamer EventSub redemptions as stale/unconfigured notifications instead of production errors
- Keep the merged raid/multi-draw EventSub schema fallback while resolving current main conflicts
- Add route and service tests for the non-reporting path and DB-error reporting path

Closes #375

## Validation
- npm_config_cache=/private/tmp/twica-maker-npm-cache npx vitest run tests/unit/gacha-service.test.ts tests/unit/eventsub-redemption.test.ts
- git diff --check
- npm run lint (existing warnings only)
- npm run build
- npm run workers:build