### PR TITLE
feat: add raid multi-draw gacha rewards

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -516,7 +516,15 @@
       "drawCount": "Draws",
       "raidOnly": "Raid only",
       "multiDraw": "{count} draws",
-      "raidLimited": "Raid limited"
+      "raidLimited": "Raid limited",
+      "raidStatusTitle": "Raid gacha window",
+      "raidStatusActive": "Active until {time}",
+      "raidStatusInactive": "Currently off",
+      "raidStatusEnable": "30 min on",
+      "raidStatusDisable": "Off",
+      "raidStatusEnabled": "Raid gacha window enabled for 30 minutes",
+      "raidStatusDisabled": "Raid gacha window disabled",
+      "raidStatusFailed": "Failed to update raid gacha window"
     }
   },
   "gachaHistory": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -512,7 +512,11 @@
       "removeFailed": "Failed to remove additional reward",
       "removeConfirm": "Remove this additional reward? EventSub subscription will also be removed.",
       "cannotUseAsMain": "This reward is registered as an additional reward. Please remove it from additional rewards first.",
-      "cannotUseAsAdditional": "This reward is already set as the main reward."
+      "cannotUseAsAdditional": "This reward is already set as the main reward.",
+      "drawCount": "Draws",
+      "raidOnly": "Raid only",
+      "multiDraw": "{count} draws",
+      "raidLimited": "Raid limited"
     }
   },
   "gachaHistory": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -480,6 +480,10 @@
       "rewardId": "Reward ID:",
       "allRewards": "All Rewards",
       "eventsubStatus": "EventSub Status",
+      "raidEventSubStatus": "Raid auto-enable",
+      "raidEventSubActive": "Incoming raid notifications are subscribed.",
+      "raidEventSubMissing": "Not registered or still pending. Use Save & Register EventSub to re-register.",
+      "raidEventSubError": "Registration failed. Use Save & Register EventSub to re-register.",
       "noSubscriptions": "No EventSub subscriptions. Click save to register.",
       "localTunnelNote": "* EventSub is not available in local environment"
     },

--- a/messages/en.json
+++ b/messages/en.json
@@ -389,7 +389,7 @@
       "enableAnnouncement": "Enable chat announcements",
       "customTemplate": "Custom Template (optional)",
       "templatePlaceholder": "@'{'user'}' got a ['{'rarity'}'] '{'card'}'!",
-      "placeholderHelp": "Available placeholders: '{'user'}'=username, '{'card'}'=card name, '{'rarity'}'=rarity, '{'num'}'=owned count, '{'unique'}'=unique types owned, '{'all'}'=total types, '{'detail'}'=card description, '{'url'}'=collection URL",
+      "placeholderHelp": "Available placeholders: '{'user'}'=username, '{'card'}'=first card name, '{'cards'}'=all card names, '{'draws'}'=draw count, '{'rarity'}'=rarity, '{'num'}'=owned count, '{'unique'}'=unique types owned, '{'all'}'=total types, '{'detail'}'=card description, '{'url'}'=collection URL",
       "previewLength": "Preview length: {current} / {max} characters"
     },
     "buttons": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -480,6 +480,10 @@
       "rewardId": "報酬ID:",
       "allRewards": "全報酬",
       "eventsubStatus": "EventSub ステータス",
+      "raidEventSubStatus": "レイド自動ON",
+      "raidEventSubActive": "incoming raid 通知を受け取れる状態です。",
+      "raidEventSubMissing": "未登録または確認中です。必要な場合は「保存 & EventSub登録」で再登録してください。",
+      "raidEventSubError": "登録に失敗しています。「保存 & EventSub登録」で再登録してください。",
       "noSubscriptions": "EventSubサブスクリプションがありません。保存ボタンを押して登録してください。",
       "localTunnelNote": "※ EventSubはローカル環境では利用できません"
     },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -512,7 +512,11 @@
       "removeFailed": "追加報酬の削除に失敗しました",
       "removeConfirm": "この追加報酬を削除しますか？EventSubサブスクリプションも削除されます。",
       "cannotUseAsMain": "この報酬は追加報酬として登録されています。先に追加報酬から削除してください。",
-      "cannotUseAsAdditional": "この報酬はメイン報酬として設定されています。"
+      "cannotUseAsAdditional": "この報酬はメイン報酬として設定されています。",
+      "drawCount": "回数",
+      "raidOnly": "レイド限定",
+      "multiDraw": "{count}連",
+      "raidLimited": "レイド限定"
     }
   },
   "gachaHistory": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -389,7 +389,7 @@
       "enableAnnouncement": "チャット通知を有効にする",
       "customTemplate": "カスタムテンプレート（任意）",
       "templatePlaceholder": "@'{'user'}' が【'{'rarity'}'】'{'card'}' を獲得しました！",
-      "placeholderHelp": "使用可能なプレースホルダー: '{'user'}'=ユーザー名, '{'card'}'=カード名, '{'rarity'}'=レアリティ, '{'num'}'=所持枚数, '{'unique'}'=所持種類数, '{'all'}'=全種類数, '{'detail'}'=カード説明, '{'url'}'=コレクションURL",
+      "placeholderHelp": "使用可能なプレースホルダー: '{'user'}'=ユーザー名, '{'card'}'=先頭カード名, '{'cards'}'=全カード名, '{'draws'}'=抽選回数, '{'rarity'}'=レアリティ, '{'num'}'=所持枚数, '{'unique'}'=所持種類数, '{'all'}'=全種類数, '{'detail'}'=カード説明, '{'url'}'=コレクションURL",
       "previewLength": "プレビュー文字数: {current} / {max}文字"
     },
     "buttons": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -516,7 +516,15 @@
       "drawCount": "回数",
       "raidOnly": "レイド限定",
       "multiDraw": "{count}連",
-      "raidLimited": "レイド限定"
+      "raidLimited": "レイド限定",
+      "raidStatusTitle": "レイドガチャ受付",
+      "raidStatusActive": "{time} まで受付中",
+      "raidStatusInactive": "現在は停止中",
+      "raidStatusEnable": "30分ON",
+      "raidStatusDisable": "OFF",
+      "raidStatusEnabled": "レイドガチャ受付を30分間有効にしました",
+      "raidStatusDisabled": "レイドガチャ受付を停止しました",
+      "raidStatusFailed": "レイドガチャ受付の更新に失敗しました"
     }
   },
   "gachaHistory": {

--- a/src/app/api/streamer/additional-rewards/route.ts
+++ b/src/app/api/streamer/additional-rewards/route.ts
@@ -8,6 +8,11 @@ import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
 import { logger } from "@/lib/logger";
 
+function isRaidOptionsSchemaError(error: { message?: string; code?: string } | null | undefined) {
+  const message = error?.message ?? "";
+  return error?.code === "PGRST204" || message.includes("draw_count") || message.includes("is_raid_limited");
+}
+
 /**
  * GET: ストリーマーの追加報酬一覧を取得
  * Fetch additional gacha rewards for the current streamer
@@ -53,11 +58,25 @@ export async function GET(request: NextRequest) {
 
     // Fetch all additional rewards for this streamer
     // このストリーマーの全ての追加報酬を取得
-    const { data: rewards, error } = await supabaseAdmin
+    let { data: rewards, error } = await supabaseAdmin
       .from("streamer_additional_gacha_rewards")
-      .select("id, reward_id, reward_name, created_at")
+      .select("id, reward_id, reward_name, draw_count, is_raid_limited, created_at")
       .eq("streamer_id", streamer.id)
       .order("created_at", { ascending: true });
+
+    if (isRaidOptionsSchemaError(error)) {
+      const fallbackResult = await supabaseAdmin
+        .from("streamer_additional_gacha_rewards")
+        .select("id, reward_id, reward_name, created_at")
+        .eq("streamer_id", streamer.id)
+        .order("created_at", { ascending: true });
+      rewards = (fallbackResult.data || []).map((reward) => ({
+        ...reward,
+        draw_count: 1,
+        is_raid_limited: false,
+      }));
+      error = fallbackResult.error;
+    }
 
     if (error) {
       return handleDatabaseError(error, "Additional Rewards API: GET");
@@ -120,10 +139,25 @@ export async function POST(request: NextRequest) {
   try {
     const supabaseAdmin = getSupabaseAdmin();
     const body = await request.json();
-    const { rewardId, rewardName } = body;
+    const { rewardId, rewardName, drawCount, isRaidLimited } = body;
 
     if (!rewardId) {
       return NextResponse.json({ error: ERROR_MESSAGES.MISSING_REWARD_ID }, { status: 400 });
+    }
+
+    const normalizedDrawCount = drawCount === undefined ? 1 : Number(drawCount);
+    if (!Number.isInteger(normalizedDrawCount) || normalizedDrawCount < 1 || normalizedDrawCount > 10) {
+      return NextResponse.json(
+        { error: "drawCount must be an integer between 1 and 10" },
+        { status: 400 }
+      );
+    }
+
+    if (isRaidLimited !== undefined && typeof isRaidLimited !== "boolean") {
+      return NextResponse.json(
+        { error: "isRaidLimited must be a boolean" },
+        { status: 400 }
+      );
     }
 
     // Get streamer info to verify ownership
@@ -158,15 +192,33 @@ export async function POST(request: NextRequest) {
 
     // Insert the new additional reward
     // 新しい追加報酬を挿入
-    const { data: newReward, error } = await supabaseAdmin
+    let { data: newReward, error } = await supabaseAdmin
       .from("streamer_additional_gacha_rewards")
       .insert({
         streamer_id: streamer.id,
         reward_id: rewardId,
         reward_name: rewardName || null,
+        draw_count: normalizedDrawCount,
+        is_raid_limited: isRaidLimited ?? false,
       })
       .select()
       .maybeSingle();
+
+    if (isRaidOptionsSchemaError(error)) {
+      const fallbackResult = await supabaseAdmin
+        .from("streamer_additional_gacha_rewards")
+        .insert({
+          streamer_id: streamer.id,
+          reward_id: rewardId,
+          reward_name: rewardName || null,
+        })
+        .select()
+        .maybeSingle();
+      newReward = fallbackResult.data
+        ? { ...fallbackResult.data, draw_count: 1, is_raid_limited: false }
+        : fallbackResult.data;
+      error = fallbackResult.error;
+    }
 
     if (error) {
       // Handle unique constraint violation (reward already added)
@@ -181,7 +233,7 @@ export async function POST(request: NextRequest) {
     }
 
     logger.info(
-      `Additional reward registered: streamerId=${streamer.id}, rewardId=${rewardId}, rewardName=${rewardName}`
+      `Additional reward registered: streamerId=${streamer.id}, rewardId=${rewardId}, rewardName=${rewardName}, drawCount=${normalizedDrawCount}, raidLimited=${isRaidLimited ?? false}`
     );
 
     return NextResponse.json({ success: true, reward: newReward });

--- a/src/app/api/streamer/raid-gacha/route.ts
+++ b/src/app/api/streamer/raid-gacha/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession, canUseStreamerFeatures } from "@/lib/session";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
+import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { ERROR_MESSAGES } from "@/lib/constants";
+import { validateCSRFToken } from "@/lib/csrf";
+import { validateContentType } from "@/lib/request-validation";
+import { logger } from "@/lib/logger";
+
+const DEFAULT_ACTIVE_MINUTES = 30;
+const MAX_ACTIVE_MINUTES = 180;
+
+function isRaidStateSchemaError(error: { message?: string; code?: string } | null | undefined) {
+  const message = error?.message ?? "";
+  return error?.code === "PGRST204" || message.includes("raid_gacha_active_until");
+}
+
+function isActiveUntil(value: string | null | undefined): boolean {
+  if (!value) return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && timestamp > Date.now();
+}
+
+async function getOwnedStreamer(twitchUserId: string) {
+  const supabaseAdmin = getSupabaseAdmin();
+  let { data: streamer, error } = await supabaseAdmin
+    .from("streamers")
+    .select("id, raid_gacha_active_until")
+    .eq("twitch_user_id", twitchUserId)
+    .maybeSingle();
+
+  if (isRaidStateSchemaError(error)) {
+    const fallbackResult = await supabaseAdmin
+      .from("streamers")
+      .select("id")
+      .eq("twitch_user_id", twitchUserId)
+      .maybeSingle();
+    streamer = fallbackResult.data
+      ? { ...fallbackResult.data, raid_gacha_active_until: null }
+      : fallbackResult.data;
+    error = fallbackResult.error;
+  }
+
+  return { streamer, error };
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getSession();
+  const identifier = await getRateLimitIdentifier(request, session?.twitchUserId);
+  const rateLimitResult = await checkRateLimit(rateLimits.streamerSettings, identifier);
+
+  if (!rateLimitResult.success) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
+      {
+        status: 429,
+        headers: {
+          "X-RateLimit-Limit": String(rateLimitResult.limit),
+          "X-RateLimit-Remaining": String(rateLimitResult.remaining),
+          "X-RateLimit-Reset": String(rateLimitResult.reset),
+        },
+      },
+    );
+  }
+
+  if (!session || !canUseStreamerFeatures(session)) {
+    return NextResponse.json({ error: ERROR_MESSAGES.UNAUTHORIZED }, { status: 401 });
+  }
+
+  try {
+    const { streamer, error } = await getOwnedStreamer(session.twitchUserId);
+    if (error) return handleDatabaseError(error, "Raid Gacha API: GET");
+    if (!streamer) return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
+
+    return NextResponse.json({
+      active: isActiveUntil(streamer.raid_gacha_active_until),
+      activeUntil: streamer.raid_gacha_active_until,
+    }, {
+      headers: { "Cache-Control": "no-store, no-cache, must-revalidate" },
+    });
+  } catch (error) {
+    return handleApiError(error, "Raid Gacha API: GET");
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const contentTypeValidation = validateContentType(request, "application/json");
+  if (contentTypeValidation) return contentTypeValidation;
+
+  const csrfValidation = await validateCSRFToken(request);
+  if (!csrfValidation.valid) {
+    return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
+  }
+
+  const session = await getSession();
+  const identifier = await getRateLimitIdentifier(request, session?.twitchUserId);
+  const rateLimitResult = await checkRateLimit(rateLimits.streamerSettings, identifier);
+
+  if (!rateLimitResult.success) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
+      {
+        status: 429,
+        headers: {
+          "X-RateLimit-Limit": String(rateLimitResult.limit),
+          "X-RateLimit-Remaining": String(rateLimitResult.remaining),
+          "X-RateLimit-Reset": String(rateLimitResult.reset),
+        },
+      },
+    );
+  }
+
+  if (!session || !canUseStreamerFeatures(session)) {
+    return NextResponse.json({ error: ERROR_MESSAGES.UNAUTHORIZED }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const active = body.active === true;
+    const requestedMinutes = body.activeMinutes === undefined
+      ? DEFAULT_ACTIVE_MINUTES
+      : Number(body.activeMinutes);
+
+    if (body.active !== undefined && typeof body.active !== "boolean") {
+      return NextResponse.json({ error: "active must be a boolean" }, { status: 400 });
+    }
+    if (!Number.isInteger(requestedMinutes) || requestedMinutes < 1 || requestedMinutes > MAX_ACTIVE_MINUTES) {
+      return NextResponse.json(
+        { error: `activeMinutes must be an integer between 1 and ${MAX_ACTIVE_MINUTES}` },
+        { status: 400 },
+      );
+    }
+
+    const { streamer, error: streamerError } = await getOwnedStreamer(session.twitchUserId);
+    if (streamerError) return handleDatabaseError(streamerError, "Raid Gacha API: POST lookup");
+    if (!streamer) return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
+
+    const activeUntil = active
+      ? new Date(Date.now() + requestedMinutes * 60 * 1000).toISOString()
+      : null;
+
+    const supabaseAdmin = getSupabaseAdmin();
+    const { data: updatedStreamer, error } = await supabaseAdmin
+      .from("streamers")
+      .update({ raid_gacha_active_until: activeUntil })
+      .eq("id", streamer.id)
+      .select("raid_gacha_active_until")
+      .maybeSingle();
+
+    if (error) return handleDatabaseError(error, "Raid Gacha API: POST update");
+
+    logger.info("Raid gacha state updated", {
+      streamerId: streamer.id,
+      active,
+      activeUntil,
+    });
+
+    return NextResponse.json({
+      success: true,
+      active: isActiveUntil(updatedStreamer?.raid_gacha_active_until),
+      activeUntil: updatedStreamer?.raid_gacha_active_until ?? null,
+    });
+  } catch (error) {
+    return handleApiError(error, "Raid Gacha API: POST");
+  }
+}

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -17,6 +17,7 @@ const MESSAGE_TYPE_VERIFICATION = "webhook_callback_verification";
 const MESSAGE_TYPE_NOTIFICATION = "notification";
 const MESSAGE_TYPE_REVOCATION = "revocation";
 const CARD_LIST_SEPARATOR = "、";
+const RAID_GACHA_EVENTSUB_ACTIVE_MINUTES = 30;
 
 function formatCardNamesForChat(cardNames: string[], maxCharacters: number): string {
   if (cardNames.length === 0) return "";
@@ -199,6 +200,8 @@ export async function POST(request: NextRequest) {
           await postRedemptionNotify(result);
         }
       }
+    } else if (subscriptionType === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_RAID) {
+      await handleRaidNotification(messageId, event);
     }
 
     return NextResponse.json({ received: true });
@@ -255,6 +258,95 @@ export async function POST(request: NextRequest) {
   }
 
   return NextResponse.json({ error: ERROR_MESSAGES.UNKNOWN_MESSAGE_TYPE }, { status: 400 });
+}
+
+function isRaidStateSchemaError(error: { message?: string; code?: string } | null | undefined) {
+  const message = error?.message ?? "";
+  return error?.code === "PGRST204" || message.includes("raid_gacha_active_until");
+}
+
+function isActiveUntilAfter(value: string | null | undefined, target: Date): boolean {
+  if (!value) return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && timestamp > target.getTime();
+}
+
+async function handleRaidNotification(messageId: string, event: {
+  from_broadcaster_user_id?: string;
+  from_broadcaster_user_login?: string;
+  from_broadcaster_user_name?: string;
+  to_broadcaster_user_id?: string;
+  to_broadcaster_user_login?: string;
+  to_broadcaster_user_name?: string;
+  viewers?: number;
+}): Promise<void> {
+  const toBroadcasterUserId = event.to_broadcaster_user_id;
+  if (!toBroadcasterUserId) {
+    logger.warn("[EventSub] Raid notification missing to_broadcaster_user_id", { messageId, event });
+    return;
+  }
+
+  const activeUntil = new Date(Date.now() + RAID_GACHA_EVENTSUB_ACTIVE_MINUTES * 60 * 1000).toISOString();
+  const supabaseAdmin = getSupabaseAdmin();
+
+  const { data: streamer, error: streamerError } = await supabaseAdmin
+    .from("streamers")
+    .select("id, raid_gacha_active_until")
+    .eq("twitch_user_id", toBroadcasterUserId)
+    .maybeSingle();
+
+  if (isRaidStateSchemaError(streamerError)) {
+    logger.warn("[EventSub] Raid gacha state column is unavailable; raid notification ignored", {
+      messageId,
+      toBroadcasterUserId,
+      error: streamerError?.message,
+    });
+    return;
+  }
+
+  if (streamerError || !streamer) {
+    await reportError(new Error(`Raid EventSub streamer lookup failed: ${streamerError?.message ?? "Streamer not found"}`), {
+      context: "eventsub:handleRaidNotification",
+      messageId,
+      toBroadcasterUserId,
+      fromBroadcasterUserId: event.from_broadcaster_user_id,
+    });
+    return;
+  }
+
+  if (isActiveUntilAfter(streamer.raid_gacha_active_until, new Date(activeUntil))) {
+    logger.info("[EventSub] Raid gacha window already extends beyond automatic activation", {
+      messageId,
+      streamerId: streamer.id,
+      activeUntil: streamer.raid_gacha_active_until,
+    });
+    return;
+  }
+
+  const { error: updateError } = await supabaseAdmin
+    .from("streamers")
+    .update({ raid_gacha_active_until: activeUntil })
+    .eq("id", streamer.id);
+
+  if (updateError) {
+    await reportError(new Error(`Raid gacha activation failed: ${updateError.message}`), {
+      context: "eventsub:handleRaidNotification",
+      messageId,
+      streamerId: streamer.id,
+      toBroadcasterUserId,
+      fromBroadcasterUserId: event.from_broadcaster_user_id,
+    });
+    return;
+  }
+
+  logger.info("[EventSub] Raid gacha window activated from raid notification", {
+    messageId,
+    streamerId: streamer.id,
+    toBroadcasterUserId,
+    fromBroadcasterUserId: event.from_broadcaster_user_id,
+    viewers: event.viewers,
+    activeUntil,
+  });
 }
 
 /** postRedemptionNotify に渡すデータ（streamer.id を streamerId として再利用し冗長を排除） */

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -238,7 +238,8 @@ async function postRedemptionNotify(data: RedemptionNotifyData): Promise<void> {
       data.streamer,
       data.gachaResult.card,
       data.gachaResult.userTwitchUsername,
-      data.userId
+      data.userId,
+      data.gachaResult.cards
     ),
   ]);
 
