### PR TITLE
fix: default cards to display order

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -122,6 +122,7 @@
       "numberLabel": "Number"
     },
     "sort": {
+      "displayOrder": "Display Order",
       "createdAt": "Date Created",
       "rarity": "Rarity",
       "cardNumber": "Card Number",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -122,6 +122,7 @@
       "numberLabel": "番号"
     },
     "sort": {
+      "displayOrder": "表示順",
       "createdAt": "設定日",
       "rarity": "レアリティ",
       "cardNumber": "カード番号",

--- a/src/app/api/cards/route.ts
+++ b/src/app/api/cards/route.ts
@@ -230,7 +230,7 @@ export async function POST(request: NextRequest) {
 
 // Valid sort fields for cards
 // カードの有効な並び替えフィールド
-const VALID_SORT_FIELDS = ["created_at", "rarity", "drop_rate", "card_number"] as const;
+const VALID_SORT_FIELDS = ["created_at", "rarity", "drop_rate", "card_number", "display_order"] as const;
 type SortField = typeof VALID_SORT_FIELDS[number];
 
 // Valid sort directions
@@ -277,15 +277,25 @@ async function fetchCardsFromDB(
   // Apply sorting - all fields use DB-side sorting for correct pagination
   // 並び替えを適用 - ページネーション整合性のため全フィールドDB側でソート
   const ascending = sortDirection === "asc";
-  // Use rarity_order generated column (CASE-based: legendary=1, epic=2, rare=3, common=4)
-  // instead of rarity text column which sorts alphabetically
-  // rarityテキストカラムはアルファベット順になるため、rarity_order generated columnを使用
-  const dbSortField = sortField === "rarity" ? "rarity_order" : sortField;
+  // Use stable DB-side ordering for correct pagination.
+  // display_order uses manually assigned card numbers first, then old cards first.
+  const dbSortField = sortField === "rarity"
+    ? "rarity_order"
+    : sortField === "display_order"
+      ? "card_number"
+      : sortField;
   query = query.order(dbSortField, { ascending, nullsFirst: false });
+  if (sortField === "display_order") {
+    query = query.order("created_at", { ascending: true, nullsFirst: false });
+  }
   query = query.range(offset, offset + limit - 1);
 
   let { data: cards, error, count } = await query;
-  if (error && sortField === "card_number" && isMissingCardNumberColumnError(error)) {
+  if (
+    error &&
+    (sortField === "card_number" || sortField === "display_order") &&
+    isMissingCardNumberColumnError(error)
+  ) {
     const fallbackQuery = supabaseAdmin
       .from("cards")
       .select("*", { count: "exact" })

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -76,7 +76,7 @@ interface CardManagerProps {
 
 // Sorting field options
 // 並び替えフィールドの選択肢
-type SortField = "created_at" | "rarity" | "card_number" | "drop_rate";
+type SortField = "display_order" | "created_at" | "rarity" | "card_number" | "drop_rate";
 type CardFormData = {
   name: string;
   description: string;
@@ -94,6 +94,18 @@ type SortDirection = "asc" | "desc";
 // Status filter options
 // ステータスフィルターの選択肢
 type StatusFilter = "all" | "active" | "inactive";
+
+const compareCardsByDisplayOrder = (a: Card, b: Card): number => {
+  const numberDiff =
+    (a.card_number ?? Number.MAX_SAFE_INTEGER) -
+    (b.card_number ?? Number.MAX_SAFE_INTEGER);
+  if (numberDiff !== 0) return numberDiff;
+
+  const createdAtDiff = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+  if (createdAtDiff !== 0) return createdAtDiff;
+
+  return a.id.localeCompare(b.id);
+};
 
 export default function CardManager({
   streamerId,
@@ -131,8 +143,8 @@ export default function CardManager({
 
   // Sorting and filtering state
   // 並び替えとフィルタリングの状態
-  const [sortField, setSortField] = useState<SortField>("created_at");
-  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  const [sortField, setSortField] = useState<SortField>("display_order");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [titleSearchQuery, setTitleSearchQuery] = useState("");
   // Track if this is the first render to skip initial reload
@@ -217,10 +229,15 @@ export default function CardManager({
       nextCards = nextCards.filter(card => card.name.toLowerCase().includes(normalizedQuery));
     }
 
-    // Cards are already sorted by server, just return as-is
-    // カードは既にサーバーでソートされているのでそのまま返す
+    if (sortField === "display_order") {
+      nextCards = [...nextCards].sort(compareCardsByDisplayOrder);
+      if (sortDirection === "desc") {
+        nextCards.reverse();
+      }
+    }
+
     return nextCards;
-  }, [cards, statusFilter, titleSearchQuery]);
+  }, [cards, sortDirection, sortField, statusFilter, titleSearchQuery]);
   const [showForm, setShowForm] = useState(false);
   const [editingCard, setEditingCard] = useState<Card | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -1786,6 +1803,7 @@ export default function CardManager({
               className="min-w-0 appearance-none rounded-lg bg-gray-700 px-3 py-1.5 pr-8 text-sm text-white border border-gray-600"
               style={SELECT_ARROW_STYLE}
             >
+              <option value="display_order">{t("sort.displayOrder")}</option>
               <option value="created_at">{t("sort.createdAt")}</option>
               <option value="rarity">{t("sort.rarity")}</option>
               <option value="card_number">{t("sort.cardNumber")}</option>

--- a/tests/unit/cards-get-api.test.ts
+++ b/tests/unit/cards-get-api.test.ts
@@ -215,6 +215,22 @@ describe('GET /api/cards', () => {
       expect(cardsQuery.order).toHaveBeenCalledWith('card_number', { ascending: true, nullsFirst: false })
     })
 
+    it('sortField=display_order の場合、card_number の後に作成日昇順で安定ソートする', async () => {
+      const { cardsQuery } = setupCardsMock({
+        streamer: { id: 'streamer-1' },
+        cards: [],
+      })
+
+      await GET(createRequest({
+        streamerId: 'streamer-1',
+        sortField: 'display_order',
+        sortDirection: 'asc',
+      }))
+
+      expect(cardsQuery.order).toHaveBeenNthCalledWith(1, 'card_number', { ascending: true, nullsFirst: false })
+      expect(cardsQuery.order).toHaveBeenNthCalledWith(2, 'created_at', { ascending: true, nullsFirst: false })
+    })
+
     it('card_number が schema cache にない場合は created_at ソートで再試行する', async () => {
       const { firstCardsQuery, retryCardsQuery } = setupCardsMockWithRetry({
         streamer: { id: 'streamer-1' },

--- a/tests/unit/components/card-manager-search.test.tsx
+++ b/tests/unit/components/card-manager-search.test.tsx
@@ -61,6 +61,18 @@ describe('CardManager title search', () => {
     expect(screen.getByText('2 件のカード')).toBeInTheDocument()
   })
 
+  it('defaults the management list to assigned display order', () => {
+    renderCardManager([
+      baseCard({ id: 'second', name: 'Second Card', card_number: 2, created_at: '2026-05-02T00:00:00Z' }),
+      baseCard({ id: 'first', name: 'First Card', card_number: 1, created_at: '2026-05-01T00:00:00Z' }),
+      baseCard({ id: 'auto', name: 'Auto Card', card_number: null, created_at: '2026-04-30T00:00:00Z' }),
+    ])
+
+    const text = document.body.textContent ?? ''
+    expect(text.indexOf('First Card')).toBeLessThan(text.indexOf('Second Card'))
+    expect(text.indexOf('Second Card')).toBeLessThan(text.indexOf('Auto Card'))
+  })
+
   it('shows a filtered empty state without replacing the no-cards message', () => {
     renderCardManager([
       baseCard({ id: 'alpha', name: 'Alpha Dragon' }),


### PR DESCRIPTION
## Summary
- Add a `display_order` card sort that uses assigned card numbers first, then old cards first for stable ordering.
- Make CardManager default to display order ascending so saved card numbers directly control the management view order, including the initial server-provided card list.
- Add localized sort labels and API/component regression coverage for the new order.

Closes #138

## Validation
- `npm_config_cache=/private/tmp/twica-maker-npm-cache npm ci`
- `npx vitest run tests/unit/cards-get-api.test.ts tests/unit/components/card-manager-search.test.tsx`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npm run workers:build`
