### PR TITLE
Fix multi-draw overlay card display

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -517,7 +517,7 @@
       "removeConfirm": "Remove this additional reward? EventSub subscription will also be removed.",
       "cannotUseAsMain": "This reward is registered as an additional reward. Please remove it from additional rewards first.",
       "cannotUseAsAdditional": "This reward is already set as the main reward.",
-      "drawCount": "Draws per redemption",
+      "drawCount": "Cards per redemption",
       "raidOnly": "Raid only",
       "multiDraw": "{count} draws",
       "raidLimited": "Raid limited",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -517,7 +517,7 @@
       "removeConfirm": "この追加報酬を削除しますか？EventSubサブスクリプションも削除されます。",
       "cannotUseAsMain": "この報酬は追加報酬として登録されています。先に追加報酬から削除してください。",
       "cannotUseAsAdditional": "この報酬はメイン報酬として設定されています。",
-      "drawCount": "一度に引ける回数",
+      "drawCount": "一度に排出する枚数",
       "raidOnly": "レイド限定",
       "multiDraw": "{count}連",
       "raidLimited": "レイド限定",

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -763,6 +763,8 @@ async function sendChatAnnouncement(
       broadcasterTwitchUserId,
       streamerId: streamer.id,
       cardName: card.name,
+      drawCount: drawnCards.length,
+      multiDraw: isMultiDraw,
     });
   } else {
     // sendChatMessage が false を返した場合のログ（API呼び出し失敗）
@@ -771,6 +773,8 @@ async function sendChatAnnouncement(
       broadcasterTwitchUserId,
       streamerId: streamer.id,
       cardName: card.name,
+      drawCount: drawnCards.length,
+      multiDraw: isMultiDraw,
     });
   }
 }

--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -515,6 +515,7 @@ export default function OverlayPage() {
         pollCursorRef.current = new Date().toISOString();
         displayResultRef.current({
           card: payload.card as unknown as Card,
+          cards: payload.cards as unknown as Card[] | undefined,
           userTwitchUsername: payload.userTwitchUsername,
         });
       }

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
-import type { RealtimeError, SubscribeOptions } from '@/lib/realtime'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import type { GachaBroadcastPayload, RealtimeError, SubscribeOptions } from '@/lib/realtime'
 import OverlayPage from '@/app/overlay/[streamerId]/page'
 
 const { subscribeMock } = vi.hoisted(() => ({
@@ -40,6 +40,7 @@ describe('OverlayPage', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
     subscribeMock.mockReset()
   })
@@ -63,5 +64,62 @@ describe('OverlayPage', () => {
     expect(await screen.findByText('Debug Mode - Connection Log')).toBeInTheDocument()
     expect(screen.getByText(`Last issue: ${connectionError.message}`)).toBeInTheDocument()
     expect(screen.queryByText('接続エラー')).not.toBeInTheDocument()
+  })
+
+  it('RealtimeのN連ガチャpayloadを1枚ずつ順番に表示する', async () => {
+    window.history.replaceState({}, '', '/overlay/streamer-1?duration=2')
+    let realtimeCallback: ((payload: GachaBroadcastPayload) => void) | undefined
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      realtimeCallback = callback as (payload: GachaBroadcastPayload) => void
+      options.onSuccess?.()
+      return vi.fn()
+    })
+
+    render(<OverlayPage />)
+
+    await waitFor(() => {
+      expect(realtimeCallback).toBeDefined()
+    })
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    act(() => {
+      realtimeCallback?.({
+        type: 'gacha',
+        card: {
+          id: 'card-1',
+          name: 'Alpha',
+          description: null,
+          image_url: null,
+          rarity: 'rare',
+        },
+        cards: [
+          {
+            id: 'card-1',
+            name: 'Alpha',
+            description: null,
+            image_url: null,
+            rarity: 'rare',
+          },
+          {
+            id: 'card-2',
+            name: 'Beta',
+            description: null,
+            image_url: null,
+            rarity: 'common',
+          },
+        ],
+        userTwitchUsername: 'Viewer',
+      })
+    })
+
+    expect(await screen.findByText('Alpha')).toBeInTheDocument()
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 3200))
+    })
+
+    expect(await screen.findByText('Beta')).toBeInTheDocument()
   })
 })

--- a/tests/unit/eventsub-reward-mismatch.test.ts
+++ b/tests/unit/eventsub-reward-mismatch.test.ts
@@ -387,6 +387,62 @@ describe('EventSub reward mismatch handling', () => {
     )
   })
 
+  it('adds all multi-draw cards to existing single-card chat templates', async () => {
+    const secret = 'eventsub-test-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = secret
+    const messageId = 'eventsub-multi-draw-single-template'
+    const timestamp = '2026-05-11T10:00:00Z'
+    const body = JSON.stringify({
+      subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
+      event: {
+        broadcaster_user_id: 'broadcaster-1',
+        user_id: 'viewer-1',
+        user_login: 'viewer',
+        user_name: 'Viewer',
+        reward: { id: 'raid-gacha', title: 'Raid Gacha', cost: 500 },
+      },
+    })
+    const signature = await signEventSubBody(secret, messageId, timestamp, body)
+
+    const cards = [
+      { id: 'card-1', name: 'Alpha', description: null, image_url: null, rarity: 'rare', drop_rate: 1 },
+      { id: 'card-2', name: 'Beta', description: null, image_url: null, rarity: 'common', drop_rate: 1 },
+      { id: 'card-3', name: 'Gamma', description: null, image_url: null, rarity: 'legendary', drop_rate: 1 },
+    ] as const
+
+    mocks.executeGachaForEventSub.mockResolvedValue({
+      success: true,
+      data: {
+        card: cards[0],
+        cards: [...cards],
+        userTwitchUsername: 'Viewer',
+        streamer: {
+          id: 'streamer-1',
+          chat_announcement_enabled: true,
+          chat_announcement_template: '@{user} が {card} を獲得しました！',
+        },
+      },
+    })
+
+    const response = await POST(new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'twitch-eventsub-message-id': messageId,
+        'twitch-eventsub-message-timestamp': timestamp,
+        'twitch-eventsub-message-type': 'notification',
+        'twitch-eventsub-message-signature': signature,
+      },
+      body,
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.sendChatMessage).toHaveBeenCalledWith(
+      'broadcaster-1',
+      '@Viewer が Alpha を獲得しました！（全3枚: Alpha、Beta、Gamma）',
+    )
+  })
+
   it('abbreviates long multi-draw card lists before sending chat announcements', async () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret


### PR DESCRIPTION
## Summary
- pass Realtime multi-draw cards through to the overlay display queue
- add chat announcement logging for draw count and multi-draw status
- clarify the additional reward draw count label as cards emitted per redemption
- add regression tests for overlay sequencing and single-card chat templates with multi-draw results

## Validation
- npm_config_cache=/private/tmp/twica-npm-cache npx vitest run tests/unit/components/overlay-page.test.tsx tests/unit/eventsub-reward-mismatch.test.ts
- npm_config_cache=/private/tmp/twica-npm-cache npm run lint
- npm_config_cache=/private/tmp/twica-npm-cache npm run build