### PR TITLE
fix: suppress stale EventSub reward mismatch reports

### DIFF
--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -313,6 +313,16 @@ async function handleRedemption(messageId: string, event: {
         logger.info('[handleRedemption] Skipped - duplicate event (RPC)', { messageId });
         return null;
       }
+      // 設定から外れた報酬の古い EventSub 通知は運用状態のズレであり、
+      // production error としてGitHub Issue化しない。
+      if (result.error === 'Reward ID mismatch') {
+        logger.warn('[handleRedemption] Reward ID mismatch - stale or unconfigured EventSub notification', {
+          messageId,
+          broadcasterUserId: event.broadcaster_user_id,
+          rewardId: event.reward.id,
+        });
+        return null;
+      }
       // カード未設定はユーザー設定の問題でありバグではない (Issue #277)
       // "No cards available" is a streamer setup issue, not a system bug
       if (result.error === 'No cards available for this streamer') {

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -227,16 +227,20 @@ export class GachaService {
 
       // Check if the reward ID matches any additional reward
       // 追加報酬のいずれかと一致するかチェック
-      const { data: additionalReward, error: additionalError } = await this.supabase
-        .from('streamer_additional_gacha_rewards')
-        .select('id')
-        .eq('streamer_id', streamer.id)
-        .eq('reward_id', event.reward.id)
-        .maybeSingle()
+      const { data: additionalReward, error: additionalError } = await withRetry(
+        () => this.supabase
+          .from('streamer_additional_gacha_rewards')
+          .select('id')
+          .eq('streamer_id', streamer.id)
+          .eq('reward_id', event.reward.id)
+          .maybeSingle(),
+        'gacha:executeGachaForEventSub:additionalReward',
+      )
 
       // maybeSingle()を使用しているため、行が見つからない場合はerrorではなくdata=nullが返る
       if (additionalError) {
         logger.warn(`Error checking additional reward: ${additionalError.message}`)
+        return err(`Database error checking additional reward: ${additionalError.message}`)
       }
 
       if (additionalReward) {

--- a/tests/unit/eventsub-reward-mismatch.test.ts
+++ b/tests/unit/eventsub-reward-mismatch.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/twitch/eventsub/route'
+import { reportError } from '@/lib/sentry/error-handler'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+
+const mocks = vi.hoisted(() => ({
+  executeGachaForEventSub: vi.fn(),
+}))
+
+vi.mock('@/lib/services/gacha', () => ({
+  GachaService: vi.fn().mockImplementation(() => ({
+    executeGachaForEventSub: mocks.executeGachaForEventSub,
+  })),
+}))
+
+vi.mock('@/lib/supabase/admin', () => ({
+  getSupabaseAdmin: vi.fn(),
+  getSupabaseAdminNoCache: vi.fn(),
+}))
+
+vi.mock('@/lib/sentry/error-handler', () => ({
+  reportError: vi.fn().mockResolvedValue(undefined),
+  reportApiError: vi.fn(),
+  logErrorFromLogger: vi.fn(),
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn(),
+  getClientIp: vi.fn(() => '127.0.0.1'),
+  rateLimits: { eventsub: {} },
+}))
+
+vi.mock('@/lib/realtime', () => ({
+  broadcastGachaResult: vi.fn(),
+}))
+
+vi.mock('@/lib/twitch/token-manager', () => ({
+  hasScope: vi.fn(),
+}))
+
+vi.mock('@/lib/twitch/chat-service', () => ({
+  DEFAULT_CHAT_TEMPLATE: '{user} got {card}',
+  TwitchChatService: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin)
+const mockReportError = vi.mocked(reportError)
+
+async function signEventSubBody(secret: string, messageId: string, timestamp: string, body: string): Promise<string> {
+  const encoder = new TextEncoder()
+  const key = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(messageId + timestamp + body))
+  return `sha256=${Array.from(new Uint8Array(signature))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')}`
+}
+
+async function createNotificationRequest(gachaError: string): Promise<NextRequest> {
+  const secret = 'eventsub-test-secret'
+  process.env.TWITCH_EVENTSUB_SECRET = secret
+  const messageId = `eventsub-${gachaError.replaceAll(' ', '-').toLowerCase()}`
+  const timestamp = '2026-05-11T10:00:00Z'
+  const body = JSON.stringify({
+    subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
+    event: {
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'viewer-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'stale-reward', title: 'Old Gacha', cost: 100 },
+    },
+  })
+  const signature = await signEventSubBody(secret, messageId, timestamp, body)
+
+  mocks.executeGachaForEventSub.mockResolvedValue({
+    success: false,
+    error: gachaError,
+  })
+
+  return new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'twitch-eventsub-message-id': messageId,
+      'twitch-eventsub-message-timestamp': timestamp,
+      'twitch-eventsub-message-type': 'notification',
+      'twitch-eventsub-message-signature': signature,
+    },
+    body,
+  })
+}
+
+describe('EventSub reward mismatch handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const historyQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'gacha_history') return historyQuery
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+  })
+
+  it('does not report stale EventSub notifications for unconfigured rewards', async () => {
+    const response = await POST(await createNotificationRequest('Reward ID mismatch'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ received: true })
+    expect(mockReportError).not.toHaveBeenCalled()
+  })
+
+  it('still reports database failures while checking additional rewards', async () => {
+    const response = await POST(
+      await createNotificationRequest('Database error checking additional reward: Database error: error code: 502'),
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockReportError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        context: 'eventsub:handleRedemption',
+        broadcasterUserId: 'broadcaster-1',
+        gachaError: 'Database error checking additional reward: Database error: error code: 502',
+      }),
+    )
+  })
+})

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -256,3 +256,91 @@ describe('GachaService.executeGacha', () => {
     }))
   })
 })
+
+describe('GachaService.executeGachaForEventSub', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('追加報酬のDBエラーをReward ID mismatchに潰さず返す', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        id: 'streamer-1',
+        channel_point_reward_id: 'main-reward',
+        chat_announcement_enabled: false,
+        chat_announcement_template: null,
+      },
+      error: null,
+    })
+    const additionalRewardQuery = createMockQueryBuilder()
+    ;(additionalRewardQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: null,
+      error: { message: 'Database error: error code: 502', code: '502' },
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        if (table === 'streamer_additional_gacha_rewards') return additionalRewardQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: vi.fn(),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'additional-reward', cost: 100 },
+    }, 'event-additional-db-error')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('Database error checking additional reward: Database error: error code: 502')
+    }
+  })
+
+  it('未設定のEventSub報酬はReward ID mismatchを返す', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        id: 'streamer-1',
+        channel_point_reward_id: 'main-reward',
+        chat_announcement_enabled: false,
+        chat_announcement_template: null,
+      },
+      error: null,
+    })
+    const additionalRewardQuery = createMockQueryBuilder()
+    ;(additionalRewardQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: null,
+      error: null,
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        if (table === 'streamer_additional_gacha_rewards') return additionalRewardQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: vi.fn(),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'stale-reward', cost: 100 },
+    }, 'event-stale-reward')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('Reward ID mismatch')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Treat EventSub reward ID mismatches as stale/unconfigured reward notifications instead of production errors
- Retry additional reward lookup and preserve DB lookup failures as reportable database errors
- Add regression coverage for EventSub mismatch suppression and additional reward DB failures

Closes #370

## Validation
- `npm_config_cache=/private/tmp/twica-maker-npm-cache npm ci`
- `npx vitest run tests/unit/gacha-service.test.ts tests/unit/eventsub-reward-mismatch.test.ts`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npm run workers:build`