@@ -388,6 +389,7 @@ async function handleRedemption(messageId: string, event: {
  * @param card - 獲得したカード（GachaCard型 - gacha serviceから返される）
  * @param userName - ガチャを引いたユーザー名
  * @param userId - ガチャを引いたユーザーのTwitch ID
+ * @param cards - 複数枚ガチャ時の獲得カード一覧
  */
 async function sendChatAnnouncement(
   broadcasterTwitchUserId: string,
@@ -398,8 +400,13 @@ async function sendChatAnnouncement(
   },
   card: GachaCard,
   userName: string,
-  userId: string
+  userId: string,
+  cards?: GachaCard[]
 ): Promise<void> {
+  const drawnCards = cards && cards.length > 0 ? cards : [card];
+  const isMultiDraw = drawnCards.length > 1;
+  const cardNames = drawnCards.map((drawnCard) => drawnCard.name).join('、');
+
   // 関数呼び出しを記録（デバッグ用：この関数が呼ばれたことを確認するため）
   // Log function entry to confirm this function is being called
   logger.info('sendChatAnnouncement called', {
@@ -407,6 +414,7 @@ async function sendChatAnnouncement(
     streamerId: streamer.id,
     chatAnnouncementEnabled: streamer.chat_announcement_enabled,
     cardName: card.name,
+    drawCount: drawnCards.length,
     userName,
   });
 
@@ -445,7 +453,10 @@ async function sendChatAnnouncement(
   // テンプレートに含まれるプレースホルダーに応じてのみDBクエリを実行
   // waitUntil内のwall time短縮のため、不要なDBクエリをスキップ
   // Run DB queries only for placeholders that appear in the template to keep waitUntil wall-time short
-  const effectiveTemplate = streamer.chat_announcement_template || DEFAULT_CHAT_TEMPLATE;
+  const messageTemplate = streamer.chat_announcement_template
+    || (isMultiDraw ? '@{user} が{draws}連ガチャで {cards} を獲得しました！' : DEFAULT_CHAT_TEMPLATE);
+  const usesMultiDrawPlaceholders = /\{cards\}|\{draws\}/.test(messageTemplate);
+  const effectiveTemplate = messageTemplate;
   const needsCardCount = /\{num\}/.test(effectiveTemplate);
   const needsUniqueCount = /\{unique\}/.test(effectiveTemplate);
   const needsAllCount = /\{all\}/.test(effectiveTemplate);
@@ -556,6 +567,8 @@ async function sendChatAnnouncement(
   const placeholders: ChatMessagePlaceholders = {
     user: userName,
     card: card.name,
+    cards: isMultiDraw ? cardNames : undefined,
+    draws: isMultiDraw ? drawnCards.length : undefined,
     rarity: rarityMap[card.rarity] || card.rarity,
     detail: card.description || undefined,
     num: cardCount,
@@ -567,7 +580,10 @@ async function sendChatAnnouncement(
   // チャットサービスでメッセージを構築・送信
   // Build and send message using chat service
   const chatService = new TwitchChatService();
-  const message = chatService.buildMessage(streamer.chat_announcement_template, placeholders);
+  const baseMessage = chatService.buildMessage(messageTemplate, placeholders);
+  const message = isMultiDraw && !usesMultiDrawPlaceholders
+    ? `${baseMessage}（全${drawnCards.length}枚: ${cardNames}）`
+    : baseMessage;
 
   const success = await chatService.sendChatMessage(broadcasterTwitchUserId, message);
 

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -210,6 +210,7 @@ interface RedemptionNotifyData {
   gachaResult: {
     type: "gacha";
     card: GachaCard;
+    cards?: GachaCard[];
     userTwitchUsername: string;
   };
   broadcasterTwitchUserId: string;
@@ -358,6 +359,7 @@ async function handleRedemption(messageId: string, event: {
     const gachaResult = {
       type: "gacha" as const,
       card: result.data.card,
+      cards: result.data.cards,
       userTwitchUsername: result.data.userTwitchUsername,
     };
 

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabaseAdmin, getSupabaseAdminNoCache } from "@/lib/supabase/admin";
 import { GachaService } from "@/lib/services/gacha";
-import { TWITCH_SUBSCRIPTION_TYPE, ERROR_MESSAGES } from "@/lib/constants";
+import { TWITCH_CHAT_MESSAGE_MAX_CHARACTERS, TWITCH_SUBSCRIPTION_TYPE, ERROR_MESSAGES } from "@/lib/constants";
 import { handleApiError } from "@/lib/error-handler";
 import { broadcastGachaResult } from "@/lib/realtime";
 import { checkRateLimit, rateLimits, getClientIp } from "@/lib/rate-limit";
@@ -11,10 +11,62 @@ import { TwitchChatService, DEFAULT_CHAT_TEMPLATE, type ChatMessagePlaceholders 
 import { hasScope } from "@/lib/twitch/token-manager";
 import { ADDITIONAL_SCOPES } from "@/lib/twitch/scopes";
 import type { GachaCard, EventSubStreamerInfo } from "@/lib/services/gacha";
+import { countCharacters } from "@/lib/text-utils";
 
 const MESSAGE_TYPE_VERIFICATION = "webhook_callback_verification";
 const MESSAGE_TYPE_NOTIFICATION = "notification";
 const MESSAGE_TYPE_REVOCATION = "revocation";
+const CARD_LIST_SEPARATOR = "、";
+
+function formatCardNamesForChat(cardNames: string[], maxCharacters: number): string {
+  if (cardNames.length === 0) return "";
+
+  const fullList = cardNames.join(CARD_LIST_SEPARATOR);
+  if (countCharacters(fullList) <= maxCharacters) {
+    return fullList;
+  }
+
+  const total = cardNames.length;
+  const displayed: string[] = [];
+
+  for (const cardName of cardNames) {
+    const nextDisplayed = [...displayed, cardName];
+    const remaining = total - nextDisplayed.length;
+    const suffix = remaining > 0 ? ` ほか${remaining}枚（${nextDisplayed.length}/${total}枚表示）` : "";
+    const candidate = `${nextDisplayed.join(CARD_LIST_SEPARATOR)}${suffix}`;
+
+    if (countCharacters(candidate) > maxCharacters) {
+      break;
+    }
+
+    displayed.push(cardName);
+  }
+
+  if (displayed.length === 0) {
+    const fallback = `ほか${total}枚（0/${total}枚表示）`;
+    return countCharacters(fallback) <= maxCharacters ? fallback : `全${total}枚`;
+  }
+
+  const remaining = total - displayed.length;
+  return `${displayed.join(CARD_LIST_SEPARATOR)} ほか${remaining}枚（${displayed.length}/${total}枚表示）`;
+}
+
+function fitCardNamesForMessage(
+  cardNames: string[],
+  renderMessage: (cardsText: string) => string
+): { cardsText: string; message: string } {
+  let cardsText = cardNames.join(CARD_LIST_SEPARATOR);
+  let message = renderMessage(cardsText);
+
+  for (let i = 0; i < 3 && countCharacters(message) > TWITCH_CHAT_MESSAGE_MAX_CHARACTERS; i++) {
+    const overflow = countCharacters(message) - TWITCH_CHAT_MESSAGE_MAX_CHARACTERS;
+    const nextMaxCharacters = Math.max(0, countCharacters(cardsText) - overflow);
+    cardsText = formatCardNamesForChat(cardNames, nextMaxCharacters);
+    message = renderMessage(cardsText);
+  }
+
+  return { cardsText, message };
+}
 
 /**
  * Verify Twitch EventSub signature using HMAC-SHA256 (Web Crypto API)
@@ -405,7 +457,7 @@ async function sendChatAnnouncement(
 ): Promise<void> {
   const drawnCards = cards && cards.length > 0 ? cards : [card];
   const isMultiDraw = drawnCards.length > 1;
-  const cardNames = drawnCards.map((drawnCard) => drawnCard.name).join('、');
+  const cardNames = drawnCards.map((drawnCard) => drawnCard.name);
 
   // 関数呼び出しを記録（デバッグ用：この関数が呼ばれたことを確認するため）
   // Log function entry to confirm this function is being called
@@ -567,7 +619,7 @@ async function sendChatAnnouncement(
   const placeholders: ChatMessagePlaceholders = {
     user: userName,
     card: card.name,
-    cards: isMultiDraw ? cardNames : undefined,
+    cards: isMultiDraw ? cardNames.join(CARD_LIST_SEPARATOR) : undefined,
     draws: isMultiDraw ? drawnCards.length : undefined,
     rarity: rarityMap[card.rarity] || card.rarity,
     detail: card.description || undefined,
@@ -580,10 +632,25 @@ async function sendChatAnnouncement(
   // チャットサービスでメッセージを構築・送信
   // Build and send message using chat service
   const chatService = new TwitchChatService();
-  const baseMessage = chatService.buildMessage(messageTemplate, placeholders);
-  const message = isMultiDraw && !usesMultiDrawPlaceholders
-    ? `${baseMessage}（全${drawnCards.length}枚: ${cardNames}）`
-    : baseMessage;
+  let message: string;
+
+  if (isMultiDraw && usesMultiDrawPlaceholders) {
+    const fitted = fitCardNamesForMessage(cardNames, (cardsText) =>
+      chatService.buildMessage(messageTemplate, { ...placeholders, cards: cardsText })
+    );
+    placeholders.cards = fitted.cardsText;
+    message = fitted.message;
+  } else {
+    const baseMessage = chatService.buildMessage(messageTemplate, placeholders);
+    if (isMultiDraw) {
+      message = fitCardNamesForMessage(
+        cardNames,
+        (cardsText) => `${baseMessage}（全${drawnCards.length}枚: ${cardsText}）`
+      ).message;
+    } else {
+      message = baseMessage;
+    }
+  }
 
   const success = await chatService.sendChatMessage(broadcasterTwitchUserId, message);
 

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -377,6 +377,14 @@ async function handleRedemption(messageId: string, event: {
         });
         return null;
       }
+      if (result.error === 'Raid-limited reward inactive') {
+        logger.info('[handleRedemption] Raid-limited reward skipped outside active raid window', {
+          messageId,
+          broadcasterUserId: event.broadcaster_user_id,
+          rewardId: event.reward.id,
+        });
+        return null;
+      }
       // カード未設定はユーザー設定の問題でありバグではない (Issue #277)
       // "No cards available" is a streamer setup issue, not a system bug
       if (result.error === 'No cards available for this streamer') {

--- a/src/app/api/twitch/eventsub/subscribe/route.ts
+++ b/src/app/api/twitch/eventsub/subscribe/route.ts
@@ -44,12 +44,16 @@ interface EventSubSubscription {
   created_at: string;
 }
 
+type RaidEventSubStatus = "none" | "pending" | "active" | "error";
+
 interface RaidSubscriptionResult {
   subscription?: EventSubSubscription;
   created?: unknown;
   warning?: string;
   deleteWarning?: string;
   createWarning?: string;
+  status: RaidEventSubStatus;
+  subscriptions: EventSubSubscription[];
 }
 
 const RECREATABLE_EVENTSUB_STATUSES = new Set([
@@ -57,6 +61,62 @@ const RECREATABLE_EVENTSUB_STATUSES = new Set([
   "notification_failures_exceeded",
   "authorization_revoked",
 ]);
+
+function getMatchingRaidSubscriptions(
+  subscriptions: EventSubSubscription[],
+  broadcasterUserId: string,
+  callbackUrl: string,
+): EventSubSubscription[] {
+  return subscriptions.filter(
+    (sub) => sub.type === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_RAID
+      && sub.condition.to_broadcaster_user_id === broadcasterUserId
+      && sub.transport.callback === callbackUrl,
+  );
+}
+
+function deriveRaidEventSubStatus(subscriptions: EventSubSubscription[]): RaidEventSubStatus {
+  if (subscriptions.some((sub) => sub.status === "enabled")) return "active";
+  if (subscriptions.some((sub) => RECREATABLE_EVENTSUB_STATUSES.has(sub.status))) return "error";
+  return subscriptions.length > 0 ? "pending" : "none";
+}
+
+function isEventSubSubscription(value: unknown): value is EventSubSubscription {
+  if (!value || typeof value !== "object") return false;
+  const subscription = value as Partial<EventSubSubscription>;
+  return typeof subscription.id === "string"
+    && typeof subscription.status === "string"
+    && typeof subscription.type === "string"
+    && typeof subscription.condition === "object"
+    && typeof subscription.transport === "object";
+}
+
+function buildRaidSubscriptionResult(
+  subscriptions: EventSubSubscription[],
+  broadcasterUserId: string,
+  callbackUrl: string,
+  extra: Omit<RaidSubscriptionResult, "status" | "subscriptions"> = {},
+  ignoredSubscriptionIds: string[] = [],
+): RaidSubscriptionResult {
+  const ignoredIds = new Set(ignoredSubscriptionIds);
+  const matchingSubscriptions = getMatchingRaidSubscriptions(subscriptions, broadcasterUserId, callbackUrl)
+    .filter((sub) => !ignoredIds.has(sub.id));
+  const createdSubscription = isEventSubSubscription(extra.created)
+    && extra.created.type === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_RAID
+    && extra.created.condition.to_broadcaster_user_id === broadcasterUserId
+    && extra.created.transport.callback === callbackUrl
+    ? extra.created
+    : undefined;
+  const effectiveSubscriptions = matchingSubscriptions.length > 0
+    ? matchingSubscriptions
+    : createdSubscription
+      ? [createdSubscription]
+      : matchingSubscriptions;
+  return {
+    ...extra,
+    status: deriveRaidEventSubStatus(effectiveSubscriptions),
+    subscriptions: effectiveSubscriptions,
+  };
+}
 
 async function deleteEventSubSubscription(appAccessToken: string, subscriptionId: string) {
   return fetch(
@@ -96,12 +156,9 @@ async function ensureRaidSubscription(
   userSubscriptions: EventSubSubscription[],
   broadcasterUserId: string,
   callbackUrl: string,
+  refreshSubscriptions: () => Promise<EventSubSubscription[]>,
 ): Promise<RaidSubscriptionResult> {
-  const existingSubs = userSubscriptions.filter(
-    (sub) => sub.type === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_RAID
-      && sub.condition.to_broadcaster_user_id === broadcasterUserId
-      && sub.transport.callback === callbackUrl,
-  );
+  const existingSubs = getMatchingRaidSubscriptions(userSubscriptions, broadcasterUserId, callbackUrl);
   const reusableSub = existingSubs.find(
     (sub) => !RECREATABLE_EVENTSUB_STATUSES.has(sub.status),
   );
@@ -109,6 +166,7 @@ async function ensureRaidSubscription(
     (sub) => RECREATABLE_EVENTSUB_STATUSES.has(sub.status),
   );
   const deleteWarnings: string[] = [];
+  const deletedSubscriptionIds: string[] = [];
 
   for (const sub of recreatableSubs) {
     logger.info(`Deleting failed raid EventSub before recreation: id=${sub.id}, status=${sub.status}`);
@@ -122,16 +180,18 @@ async function ensureRaidSubscription(
         error,
       });
       deleteWarnings.push(`failed raid EventSub の削除に失敗しました: id=${sub.id}, status=${deleteResponse.status}`);
+    } else {
+      deletedSubscriptionIds.push(sub.id);
     }
   }
 
   const deleteWarning = deleteWarnings.length > 0 ? deleteWarnings.join("; ") : undefined;
 
   if (reusableSub) {
-    return {
+    return buildRaidSubscriptionResult(userSubscriptions, broadcasterUserId, callbackUrl, {
       subscription: reusableSub,
       ...(deleteWarning ? { warning: deleteWarning, deleteWarning } : {}),
-    };
+    }, deletedSubscriptionIds);
   }
 
   if (recreatableSubs.length > 0) {
@@ -153,10 +213,11 @@ async function ensureRaidSubscription(
 
   if (response.ok) {
     const data = await response.json();
-    return {
+    const latestSubscriptions = await refreshSubscriptions();
+    return buildRaidSubscriptionResult(latestSubscriptions, broadcasterUserId, callbackUrl, {
       created: data.data?.[0],
       ...(deleteWarning ? { warning: deleteWarning, deleteWarning } : {}),
-    };
+    }, deletedSubscriptionIds);
   }
 
   const error = await response.json().catch(() => ({}));
@@ -166,11 +227,14 @@ async function ensureRaidSubscription(
     error,
   });
   const createWarning = `raid EventSub の作成に失敗しました: status=${response.status}`;
-  return {
+  const latestSubscriptions = recreatableSubs.length > 0
+    ? await refreshSubscriptions()
+    : userSubscriptions;
+  return buildRaidSubscriptionResult(latestSubscriptions, broadcasterUserId, callbackUrl, {
     warning: [deleteWarning, createWarning].filter(Boolean).join("; "),
     ...(deleteWarning ? { deleteWarning } : {}),
     createWarning,
-  };
+  }, deletedSubscriptionIds);
 }
 
 async function getSubscriptionsByUserId(
@@ -272,6 +336,7 @@ export async function POST(request: NextRequest) {
     // user_idパラメータで対象ユーザーのサブスクリプションのみを取得
     // Twitch API側でフィルタリングされるため、全件取得より効率的
     const userSubscriptions = await getSubscriptionsByUserId(appAccessToken, session.twitchUserId);
+    const refreshUserSubscriptions = () => getSubscriptionsByUserId(appAccessToken, session.twitchUserId);
 
     // 既存サブスクリプション数と状態をログに記録
     // channel_points_custom_reward_redemption.addタイプのサブスクリプションをフィルタリング
@@ -363,7 +428,13 @@ export async function POST(request: NextRequest) {
         );
 
         if (existingSub) {
-          const raidSubscription = await ensureRaidSubscription(appAccessToken, recheckUserSubs, session.twitchUserId, callbackUrl);
+          const raidSubscription = await ensureRaidSubscription(
+            appAccessToken,
+            recheckUserSubs,
+            session.twitchUserId,
+            callbackUrl,
+            refreshUserSubscriptions,
+          );
 
           // 既存のサブスクリプションが見つかった場合、それを返す（200 OK）
           logger.info(
@@ -416,7 +487,13 @@ export async function POST(request: NextRequest) {
 
           if (retryResponse.ok) {
             const retryData = await retryResponse.json();
-            const raidSubscription = await ensureRaidSubscription(appAccessToken, recheckUserSubs, session.twitchUserId, callbackUrl);
+            const raidSubscription = await ensureRaidSubscription(
+              appAccessToken,
+              recheckUserSubs,
+              session.twitchUserId,
+              callbackUrl,
+              refreshUserSubscriptions,
+            );
             logger.info(`Retry successful: subscriptionId=${retryData.data[0]?.id}`);
             return NextResponse.json({
               success: true,
@@ -448,7 +525,13 @@ export async function POST(request: NextRequest) {
     }
 
     const subscriptionData = await subscribeResponse.json();
-    const raidSubscription = await ensureRaidSubscription(appAccessToken, userSubscriptions, session.twitchUserId, callbackUrl);
+    const raidSubscription = await ensureRaidSubscription(
+      appAccessToken,
+      userSubscriptions,
+      session.twitchUserId,
+      callbackUrl,
+      refreshUserSubscriptions,
+    );
 
     // EventSub登録成功をログに記録
     logger.info(

--- a/src/app/api/twitch/eventsub/subscribe/route.ts
+++ b/src/app/api/twitch/eventsub/subscribe/route.ts
@@ -44,6 +44,14 @@ interface EventSubSubscription {
   created_at: string;
 }
 
+interface RaidSubscriptionResult {
+  subscription?: EventSubSubscription;
+  created?: unknown;
+  warning?: string;
+  deleteWarning?: string;
+  createWarning?: string;
+}
+
 const RECREATABLE_EVENTSUB_STATUSES = new Set([
   "webhook_callback_verification_failed",
   "notification_failures_exceeded",
@@ -88,7 +96,7 @@ async function ensureRaidSubscription(
   userSubscriptions: EventSubSubscription[],
   broadcasterUserId: string,
   callbackUrl: string,
-): Promise<{ subscription?: EventSubSubscription; created?: unknown; warning?: string }> {
+): Promise<RaidSubscriptionResult> {
   const existingSubs = userSubscriptions.filter(
     (sub) => sub.type === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_RAID
       && sub.condition.to_broadcaster_user_id === broadcasterUserId
@@ -100,6 +108,7 @@ async function ensureRaidSubscription(
   const recreatableSubs = existingSubs.filter(
     (sub) => RECREATABLE_EVENTSUB_STATUSES.has(sub.status),
   );
+  const deleteWarnings: string[] = [];
 
   for (const sub of recreatableSubs) {
     logger.info(`Deleting failed raid EventSub before recreation: id=${sub.id}, status=${sub.status}`);
@@ -112,11 +121,17 @@ async function ensureRaidSubscription(
         status: deleteResponse.status,
         error,
       });
+      deleteWarnings.push(`failed raid EventSub の削除に失敗しました: id=${sub.id}, status=${deleteResponse.status}`);
     }
   }
 
+  const deleteWarning = deleteWarnings.length > 0 ? deleteWarnings.join("; ") : undefined;
+
   if (reusableSub) {
-    return { subscription: reusableSub };
+    return {
+      subscription: reusableSub,
+      ...(deleteWarning ? { warning: deleteWarning, deleteWarning } : {}),
+    };
   }
 
   if (recreatableSubs.length > 0) {
@@ -138,7 +153,10 @@ async function ensureRaidSubscription(
 
   if (response.ok) {
     const data = await response.json();
-    return { created: data.data?.[0] };
+    return {
+      created: data.data?.[0],
+      ...(deleteWarning ? { warning: deleteWarning, deleteWarning } : {}),
+    };
   }
 
   const error = await response.json().catch(() => ({}));
@@ -147,7 +165,12 @@ async function ensureRaidSubscription(
     status: response.status,
     error,
   });
-  return { warning: `raid subscription failed: ${response.status}` };
+  const createWarning = `raid EventSub の作成に失敗しました: status=${response.status}`;
+  return {
+    warning: [deleteWarning, createWarning].filter(Boolean).join("; "),
+    ...(deleteWarning ? { deleteWarning } : {}),
+    createWarning,
+  };
 }
 
 async function getSubscriptionsByUserId(

--- a/src/app/api/twitch/eventsub/subscribe/route.ts
+++ b/src/app/api/twitch/eventsub/subscribe/route.ts
@@ -44,6 +44,25 @@ interface EventSubSubscription {
   created_at: string;
 }
 
+const RECREATABLE_EVENTSUB_STATUSES = new Set([
+  "webhook_callback_verification_failed",
+  "notification_failures_exceeded",
+  "authorization_revoked",
+]);
+
+async function deleteEventSubSubscription(appAccessToken: string, subscriptionId: string) {
+  return fetch(
+    `${TWITCH_API_URL}/eventsub/subscriptions?id=${subscriptionId}`,
+    {
+      method: "DELETE",
+      headers: {
+        "Authorization": `Bearer ${appAccessToken}`,
+        "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
+      },
+    },
+  );
+}
+
 async function createEventSubSubscription(
   appAccessToken: string,
   body: {
@@ -70,14 +89,38 @@ async function ensureRaidSubscription(
   broadcasterUserId: string,
   callbackUrl: string,
 ): Promise<{ subscription?: EventSubSubscription; created?: unknown; warning?: string }> {
-  const existingSub = userSubscriptions.find(
+  const existingSubs = userSubscriptions.filter(
     (sub) => sub.type === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_RAID
       && sub.condition.to_broadcaster_user_id === broadcasterUserId
       && sub.transport.callback === callbackUrl,
   );
+  const reusableSub = existingSubs.find(
+    (sub) => !RECREATABLE_EVENTSUB_STATUSES.has(sub.status),
+  );
+  const recreatableSubs = existingSubs.filter(
+    (sub) => RECREATABLE_EVENTSUB_STATUSES.has(sub.status),
+  );
 
-  if (existingSub) {
-    return { subscription: existingSub };
+  for (const sub of recreatableSubs) {
+    logger.info(`Deleting failed raid EventSub before recreation: id=${sub.id}, status=${sub.status}`);
+    const deleteResponse = await deleteEventSubSubscription(appAccessToken, sub.id);
+    if (!deleteResponse.ok && deleteResponse.status !== 404) {
+      const error = await deleteResponse.json().catch(() => ({}));
+      logger.warn("Failed to delete failed raid EventSub subscription before recreation", {
+        broadcasterUserId,
+        subscriptionId: sub.id,
+        status: deleteResponse.status,
+        error,
+      });
+    }
+  }
+
+  if (reusableSub) {
+    return { subscription: reusableSub };
+  }
+
+  if (recreatableSubs.length > 0) {
+    await new Promise(resolve => setTimeout(resolve, 500));
   }
 
   const response = await createEventSubSubscription(appAccessToken, {
@@ -229,16 +272,7 @@ export async function POST(request: NextRequest) {
     // 対象報酬のサブスクリプションのみ削除
     for (const sub of subscriptionsToDelete) {
       logger.info(`Deleting existing EventSub for target reward: id=${sub.id}, status=${sub.status}, rewardId=${sub.condition.reward_id}, callback=${sub.transport.callback}`);
-      const deleteResponse = await fetch(
-        `${TWITCH_API_URL}/eventsub/subscriptions?id=${sub.id}`,
-        {
-          method: "DELETE",
-          headers: {
-            "Authorization": `Bearer ${appAccessToken}`,
-            "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-          },
-        }
-      );
+      const deleteResponse = await deleteEventSubSubscription(appAccessToken, sub.id);
 
       // 削除結果を確認（204は成功、404は既に削除済み）
       if (!deleteResponse.ok && deleteResponse.status !== 404) {
@@ -335,16 +369,7 @@ export async function POST(request: NextRequest) {
           logger.info(`Found ${allMySubs.length} subscriptions for other rewards, attempting cleanup`);
 
           for (const sub of allMySubs) {
-            const delResponse = await fetch(
-              `${TWITCH_API_URL}/eventsub/subscriptions?id=${sub.id}`,
-              {
-                method: "DELETE",
-                headers: {
-                  "Authorization": `Bearer ${appAccessToken}`,
-                  "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-                },
-              }
-            );
+            const delResponse = await deleteEventSubSubscription(appAccessToken, sub.id);
             logger.info(`Cleanup delete: id=${sub.id}, status=${delResponse.status}`);
           }
 
@@ -507,16 +532,7 @@ export async function DELETE(request: NextRequest) {
     // Delete each subscription
     const results = [];
     for (const sub of mySubscriptions) {
-      const deleteResponse = await fetch(
-        `${TWITCH_API_URL}/eventsub/subscriptions?id=${sub.id}`,
-        {
-          method: "DELETE",
-          headers: {
-            "Authorization": `Bearer ${appAccessToken}`,
-            "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-          },
-        }
-      );
+      const deleteResponse = await deleteEventSubSubscription(appAccessToken, sub.id);
 
       // 204: 成功、404: 既に削除済み（どちらも成功扱い）
       // 204: Success, 404: Already deleted (both count as success)

--- a/src/app/api/twitch/eventsub/subscribe/route.ts
+++ b/src/app/api/twitch/eventsub/subscribe/route.ts
@@ -425,7 +425,7 @@ export async function POST(request: NextRequest) {
  *
  * Query parameters:
  * - ?rewardId=xxx: Delete subscription for specific reward ID only
- * - (no params): Delete all channel point subscriptions for the broadcaster
+ * - (no params): Delete all channel point subscriptions and same-callback raid subscriptions for the broadcaster
  */
 export async function DELETE(request: NextRequest) {
   // 状態変更 API（EventSub 解除）のため CSRF 検証を最初に行う。
@@ -469,6 +469,7 @@ export async function DELETE(request: NextRequest) {
     const appAccessToken = await getAppAccessToken();
     const url = new URL(request.url);
     const specificRewardId = url.searchParams.get("rewardId");
+    const callbackUrl = `${process.env.NEXT_PUBLIC_APP_URL}/api/twitch/eventsub`;
 
     // 対象ユーザーのサブスクリプションを取得
     // Get subscriptions for this user using user_id filter
@@ -493,11 +494,12 @@ export async function DELETE(request: NextRequest) {
       mySubscriptions = userSubscriptions.filter(
         (sub) => sub.type === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_POINTS_REDEMPTION_ADD
           || (sub.type === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_RAID
-            && sub.condition.to_broadcaster_user_id === session.twitchUserId)
+            && sub.condition.to_broadcaster_user_id === session.twitchUserId
+            && sub.transport.callback === callbackUrl)
       );
       logger.info(
         `Deleting all EventSub subscriptions for broadcaster=${session.twitchUserId}: found ${mySubscriptions.length} subscriptions`,
-        { subscriptions: mySubscriptions.map((s) => ({ id: s.id, status: s.status, rewardId: s.condition.reward_id })) }
+        { subscriptions: mySubscriptions.map((s) => ({ id: s.id, status: s.status, type: s.type, rewardId: s.condition.reward_id, callback: s.transport.callback })) }
       );
     }
 
@@ -521,6 +523,7 @@ export async function DELETE(request: NextRequest) {
       const success = deleteResponse.status === 204 || deleteResponse.status === 404;
       results.push({
         id: sub.id,
+        type: sub.type,
         rewardId: sub.condition.reward_id,
         success,
         status: deleteResponse.status,

--- a/src/app/api/twitch/eventsub/subscribe/route.ts
+++ b/src/app/api/twitch/eventsub/subscribe/route.ts
@@ -3,7 +3,7 @@ import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { getSupabaseAdmin } from "@/lib/supabase/admin";
 import { handleApiError } from "@/lib/error-handler";
 import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
-import { ERROR_MESSAGES } from "@/lib/constants";
+import { ERROR_MESSAGES, TWITCH_SUBSCRIPTION_TYPE } from "@/lib/constants";
 import { logger } from "@/lib/logger";
 import { validateCSRFToken } from "@/lib/csrf";
 
@@ -39,9 +39,72 @@ interface EventSubSubscription {
   id: string;
   status: string;
   type: string;
-  condition: { broadcaster_user_id: string; reward_id?: string };
+  condition: { broadcaster_user_id?: string; reward_id?: string; to_broadcaster_user_id?: string };
   transport: { method: string; callback: string };
   created_at: string;
+}
+
+async function createEventSubSubscription(
+  appAccessToken: string,
+  body: {
+    type: string;
+    version: string;
+    condition: Record<string, string>;
+    transport: { method: "webhook"; callback: string; secret: string | undefined };
+  },
+) {
+  return fetch(`${TWITCH_API_URL}/eventsub/subscriptions`, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${appAccessToken}`,
+      "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function ensureRaidSubscription(
+  appAccessToken: string,
+  userSubscriptions: EventSubSubscription[],
+  broadcasterUserId: string,
+  callbackUrl: string,
+): Promise<{ subscription?: EventSubSubscription; created?: unknown; warning?: string }> {
+  const existingSub = userSubscriptions.find(
+    (sub) => sub.type === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_RAID
+      && sub.condition.to_broadcaster_user_id === broadcasterUserId
+      && sub.transport.callback === callbackUrl,
+  );
+
+  if (existingSub) {
+    return { subscription: existingSub };
+  }
+
+  const response = await createEventSubSubscription(appAccessToken, {
+    type: TWITCH_SUBSCRIPTION_TYPE.CHANNEL_RAID,
+    version: "1",
+    condition: {
+      to_broadcaster_user_id: broadcasterUserId,
+    },
+    transport: {
+      method: "webhook",
+      callback: callbackUrl,
+      secret: process.env.TWITCH_EVENTSUB_SECRET,
+    },
+  });
+
+  if (response.ok) {
+    const data = await response.json();
+    return { created: data.data?.[0] };
+  }
+
+  const error = await response.json().catch(() => ({}));
+  logger.warn("Failed to create raid EventSub subscription", {
+    broadcasterUserId,
+    status: response.status,
+    error,
+  });
+  return { warning: `raid subscription failed: ${response.status}` };
 }
 
 async function getSubscriptionsByUserId(
@@ -147,7 +210,7 @@ export async function POST(request: NextRequest) {
     // 既存サブスクリプション数と状態をログに記録
     // channel_points_custom_reward_redemption.addタイプのサブスクリプションをフィルタリング
     const mySubscriptions = userSubscriptions.filter(
-      (sub) => sub.type === "channel.channel_points_custom_reward_redemption.add"
+      (sub) => sub.type === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_POINTS_REDEMPTION_ADD
     );
     logger.info(
       `Existing EventSub subscriptions for broadcaster=${session.twitchUserId}: count=${mySubscriptions.length} (total for user: ${userSubscriptions.length})`,
@@ -196,30 +259,19 @@ export async function POST(request: NextRequest) {
     }
 
     // Create new subscription
-    const subscribeResponse = await fetch(
-      `${TWITCH_API_URL}/eventsub/subscriptions`,
-      {
-        method: "POST",
-        headers: {
-          "Authorization": `Bearer ${appAccessToken}`,
-          "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          type: "channel.channel_points_custom_reward_redemption.add",
-          version: "1",
-          condition: {
-            broadcaster_user_id: session.twitchUserId,
-            reward_id: rewardId,
-          },
-          transport: {
-            method: "webhook",
-            callback: callbackUrl,
-            secret: process.env.TWITCH_EVENTSUB_SECRET,
-          },
-        }),
-      }
-    );
+    const subscribeResponse = await createEventSubSubscription(appAccessToken, {
+      type: TWITCH_SUBSCRIPTION_TYPE.CHANNEL_POINTS_REDEMPTION_ADD,
+      version: "1",
+      condition: {
+        broadcaster_user_id: session.twitchUserId,
+        reward_id: rewardId,
+      },
+      transport: {
+        method: "webhook",
+        callback: callbackUrl,
+        secret: process.env.TWITCH_EVENTSUB_SECRET,
+      },
+    });
 
     if (!subscribeResponse.ok) {
       const error = await subscribeResponse.json();
@@ -237,7 +289,7 @@ export async function POST(request: NextRequest) {
 
         // channel_points_custom_reward_redemption.addタイプのサブスクリプションをフィルタリング（デバッグ用）
         const allMySubs = recheckUserSubs.filter(
-          (sub) => sub.type === "channel.channel_points_custom_reward_redemption.add"
+          (sub) => sub.type === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_POINTS_REDEMPTION_ADD
         );
         logger.info(
           `All EventSub subscriptions after 409: count=${allMySubs.length} (total for user: ${recheckUserSubs.length})`,
@@ -254,10 +306,12 @@ export async function POST(request: NextRequest) {
         );
 
         if (existingSub) {
+          const raidSubscription = await ensureRaidSubscription(appAccessToken, recheckUserSubs, session.twitchUserId, callbackUrl);
+
           // 既存のサブスクリプションが見つかった場合、それを返す（200 OK）
           logger.info(
             `Found existing EventSub subscription: id=${existingSub.id}, status=${existingSub.status}`,
-            { existingSub }
+            { existingSub, raidSubscription }
           );
 
           // callback URLが異なる場合は警告
@@ -270,6 +324,7 @@ export async function POST(request: NextRequest) {
           return NextResponse.json({
             success: true,
             subscription: existingSub,
+            raidSubscription,
             message: "既存のサブスクリプションを使用しています",
           });
         }
@@ -297,37 +352,28 @@ export async function POST(request: NextRequest) {
           await new Promise(resolve => setTimeout(resolve, 1000));
 
           // 再試行
-          const retryResponse = await fetch(
-            `${TWITCH_API_URL}/eventsub/subscriptions`,
-            {
-              method: "POST",
-              headers: {
-                "Authorization": `Bearer ${appAccessToken}`,
-                "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({
-                type: "channel.channel_points_custom_reward_redemption.add",
-                version: "1",
-                condition: {
-                  broadcaster_user_id: session.twitchUserId,
-                  reward_id: rewardId,
-                },
-                transport: {
-                  method: "webhook",
-                  callback: callbackUrl,
-                  secret: process.env.TWITCH_EVENTSUB_SECRET,
-                },
-              }),
-            }
-          );
+          const retryResponse = await createEventSubSubscription(appAccessToken, {
+            type: TWITCH_SUBSCRIPTION_TYPE.CHANNEL_POINTS_REDEMPTION_ADD,
+            version: "1",
+            condition: {
+              broadcaster_user_id: session.twitchUserId,
+              reward_id: rewardId,
+            },
+            transport: {
+              method: "webhook",
+              callback: callbackUrl,
+              secret: process.env.TWITCH_EVENTSUB_SECRET,
+            },
+          });
 
           if (retryResponse.ok) {
             const retryData = await retryResponse.json();
+            const raidSubscription = await ensureRaidSubscription(appAccessToken, recheckUserSubs, session.twitchUserId, callbackUrl);
             logger.info(`Retry successful: subscriptionId=${retryData.data[0]?.id}`);
             return NextResponse.json({
               success: true,
               subscription: retryData.data[0],
+              raidSubscription,
               message: "クリーンアップ後に登録しました",
             });
           } else {
@@ -354,16 +400,18 @@ export async function POST(request: NextRequest) {
     }
 
     const subscriptionData = await subscribeResponse.json();
+    const raidSubscription = await ensureRaidSubscription(appAccessToken, userSubscriptions, session.twitchUserId, callbackUrl);
 
     // EventSub登録成功をログに記録
     logger.info(
       `EventSub subscription created: broadcaster=${session.twitchUserId}, rewardId=${rewardId}, subscriptionId=${subscriptionData.data[0]?.id}`,
-      { status: subscriptionData.data[0]?.status }
+      { status: subscriptionData.data[0]?.status, raidSubscription }
     );
 
     return NextResponse.json({
       success: true,
       subscription: subscriptionData.data[0],
+      raidSubscription,
     });
   } catch (error) {
     return handleApiError(error, "EventSub Subscribe API");
@@ -429,7 +477,7 @@ export async function DELETE(request: NextRequest) {
     // channel_points_custom_reward_redemption.add タイプのみフィルタ
     // Filter to only channel point redemption subscriptions
     let mySubscriptions = userSubscriptions.filter(
-      (sub) => sub.type === "channel.channel_points_custom_reward_redemption.add"
+      (sub) => sub.type === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_POINTS_REDEMPTION_ADD
     );
 
     // If rewardId is specified, filter to only that reward
@@ -442,6 +490,11 @@ export async function DELETE(request: NextRequest) {
         `Deleting EventSub subscription for specific reward: broadcaster=${session.twitchUserId}, rewardId=${specificRewardId}, found ${mySubscriptions.length} subscriptions`
       );
     } else {
+      mySubscriptions = userSubscriptions.filter(
+        (sub) => sub.type === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_POINTS_REDEMPTION_ADD
+          || (sub.type === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_RAID
+            && sub.condition.to_broadcaster_user_id === session.twitchUserId)
+      );
       logger.info(
         `Deleting all EventSub subscriptions for broadcaster=${session.twitchUserId}: found ${mySubscriptions.length} subscriptions`,
         { subscriptions: mySubscriptions.map((s) => ({ id: s.id, status: s.status, rewardId: s.condition.reward_id })) }

--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -28,6 +28,7 @@ const getRarityInfo = (rarity: Rarity) =>
 
 interface GachaResult {
   card: Card;
+  cards?: Card[];
   userTwitchUsername: string;
   historyId?: string;
 }
@@ -400,7 +401,14 @@ export default function OverlayPage() {
    * Enqueue a new gacha result; start playback if idle
    */
   const enqueueResult = useCallback((data: GachaResult) => {
-    queueRef.current.push(data);
+    const cards = data.cards?.length ? data.cards : [data.card];
+    queueRef.current.push(
+      ...cards.map((card) => ({
+        ...data,
+        card,
+        cards: undefined,
+      }))
+    );
     if (!isDisplayingRef.current) {
       processQueue();
     }

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -54,6 +54,11 @@ const FAILED_EVENTSUB_STATUSES = [
 
 const matchesExpectedCallback = (sub: EventSubSubscription) => sub.debug?.callbackMatch ?? true;
 
+const getRaidSubscriptionWarning = (data: unknown): string => {
+  const raidSubscription = (data as { raidSubscription?: { warning?: unknown } })?.raidSubscription;
+  return typeof raidSubscription?.warning === "string" ? raidSubscription.warning : "";
+};
+
 export function deriveEventSubStatus(
   subs: EventSubSubscription[],
   rewardIdToCheck: string,
@@ -124,6 +129,7 @@ export default function ChannelPointSettings({
   const [error, setError] = useState("");
   const [eventSubStatus, setEventSubStatus] = useState<EventSubStatus>("none");
   const [raidEventSubStatus, setRaidEventSubStatus] = useState<EventSubStatus>("none");
+  const [raidEventSubWarning, setRaidEventSubWarning] = useState("");
   const [subscriptions, setSubscriptions] = useState<EventSubSubscription[]>([]);
   // チャネルポイント用スコープ不足でstep-up再認証が必要かどうか
   // Whether step-up reauth is needed because channel point scopes are missing
@@ -319,6 +325,7 @@ export default function ChannelPointSettings({
         logger.info("[EventSub] Status check", { ...derivedStatus, rewardIdToCheck, subsLength: subs.length });
         setEventSubStatus(derivedStatus.rewardStatus);
         setRaidEventSubStatus(derivedStatus.raidStatus);
+        setRaidEventSubWarning("");
       }
       } catch {
         logger.error("Failed to fetch EventSub status");
@@ -435,15 +442,20 @@ export default function ChannelPointSettings({
       });
 
       const eventSubData = await eventSubResponse.json();
+      const raidSubscriptionWarning = getRaidSubscriptionWarning(eventSubData);
 
       // レスポンスのsuccessフィールドで判定（ステータスコードではなく）
       if (eventSubData.success) {
-        setMessage(eventSubData.message || t("messages.saveSuccess"));
+        setMessage(raidSubscriptionWarning || eventSubData.message || t("messages.saveSuccess"));
         setEventSubStatus("pending");
         setRegistrationFailed(false);
         setSavedMainRewardId(selectedRewardId);
         // Refresh status - 保存した報酬IDを明示的に渡して正しく比較
         await fetchEventSubStatus(selectedRewardId);
+        setRaidEventSubWarning(raidSubscriptionWarning);
+        if (raidSubscriptionWarning) {
+          setRaidEventSubStatus("error");
+        }
       } else if (eventSubData.warning) {
         // 警告状態：サブスクリプションの確認が必要
         setMessage(eventSubData.message || "状態を確認してください");
@@ -451,6 +463,10 @@ export default function ChannelPointSettings({
         setRegistrationFailed(false);
         setSavedMainRewardId(selectedRewardId);
         await fetchEventSubStatus(selectedRewardId);
+        setRaidEventSubWarning(raidSubscriptionWarning);
+        if (raidSubscriptionWarning) {
+          setRaidEventSubStatus("error");
+        }
       } else if (eventSubResponse.status === 429) {
         setMessage(eventSubData.error || t("messages.rateLimit"));
       } else {
@@ -502,6 +518,7 @@ export default function ChannelPointSettings({
       });
 
       const eventSubData = await eventSubResponse.json();
+      const raidSubscriptionWarning = getRaidSubscriptionWarning(eventSubData);
 
       if (!eventSubData.success && !eventSubData.warning) {
         setMessage(eventSubData.error || t("additionalRewards.addFailed"));
@@ -533,7 +550,11 @@ export default function ChannelPointSettings({
 
       // 3. Update state
       // 状態を更新
-      setMessage(t("additionalRewards.addSuccess"));
+      setMessage(raidSubscriptionWarning || t("additionalRewards.addSuccess"));
+      setRaidEventSubWarning(raidSubscriptionWarning);
+      if (raidSubscriptionWarning) {
+        setRaidEventSubStatus("error");
+      }
       setSelectedAdditionalRewardId("");
       setAdditionalDrawCount(1);
       setAdditionalRaidLimited(false);
@@ -652,6 +673,7 @@ export default function ChannelPointSettings({
       setSavedMainRewardId("");
       setEventSubStatus("none");
       setRaidEventSubStatus("none");
+      setRaidEventSubWarning("");
       setSubscriptions([]);
       setAdditionalRewards([]);
       setMessage(t("messages2.disconnectSuccess"));
@@ -912,6 +934,11 @@ export default function ChannelPointSettings({
                      ? t("form.raidEventSubError")
                      : t("form.raidEventSubMissing")}
                </p>
+               {raidEventSubWarning && (
+                 <p className="mt-2 text-red-300">
+                   {raidEventSubWarning}
+                 </p>
+               )}
              </div>
              {subscriptions.length > 0 ? (
                <div className="space-y-2">

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -19,6 +19,8 @@ interface AdditionalReward {
   id: string;
   reward_id: string;
   reward_name: string | null;
+  draw_count: number;
+  is_raid_limited: boolean;
   created_at: string;
 }
 
@@ -78,6 +80,8 @@ export default function ChannelPointSettings({
   const [additionalRewards, setAdditionalRewards] = useState<AdditionalReward[]>([]);
   const [addingAdditional, setAddingAdditional] = useState(false);
   const [selectedAdditionalRewardId, setSelectedAdditionalRewardId] = useState("");
+  const [additionalDrawCount, setAdditionalDrawCount] = useState(1);
+  const [additionalRaidLimited, setAdditionalRaidLimited] = useState(false);
   // Track if registration failed (webhook unreachable)
   // 登録失敗を追跡（Webhookに到達できなかった場合）
   const [registrationFailed, setRegistrationFailed] = useState(false);
@@ -442,6 +446,8 @@ export default function ChannelPointSettings({
         body: JSON.stringify({
           rewardId: selectedAdditionalRewardId,
           rewardName: rewardName,
+          drawCount: additionalDrawCount,
+          isRaidLimited: additionalRaidLimited,
         }),
       });
 
@@ -457,6 +463,8 @@ export default function ChannelPointSettings({
       // 状態を更新
       setMessage(t("additionalRewards.addSuccess"));
       setSelectedAdditionalRewardId("");
+      setAdditionalDrawCount(1);
+      setAdditionalRaidLimited(false);
       await fetchAdditionalRewards();
       await fetchEventSubStatus(selectedRewardId);
 
@@ -950,6 +958,18 @@ export default function ChannelPointSettings({
                          <span className="ml-2 text-xs text-gray-400 whitespace-nowrap">
                            ({reward.reward_id.slice(0, 8)}...)
                          </span>
+                         <div className="mt-1 flex flex-wrap gap-1 text-xs">
+                           {reward.draw_count > 1 && (
+                             <span className="rounded bg-purple-500/20 px-2 py-0.5 text-purple-200">
+                               {t("additionalRewards.multiDraw", { count: reward.draw_count })}
+                             </span>
+                           )}
+                           {reward.is_raid_limited && (
+                             <span className="rounded bg-cyan-500/20 px-2 py-0.5 text-cyan-200">
+                               {t("additionalRewards.raidLimited")}
+                             </span>
+                           )}
+                         </div>
                        </div>
                        <button
                          onClick={() => handleRemoveAdditionalReward(reward.reward_id)}
@@ -964,11 +984,11 @@ export default function ChannelPointSettings({
 
                {/* Add new additional reward */}
                {/* 新しい追加報酬を追加 */}
-               <div className="flex items-center gap-2">
+               <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_110px_auto_auto] sm:items-center">
                  <select
                    value={selectedAdditionalRewardId}
                    onChange={(e) => setSelectedAdditionalRewardId(e.target.value)}
-                   className="flex-1 rounded-lg bg-gray-600 px-3 py-2 text-sm text-gray-200"
+                   className="min-w-0 rounded-lg bg-gray-600 px-3 py-2 text-sm text-gray-200"
                  >
                    <option value="">{t("additionalRewards.selectToAdd")}</option>
                    {rewards
@@ -985,6 +1005,30 @@ export default function ChannelPointSettings({
                        </option>
                      ))}
                  </select>
+                 <label className="flex items-center gap-2 rounded-lg bg-gray-600 px-3 py-2 text-sm text-gray-200">
+                   <span className="whitespace-nowrap text-xs text-gray-300">
+                     {t("additionalRewards.drawCount")}
+                   </span>
+                   <input
+                     type="number"
+                     min={1}
+                     max={10}
+                     value={additionalDrawCount}
+                     onChange={(e) => setAdditionalDrawCount(Math.min(10, Math.max(1, Number(e.target.value) || 1)))}
+                     className="w-12 rounded bg-gray-700 px-2 py-1 text-sm text-gray-100"
+                   />
+                 </label>
+                 <label className="flex items-center gap-2 rounded-lg bg-gray-600 px-3 py-2 text-sm text-gray-200">
+                   <input
+                     type="checkbox"
+                     checked={additionalRaidLimited}
+                     onChange={(e) => setAdditionalRaidLimited(e.target.checked)}
+                     className="h-4 w-4 rounded border-gray-500 bg-gray-700"
+                   />
+                   <span className="whitespace-nowrap text-xs text-gray-300">
+                     {t("additionalRewards.raidOnly")}
+                   </span>
+                 </label>
                  <button
                    onClick={handleAddAdditionalReward}
                    disabled={addingAdditional || !selectedAdditionalRewardId}

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -82,12 +82,17 @@ export default function ChannelPointSettings({
   const [selectedAdditionalRewardId, setSelectedAdditionalRewardId] = useState("");
   const [additionalDrawCount, setAdditionalDrawCount] = useState(1);
   const [additionalRaidLimited, setAdditionalRaidLimited] = useState(false);
+  const [raidGachaActiveUntil, setRaidGachaActiveUntil] = useState<string | null>(null);
+  const [updatingRaidGacha, setUpdatingRaidGacha] = useState(false);
   // Track if registration failed (webhook unreachable)
   // 登録失敗を追跡（Webhookに到達できなかった場合）
   const [registrationFailed, setRegistrationFailed] = useState(false);
   // Track the saved main reward ID (to detect changes for cleanup)
   // 保存済みのメイン報酬IDを追跡（変更検出とクリーンアップ用）
   const [savedMainRewardId, setSavedMainRewardId] = useState(currentRewardId || "");
+  const isRaidGachaActive = Boolean(
+    raidGachaActiveUntil && Date.parse(raidGachaActiveUntil) > Date.now()
+  );
 
   // チャネルポイント系スコープが付与済みか事前確認する。
   // 初回ログインではこれらのスコープを要求しないため、
@@ -200,6 +205,48 @@ export default function ChannelPointSettings({
     }
   }, []);
 
+  const fetchRaidGachaStatus = useCallback(async () => {
+    try {
+      const response = await fetch("/api/streamer/raid-gacha", {
+        credentials: "include",
+        cache: "no-store",
+      });
+      if (response.ok) {
+        const data = await response.json();
+        setRaidGachaActiveUntil(data.activeUntil ?? null);
+      }
+    } catch {
+      logger.error("Failed to fetch raid gacha status");
+    }
+  }, []);
+
+  const updateRaidGachaStatus = async (active: boolean) => {
+    setUpdatingRaidGacha(true);
+    setMessage("");
+
+    try {
+      const response = await fetch("/api/streamer/raid-gacha", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ active, activeMinutes: 30 }),
+      });
+      const data = await response.json();
+
+      if (!response.ok) {
+        setMessage(data.error || t("additionalRewards.raidStatusFailed"));
+        return;
+      }
+
+      setRaidGachaActiveUntil(data.activeUntil ?? null);
+      setMessage(active ? t("additionalRewards.raidStatusEnabled") : t("additionalRewards.raidStatusDisabled"));
+    } catch {
+      setMessage(t("additionalRewards.raidStatusFailed"));
+    } finally {
+      setUpdatingRaidGacha(false);
+    }
+  };
+
   // targetRewardIdを引数で受け取ることで、保存直後に最新のrewardIdで比較できる
   // 引数が省略された場合はselectedRewardIdを使用（初期ロード時など）
   const fetchEventSubStatus = useCallback(async (targetRewardId?: string) => {
@@ -265,6 +312,7 @@ export default function ChannelPointSettings({
     // メイン報酬が設定されている場合は追加報酬も取得
     if (currentRewardId) {
       fetchAdditionalRewards();
+      fetchRaidGachaStatus();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -979,6 +1027,41 @@ export default function ChannelPointSettings({
                        </button>
                      </div>
                    ))}
+                 </div>
+               )}
+
+               {additionalRewards.some((reward) => reward.is_raid_limited) && (
+                 <div className="mb-3 flex flex-wrap items-center justify-between gap-2 rounded bg-gray-600/50 px-3 py-2">
+                   <div>
+                     <div className="text-sm text-gray-200">
+                       {t("additionalRewards.raidStatusTitle")}
+                     </div>
+                     <div className="text-xs text-gray-400">
+                       {isRaidGachaActive
+                         ? t("additionalRewards.raidStatusActive", {
+                             time: new Date(raidGachaActiveUntil as string).toLocaleTimeString(),
+                           })
+                         : t("additionalRewards.raidStatusInactive")}
+                     </div>
+                   </div>
+                   <div className="flex gap-2">
+                     <button
+                       type="button"
+                       onClick={() => updateRaidGachaStatus(true)}
+                       disabled={updatingRaidGacha}
+                       className="rounded-lg bg-cyan-600 px-3 py-2 text-xs text-white hover:bg-cyan-700 disabled:opacity-50"
+                     >
+                       {t("additionalRewards.raidStatusEnable")}
+                     </button>
+                     <button
+                       type="button"
+                       onClick={() => updateRaidGachaStatus(false)}
+                       disabled={updatingRaidGacha || !isRaidGachaActive}
+                       className="rounded-lg bg-gray-700 px-3 py-2 text-xs text-gray-200 hover:bg-gray-800 disabled:opacity-50"
+                     >
+                       {t("additionalRewards.raidStatusDisable")}
+                     </button>
+                   </div>
                  </div>
                )}
 

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -29,8 +29,9 @@ interface EventSubSubscription {
   status: string;
   type: string;
   condition: {
-    broadcaster_user_id: string;
+    broadcaster_user_id?: string;
     reward_id?: string;
+    to_broadcaster_user_id?: string;
   };
   transport?: {
     callback?: string;
@@ -38,6 +39,56 @@ interface EventSubSubscription {
   debug?: {
     expectedCallbackUrl: string;
     callbackMatch: boolean;
+  };
+}
+
+type EventSubStatus = "none" | "pending" | "active" | "error";
+
+const CHANNEL_POINTS_EVENTSUB_TYPE = "channel.channel_points_custom_reward_redemption.add";
+const RAID_EVENTSUB_TYPE = "channel.raid";
+const FAILED_EVENTSUB_STATUSES = [
+  "webhook_callback_verification_failed",
+  "notification_failures_exceeded",
+  "authorization_revoked",
+];
+
+export function deriveEventSubStatus(
+  subs: EventSubSubscription[],
+  rewardIdToCheck: string,
+): { rewardStatus: EventSubStatus; raidStatus: EventSubStatus } {
+  const rewardSubscriptions = subs.filter(
+    (sub) => sub.type === CHANNEL_POINTS_EVENTSUB_TYPE
+  );
+  const raidSubscriptions = subs.filter(
+    (sub) => sub.type === RAID_EVENTSUB_TYPE
+  );
+
+  const hasActiveRewardSub = rewardSubscriptions.some(
+    (sub) => sub.status === "enabled" && sub.condition.reward_id === rewardIdToCheck
+  );
+  const hasFailedRewardSub = rewardSubscriptions.some(
+    (sub) => FAILED_EVENTSUB_STATUSES.includes(sub.status)
+  );
+  const hasActiveRaidSub = raidSubscriptions.some((sub) => sub.status === "enabled");
+  const hasFailedRaidSub = raidSubscriptions.some(
+    (sub) => FAILED_EVENTSUB_STATUSES.includes(sub.status)
+  );
+
+  return {
+    rewardStatus: hasActiveRewardSub
+      ? "active"
+      : hasFailedRewardSub
+        ? "error"
+        : rewardSubscriptions.length > 0
+          ? "pending"
+          : "none",
+    raidStatus: hasActiveRaidSub
+      ? "active"
+      : hasFailedRaidSub
+        ? "error"
+        : raidSubscriptions.length > 0
+          ? "pending"
+          : "none",
   };
 }
 
@@ -69,7 +120,8 @@ export default function ChannelPointSettings({
   const [disconnecting, setDisconnecting] = useState(false);
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
-  const [eventSubStatus, setEventSubStatus] = useState<"none" | "pending" | "active" | "error">("none");
+  const [eventSubStatus, setEventSubStatus] = useState<EventSubStatus>("none");
+  const [raidEventSubStatus, setRaidEventSubStatus] = useState<EventSubStatus>("none");
   const [subscriptions, setSubscriptions] = useState<EventSubSubscription[]>([]);
   // チャネルポイント用スコープ不足でstep-up再認証が必要かどうか
   // Whether step-up reauth is needed because channel point scopes are missing
@@ -261,40 +313,10 @@ export default function ChannelPointSettings({
         logger.info("[EventSub] API response", { subsCount: subs.length, subs: subs.map((s: EventSubSubscription) => ({ id: s.id, status: s.status, reward_id: s.condition.reward_id })) });
         setSubscriptions(subs);
 
-        // Check if we have an active subscription for the target reward
-        // 引数で渡されたrewardIdを使うことで、保存直後でも正しく判定できる
-        const activeSub = subs.find(
-          (sub: EventSubSubscription) =>
-            sub.status === "enabled" &&
-            sub.condition.reward_id === rewardIdToCheck
-        );
-
-        // Check for failed subscriptions
-        // 失敗したサブスクリプションをチェック
-        const failedStatuses = [
-          "webhook_callback_verification_failed",
-          "notification_failures_exceeded",
-          "authorization_revoked",
-        ];
-        const hasFailedSub = subs.some(
-          (sub: EventSubSubscription) => failedStatuses.includes(sub.status)
-        );
-
-        logger.info("[EventSub] Status check", { activeSub: !!activeSub, hasFailedSub, rewardIdToCheck, subsLength: subs.length });
-
-        if (activeSub) {
-          logger.info("[EventSub] Setting status to ACTIVE");
-          setEventSubStatus("active");
-        } else if (hasFailedSub) {
-          logger.info("[EventSub] Setting status to ERROR (failed subscription found)");
-          setEventSubStatus("error");
-        } else if (subs.length > 0) {
-          logger.info("[EventSub] Setting status to PENDING");
-          setEventSubStatus("pending");
-        } else {
-          logger.info("[EventSub] Setting status to NONE");
-          setEventSubStatus("none");
-        }
+        const derivedStatus = deriveEventSubStatus(subs, rewardIdToCheck);
+        logger.info("[EventSub] Status check", { ...derivedStatus, rewardIdToCheck, subsLength: subs.length });
+        setEventSubStatus(derivedStatus.rewardStatus);
+        setRaidEventSubStatus(derivedStatus.raidStatus);
       }
       } catch {
         logger.error("Failed to fetch EventSub status");
@@ -745,6 +767,39 @@ export default function ChannelPointSettings({
     }
   };
 
+  const getStatusText = (status: EventSubStatus) => t(`status.${status}`);
+  const getStatusColor = (status: EventSubStatus) => {
+    switch (status) {
+      case "active":
+        return "text-green-400";
+      case "error":
+        return "text-red-400";
+      case "pending":
+        return "text-yellow-400";
+      default:
+        return "text-gray-400";
+    }
+  };
+
+  const getSubscriptionLabel = (sub: EventSubSubscription) => {
+    if (sub.type === RAID_EVENTSUB_TYPE) {
+      return t("form.raidEventSubStatus");
+    }
+
+    if (!sub.condition.reward_id) {
+      return t("form.allRewards");
+    }
+
+    return (
+      <>
+        {getRewardNameById(sub.condition.reward_id) || `${t("form.rewardId")} ${sub.condition.reward_id.slice(0, 8)}...`}
+        <span className="ml-1 text-gray-500">
+          ({sub.condition.reward_id.slice(0, 8)}...)
+        </span>
+      </>
+    );
+  };
+
   return (
     <div className="rounded-xl bg-gray-800 p-6">
       <div className="mb-4 flex items-center justify-between">
@@ -840,22 +895,28 @@ export default function ChannelPointSettings({
            {/* EventSub Info */}
            <div className="rounded-lg bg-gray-700/50 p-4">
              <h3 className="mb-2 text-sm font-medium text-gray-300">{t("form.eventsubStatus")}</h3>
+             <div className="mb-3 rounded bg-gray-800/60 p-3 text-xs">
+               <div className="flex items-center justify-between gap-3">
+                 <span className="text-gray-300">{t("form.raidEventSubStatus")}</span>
+                 <span className={getStatusColor(raidEventSubStatus)}>
+                   {getStatusText(raidEventSubStatus)}
+                 </span>
+               </div>
+               <p className="mt-1 text-gray-500">
+                 {raidEventSubStatus === "active"
+                   ? t("form.raidEventSubActive")
+                   : raidEventSubStatus === "error"
+                     ? t("form.raidEventSubError")
+                     : t("form.raidEventSubMissing")}
+               </p>
+             </div>
              {subscriptions.length > 0 ? (
                <div className="space-y-2">
                  {subscriptions.map((sub) => (
                    <div key={sub.id}>
                      <div className="flex items-center justify-between text-xs">
                        <span className="text-gray-400">
-                         {sub.condition.reward_id ? (
-                           <>
-                             {/* Display reward name if available, otherwise show truncated ID */}
-                             {/* 報酬名があれば表示、なければ短縮IDを表示 */}
-                             {getRewardNameById(sub.condition.reward_id) || `${t("form.rewardId")} ${sub.condition.reward_id.slice(0, 8)}...`}
-                             <span className="ml-1 text-gray-500">
-                               ({sub.condition.reward_id.slice(0, 8)}...)
-                             </span>
-                           </>
-                         ) : t("form.allRewards")}
+                         {getSubscriptionLabel(sub)}
                        </span>
                        <span className={
                          sub.status === "enabled"

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -52,15 +52,17 @@ const FAILED_EVENTSUB_STATUSES = [
   "authorization_revoked",
 ];
 
+const matchesExpectedCallback = (sub: EventSubSubscription) => sub.debug?.callbackMatch ?? true;
+
 export function deriveEventSubStatus(
   subs: EventSubSubscription[],
   rewardIdToCheck: string,
 ): { rewardStatus: EventSubStatus; raidStatus: EventSubStatus } {
   const rewardSubscriptions = subs.filter(
-    (sub) => sub.type === CHANNEL_POINTS_EVENTSUB_TYPE
+    (sub) => sub.type === CHANNEL_POINTS_EVENTSUB_TYPE && matchesExpectedCallback(sub)
   );
   const raidSubscriptions = subs.filter(
-    (sub) => sub.type === RAID_EVENTSUB_TYPE
+    (sub) => sub.type === RAID_EVENTSUB_TYPE && matchesExpectedCallback(sub)
   );
 
   const hasActiveRewardSub = rewardSubscriptions.some(
@@ -649,6 +651,7 @@ export default function ChannelPointSettings({
       setSelectedRewardName("");
       setSavedMainRewardId("");
       setEventSubStatus("none");
+      setRaidEventSubStatus("none");
       setSubscriptions([]);
       setAdditionalRewards([]);
       setMessage(t("messages2.disconnectSuccess"));

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -59,6 +59,13 @@ const getRaidSubscriptionWarning = (data: unknown): string => {
   return typeof raidSubscription?.warning === "string" ? raidSubscription.warning : "";
 };
 
+const getRaidSubscriptionStatus = (data: unknown): EventSubStatus | null => {
+  const status = (data as { raidSubscription?: { status?: unknown } })?.raidSubscription?.status;
+  return status === "none" || status === "pending" || status === "active" || status === "error"
+    ? status
+    : null;
+};
+
 export function deriveEventSubStatus(
   subs: EventSubSubscription[],
   rewardIdToCheck: string,
@@ -443,6 +450,7 @@ export default function ChannelPointSettings({
 
       const eventSubData = await eventSubResponse.json();
       const raidSubscriptionWarning = getRaidSubscriptionWarning(eventSubData);
+      const raidSubscriptionStatus = getRaidSubscriptionStatus(eventSubData);
 
       // レスポンスのsuccessフィールドで判定（ステータスコードではなく）
       if (eventSubData.success) {
@@ -453,7 +461,9 @@ export default function ChannelPointSettings({
         // Refresh status - 保存した報酬IDを明示的に渡して正しく比較
         await fetchEventSubStatus(selectedRewardId);
         setRaidEventSubWarning(raidSubscriptionWarning);
-        if (raidSubscriptionWarning) {
+        if (raidSubscriptionStatus) {
+          setRaidEventSubStatus(raidSubscriptionWarning ? "error" : raidSubscriptionStatus);
+        } else if (raidSubscriptionWarning) {
           setRaidEventSubStatus("error");
         }
       } else if (eventSubData.warning) {
@@ -464,7 +474,9 @@ export default function ChannelPointSettings({
         setSavedMainRewardId(selectedRewardId);
         await fetchEventSubStatus(selectedRewardId);
         setRaidEventSubWarning(raidSubscriptionWarning);
-        if (raidSubscriptionWarning) {
+        if (raidSubscriptionStatus) {
+          setRaidEventSubStatus(raidSubscriptionWarning ? "error" : raidSubscriptionStatus);
+        } else if (raidSubscriptionWarning) {
           setRaidEventSubStatus("error");
         }
       } else if (eventSubResponse.status === 429) {
@@ -519,6 +531,7 @@ export default function ChannelPointSettings({
 
       const eventSubData = await eventSubResponse.json();
       const raidSubscriptionWarning = getRaidSubscriptionWarning(eventSubData);
+      const raidSubscriptionStatus = getRaidSubscriptionStatus(eventSubData);
 
       if (!eventSubData.success && !eventSubData.warning) {
         setMessage(eventSubData.error || t("additionalRewards.addFailed"));
@@ -551,15 +564,17 @@ export default function ChannelPointSettings({
       // 3. Update state
       // 状態を更新
       setMessage(raidSubscriptionWarning || t("additionalRewards.addSuccess"));
-      setRaidEventSubWarning(raidSubscriptionWarning);
-      if (raidSubscriptionWarning) {
-        setRaidEventSubStatus("error");
-      }
       setSelectedAdditionalRewardId("");
       setAdditionalDrawCount(1);
       setAdditionalRaidLimited(false);
       await fetchAdditionalRewards();
       await fetchEventSubStatus(selectedRewardId);
+      setRaidEventSubWarning(raidSubscriptionWarning);
+      if (raidSubscriptionStatus) {
+        setRaidEventSubStatus(raidSubscriptionWarning ? "error" : raidSubscriptionStatus);
+      } else if (raidSubscriptionWarning) {
+        setRaidEventSubStatus("error");
+      }
 
     } catch {
       setMessage(t("messages.errorOccurred"));

--- a/src/components/ChatAnnouncementSettings.tsx
+++ b/src/components/ChatAnnouncementSettings.tsx
@@ -25,6 +25,7 @@ const DEFAULT_CHAT_TEMPLATE = "@{user} が【{rarity}】{card} を獲得しま�
 const MAX_TEMPLATE_PLACEHOLDER_LENGTHS = {
   user: 25,
   card: 100,
+  cards: 300,
   rarity: 12,
   num: 10,
   // コンプ進捗のユニーク/全種類数は現実的に4桁で十分
@@ -39,6 +40,8 @@ function buildChatPreviewMessage(
   placeholders: {
     user: string;
     card: string;
+    cards: string;
+    draws: string;
     rarity: string;
     num: string;
     unique: string;
@@ -50,6 +53,8 @@ function buildChatPreviewMessage(
   return template
     .replace(/\{user\}/g, placeholders.user)
     .replace(/\{card\}/g, placeholders.card)
+    .replace(/\{cards\}/g, placeholders.cards)
+    .replace(/\{draws\}/g, placeholders.draws)
     .replace(/\{rarity\}/g, placeholders.rarity)
     .replace(/\{num\}/g, placeholders.num)
     .replace(/\{unique\}/g, placeholders.unique)
@@ -100,6 +105,8 @@ export default function ChatAnnouncementSettings({
     return buildChatPreviewMessage(activeTemplate, {
       user: "SampleUser",
       card: "レジェンダリーカード",
+      cards: "レジェンダリーカード、レアカード、コモンカード",
+      draws: "3",
       rarity: "レジェンダリー",
       num: "3",
       unique: "5",
@@ -119,6 +126,8 @@ export default function ChatAnnouncementSettings({
       buildChatPreviewMessage(activeTemplate, {
         user: "U".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.user),
         card: "カ".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.card),
+        cards: "カ".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.cards),
+        draws: "10",
         rarity: "レ".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.rarity),
         num: "9".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.num),
         unique: "9".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.unique),

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -8,6 +8,7 @@ export const BROADCASTER_TYPE = {
 
 export const TWITCH_SUBSCRIPTION_TYPE = {
   CHANNEL_POINTS_REDEMPTION_ADD: 'channel.channel_points_custom_reward_redemption.add' as const,
+  CHANNEL_RAID: 'channel.raid' as const,
 }
 
 export const COOKIE_NAMES = {

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -76,6 +76,13 @@ export interface GachaBroadcastPayload {
     image_url: string | null
     rarity: string
   }
+  cards?: Array<{
+    id: string
+    name: string
+    description: string | null
+    image_url: string | null
+    rarity: string
+  }>
   userTwitchUsername: string
 }
 

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -38,6 +38,17 @@ function isRaidOptionsSchemaError(error: { message?: string; code?: string } | n
   return error?.code === 'PGRST204' || message.includes('draw_count') || message.includes('is_raid_limited')
 }
 
+function isRaidStateSchemaError(error: { message?: string; code?: string } | null | undefined) {
+  const message = error?.message ?? ''
+  return error?.code === 'PGRST204' || message.includes('raid_gacha_active_until')
+}
+
+function isRaidGachaActive(activeUntil: string | null | undefined, now = new Date()): boolean {
+  if (!activeUntil) return false
+  const activeUntilTime = Date.parse(activeUntil)
+  return Number.isFinite(activeUntilTime) && activeUntilTime > now.getTime()
+}
+
 export class GachaService {
   private supabase = getSupabaseAdmin()
 
@@ -252,11 +263,21 @@ export class GachaService {
   ): Promise<Result<GachaResult>> {
     try {
       // chat_announcement_enabled/template も同時取得してクエリ統合（CPU時間削減）
-      const { data: streamer, error: streamerError } = await this.supabase
+      let { data: streamer, error: streamerError } = await this.supabase
         .from('streamers')
-        .select('id, channel_point_reward_id, chat_announcement_enabled, chat_announcement_template')
+        .select('id, channel_point_reward_id, chat_announcement_enabled, chat_announcement_template, raid_gacha_active_until')
         .eq('twitch_user_id', event.broadcaster_user_id)
         .maybeSingle()
+
+      if (isRaidStateSchemaError(streamerError)) {
+        const fallbackResult = await this.supabase
+          .from('streamers')
+          .select('id, channel_point_reward_id, chat_announcement_enabled, chat_announcement_template')
+          .eq('twitch_user_id', event.broadcaster_user_id)
+          .maybeSingle()
+        streamer = fallbackResult.data ? { ...fallbackResult.data, raid_gacha_active_until: null } : fallbackResult.data
+        streamerError = fallbackResult.error
+      }
 
       if (streamerError || !streamer) {
         return err('Streamer not found')
@@ -324,6 +345,15 @@ export class GachaService {
       }
 
       if (additionalReward) {
+        if (additionalReward.is_raid_limited && !isRaidGachaActive(streamer.raid_gacha_active_until)) {
+          logger.info('Raid-limited gacha skipped because raid gacha is inactive', {
+            rewardId: event.reward.id,
+            streamerId: streamer.id,
+            raidGachaActiveUntil: streamer.raid_gacha_active_until,
+          })
+          return err('Raid-limited reward inactive')
+        }
+
         // Additional reward matched, execute gacha
         // 追加報酬が一致したのでガチャを実行
         const drawCount = Math.min(Math.max(Number(additionalReward.draw_count ?? 1), 1), 10)

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -27,9 +27,15 @@ export interface EventSubStreamerInfo {
 
 export interface GachaResult {
   card: GachaCard
+  cards?: GachaCard[]
   userTwitchUsername: string
   /** EventSub経由の場合のみ設定。クエリ統合のためガチャ結果と一緒に返す */
   streamer?: EventSubStreamerInfo
+}
+
+function isRaidOptionsSchemaError(error: { message?: string; code?: string } | null | undefined) {
+  const message = error?.message ?? ''
+  return error?.code === 'PGRST204' || message.includes('draw_count') || message.includes('is_raid_limited')
 }
 
 export class GachaService {
@@ -111,6 +117,57 @@ export class GachaService {
     } catch (error) {
       return err(`Unexpected error: ${error}`)
     }
+  }
+
+  private async executeGachaDraws(
+    streamerId: string,
+    userTwitchId: string,
+    userTwitchUsername: string,
+    drawCount: number,
+    eventId?: string,
+    rewardCost?: number
+  ): Promise<Result<GachaResult>> {
+    const cards: GachaCard[] = []
+    let firstResult: GachaResult | null = null
+
+    for (let index = 0; index < drawCount; index += 1) {
+      const drawEventId = eventId && index > 0 ? `${eventId}:${index + 1}` : eventId
+      const drawRewardCost = index === 0 ? rewardCost : undefined
+      const result = await this.executeGacha(
+        streamerId,
+        userTwitchId,
+        userTwitchUsername,
+        drawEventId,
+        drawRewardCost
+      )
+
+      if (!result.success) {
+        if (cards.length > 0 && result.error !== 'Duplicate event') {
+          logger.warn('Multi-draw gacha stopped after partial success', {
+            streamerId,
+            userTwitchId,
+            eventId,
+            completedDraws: cards.length,
+            requestedDraws: drawCount,
+            error: result.error,
+          })
+          break
+        }
+        return result
+      }
+
+      cards.push(result.data.card)
+      firstResult ??= result.data
+    }
+
+    if (!firstResult) {
+      return err('Failed to execute gacha draws')
+    }
+
+    return ok({
+      ...firstResult,
+      cards,
+    })
   }
 
   /**
@@ -206,8 +263,15 @@ export class GachaService {
       }
 
       // ガチャ実行用のヘルパー: 結果にストリーマー情報を付加して返す
-      const executeAndAttachStreamer = async (): Promise<Result<GachaResult>> => {
-        const result = await this.executeGacha(streamer.id, event.user_id, event.user_name, eventId, event.reward.cost)
+      const executeAndAttachStreamer = async (drawCount = 1): Promise<Result<GachaResult>> => {
+        const result = await this.executeGachaDraws(
+          streamer.id,
+          event.user_id,
+          event.user_name,
+          drawCount,
+          eventId,
+          event.reward.cost
+        )
         if (!result.success) return result
         return ok({
           ...result.data,
@@ -227,15 +291,31 @@ export class GachaService {
 
       // Check if the reward ID matches any additional reward
       // 追加報酬のいずれかと一致するかチェック
-      const { data: additionalReward, error: additionalError } = await withRetry(
+      let { data: additionalReward, error: additionalError } = await withRetry(
         () => this.supabase
           .from('streamer_additional_gacha_rewards')
-          .select('id')
+          .select('id, draw_count, is_raid_limited')
           .eq('streamer_id', streamer.id)
           .eq('reward_id', event.reward.id)
           .maybeSingle(),
         'gacha:executeGachaForEventSub:additionalReward',
       )
+
+      if (isRaidOptionsSchemaError(additionalError)) {
+        const fallbackResult = await withRetry(
+          () => this.supabase
+            .from('streamer_additional_gacha_rewards')
+            .select('id')
+            .eq('streamer_id', streamer.id)
+            .eq('reward_id', event.reward.id)
+            .maybeSingle(),
+          'gacha:executeGachaForEventSub:additionalReward:fallback',
+        )
+        additionalReward = fallbackResult.data
+          ? { ...fallbackResult.data, draw_count: 1, is_raid_limited: false }
+          : fallbackResult.data
+        additionalError = fallbackResult.error
+      }
 
       // maybeSingle()を使用しているため、行が見つからない場合はerrorではなくdata=nullが返る
       if (additionalError) {
@@ -246,8 +326,9 @@ export class GachaService {
       if (additionalReward) {
         // Additional reward matched, execute gacha
         // 追加報酬が一致したのでガチャを実行
-        logger.info(`Gacha triggered by additional reward: rewardId=${event.reward.id}, streamerId=${streamer.id}`)
-        return await executeAndAttachStreamer()
+        const drawCount = Math.min(Math.max(Number(additionalReward.draw_count ?? 1), 1), 10)
+        logger.info(`Gacha triggered by additional reward: rewardId=${event.reward.id}, streamerId=${streamer.id}, drawCount=${drawCount}, raidLimited=${Boolean(additionalReward.is_raid_limited)}`)
+        return await executeAndAttachStreamer(drawCount)
       }
 
       return err('Reward ID mismatch')

--- a/src/lib/twitch/chat-service.ts
+++ b/src/lib/twitch/chat-service.ts
@@ -32,6 +32,12 @@ export interface ChatMessagePlaceholders {
   // 獲得したカードの名前
   // Name of the card obtained
   card: string
+  // 複数枚ガチャ時の獲得カード名一覧（オプション）
+  // All obtained card names for multi-draw announcements (optional)
+  cards?: string
+  // 複数枚ガチャ時の抽選回数（オプション）
+  // Draw count for multi-draw announcements (optional)
+  draws?: number
   // カードのレアリティ（日本語または英語）
   // Card rarity (Japanese or English)
   rarity: string
@@ -321,6 +327,18 @@ export class TwitchChatService {
       message = message.replace(/\{all\}/g, String(placeholders.all))
     } else {
       message = message.replace(/\{all\}/g, '')
+    }
+
+    if (placeholders.cards) {
+      message = message.replace(/\{cards\}/g, placeholders.cards)
+    } else {
+      message = message.replace(/\{cards\}/g, '')
+    }
+
+    if (placeholders.draws !== undefined) {
+      message = message.replace(/\{draws\}/g, String(placeholders.draws))
+    } else {
+      message = message.replace(/\{draws\}/g, '')
     }
 
     // 連続する空白を1つにまとめ、前後の空白を削除

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -431,6 +431,8 @@ export interface Database {
           streamer_id: string
           reward_id: string
           reward_name: string | null
+          draw_count: number
+          is_raid_limited: boolean
           created_at: string
         }
         Insert: {
@@ -438,6 +440,8 @@ export interface Database {
           streamer_id: string
           reward_id: string
           reward_name?: string | null
+          draw_count?: number
+          is_raid_limited?: boolean
           created_at?: string
         }
         Update: {
@@ -445,6 +449,8 @@ export interface Database {
           streamer_id?: string
           reward_id?: string
           reward_name?: string | null
+          draw_count?: number
+          is_raid_limited?: boolean
           created_at?: string
         }
       }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -45,6 +45,9 @@ export interface Database {
           // 未所持カード表示時に画像/説明まで公開するか（false=プレースホルダーのみ）
           // When unowned cards are shown, whether to reveal card image/description
           show_unowned_card_details: boolean
+          // レイド限定ガチャを受け付ける期限（null/期限切れは不明状態としてブロック）
+          // Until when raid-limited gacha rewards are accepted. Null/expired blocks them.
+          raid_gacha_active_until: string | null
           created_at: string
           updated_at: string
         }
@@ -64,6 +67,7 @@ export interface Database {
           rarity_weights?: Record<string, number> | null
           show_unowned_cards?: boolean
           show_unowned_card_details?: boolean
+          raid_gacha_active_until?: string | null
           created_at?: string
           updated_at?: string
         }
@@ -83,6 +87,7 @@ export interface Database {
           rarity_weights?: Record<string, number> | null
           show_unowned_cards?: boolean
           show_unowned_card_details?: boolean
+          raid_gacha_active_until?: string | null
           created_at?: string
           updated_at?: string
         }

--- a/supabase/migrations/00041_add_raid_gacha_reward_options.sql
+++ b/supabase/migrations/00041_add_raid_gacha_reward_options.sql
@@ -1,0 +1,17 @@
+-- Add per-reward options for raid-limited and multi-draw gacha triggers.
+ALTER TABLE streamer_additional_gacha_rewards
+  ADD COLUMN IF NOT EXISTS draw_count INTEGER NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS is_raid_limited BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE streamer_additional_gacha_rewards
+  DROP CONSTRAINT IF EXISTS streamer_additional_gacha_rewards_draw_count_check;
+
+ALTER TABLE streamer_additional_gacha_rewards
+  ADD CONSTRAINT streamer_additional_gacha_rewards_draw_count_check
+  CHECK (draw_count BETWEEN 1 AND 10);
+
+COMMENT ON COLUMN streamer_additional_gacha_rewards.draw_count IS
+  'Number of cards granted by this additional channel point reward. 1 = normal gacha, 10 max.';
+
+COMMENT ON COLUMN streamer_additional_gacha_rewards.is_raid_limited IS
+  'Marks this additional reward as a raid-limited gacha trigger for streamer-facing management.';

--- a/supabase/migrations/00042_add_raid_gacha_active_until.sql
+++ b/supabase/migrations/00042_add_raid_gacha_active_until.sql
@@ -1,0 +1,6 @@
+-- Track the short-lived manual raid window used by raid-limited additional rewards.
+ALTER TABLE streamers
+  ADD COLUMN IF NOT EXISTS raid_gacha_active_until TIMESTAMPTZ;
+
+COMMENT ON COLUMN streamers.raid_gacha_active_until IS
+  'Manual raid-gacha activation window. Raid-limited additional rewards are blocked when this is null, invalid, or in the past.';

--- a/tests/unit/additional-rewards-api.test.ts
+++ b/tests/unit/additional-rewards-api.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET, POST } from '@/app/api/streamer/additional-rewards/route'
+import { getSession, canUseStreamerFeatures } from '@/lib/session'
+import { checkRateLimit } from '@/lib/rate-limit'
+import { validateCSRFToken } from '@/lib/csrf'
+import { validateContentType } from '@/lib/request-validation'
+import { createMockQueryBuilder } from '../utils/supabase-mock'
+
+vi.mock('@/lib/session')
+vi.mock('@/lib/rate-limit')
+vi.mock('@/lib/csrf')
+vi.mock('@/lib/request-validation')
+vi.mock('@/lib/supabase/admin', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/supabase/admin')>()
+  return {
+    ...actual,
+    getSupabaseAdmin: vi.fn(),
+  }
+})
+
+const mockGetSession = vi.mocked(getSession)
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)
+const mockCheckRateLimit = vi.mocked(checkRateLimit)
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken)
+const mockValidateContentType = vi.mocked(validateContentType)
+
+function createThenableQuery(data: unknown, error: unknown = null) {
+  const query = createMockQueryBuilder()
+  ;(query as unknown as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
+    resolve({ data, error })
+    return query
+  }
+  return query
+}
+
+describe('/api/streamer/additional-rewards raid options', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'streamer-twitch-1',
+      twitchUsername: 'streamer',
+      twitchDisplayName: 'Streamer',
+      twitchProfileImageUrl: null,
+      broadcasterType: 'affiliate',
+      expiresAt: Date.now() + 60_000,
+      version: 1,
+    })
+    mockCanUseStreamerFeatures.mockReturnValue(true)
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: Date.now() + 60_000,
+    })
+    mockValidateCSRFToken.mockResolvedValue({ valid: true })
+    mockValidateContentType.mockReturnValue(null)
+  })
+
+  it('persists drawCount and raid-limited options for an additional reward', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: 'streamer-1', channel_point_reward_id: 'main-reward' },
+      error: null,
+    })
+    const insertQuery = createMockQueryBuilder()
+    ;(insertQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        id: 'additional-1',
+        reward_id: 'raid-reward',
+        reward_name: 'Raid 10',
+        draw_count: 10,
+        is_raid_limited: true,
+      },
+      error: null,
+    })
+    const fromMock = vi.fn((table: string) => {
+      if (table === 'streamers') return streamerQuery
+      if (table === 'streamer_additional_gacha_rewards') return insertQuery
+      return createMockQueryBuilder()
+    })
+
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const response = await POST(new NextRequest('http://localhost/api/streamer/additional-rewards', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        rewardId: 'raid-reward',
+        rewardName: 'Raid 10',
+        drawCount: 10,
+        isRaidLimited: true,
+      }),
+    }))
+
+    expect(response.status).toBe(200)
+    expect(insertQuery.insert).toHaveBeenCalledWith(expect.objectContaining({
+      draw_count: 10,
+      is_raid_limited: true,
+    }))
+  })
+
+  it('rejects drawCount outside the supported range', async () => {
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from: vi.fn() } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const response = await POST(new NextRequest('http://localhost/api/streamer/additional-rewards', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        rewardId: 'raid-reward',
+        rewardName: 'Raid 20',
+        drawCount: 20,
+        isRaidLimited: true,
+      }),
+    }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'drawCount must be an integer between 1 and 10',
+    })
+  })
+
+  it('normalizes legacy rows when raid option columns are not in schema cache yet', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: 'streamer-1' },
+      error: null,
+    })
+    const optionQuery = createThenableQuery(null, {
+      message: "Could not find the 'draw_count' column",
+      code: 'PGRST204',
+    })
+    const fallbackQuery = createThenableQuery([
+      {
+        id: 'additional-1',
+        reward_id: 'legacy-reward',
+        reward_name: 'Legacy',
+        created_at: '2026-05-12T00:00:00Z',
+      },
+    ])
+    let additionalQueryCount = 0
+    const fromMock = vi.fn((table: string) => {
+      if (table === 'streamers') return streamerQuery
+      if (table === 'streamer_additional_gacha_rewards') {
+        additionalQueryCount += 1
+        return additionalQueryCount === 1 ? optionQuery : fallbackQuery
+      }
+      return createMockQueryBuilder()
+    })
+
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const response = await GET(new NextRequest('http://localhost/api/streamer/additional-rewards'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual([
+      expect.objectContaining({
+        reward_id: 'legacy-reward',
+        draw_count: 1,
+        is_raid_limited: false,
+      }),
+    ])
+  })
+})

--- a/tests/unit/channel-point-settings-eventsub.test.ts
+++ b/tests/unit/channel-point-settings-eventsub.test.ts
@@ -61,4 +61,24 @@ describe('deriveEventSubStatus', () => {
       raidStatus: 'pending',
     })
   })
+
+  it('ignores stale raid subscriptions for a different callback URL', () => {
+    const status = deriveEventSubStatus([
+      {
+        id: 'old-raid-sub',
+        status: 'enabled',
+        type: 'channel.raid',
+        condition: { to_broadcaster_user_id: 'streamer-1' },
+        debug: {
+          expectedCallbackUrl: 'https://twica.example/api/twitch/eventsub',
+          callbackMatch: false,
+        },
+      },
+    ], 'main-reward')
+
+    expect(status).toEqual({
+      rewardStatus: 'none',
+      raidStatus: 'none',
+    })
+  })
 })

--- a/tests/unit/channel-point-settings-eventsub.test.ts
+++ b/tests/unit/channel-point-settings-eventsub.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { deriveEventSubStatus } from '@/components/ChannelPointSettings'
+
+describe('deriveEventSubStatus', () => {
+  it('separates reward and raid EventSub subscriptions', () => {
+    const status = deriveEventSubStatus([
+      {
+        id: 'raid-sub',
+        status: 'enabled',
+        type: 'channel.raid',
+        condition: { to_broadcaster_user_id: 'streamer-1' },
+      },
+      {
+        id: 'other-reward-sub',
+        status: 'enabled',
+        type: 'channel.channel_points_custom_reward_redemption.add',
+        condition: { broadcaster_user_id: 'streamer-1', reward_id: 'other-reward' },
+      },
+    ], 'main-reward')
+
+    expect(status).toEqual({
+      rewardStatus: 'pending',
+      raidStatus: 'active',
+    })
+  })
+
+  it('does not let failed reward subscriptions mark raid EventSub as failed', () => {
+    const status = deriveEventSubStatus([
+      {
+        id: 'reward-sub',
+        status: 'webhook_callback_verification_failed',
+        type: 'channel.channel_points_custom_reward_redemption.add',
+        condition: { broadcaster_user_id: 'streamer-1', reward_id: 'main-reward' },
+      },
+      {
+        id: 'raid-sub',
+        status: 'enabled',
+        type: 'channel.raid',
+        condition: { to_broadcaster_user_id: 'streamer-1' },
+      },
+    ], 'main-reward')
+
+    expect(status).toEqual({
+      rewardStatus: 'error',
+      raidStatus: 'active',
+    })
+  })
+
+  it('does not let pending raid subscriptions mark reward EventSub as pending', () => {
+    const status = deriveEventSubStatus([
+      {
+        id: 'raid-sub',
+        status: 'webhook_callback_verification_pending',
+        type: 'channel.raid',
+        condition: { to_broadcaster_user_id: 'streamer-1' },
+      },
+    ], 'main-reward')
+
+    expect(status).toEqual({
+      rewardStatus: 'none',
+      raidStatus: 'pending',
+    })
+  })
+})

--- a/tests/unit/chat-service.test.ts
+++ b/tests/unit/chat-service.test.ts
@@ -501,5 +501,23 @@ describe('TwitchChatService', () => {
       );
       expect(message).toBe('@SampleUser が【レジェンダリー】Legendary Card（3枚目 / コンプ 5/10）を獲得！');
     });
+
+    it('N連ガチャ用の {cards} と {draws} を値に置換する', () => {
+      const message = service.buildMessage(
+        '@{user} が{draws}連ガチャで {cards} を獲得！先頭は {card}',
+        { ...basePlaceholders, cards: 'Legendary Card、Rare Card、Common Card', draws: 3 }
+      );
+
+      expect(message).toBe('@SampleUser が3連ガチャで Legendary Card、Rare Card、Common Card を獲得！先頭は Legendary Card');
+    });
+
+    it('N連ガチャ用プレースホルダー未指定時は空文字に置換される', () => {
+      const message = service.buildMessage(
+        '{user} が {card} を獲得！{draws}{cards}',
+        basePlaceholders
+      );
+
+      expect(message).toBe('SampleUser が Legendary Card を獲得！');
+    });
   });
 });

--- a/tests/unit/eventsub-reward-mismatch.test.ts
+++ b/tests/unit/eventsub-reward-mismatch.test.ts
@@ -4,9 +4,22 @@ import { POST } from '@/app/api/twitch/eventsub/route'
 import { reportError } from '@/lib/sentry/error-handler'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { broadcastGachaResult } from '@/lib/realtime'
+import { TwitchChatService } from '@/lib/twitch/chat-service'
+import { hasScope } from '@/lib/twitch/token-manager'
 
 const mocks = vi.hoisted(() => ({
   executeGachaForEventSub: vi.fn(),
+  buildMessage: vi.fn((template: string | null, placeholders: { user: string; card: string; cards?: string; draws?: number }) => {
+    const messageTemplate = template || '{user} got {card}'
+    return messageTemplate
+      .replace(/\{user\}/g, placeholders.user)
+      .replace(/\{card\}/g, placeholders.card)
+      .replace(/\{cards\}/g, placeholders.cards ?? '')
+      .replace(/\{draws\}/g, placeholders.draws === undefined ? '' : String(placeholders.draws))
+      .replace(/\s+/g, ' ')
+      .trim()
+  }),
+  sendChatMessage: vi.fn().mockResolvedValue(true),
 }))
 
 vi.mock('@/lib/services/gacha', () => ({
@@ -37,12 +50,15 @@ vi.mock('@/lib/realtime', () => ({
 }))
 
 vi.mock('@/lib/twitch/token-manager', () => ({
-  hasScope: vi.fn(),
+  hasScope: vi.fn().mockResolvedValue(true),
 }))
 
 vi.mock('@/lib/twitch/chat-service', () => ({
   DEFAULT_CHAT_TEMPLATE: '{user} got {card}',
-  TwitchChatService: vi.fn(),
+  TwitchChatService: vi.fn().mockImplementation(() => ({
+    buildMessage: mocks.buildMessage,
+    sendChatMessage: mocks.sendChatMessage,
+  })),
 }))
 
 vi.mock('@/lib/logger', () => ({
@@ -56,6 +72,8 @@ vi.mock('@/lib/logger', () => ({
 const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin)
 const mockReportError = vi.mocked(reportError)
 const mockBroadcastGachaResult = vi.mocked(broadcastGachaResult)
+const mockTwitchChatService = vi.mocked(TwitchChatService)
+const mockHasScope = vi.mocked(hasScope)
 
 async function signEventSubBody(secret: string, messageId: string, timestamp: string, body: string): Promise<string> {
   const encoder = new TextEncoder()
@@ -110,6 +128,18 @@ async function createNotificationRequest(gachaError: string): Promise<NextReques
 describe('EventSub reward mismatch handling', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockHasScope.mockResolvedValue(true)
+    mocks.buildMessage.mockImplementation((template: string | null, placeholders: { user: string; card: string; cards?: string; draws?: number }) => {
+      const messageTemplate = template || '{user} got {card}'
+      return messageTemplate
+        .replace(/\{user\}/g, placeholders.user)
+        .replace(/\{card\}/g, placeholders.card)
+        .replace(/\{cards\}/g, placeholders.cards ?? '')
+        .replace(/\{draws\}/g, placeholders.draws === undefined ? '' : String(placeholders.draws))
+        .replace(/\s+/g, ' ')
+        .trim()
+    })
+    mocks.sendChatMessage.mockResolvedValue(true)
     const historyQuery = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
@@ -203,6 +233,78 @@ describe('EventSub reward mismatch handling', () => {
         userTwitchUsername: 'Viewer',
       }),
       expect.any(Object),
+    )
+  })
+
+  it('sends multi-draw chat announcements with all cards while preserving {card} as the first card', async () => {
+    const secret = 'eventsub-test-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = secret
+    const messageId = 'eventsub-multi-draw-chat'
+    const timestamp = '2026-05-11T10:00:00Z'
+    const body = JSON.stringify({
+      subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
+      event: {
+        broadcaster_user_id: 'broadcaster-1',
+        user_id: 'viewer-1',
+        user_login: 'viewer',
+        user_name: 'Viewer',
+        reward: { id: 'raid-gacha', title: 'Raid Gacha', cost: 500 },
+      },
+    })
+    const signature = await signEventSubBody(secret, messageId, timestamp, body)
+
+    const cards = [
+      { id: 'card-1', name: 'Alpha', description: null, image_url: null, rarity: 'rare', drop_rate: 1 },
+      { id: 'card-2', name: 'Beta', description: null, image_url: null, rarity: 'common', drop_rate: 1 },
+      { id: 'card-3', name: 'Gamma', description: null, image_url: null, rarity: 'legendary', drop_rate: 1 },
+    ] as const
+
+    mocks.executeGachaForEventSub.mockResolvedValue({
+      success: true,
+      data: {
+        card: cards[0],
+        cards: [...cards],
+        userTwitchUsername: 'Viewer',
+        streamer: {
+          id: 'streamer-1',
+          chat_announcement_enabled: true,
+          chat_announcement_template: '{user}: first={card} all={cards} count={draws}',
+        },
+      },
+    })
+
+    const response = await POST(new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'twitch-eventsub-message-id': messageId,
+        'twitch-eventsub-message-timestamp': timestamp,
+        'twitch-eventsub-message-type': 'notification',
+        'twitch-eventsub-message-signature': signature,
+      },
+      body,
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ received: true })
+    expect(mockBroadcastGachaResult).toHaveBeenCalledWith(
+      'streamer-1',
+      expect.objectContaining({ card: cards[0], cards: [...cards] }),
+      expect.any(Object),
+    )
+    expect(mockTwitchChatService).toHaveBeenCalled()
+    expect(mocks.buildMessage).toHaveBeenCalledWith(
+      '{user}: first={card} all={cards} count={draws}',
+      expect.objectContaining({
+        user: 'Viewer',
+        card: 'Alpha',
+        cards: 'Alpha、Beta、Gamma',
+        draws: 3,
+      }),
+    )
+    expect(mocks.sendChatMessage).toHaveBeenCalledWith(
+      'broadcaster-1',
+      'Viewer: first=Alpha all=Alpha、Beta、Gamma count=3',
     )
   })
 })

--- a/tests/unit/eventsub-reward-mismatch.test.ts
+++ b/tests/unit/eventsub-reward-mismatch.test.ts
@@ -169,6 +169,71 @@ describe('EventSub reward mismatch handling', () => {
     expect(mockReportError).not.toHaveBeenCalled()
   })
 
+  it('activates the raid gacha window from incoming Twitch raid notifications', async () => {
+    const secret = 'eventsub-test-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = secret
+    const messageId = 'eventsub-channel-raid'
+    const timestamp = '2026-05-12T00:00:00Z'
+    const body = JSON.stringify({
+      subscription: { type: 'channel.raid' },
+      event: {
+        from_broadcaster_user_id: 'raider-1',
+        from_broadcaster_user_login: 'raider',
+        from_broadcaster_user_name: 'Raider',
+        to_broadcaster_user_id: 'broadcaster-1',
+        to_broadcaster_user_login: 'streamer',
+        to_broadcaster_user_name: 'Streamer',
+        viewers: 42,
+      },
+    })
+    const signature = await signEventSubBody(secret, messageId, timestamp, body)
+    const updateQuery = {
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    }
+    const streamerQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({
+        data: { id: 'streamer-1', raid_gacha_active_until: null },
+        error: null,
+      }),
+    }
+    const from = vi.fn((table: string) => {
+      if (table === 'streamers') {
+        return {
+          select: streamerQuery.select,
+          eq: streamerQuery.eq,
+          maybeSingle: streamerQuery.maybeSingle,
+          update: vi.fn((value: { raid_gacha_active_until: string }) => {
+            expect(Date.parse(value.raid_gacha_active_until)).toBeGreaterThan(Date.now())
+            return updateQuery
+          }),
+        }
+      }
+      throw new Error(`Unexpected table: ${table}`)
+    })
+    mockGetSupabaseAdmin.mockReturnValue({ from } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const response = await POST(new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'twitch-eventsub-message-id': messageId,
+        'twitch-eventsub-message-timestamp': timestamp,
+        'twitch-eventsub-message-type': 'notification',
+        'twitch-eventsub-message-signature': signature,
+      },
+      body,
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ received: true })
+    expect(mocks.executeGachaForEventSub).not.toHaveBeenCalled()
+    expect(streamerQuery.eq).toHaveBeenCalledWith('twitch_user_id', 'broadcaster-1')
+    expect(updateQuery.eq).toHaveBeenCalledWith('id', 'streamer-1')
+    expect(mockReportError).not.toHaveBeenCalled()
+  })
+
   it('still reports database failures while checking additional rewards', async () => {
     const response = await POST(
       await createNotificationRequest('Database error checking additional reward: Database error: error code: 502'),

--- a/tests/unit/eventsub-reward-mismatch.test.ts
+++ b/tests/unit/eventsub-reward-mismatch.test.ts
@@ -161,6 +161,14 @@ describe('EventSub reward mismatch handling', () => {
     expect(mockReportError).not.toHaveBeenCalled()
   })
 
+  it('does not report raid-limited redemptions outside the active raid window', async () => {
+    const response = await POST(await createNotificationRequest('Raid-limited reward inactive'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ received: true })
+    expect(mockReportError).not.toHaveBeenCalled()
+  })
+
   it('still reports database failures while checking additional rewards', async () => {
     const response = await POST(
       await createNotificationRequest('Database error checking additional reward: Database error: error code: 502'),

--- a/tests/unit/eventsub-reward-mismatch.test.ts
+++ b/tests/unit/eventsub-reward-mismatch.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server'
 import { POST } from '@/app/api/twitch/eventsub/route'
 import { reportError } from '@/lib/sentry/error-handler'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { broadcastGachaResult } from '@/lib/realtime'
 
 const mocks = vi.hoisted(() => ({
   executeGachaForEventSub: vi.fn(),
@@ -54,6 +55,7 @@ vi.mock('@/lib/logger', () => ({
 
 const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin)
 const mockReportError = vi.mocked(reportError)
+const mockBroadcastGachaResult = vi.mocked(broadcastGachaResult)
 
 async function signEventSubBody(secret: string, messageId: string, timestamp: string, body: string): Promise<string> {
   const encoder = new TextEncoder()
@@ -142,6 +144,65 @@ describe('EventSub reward mismatch handling', () => {
         broadcasterUserId: 'broadcaster-1',
         gachaError: 'Database error checking additional reward: Database error: error code: 502',
       }),
+    )
+  })
+
+  it('broadcasts all cards returned by a multi-draw EventSub redemption', async () => {
+    const secret = 'eventsub-test-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = secret
+    const messageId = 'eventsub-multi-draw'
+    const timestamp = '2026-05-12T00:00:00Z'
+    const body = JSON.stringify({
+      subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
+      event: {
+        broadcaster_user_id: 'broadcaster-1',
+        user_id: 'viewer-1',
+        user_login: 'viewer',
+        user_name: 'Viewer',
+        reward: { id: 'raid-reward', title: 'Raid Gacha', cost: 500 },
+      },
+    })
+    const signature = await signEventSubBody(secret, messageId, timestamp, body)
+    const cards = [
+      { id: 'card-1', name: 'Card 1', description: null, image_url: null, rarity: 'common' },
+      { id: 'card-2', name: 'Card 2', description: null, image_url: null, rarity: 'rare' },
+      { id: 'card-3', name: 'Card 3', description: null, image_url: null, rarity: 'epic' },
+    ]
+    mocks.executeGachaForEventSub.mockResolvedValue({
+      success: true,
+      data: {
+        card: cards[0],
+        cards,
+        userTwitchUsername: 'Viewer',
+        streamer: {
+          id: 'streamer-1',
+          chat_announcement_enabled: false,
+          chat_announcement_template: null,
+        },
+      },
+    })
+
+    const response = await POST(new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'twitch-eventsub-message-id': messageId,
+        'twitch-eventsub-message-timestamp': timestamp,
+        'twitch-eventsub-message-type': 'notification',
+        'twitch-eventsub-message-signature': signature,
+      },
+      body,
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mockBroadcastGachaResult).toHaveBeenCalledWith(
+      'streamer-1',
+      expect.objectContaining({
+        card: cards[0],
+        cards,
+        userTwitchUsername: 'Viewer',
+      }),
+      expect.any(Object),
     )
   })
 })

--- a/tests/unit/eventsub-reward-mismatch.test.ts
+++ b/tests/unit/eventsub-reward-mismatch.test.ts
@@ -307,4 +307,65 @@ describe('EventSub reward mismatch handling', () => {
       'Viewer: first=Alpha all=Alpha、Beta、Gamma count=3',
     )
   })
+
+  it('abbreviates long multi-draw card lists before sending chat announcements', async () => {
+    const secret = 'eventsub-test-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = secret
+    const messageId = 'eventsub-long-multi-draw-chat'
+    const timestamp = '2026-05-11T10:00:00Z'
+    const body = JSON.stringify({
+      subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
+      event: {
+        broadcaster_user_id: 'broadcaster-1',
+        user_id: 'viewer-1',
+        user_login: 'viewer',
+        user_name: 'Viewer',
+        reward: { id: 'raid-gacha', title: 'Raid Gacha', cost: 500 },
+      },
+    })
+    const signature = await signEventSubBody(secret, messageId, timestamp, body)
+
+    const cards = Array.from({ length: 10 }, (_, index) => ({
+      id: `card-${index + 1}`,
+      name: `CardName${String(index + 1).padStart(2, '0')}-${'A'.repeat(60)}`,
+      description: null,
+      image_url: null,
+      rarity: 'rare',
+      drop_rate: 1,
+    }))
+
+    mocks.executeGachaForEventSub.mockResolvedValue({
+      success: true,
+      data: {
+        card: cards[0],
+        cards,
+        userTwitchUsername: 'Viewer',
+        streamer: {
+          id: 'streamer-1',
+          chat_announcement_enabled: true,
+          chat_announcement_template: '@{user} が{draws}連ガチャで {cards} を獲得しました！',
+        },
+      },
+    })
+
+    const response = await POST(new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'twitch-eventsub-message-id': messageId,
+        'twitch-eventsub-message-timestamp': timestamp,
+        'twitch-eventsub-message-type': 'notification',
+        'twitch-eventsub-message-signature': signature,
+      },
+      body,
+    }))
+
+    expect(response.status).toBe(200)
+    const placeholders = mocks.buildMessage.mock.calls.at(-1)?.[1]
+    expect(placeholders?.cards).toMatch(/ほか\d+枚（\d+\/10枚表示）/)
+    expect(placeholders?.cards).not.toContain('...')
+    const sentMessage = mocks.sendChatMessage.mock.calls.at(-1)?.[1] as string
+    expect(sentMessage.length).toBeLessThanOrEqual(500)
+    expect(sentMessage).toContain('10連ガチャ')
+  })
 })

--- a/tests/unit/eventsub-subscribe-csrf.test.ts
+++ b/tests/unit/eventsub-subscribe-csrf.test.ts
@@ -5,6 +5,7 @@ import { validateCSRFToken } from '@/lib/csrf'
 import { getSession, canUseStreamerFeatures } from '@/lib/session'
 import { checkRateLimit, getRateLimitIdentifier } from '@/lib/rate-limit'
 import { ERROR_MESSAGES } from '@/lib/constants'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
 
 // Issue #399 に対応するテスト: 状態変更 API (EventSub 登録/解除) が CSRF 検証失敗時に 403 を返すこと。
 // 正常系の詳細（Twitch API との連携）は既存 E2E の対象であり、ここでは CSRF ゲートのみ検証する。
@@ -32,6 +33,7 @@ const mockGetSession = vi.mocked(getSession)
 const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)
 const mockCheckRateLimit = vi.mocked(checkRateLimit)
 const mockGetRateLimitIdentifier = vi.mocked(getRateLimitIdentifier)
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin)
 
 function createPostRequest(): NextRequest {
   return new NextRequest('http://localhost:3000/api/twitch/eventsub/subscribe', {
@@ -100,6 +102,62 @@ describe('EventSub subscribe API - CSRF enforcement (issue #399)', () => {
 
     expect(response.status).toBe(401)
     await expect(response.json()).resolves.toEqual({ error: ERROR_MESSAGES.UNAUTHORIZED })
+  })
+
+  it('POST: チャネルポイント登録時に incoming raid EventSub も登録する', async () => {
+    mockValidateCSRFToken.mockResolvedValue({ valid: true })
+    process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'client-id'
+    process.env.TWITCH_CLIENT_SECRET = 'client-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = 'eventsub-secret'
+    process.env.NEXT_PUBLIC_APP_URL = 'https://twica.example'
+    const streamerQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'streamer-1' }, error: null }),
+    }
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: 'app-token' }), { status: 200 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [], pagination: {} }), { status: 200 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [{ id: 'reward-sub', status: 'enabled' }] }), { status: 202 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [{ id: 'raid-sub', status: 'enabled' }] }), { status: 202 }),
+    )
+
+    const response = await POST(createPostRequest())
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      subscription: { id: 'reward-sub' },
+      raidSubscription: { created: { id: 'raid-sub' } },
+    })
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      4,
+      'https://api.twitch.tv/helix/eventsub/subscriptions',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          type: 'channel.raid',
+          version: '1',
+          condition: { to_broadcaster_user_id: '123456789' },
+          transport: {
+            method: 'webhook',
+            callback: 'https://twica.example/api/twitch/eventsub',
+            secret: 'eventsub-secret',
+          },
+        }),
+      }),
+    )
+
+    fetchMock.mockRestore()
   })
 
   it('DELETE: CSRF 有効かつ未認証のストリーマーは 401 を返す', async () => {

--- a/tests/unit/eventsub-subscribe-csrf.test.ts
+++ b/tests/unit/eventsub-subscribe-csrf.test.ts
@@ -166,6 +166,135 @@ describe('EventSub subscribe API - CSRF enforcement (issue #399)', () => {
     fetchMock.mockRestore()
   })
 
+  it('POST: 失敗済み incoming raid EventSub は削除して再作成する', async () => {
+    vi.useFakeTimers()
+    mockValidateCSRFToken.mockResolvedValue({ valid: true })
+    process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'client-id'
+    process.env.TWITCH_CLIENT_SECRET = 'client-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = 'eventsub-secret'
+    process.env.NEXT_PUBLIC_APP_URL = 'https://twica.example'
+    const streamerQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'streamer-1' }, error: null }),
+    }
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: 'app-token' }), { status: 200 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        data: [
+          {
+            id: 'failed-raid-sub',
+            status: 'webhook_callback_verification_failed',
+            type: 'channel.raid',
+            condition: { to_broadcaster_user_id: '123456789' },
+            transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+          },
+        ],
+        pagination: {},
+      }), { status: 200 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [{ id: 'reward-sub', status: 'enabled' }] }), { status: 202 }),
+    ).mockResolvedValueOnce(
+      new Response(null, { status: 204 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [{ id: 'new-raid-sub', status: 'webhook_callback_verification_pending' }] }), { status: 202 }),
+    )
+
+    const responsePromise = POST(createPostRequest())
+    await vi.advanceTimersByTimeAsync(500)
+    const response = await responsePromise
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      subscription: { id: 'reward-sub' },
+      raidSubscription: { created: { id: 'new-raid-sub' } },
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.twitch.tv/helix/eventsub/subscriptions?id=failed-raid-sub',
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'https://api.twitch.tv/helix/eventsub/subscriptions',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          type: 'channel.raid',
+          version: '1',
+          condition: { to_broadcaster_user_id: '123456789' },
+          transport: {
+            method: 'webhook',
+            callback: 'https://twica.example/api/twitch/eventsub',
+            secret: 'eventsub-secret',
+          },
+        }),
+      }),
+    )
+
+    fetchMock.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it('POST: 有効な incoming raid EventSub は重複作成せず再利用する', async () => {
+    mockValidateCSRFToken.mockResolvedValue({ valid: true })
+    process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'client-id'
+    process.env.TWITCH_CLIENT_SECRET = 'client-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = 'eventsub-secret'
+    process.env.NEXT_PUBLIC_APP_URL = 'https://twica.example'
+    const streamerQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'streamer-1' }, error: null }),
+    }
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: 'app-token' }), { status: 200 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        data: [
+          {
+            id: 'existing-raid-sub',
+            status: 'enabled',
+            type: 'channel.raid',
+            condition: { to_broadcaster_user_id: '123456789' },
+            transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+          },
+        ],
+        pagination: {},
+      }), { status: 200 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [{ id: 'reward-sub', status: 'enabled' }] }), { status: 202 }),
+    )
+
+    const response = await POST(createPostRequest())
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      success: true,
+      subscription: { id: 'reward-sub' },
+      raidSubscription: { subscription: { id: 'existing-raid-sub' } },
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      'https://api.twitch.tv/helix/eventsub/subscriptions?id=existing-raid-sub',
+      expect.anything(),
+    )
+
+    fetchMock.mockRestore()
+  })
+
   it('DELETE: CSRF 有効かつ未認証のストリーマーは 401 を返す', async () => {
     mockValidateCSRFToken.mockResolvedValue({ valid: true })
     mockCanUseStreamerFeatures.mockReturnValue(false)

--- a/tests/unit/eventsub-subscribe-csrf.test.ts
+++ b/tests/unit/eventsub-subscribe-csrf.test.ts
@@ -242,6 +242,72 @@ describe('EventSub subscribe API - CSRF enforcement (issue #399)', () => {
     vi.useRealTimers()
   })
 
+  it('POST: failed raid EventSub の削除失敗と作成失敗を区別して返す', async () => {
+    vi.useFakeTimers()
+    mockValidateCSRFToken.mockResolvedValue({ valid: true })
+    process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'client-id'
+    process.env.TWITCH_CLIENT_SECRET = 'client-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = 'eventsub-secret'
+    process.env.NEXT_PUBLIC_APP_URL = 'https://twica.example'
+    const streamerQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'streamer-1' }, error: null }),
+    }
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        throw new Error(`Unexpected table: ${table}`)
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: 'app-token' }), { status: 200 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        data: [
+          {
+            id: 'failed-raid-sub',
+            status: 'webhook_callback_verification_failed',
+            type: 'channel.raid',
+            condition: { to_broadcaster_user_id: '123456789' },
+            transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+          },
+        ],
+        pagination: {},
+      }), { status: 200 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [{ id: 'reward-sub', status: 'enabled' }] }), { status: 202 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'delete rejected' }), { status: 500 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'subscription still exists' }), { status: 409 }),
+    )
+
+    const responsePromise = POST(createPostRequest())
+    await vi.advanceTimersByTimeAsync(500)
+    const response = await responsePromise
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      success: true,
+      subscription: { id: 'reward-sub' },
+      raidSubscription: {
+        deleteWarning: 'failed raid EventSub の削除に失敗しました: id=failed-raid-sub, status=500',
+        createWarning: 'raid EventSub の作成に失敗しました: status=409',
+      },
+    })
+    expect(body.raidSubscription.warning).toContain('failed raid EventSub の削除に失敗しました: id=failed-raid-sub, status=500')
+    expect(body.raidSubscription.warning).toContain('raid EventSub の作成に失敗しました: status=409')
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.twitch.tv/helix/eventsub/subscriptions?id=failed-raid-sub',
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+
+    fetchMock.mockRestore()
+    vi.useRealTimers()
+  })
+
   it('POST: 有効な incoming raid EventSub は重複作成せず再利用する', async () => {
     mockValidateCSRFToken.mockResolvedValue({ valid: true })
     process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'client-id'

--- a/tests/unit/eventsub-subscribe-csrf.test.ts
+++ b/tests/unit/eventsub-subscribe-csrf.test.ts
@@ -134,7 +134,22 @@ describe('EventSub subscribe API - CSRF enforcement (issue #399)', () => {
     ).mockResolvedValueOnce(
       new Response(JSON.stringify({ data: [{ id: 'reward-sub', status: 'enabled' }] }), { status: 202 }),
     ).mockResolvedValueOnce(
-      new Response(JSON.stringify({ data: [{ id: 'raid-sub', status: 'enabled' }] }), { status: 202 }),
+      new Response(JSON.stringify({
+        data: [
+          {
+            id: 'raid-sub',
+            status: 'enabled',
+            type: 'channel.raid',
+            condition: { to_broadcaster_user_id: '123456789' },
+            transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+          },
+        ],
+      }), { status: 202 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        data: [],
+        pagination: {},
+      }), { status: 200 }),
     )
 
     const response = await POST(createPostRequest())
@@ -143,7 +158,11 @@ describe('EventSub subscribe API - CSRF enforcement (issue #399)', () => {
     await expect(response.json()).resolves.toMatchObject({
       success: true,
       subscription: { id: 'reward-sub' },
-      raidSubscription: { created: { id: 'raid-sub' } },
+      raidSubscription: {
+        created: { id: 'raid-sub' },
+        status: 'active',
+        subscriptions: [{ id: 'raid-sub' }],
+      },
     })
     expect(fetchMock).toHaveBeenNthCalledWith(
       4,
@@ -204,7 +223,37 @@ describe('EventSub subscribe API - CSRF enforcement (issue #399)', () => {
     ).mockResolvedValueOnce(
       new Response(null, { status: 204 }),
     ).mockResolvedValueOnce(
-      new Response(JSON.stringify({ data: [{ id: 'new-raid-sub', status: 'webhook_callback_verification_pending' }] }), { status: 202 }),
+      new Response(JSON.stringify({
+        data: [
+          {
+            id: 'new-raid-sub',
+            status: 'webhook_callback_verification_pending',
+            type: 'channel.raid',
+            condition: { to_broadcaster_user_id: '123456789' },
+            transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+          },
+        ],
+      }), { status: 202 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        data: [
+          {
+            id: 'failed-raid-sub',
+            status: 'webhook_callback_verification_failed',
+            type: 'channel.raid',
+            condition: { to_broadcaster_user_id: '123456789' },
+            transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+          },
+          {
+            id: 'new-raid-sub',
+            status: 'webhook_callback_verification_pending',
+            type: 'channel.raid',
+            condition: { to_broadcaster_user_id: '123456789' },
+            transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+          },
+        ],
+        pagination: {},
+      }), { status: 200 }),
     )
 
     const responsePromise = POST(createPostRequest())
@@ -215,13 +264,18 @@ describe('EventSub subscribe API - CSRF enforcement (issue #399)', () => {
     await expect(response.json()).resolves.toMatchObject({
       success: true,
       subscription: { id: 'reward-sub' },
-      raidSubscription: { created: { id: 'new-raid-sub' } },
+      raidSubscription: {
+        created: { id: 'new-raid-sub' },
+        status: 'pending',
+        subscriptions: [{ id: 'new-raid-sub' }],
+      },
     })
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.twitch.tv/helix/eventsub/subscriptions?id=failed-raid-sub',
       expect.objectContaining({ method: 'DELETE' }),
     )
-    expect(fetchMock).toHaveBeenLastCalledWith(
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      5,
       'https://api.twitch.tv/helix/eventsub/subscriptions',
       expect.objectContaining({
         method: 'POST',
@@ -281,6 +335,19 @@ describe('EventSub subscribe API - CSRF enforcement (issue #399)', () => {
       new Response(JSON.stringify({ message: 'delete rejected' }), { status: 500 }),
     ).mockResolvedValueOnce(
       new Response(JSON.stringify({ message: 'subscription still exists' }), { status: 409 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        data: [
+          {
+            id: 'failed-raid-sub',
+            status: 'webhook_callback_verification_failed',
+            type: 'channel.raid',
+            condition: { to_broadcaster_user_id: '123456789' },
+            transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+          },
+        ],
+        pagination: {},
+      }), { status: 200 }),
     )
 
     const responsePromise = POST(createPostRequest())
@@ -295,6 +362,8 @@ describe('EventSub subscribe API - CSRF enforcement (issue #399)', () => {
       raidSubscription: {
         deleteWarning: 'failed raid EventSub の削除に失敗しました: id=failed-raid-sub, status=500',
         createWarning: 'raid EventSub の作成に失敗しました: status=409',
+        status: 'error',
+        subscriptions: [{ id: 'failed-raid-sub' }],
       },
     })
     expect(body.raidSubscription.warning).toContain('failed raid EventSub の削除に失敗しました: id=failed-raid-sub, status=500')
@@ -350,7 +419,11 @@ describe('EventSub subscribe API - CSRF enforcement (issue #399)', () => {
     await expect(response.json()).resolves.toMatchObject({
       success: true,
       subscription: { id: 'reward-sub' },
-      raidSubscription: { subscription: { id: 'existing-raid-sub' } },
+      raidSubscription: {
+        subscription: { id: 'existing-raid-sub' },
+        status: 'active',
+        subscriptions: [{ id: 'existing-raid-sub' }],
+      },
     })
     expect(fetchMock).toHaveBeenCalledTimes(3)
     expect(fetchMock).not.toHaveBeenCalledWith(

--- a/tests/unit/eventsub-subscribe-csrf.test.ts
+++ b/tests/unit/eventsub-subscribe-csrf.test.ts
@@ -49,6 +49,12 @@ function createDeleteRequest(): NextRequest {
   })
 }
 
+function createDeleteRewardRequest(rewardId: string): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/twitch/eventsub/subscribe?rewardId=${rewardId}`, {
+    method: 'DELETE',
+  })
+}
+
 describe('EventSub subscribe API - CSRF enforcement (issue #399)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -168,5 +174,140 @@ describe('EventSub subscribe API - CSRF enforcement (issue #399)', () => {
 
     expect(response.status).toBe(401)
     await expect(response.json()).resolves.toEqual({ error: ERROR_MESSAGES.UNAUTHORIZED })
+  })
+
+  it('DELETE: 完全解除では同一 callback の channel point と raid EventSub を削除する', async () => {
+    mockValidateCSRFToken.mockResolvedValue({ valid: true })
+    process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'client-id'
+    process.env.TWITCH_CLIENT_SECRET = 'client-secret'
+    process.env.NEXT_PUBLIC_APP_URL = 'https://twica.example'
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: 'app-token' }), { status: 200 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        data: [
+          {
+            id: 'reward-sub',
+            status: 'enabled',
+            type: 'channel.channel_points_custom_reward_redemption.add',
+            condition: { broadcaster_user_id: '123456789', reward_id: 'main-reward' },
+            transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+          },
+          {
+            id: 'raid-sub',
+            status: 'enabled',
+            type: 'channel.raid',
+            condition: { to_broadcaster_user_id: '123456789' },
+            transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+          },
+          {
+            id: 'other-callback-raid-sub',
+            status: 'enabled',
+            type: 'channel.raid',
+            condition: { to_broadcaster_user_id: '123456789' },
+            transport: { method: 'webhook', callback: 'https://other.example/api/twitch/eventsub' },
+          },
+        ],
+        pagination: {},
+      }), { status: 200 }),
+    ).mockResolvedValue(
+      new Response(null, { status: 204 }),
+    )
+
+    const response = await DELETE(createDeleteRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      success: true,
+      deletedCount: 2,
+      totalCount: 2,
+      results: [
+        { id: 'reward-sub', type: 'channel.channel_points_custom_reward_redemption.add', success: true },
+        { id: 'raid-sub', type: 'channel.raid', success: true },
+      ],
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.twitch.tv/helix/eventsub/subscriptions?id=reward-sub',
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.twitch.tv/helix/eventsub/subscriptions?id=raid-sub',
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      'https://api.twitch.tv/helix/eventsub/subscriptions?id=other-callback-raid-sub',
+      expect.anything(),
+    )
+
+    fetchMock.mockRestore()
+  })
+
+  it('DELETE: rewardId 指定では raid EventSub を削除しない', async () => {
+    mockValidateCSRFToken.mockResolvedValue({ valid: true })
+    process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'client-id'
+    process.env.TWITCH_CLIENT_SECRET = 'client-secret'
+    process.env.NEXT_PUBLIC_APP_URL = 'https://twica.example'
+
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: 'app-token' }), { status: 200 }),
+    ).mockResolvedValueOnce(
+      new Response(JSON.stringify({
+        data: [
+          {
+            id: 'target-reward-sub',
+            status: 'enabled',
+            type: 'channel.channel_points_custom_reward_redemption.add',
+            condition: { broadcaster_user_id: '123456789', reward_id: 'target-reward' },
+            transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+          },
+          {
+            id: 'other-reward-sub',
+            status: 'enabled',
+            type: 'channel.channel_points_custom_reward_redemption.add',
+            condition: { broadcaster_user_id: '123456789', reward_id: 'other-reward' },
+            transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+          },
+          {
+            id: 'raid-sub',
+            status: 'enabled',
+            type: 'channel.raid',
+            condition: { to_broadcaster_user_id: '123456789' },
+            transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+          },
+        ],
+        pagination: {},
+      }), { status: 200 }),
+    ).mockResolvedValue(
+      new Response(null, { status: 204 }),
+    )
+
+    const response = await DELETE(createDeleteRewardRequest('target-reward'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({
+      success: true,
+      deletedCount: 1,
+      totalCount: 1,
+      results: [
+        { id: 'target-reward-sub', type: 'channel.channel_points_custom_reward_redemption.add', success: true },
+      ],
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.twitch.tv/helix/eventsub/subscriptions?id=target-reward-sub',
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      'https://api.twitch.tv/helix/eventsub/subscriptions?id=other-reward-sub',
+      expect.anything(),
+    )
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      'https://api.twitch.tv/helix/eventsub/subscriptions?id=raid-sub',
+      expect.anything(),
+    )
+
+    fetchMock.mockRestore()
   })
 })

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -270,6 +270,7 @@ describe('GachaService.executeGachaForEventSub', () => {
         channel_point_reward_id: 'main-reward',
         chat_announcement_enabled: false,
         chat_announcement_template: null,
+        raid_gacha_active_until: '2099-01-01T00:00:00.000Z',
       },
       error: null,
     })
@@ -311,6 +312,7 @@ describe('GachaService.executeGachaForEventSub', () => {
         channel_point_reward_id: 'main-reward',
         chat_announcement_enabled: false,
         chat_announcement_template: null,
+        raid_gacha_active_until: '2099-01-01T00:00:00.000Z',
       },
       error: null,
     })
@@ -352,6 +354,7 @@ describe('GachaService.executeGachaForEventSub', () => {
         channel_point_reward_id: 'main-reward',
         chat_announcement_enabled: false,
         chat_announcement_template: null,
+        raid_gacha_active_until: '2099-01-01T00:00:00.000Z',
       },
       error: null,
     })
@@ -402,6 +405,50 @@ describe('GachaService.executeGachaForEventSub', () => {
       p_event_id: 'event-raid:3',
       p_reward_cost: null,
     }))
+  })
+
+  it('レイド限定の追加報酬はレイド受付期限がない通常時に発火しない', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        id: 'streamer-1',
+        channel_point_reward_id: 'main-reward',
+        chat_announcement_enabled: false,
+        chat_announcement_template: null,
+        raid_gacha_active_until: null,
+      },
+      error: null,
+    })
+    const additionalRewardQuery = createMockQueryBuilder()
+    ;(additionalRewardQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: 'additional-1', draw_count: 3, is_raid_limited: true },
+      error: null,
+    })
+    const mockRpc = vi.fn()
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        if (table === 'streamer_additional_gacha_rewards') return additionalRewardQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'raid-reward', cost: 500 },
+    }, 'event-raid-inactive')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('Raid-limited reward inactive')
+    }
+    expect(mockRpc).not.toHaveBeenCalled()
   })
 
   it('追加報酬オプション未適用のschema cacheでは通常の1回ガチャにフォールバックする', async () => {

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -343,4 +343,118 @@ describe('GachaService.executeGachaForEventSub', () => {
       expect(result.error).toBe('Reward ID mismatch')
     }
   })
+
+  it('追加報酬のdraw_countに応じて同一EventSubから複数カードを付与する', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        id: 'streamer-1',
+        channel_point_reward_id: 'main-reward',
+        chat_announcement_enabled: false,
+        chat_announcement_template: null,
+      },
+      error: null,
+    })
+    const additionalRewardQuery = createMockQueryBuilder()
+    ;(additionalRewardQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: 'additional-1', draw_count: 3, is_raid_limited: true },
+      error: null,
+    })
+    const cardsQuery = createCardsQuery(testCards)
+    const mockRpc = vi.fn().mockResolvedValue({
+      data: { is_duplicate: false },
+      error: null,
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        if (table === 'streamer_additional_gacha_rewards') return additionalRewardQuery
+        if (table === 'cards') return cardsQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'raid-reward', cost: 500 },
+    }, 'event-raid')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.cards).toHaveLength(3)
+    }
+    expect(mockRpc).toHaveBeenCalledTimes(3)
+    expect(mockRpc).toHaveBeenNthCalledWith(1, 'execute_gacha_transaction', expect.objectContaining({
+      p_event_id: 'event-raid',
+      p_reward_cost: 500,
+    }))
+    expect(mockRpc).toHaveBeenNthCalledWith(2, 'execute_gacha_transaction', expect.objectContaining({
+      p_event_id: 'event-raid:2',
+      p_reward_cost: null,
+    }))
+    expect(mockRpc).toHaveBeenNthCalledWith(3, 'execute_gacha_transaction', expect.objectContaining({
+      p_event_id: 'event-raid:3',
+      p_reward_cost: null,
+    }))
+  })
+
+  it('追加報酬オプション未適用のschema cacheでは通常の1回ガチャにフォールバックする', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        id: 'streamer-1',
+        channel_point_reward_id: 'main-reward',
+        chat_announcement_enabled: false,
+        chat_announcement_template: null,
+      },
+      error: null,
+    })
+    const optionQuery = createMockQueryBuilder()
+    ;(optionQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: null,
+      error: { message: "Could not find the 'draw_count' column", code: 'PGRST204' },
+    })
+    const fallbackQuery = createMockQueryBuilder()
+    ;(fallbackQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: 'additional-1' },
+      error: null,
+    })
+    const cardsQuery = createCardsQuery(testCards)
+    const mockRpc = vi.fn().mockResolvedValue({
+      data: { is_duplicate: false },
+      error: null,
+    })
+    let additionalQueryCount = 0
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        if (table === 'streamer_additional_gacha_rewards') {
+          additionalQueryCount += 1
+          return additionalQueryCount === 1 ? optionQuery : fallbackQuery
+        }
+        if (table === 'cards') return cardsQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'legacy-reward', cost: 100 },
+    }, 'event-legacy')
+
+    expect(result.success).toBe(true)
+    expect(mockRpc).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
## Summary
- add raid-limited and multi-draw options to additional channel point gacha rewards
- execute additional rewards as 1-10 draw batches while keeping reward cost counted once
- broadcast all multi-draw cards to the overlay queue while preserving single-card payload compatibility
- announce multi-draw chat results with all card names while keeping {card} as the first-card placeholder
- abbreviate long {cards} chat lists without cutting card names, including shown/total draw counts
- gate raid-limited additional rewards on an explicit short-lived raid gacha window; unknown/expired state blocks execution
- add a streamer API and settings controls to turn the raid gacha window on for 30 minutes or off manually
- subscribe the same EventSub webhook to incoming channel.raid notifications and auto-extend the raid gacha window for 30 minutes without shortening a longer manual window
- show the incoming raid EventSub registration state separately from channel point reward subscriptions in settings
- delete incoming raid EventSub subscriptions during full channel point disconnect while preserving reward-specific cleanup boundaries
- recreate failed incoming raid EventSub subscriptions during registration while reusing enabled or pending raid subscriptions
- surface failed incoming raid EventSub deletion/creation warnings separately in the settings UI
- return refreshed incoming raid EventSub status and matching subscriptions from the registration API after recreation/reuse
- add rollout-safe fallback when the new reward option or raid state columns are not in the schema cache yet

Closes #334
Closes #470
Closes #471
Closes #472
Closes #473
Closes #474
Closes #475
Closes #476
Closes #477
Closes #478

## Validation
- npx vitest run tests/unit/eventsub-subscribe-csrf.test.ts tests/unit/channel-point-settings-eventsub.test.ts
- git diff --check
- npm run lint (existing warnings only)
- npm run build
- npm run workers:build
