### PR TITLE
fix: gift raid gacha draws to raiders

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -521,6 +521,10 @@
       "raidOnly": "Raid only",
       "multiDraw": "{count} draws",
       "raidLimited": "Raid limited",
+      "raidGiftTitle": "Raider gift",
+      "raidGiftEnabled": "Incoming raids gift {count} gacha draws to the raider.",
+      "raidGiftDisabled": "Set to 0 to disable raid gifts.",
+      "raidGiftSaved": "Raid gift settings saved",
       "raidStatusTitle": "Raid gacha window",
       "raidStatusActive": "Active until {time}",
       "raidStatusInactive": "Currently off",
@@ -528,7 +532,7 @@
       "raidStatusDisable": "Off",
       "raidStatusEnabled": "Raid gacha window enabled for 30 minutes",
       "raidStatusDisabled": "Raid gacha window disabled",
-      "raidStatusFailed": "Failed to update raid gacha window"
+      "raidStatusFailed": "Failed to update raid gacha settings"
     }
   },
   "gachaHistory": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -521,6 +521,10 @@
       "raidOnly": "レイド限定",
       "multiDraw": "{count}連",
       "raidLimited": "レイド限定",
+      "raidGiftTitle": "レイド送信者プレゼント",
+      "raidGiftEnabled": "レイドが来たら送信者に {count} 連ガチャを付与します",
+      "raidGiftDisabled": "0 にするとレイドプレゼントは無効です",
+      "raidGiftSaved": "レイド送信者プレゼント設定を保存しました",
       "raidStatusTitle": "レイドガチャ受付",
       "raidStatusActive": "{time} まで受付中",
       "raidStatusInactive": "現在は停止中",
@@ -528,7 +532,7 @@
       "raidStatusDisable": "OFF",
       "raidStatusEnabled": "レイドガチャ受付を30分間有効にしました",
       "raidStatusDisabled": "レイドガチャ受付を停止しました",
-      "raidStatusFailed": "レイドガチャ受付の更新に失敗しました"
+      "raidStatusFailed": "レイドガチャ設定の更新に失敗しました"
     }
   },
   "gachaHistory": {

--- a/src/app/api/streamer/raid-gacha/route.ts
+++ b/src/app/api/streamer/raid-gacha/route.ts
@@ -8,12 +8,11 @@ import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
 import { logger } from "@/lib/logger";
 
-const DEFAULT_ACTIVE_MINUTES = 30;
-const MAX_ACTIVE_MINUTES = 180;
-
 function isRaidStateSchemaError(error: { message?: string; code?: string } | null | undefined) {
   const message = error?.message ?? "";
-  return error?.code === "PGRST204" || message.includes("raid_gacha_active_until");
+  return error?.code === "PGRST204"
+    || message.includes("raid_gacha_active_until")
+    || message.includes("raid_gacha_draw_count");
 }
 
 function isActiveUntil(value: string | null | undefined): boolean {
@@ -26,7 +25,7 @@ async function getOwnedStreamer(twitchUserId: string) {
   const supabaseAdmin = getSupabaseAdmin();
   let { data: streamer, error } = await supabaseAdmin
     .from("streamers")
-    .select("id, raid_gacha_active_until")
+    .select("id, raid_gacha_active_until, raid_gacha_draw_count")
     .eq("twitch_user_id", twitchUserId)
     .maybeSingle();
 
@@ -37,7 +36,7 @@ async function getOwnedStreamer(twitchUserId: string) {
       .eq("twitch_user_id", twitchUserId)
       .maybeSingle();
     streamer = fallbackResult.data
-      ? { ...fallbackResult.data, raid_gacha_active_until: null }
+      ? { ...fallbackResult.data, raid_gacha_active_until: null, raid_gacha_draw_count: 0 }
       : fallbackResult.data;
     error = fallbackResult.error;
   }
@@ -76,6 +75,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({
       active: isActiveUntil(streamer.raid_gacha_active_until),
       activeUntil: streamer.raid_gacha_active_until,
+      drawCount: streamer.raid_gacha_draw_count ?? 0,
     }, {
       headers: { "Cache-Control": "no-store, no-cache, must-revalidate" },
     });
@@ -117,17 +117,11 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
-    const active = body.active === true;
-    const requestedMinutes = body.activeMinutes === undefined
-      ? DEFAULT_ACTIVE_MINUTES
-      : Number(body.activeMinutes);
+    const requestedDrawCount = body.drawCount === undefined ? 0 : Number(body.drawCount);
 
-    if (body.active !== undefined && typeof body.active !== "boolean") {
-      return NextResponse.json({ error: "active must be a boolean" }, { status: 400 });
-    }
-    if (!Number.isInteger(requestedMinutes) || requestedMinutes < 1 || requestedMinutes > MAX_ACTIVE_MINUTES) {
+    if (!Number.isInteger(requestedDrawCount) || requestedDrawCount < 0 || requestedDrawCount > 10) {
       return NextResponse.json(
-        { error: `activeMinutes must be an integer between 1 and ${MAX_ACTIVE_MINUTES}` },
+        { error: "drawCount must be an integer between 0 and 10" },
         { status: 400 },
       );
     }
@@ -136,30 +130,26 @@ export async function POST(request: NextRequest) {
     if (streamerError) return handleDatabaseError(streamerError, "Raid Gacha API: POST lookup");
     if (!streamer) return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
 
-    const activeUntil = active
-      ? new Date(Date.now() + requestedMinutes * 60 * 1000).toISOString()
-      : null;
-
     const supabaseAdmin = getSupabaseAdmin();
     const { data: updatedStreamer, error } = await supabaseAdmin
       .from("streamers")
-      .update({ raid_gacha_active_until: activeUntil })
+      .update({ raid_gacha_draw_count: requestedDrawCount })
       .eq("id", streamer.id)
-      .select("raid_gacha_active_until")
+      .select("raid_gacha_active_until, raid_gacha_draw_count")
       .maybeSingle();
 
     if (error) return handleDatabaseError(error, "Raid Gacha API: POST update");
 
     logger.info("Raid gacha state updated", {
       streamerId: streamer.id,
-      active,
-      activeUntil,
+      drawCount: requestedDrawCount,
     });
 
     return NextResponse.json({
       success: true,
       active: isActiveUntil(updatedStreamer?.raid_gacha_active_until),
       activeUntil: updatedStreamer?.raid_gacha_active_until ?? null,
+      drawCount: updatedStreamer?.raid_gacha_draw_count ?? requestedDrawCount,
     });
   } catch (error) {
     return handleApiError(error, "Raid Gacha API: POST");

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -17,7 +17,6 @@ const MESSAGE_TYPE_VERIFICATION = "webhook_callback_verification";
 const MESSAGE_TYPE_NOTIFICATION = "notification";
 const MESSAGE_TYPE_REVOCATION = "revocation";
 const CARD_LIST_SEPARATOR = "、";
-const RAID_GACHA_EVENTSUB_ACTIVE_MINUTES = 30;
 
 function formatCardNamesForChat(cardNames: string[], maxCharacters: number): string {
   if (cardNames.length === 0) return "";
@@ -201,7 +200,19 @@ export async function POST(request: NextRequest) {
         }
       }
     } else if (subscriptionType === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_RAID) {
-      await handleRaidNotification(messageId, event);
+      const result = await handleRaidNotification(messageId, event);
+      if (result) {
+        try {
+          const { getCloudflareContext } = await import('@opennextjs/cloudflare');
+          const { ctx } = await getCloudflareContext({ async: true });
+          ctx.waitUntil(postRedemptionNotify(result));
+        } catch (e) {
+          logger.warn('[EventSub] waitUntil unavailable for raid gift, falling back to sync', {
+            error: e instanceof Error ? e.message : String(e),
+          });
+          await postRedemptionNotify(result);
+        }
+      }
     }
 
     return NextResponse.json({ received: true });
@@ -260,17 +271,6 @@ export async function POST(request: NextRequest) {
   return NextResponse.json({ error: ERROR_MESSAGES.UNKNOWN_MESSAGE_TYPE }, { status: 400 });
 }
 
-function isRaidStateSchemaError(error: { message?: string; code?: string } | null | undefined) {
-  const message = error?.message ?? "";
-  return error?.code === "PGRST204" || message.includes("raid_gacha_active_until");
-}
-
-function isActiveUntilAfter(value: string | null | undefined, target: Date): boolean {
-  if (!value) return false;
-  const timestamp = Date.parse(value);
-  return Number.isFinite(timestamp) && timestamp > target.getTime();
-}
-
 async function handleRaidNotification(messageId: string, event: {
   from_broadcaster_user_id?: string;
   from_broadcaster_user_login?: string;
@@ -279,74 +279,78 @@ async function handleRaidNotification(messageId: string, event: {
   to_broadcaster_user_login?: string;
   to_broadcaster_user_name?: string;
   viewers?: number;
-}): Promise<void> {
+}): Promise<RedemptionNotifyData | null> {
   const toBroadcasterUserId = event.to_broadcaster_user_id;
-  if (!toBroadcasterUserId) {
-    logger.warn("[EventSub] Raid notification missing to_broadcaster_user_id", { messageId, event });
-    return;
+  const fromBroadcasterUserId = event.from_broadcaster_user_id;
+  if (!toBroadcasterUserId || !fromBroadcasterUserId) {
+    logger.warn("[EventSub] Raid notification missing broadcaster id", { messageId, event });
+    return null;
   }
 
-  const activeUntil = new Date(Date.now() + RAID_GACHA_EVENTSUB_ACTIVE_MINUTES * 60 * 1000).toISOString();
-  const supabaseAdmin = getSupabaseAdmin();
+  const gachaService = new GachaService();
+  const result = await gachaService.executeGachaForRaidEvent({
+    to_broadcaster_user_id: toBroadcasterUserId,
+    from_broadcaster_user_id: fromBroadcasterUserId,
+    from_broadcaster_user_login: event.from_broadcaster_user_login,
+    from_broadcaster_user_name: event.from_broadcaster_user_name,
+  }, messageId);
 
-  const { data: streamer, error: streamerError } = await supabaseAdmin
-    .from("streamers")
-    .select("id, raid_gacha_active_until")
-    .eq("twitch_user_id", toBroadcasterUserId)
-    .maybeSingle();
-
-  if (isRaidStateSchemaError(streamerError)) {
-    logger.warn("[EventSub] Raid gacha state column is unavailable; raid notification ignored", {
-      messageId,
-      toBroadcasterUserId,
-      error: streamerError?.message,
-    });
-    return;
-  }
-
-  if (streamerError || !streamer) {
-    await reportError(new Error(`Raid EventSub streamer lookup failed: ${streamerError?.message ?? "Streamer not found"}`), {
+  if (!result.success) {
+    if (result.error === 'Raid gacha disabled') {
+      logger.info("[EventSub] Raid gacha gift skipped because it is disabled", {
+        messageId,
+        toBroadcasterUserId,
+        fromBroadcasterUserId,
+      });
+      return null;
+    }
+    if (result.error === 'Duplicate event') {
+      logger.info("[EventSub] Raid gacha gift skipped - duplicate event", { messageId });
+      return null;
+    }
+    if (result.error === 'No cards available for this streamer') {
+      logger.warn("[EventSub] Raid gacha gift skipped - no cards available", {
+        messageId,
+        toBroadcasterUserId,
+      });
+      return null;
+    }
+    await reportError(new Error(`Raid gacha gift failed: ${result.error}`), {
       context: "eventsub:handleRaidNotification",
       messageId,
       toBroadcasterUserId,
-      fromBroadcasterUserId: event.from_broadcaster_user_id,
+      fromBroadcasterUserId,
+      gachaError: result.error,
     });
-    return;
+    return null;
   }
 
-  if (isActiveUntilAfter(streamer.raid_gacha_active_until, new Date(activeUntil))) {
-    logger.info("[EventSub] Raid gacha window already extends beyond automatic activation", {
-      messageId,
-      streamerId: streamer.id,
-      activeUntil: streamer.raid_gacha_active_until,
-    });
-    return;
+  const streamer = result.data.streamer;
+  if (!streamer) {
+    logger.warn("[EventSub] Raid gacha gift missing streamer info", { messageId });
+    return null;
   }
 
-  const { error: updateError } = await supabaseAdmin
-    .from("streamers")
-    .update({ raid_gacha_active_until: activeUntil })
-    .eq("id", streamer.id);
-
-  if (updateError) {
-    await reportError(new Error(`Raid gacha activation failed: ${updateError.message}`), {
-      context: "eventsub:handleRaidNotification",
-      messageId,
-      streamerId: streamer.id,
-      toBroadcasterUserId,
-      fromBroadcasterUserId: event.from_broadcaster_user_id,
-    });
-    return;
-  }
-
-  logger.info("[EventSub] Raid gacha window activated from raid notification", {
+  logger.info("[EventSub] Raid gacha gift succeeded", {
     messageId,
     streamerId: streamer.id,
     toBroadcasterUserId,
-    fromBroadcasterUserId: event.from_broadcaster_user_id,
+    fromBroadcasterUserId,
     viewers: event.viewers,
-    activeUntil,
+    drawCount: result.data.cards?.length ?? 1,
   });
+
+  return {
+    gachaResult: {
+      type: "gacha",
+      card: result.data.card,
+      cards: result.data.cards,
+      userTwitchUsername: result.data.userTwitchUsername,
+    },
+    broadcasterTwitchUserId: toBroadcasterUserId,
+    streamer,
+    userId: fromBroadcasterUserId,
+  };
 }
 
 /** postRedemptionNotify に渡すデータ（streamer.id を streamerId として再利用し冗長を排除） */

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -148,18 +148,14 @@ export default function ChannelPointSettings({
   const [addingAdditional, setAddingAdditional] = useState(false);
   const [selectedAdditionalRewardId, setSelectedAdditionalRewardId] = useState("");
   const [additionalDrawCount, setAdditionalDrawCount] = useState(1);
-  const [additionalRaidLimited, setAdditionalRaidLimited] = useState(false);
-  const [raidGachaActiveUntil, setRaidGachaActiveUntil] = useState<string | null>(null);
-  const [updatingRaidGacha, setUpdatingRaidGacha] = useState(false);
+  const [raidGiftDrawCount, setRaidGiftDrawCount] = useState(0);
+  const [updatingRaidGift, setUpdatingRaidGift] = useState(false);
   // Track if registration failed (webhook unreachable)
   // 登録失敗を追跡（Webhookに到達できなかった場合）
   const [registrationFailed, setRegistrationFailed] = useState(false);
   // Track the saved main reward ID (to detect changes for cleanup)
   // 保存済みのメイン報酬IDを追跡（変更検出とクリーンアップ用）
   const [savedMainRewardId, setSavedMainRewardId] = useState(currentRewardId || "");
-  const isRaidGachaActive = Boolean(
-    raidGachaActiveUntil && Date.parse(raidGachaActiveUntil) > Date.now()
-  );
 
   // チャネルポイント系スコープが付与済みか事前確認する。
   // 初回ログインではこれらのスコープを要求しないため、
@@ -280,15 +276,15 @@ export default function ChannelPointSettings({
       });
       if (response.ok) {
         const data = await response.json();
-        setRaidGachaActiveUntil(data.activeUntil ?? null);
+        setRaidGiftDrawCount(Math.min(10, Math.max(0, Number(data.drawCount ?? 0))));
       }
     } catch {
       logger.error("Failed to fetch raid gacha status");
     }
   }, []);
 
-  const updateRaidGachaStatus = async (active: boolean) => {
-    setUpdatingRaidGacha(true);
+  const updateRaidGiftSettings = async () => {
+    setUpdatingRaidGift(true);
     setMessage("");
 
     try {
@@ -296,7 +292,7 @@ export default function ChannelPointSettings({
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ active, activeMinutes: 30 }),
+        body: JSON.stringify({ drawCount: raidGiftDrawCount }),
       });
       const data = await response.json();
 
@@ -305,12 +301,12 @@ export default function ChannelPointSettings({
         return;
       }
 
-      setRaidGachaActiveUntil(data.activeUntil ?? null);
-      setMessage(active ? t("additionalRewards.raidStatusEnabled") : t("additionalRewards.raidStatusDisabled"));
+      setRaidGiftDrawCount(Math.min(10, Math.max(0, Number(data.drawCount ?? 0))));
+      setMessage(t("additionalRewards.raidGiftSaved"));
     } catch {
       setMessage(t("additionalRewards.raidStatusFailed"));
     } finally {
-      setUpdatingRaidGacha(false);
+      setUpdatingRaidGift(false);
     }
   };
 
@@ -549,7 +545,7 @@ export default function ChannelPointSettings({
           rewardId: selectedAdditionalRewardId,
           rewardName: rewardName,
           drawCount: additionalDrawCount,
-          isRaidLimited: additionalRaidLimited,
+          isRaidLimited: false,
         }),
       });
 
@@ -566,7 +562,6 @@ export default function ChannelPointSettings({
       setMessage(raidSubscriptionWarning || t("additionalRewards.addSuccess"));
       setSelectedAdditionalRewardId("");
       setAdditionalDrawCount(1);
-      setAdditionalRaidLimited(false);
       await fetchAdditionalRewards();
       await fetchEventSubStatus(selectedRewardId);
       setRaidEventSubWarning(raidSubscriptionWarning);
@@ -1136,44 +1131,40 @@ export default function ChannelPointSettings({
                  </div>
                )}
 
-               {additionalRewards.some((reward) => reward.is_raid_limited) && (
-                 <div className="mb-3 flex flex-wrap items-center justify-between gap-2 rounded bg-gray-600/50 px-3 py-2">
-                   <div>
-                     <div className="text-sm text-gray-200">
-                       {t("additionalRewards.raidStatusTitle")}
-                     </div>
-                     <div className="text-xs text-gray-400">
-                       {isRaidGachaActive
-                         ? t("additionalRewards.raidStatusActive", {
-                             time: new Date(raidGachaActiveUntil as string).toLocaleTimeString(),
-                           })
-                         : t("additionalRewards.raidStatusInactive")}
-                     </div>
+               <div className="mb-3 flex flex-wrap items-center justify-between gap-2 rounded bg-gray-600/50 px-3 py-2">
+                 <div>
+                   <div className="text-sm text-gray-200">
+                     {t("additionalRewards.raidGiftTitle")}
                    </div>
-                   <div className="flex gap-2">
-                     <button
-                       type="button"
-                       onClick={() => updateRaidGachaStatus(true)}
-                       disabled={updatingRaidGacha}
-                       className="rounded-lg bg-cyan-600 px-3 py-2 text-xs text-white hover:bg-cyan-700 disabled:opacity-50"
-                     >
-                       {t("additionalRewards.raidStatusEnable")}
-                     </button>
-                     <button
-                       type="button"
-                       onClick={() => updateRaidGachaStatus(false)}
-                       disabled={updatingRaidGacha || !isRaidGachaActive}
-                       className="rounded-lg bg-gray-700 px-3 py-2 text-xs text-gray-200 hover:bg-gray-800 disabled:opacity-50"
-                     >
-                       {t("additionalRewards.raidStatusDisable")}
-                     </button>
+                   <div className="text-xs text-gray-400">
+                     {raidGiftDrawCount > 0
+                       ? t("additionalRewards.raidGiftEnabled", { count: raidGiftDrawCount })
+                       : t("additionalRewards.raidGiftDisabled")}
                    </div>
                  </div>
-               )}
+                 <div className="flex items-center gap-2">
+                   <input
+                     type="number"
+                     min={0}
+                     max={10}
+                     value={raidGiftDrawCount}
+                     onChange={(e) => setRaidGiftDrawCount(Math.min(10, Math.max(0, Number(e.target.value) || 0)))}
+                     className="w-16 rounded bg-gray-700 px-2 py-1 text-sm text-gray-100"
+                   />
+                   <button
+                     type="button"
+                     onClick={updateRaidGiftSettings}
+                     disabled={updatingRaidGift}
+                     className="rounded-lg bg-cyan-600 px-3 py-2 text-xs text-white hover:bg-cyan-700 disabled:opacity-50"
+                   >
+                     {updatingRaidGift ? tCommon("loading") : tCommon("save")}
+                   </button>
+                 </div>
+               </div>
 
                {/* Add new additional reward */}
                {/* 新しい追加報酬を追加 */}
-               <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_110px_auto_auto] sm:items-center">
+               <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_110px_auto] sm:items-center">
                  <select
                    value={selectedAdditionalRewardId}
                    onChange={(e) => setSelectedAdditionalRewardId(e.target.value)}
@@ -1206,17 +1197,6 @@ export default function ChannelPointSettings({
                      onChange={(e) => setAdditionalDrawCount(Math.min(10, Math.max(1, Number(e.target.value) || 1)))}
                      className="w-12 rounded bg-gray-700 px-2 py-1 text-sm text-gray-100"
                    />
-                 </label>
-                 <label className="flex items-center gap-2 rounded-lg bg-gray-600 px-3 py-2 text-sm text-gray-200">
-                   <input
-                     type="checkbox"
-                     checked={additionalRaidLimited}
-                     onChange={(e) => setAdditionalRaidLimited(e.target.checked)}
-                     className="h-4 w-4 rounded border-gray-500 bg-gray-700"
-                   />
-                   <span className="whitespace-nowrap text-xs text-gray-300">
-                     {t("additionalRewards.raidOnly")}
-                   </span>
                  </label>
                  <button
                    onClick={handleAddAdditionalReward}

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -40,7 +40,9 @@ function isRaidOptionsSchemaError(error: { message?: string; code?: string } | n
 
 function isRaidStateSchemaError(error: { message?: string; code?: string } | null | undefined) {
   const message = error?.message ?? ''
-  return error?.code === 'PGRST204' || message.includes('raid_gacha_active_until')
+  return error?.code === 'PGRST204'
+    || message.includes('raid_gacha_active_until')
+    || message.includes('raid_gacha_draw_count')
 }
 
 function isRaidGachaActive(activeUntil: string | null | undefined, now = new Date()): boolean {
@@ -362,6 +364,66 @@ export class GachaService {
       }
 
       return err('Reward ID mismatch')
+    } catch (error) {
+      return err(`Unexpected error: ${error}`)
+    }
+  }
+
+  async executeGachaForRaidEvent(
+    event: {
+      to_broadcaster_user_id: string
+      from_broadcaster_user_id: string
+      from_broadcaster_user_login?: string
+      from_broadcaster_user_name?: string
+    },
+    eventId?: string
+  ): Promise<Result<GachaResult>> {
+    try {
+      let { data: streamer, error: streamerError } = await this.supabase
+        .from('streamers')
+        .select('id, chat_announcement_enabled, chat_announcement_template, raid_gacha_draw_count')
+        .eq('twitch_user_id', event.to_broadcaster_user_id)
+        .maybeSingle()
+
+      if (isRaidStateSchemaError(streamerError)) {
+        const fallbackResult = await this.supabase
+          .from('streamers')
+          .select('id, chat_announcement_enabled, chat_announcement_template')
+          .eq('twitch_user_id', event.to_broadcaster_user_id)
+          .maybeSingle()
+        streamer = fallbackResult.data ? { ...fallbackResult.data, raid_gacha_draw_count: 0 } : fallbackResult.data
+        streamerError = fallbackResult.error
+      }
+
+      if (streamerError || !streamer) {
+        return err('Streamer not found')
+      }
+
+      const drawCount = Math.min(Math.max(Number(streamer.raid_gacha_draw_count ?? 0), 0), 10)
+      if (drawCount < 1) {
+        return err('Raid gacha disabled')
+      }
+
+      const userName = event.from_broadcaster_user_name || event.from_broadcaster_user_login || event.from_broadcaster_user_id
+      const result = await this.executeGachaDraws(
+        streamer.id,
+        event.from_broadcaster_user_id,
+        userName,
+        drawCount,
+        eventId,
+        undefined
+      )
+
+      if (!result.success) return result
+
+      return ok({
+        ...result.data,
+        streamer: {
+          id: streamer.id,
+          chat_announcement_enabled: streamer.chat_announcement_enabled,
+          chat_announcement_template: streamer.chat_announcement_template,
+        },
+      })
     } catch (error) {
       return err(`Unexpected error: ${error}`)
     }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -48,6 +48,9 @@ export interface Database {
           // レイド限定ガチャを受け付ける期限（null/期限切れは不明状態としてブロック）
           // Until when raid-limited gacha rewards are accepted. Null/expired blocks them.
           raid_gacha_active_until: string | null
+          // incoming raid 送信者に自動付与するガチャ回数（0=無効）
+          // Number of gacha draws gifted to the raider on incoming raids. 0 disables gifts.
+          raid_gacha_draw_count: number
           created_at: string
           updated_at: string
         }
@@ -68,6 +71,7 @@ export interface Database {
           show_unowned_cards?: boolean
           show_unowned_card_details?: boolean
           raid_gacha_active_until?: string | null
+          raid_gacha_draw_count?: number
           created_at?: string
           updated_at?: string
         }
@@ -88,6 +92,7 @@ export interface Database {
           show_unowned_cards?: boolean
           show_unowned_card_details?: boolean
           raid_gacha_active_until?: string | null
+          raid_gacha_draw_count?: number
           created_at?: string
           updated_at?: string
         }

--- a/supabase/migrations/00043_add_raid_gacha_draw_count.sql
+++ b/supabase/migrations/00043_add_raid_gacha_draw_count.sql
@@ -1,0 +1,13 @@
+-- Configure automatic gacha gifts for incoming raids.
+ALTER TABLE streamers
+  ADD COLUMN IF NOT EXISTS raid_gacha_draw_count INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE streamers
+  DROP CONSTRAINT IF EXISTS streamers_raid_gacha_draw_count_check;
+
+ALTER TABLE streamers
+  ADD CONSTRAINT streamers_raid_gacha_draw_count_check
+  CHECK (raid_gacha_draw_count BETWEEN 0 AND 10);
+
+COMMENT ON COLUMN streamers.raid_gacha_draw_count IS
+  'Number of gacha draws granted to the raider when an incoming raid is received. 0 disables raid gifts.';

--- a/tests/unit/eventsub-reward-mismatch.test.ts
+++ b/tests/unit/eventsub-reward-mismatch.test.ts
@@ -9,6 +9,7 @@ import { hasScope } from '@/lib/twitch/token-manager'
 
 const mocks = vi.hoisted(() => ({
   executeGachaForEventSub: vi.fn(),
+  executeGachaForRaidEvent: vi.fn(),
   buildMessage: vi.fn((template: string | null, placeholders: { user: string; card: string; cards?: string; draws?: number }) => {
     const messageTemplate = template || '{user} got {card}'
     return messageTemplate
@@ -25,6 +26,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@/lib/services/gacha', () => ({
   GachaService: vi.fn().mockImplementation(() => ({
     executeGachaForEventSub: mocks.executeGachaForEventSub,
+    executeGachaForRaidEvent: mocks.executeGachaForRaidEvent,
   })),
 }))
 
@@ -169,7 +171,7 @@ describe('EventSub reward mismatch handling', () => {
     expect(mockReportError).not.toHaveBeenCalled()
   })
 
-  it('activates the raid gacha window from incoming Twitch raid notifications', async () => {
+  it('gifts configured raid gacha draws to the incoming raider', async () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret
     const messageId = 'eventsub-channel-raid'
@@ -187,32 +189,23 @@ describe('EventSub reward mismatch handling', () => {
       },
     })
     const signature = await signEventSubBody(secret, messageId, timestamp, body)
-    const updateQuery = {
-      eq: vi.fn().mockResolvedValue({ error: null }),
-    }
-    const streamerQuery = {
-      select: vi.fn().mockReturnThis(),
-      eq: vi.fn().mockReturnThis(),
-      maybeSingle: vi.fn().mockResolvedValue({
-        data: { id: 'streamer-1', raid_gacha_active_until: null },
-        error: null,
-      }),
-    }
-    const from = vi.fn((table: string) => {
-      if (table === 'streamers') {
-        return {
-          select: streamerQuery.select,
-          eq: streamerQuery.eq,
-          maybeSingle: streamerQuery.maybeSingle,
-          update: vi.fn((value: { raid_gacha_active_until: string }) => {
-            expect(Date.parse(value.raid_gacha_active_until)).toBeGreaterThan(Date.now())
-            return updateQuery
-          }),
-        }
-      }
-      throw new Error(`Unexpected table: ${table}`)
+    const cards = [
+      { id: 'card-1', name: 'Raid Card 1', description: null, image_url: null, rarity: 'common', drop_rate: 1 },
+      { id: 'card-2', name: 'Raid Card 2', description: null, image_url: null, rarity: 'rare', drop_rate: 1 },
+    ]
+    mocks.executeGachaForRaidEvent.mockResolvedValue({
+      success: true,
+      data: {
+        card: cards[0],
+        cards,
+        userTwitchUsername: 'Raider',
+        streamer: {
+          id: 'streamer-1',
+          chat_announcement_enabled: false,
+          chat_announcement_template: null,
+        },
+      },
     })
-    mockGetSupabaseAdmin.mockReturnValue({ from } as unknown as ReturnType<typeof getSupabaseAdmin>)
 
     const response = await POST(new NextRequest('http://localhost:3000/api/twitch/eventsub', {
       method: 'POST',
@@ -229,8 +222,21 @@ describe('EventSub reward mismatch handling', () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ received: true })
     expect(mocks.executeGachaForEventSub).not.toHaveBeenCalled()
-    expect(streamerQuery.eq).toHaveBeenCalledWith('twitch_user_id', 'broadcaster-1')
-    expect(updateQuery.eq).toHaveBeenCalledWith('id', 'streamer-1')
+    expect(mocks.executeGachaForRaidEvent).toHaveBeenCalledWith({
+      to_broadcaster_user_id: 'broadcaster-1',
+      from_broadcaster_user_id: 'raider-1',
+      from_broadcaster_user_login: 'raider',
+      from_broadcaster_user_name: 'Raider',
+    }, messageId)
+    expect(mockBroadcastGachaResult).toHaveBeenCalledWith(
+      'streamer-1',
+      expect.objectContaining({
+        card: cards[0],
+        cards,
+        userTwitchUsername: 'Raider',
+      }),
+      expect.any(Object),
+    )
     expect(mockReportError).not.toHaveBeenCalled()
   })
 

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -505,3 +505,97 @@ describe('GachaService.executeGachaForEventSub', () => {
     expect(mockRpc).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('GachaService.executeGachaForRaidEvent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('incoming raid の送信者に設定回数分のガチャを付与する', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        id: 'streamer-1',
+        chat_announcement_enabled: false,
+        chat_announcement_template: null,
+        raid_gacha_draw_count: 2,
+      },
+      error: null,
+    })
+    const cardsQuery = createCardsQuery(testCards)
+    const mockRpc = vi.fn().mockResolvedValue({
+      data: { is_duplicate: false },
+      error: null,
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        if (table === 'cards') return cardsQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForRaidEvent({
+      to_broadcaster_user_id: 'broadcaster-1',
+      from_broadcaster_user_id: 'raider-1',
+      from_broadcaster_user_login: 'raider',
+      from_broadcaster_user_name: 'Raider',
+    }, 'raid-event-1')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.cards).toHaveLength(2)
+      expect(result.data.userTwitchUsername).toBe('Raider')
+      expect(result.data.streamer?.id).toBe('streamer-1')
+    }
+    expect(streamerQuery.eq).toHaveBeenCalledWith('twitch_user_id', 'broadcaster-1')
+    expect(mockRpc).toHaveBeenNthCalledWith(1, 'execute_gacha_transaction', expect.objectContaining({
+      p_event_id: 'raid-event-1',
+      p_user_twitch_id: 'raider-1',
+      p_reward_cost: null,
+    }))
+    expect(mockRpc).toHaveBeenNthCalledWith(2, 'execute_gacha_transaction', expect.objectContaining({
+      p_event_id: 'raid-event-1:2',
+      p_user_twitch_id: 'raider-1',
+      p_reward_cost: null,
+    }))
+  })
+
+  it('レイド送信者プレゼントが0回ならガチャを実行しない', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        id: 'streamer-1',
+        chat_announcement_enabled: false,
+        chat_announcement_template: null,
+        raid_gacha_draw_count: 0,
+      },
+      error: null,
+    })
+    const mockRpc = vi.fn()
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForRaidEvent({
+      to_broadcaster_user_id: 'broadcaster-1',
+      from_broadcaster_user_id: 'raider-1',
+      from_broadcaster_user_name: 'Raider',
+    }, 'raid-event-disabled')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('Raid gacha disabled')
+    }
+    expect(mockRpc).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- replace the raid window behavior with a raider gift setting that grants N gacha draws to the incoming raider on channel.raid
- store the raider gift draw count on streamers with 0-10 validation and expose it in the settings UI
- broadcast/chat announce raid gifts using the same multi-draw payload path as channel point gachas

## Validation
- npx vitest run tests/unit/gacha-service.test.ts tests/unit/eventsub-reward-mismatch.test.ts
- npm run lint (existing warnings only)
- npm run build
- npm run workers:build