### PR TITLE
feat: add multi-draw chat announcement settings

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -387,9 +387,14 @@
     "noLineBreakNote": "* Twitch chat does not support line breaks. Messages with line breaks will be sent as a single line.",
     "form": {
       "enableAnnouncement": "Enable chat announcements",
+      "showAdvanced": "Show advanced settings",
       "customTemplate": "Custom Template (optional)",
       "templatePlaceholder": "@'{'user'}' got a ['{'rarity'}'] '{'card'}'!",
-      "placeholderHelp": "Available placeholders: '{'user'}'=username, '{'card'}'=first card name, '{'cards'}'=all card names, '{'draws'}'=draw count, '{'rarity'}'=rarity, '{'num'}'=owned count, '{'unique'}'=unique types owned, '{'all'}'=total types, '{'detail'}'=card description, '{'url'}'=collection URL",
+      "multiTemplate": "Multi-draw Template (optional)",
+      "multiTemplatePlaceholder": "@'{'user'}' got '{'rarityCounts'}' from a '{'draws'}'-draw gacha! '{'cards'}'",
+      "multiShowCards": "Include card-name list in multi-draw announcements",
+      "placeholderHelp": "Available placeholders: '{'user'}'=username, '{'card'}'=first card name, '{'rarity'}'=rarity, '{'num'}'=owned count, '{'unique'}'=unique types owned, '{'all'}'=total types, '{'detail'}'=card description, '{'url'}'=collection URL",
+      "multiPlaceholderHelp": "Multi-draw only: '{'draws'}'=draw count, '{'rarityCounts'}'=rarity counts (e.g. Rare x3, Common x3), '{'cards'}'=card-name list",
       "previewLength": "Preview length: {current} / {max} characters"
     },
     "buttons": {
@@ -418,6 +423,8 @@
     "demo": {
       "title": "Chat Message Preview",
       "description": "Preview of the message that will be sent (using sample data)",
+      "singleTitle": "Single draw",
+      "multiTitle": "Multi-draw",
       "close": "Close"
     },
     "bot": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -387,9 +387,14 @@
     "noLineBreakNote": "※ Twitchチャットは改行に対応していません。改行を含むメッセージは1行で送信されます。",
     "form": {
       "enableAnnouncement": "チャット通知を有効にする",
+      "showAdvanced": "詳細設定を表示する",
       "customTemplate": "カスタムテンプレート（任意）",
       "templatePlaceholder": "@'{'user'}' が【'{'rarity'}'】'{'card'}' を獲得しました！",
-      "placeholderHelp": "使用可能なプレースホルダー: '{'user'}'=ユーザー名, '{'card'}'=先頭カード名, '{'cards'}'=全カード名, '{'draws'}'=抽選回数, '{'rarity'}'=レアリティ, '{'num'}'=所持枚数, '{'unique'}'=所持種類数, '{'all'}'=全種類数, '{'detail'}'=カード説明, '{'url'}'=コレクションURL",
+      "multiTemplate": "N連ガチャ用テンプレート（任意）",
+      "multiTemplatePlaceholder": "@'{'user'}' が'{'draws'}'連ガチャで '{'rarityCounts'}' を獲得しました！'{'cards'}'",
+      "multiShowCards": "N連通知にカード名一覧を含める",
+      "placeholderHelp": "使用可能なプレースホルダー: '{'user'}'=ユーザー名, '{'card'}'=先頭カード名, '{'rarity'}'=レアリティ, '{'num'}'=所持枚数, '{'unique'}'=所持種類数, '{'all'}'=全種類数, '{'detail'}'=カード説明, '{'url'}'=コレクションURL",
+      "multiPlaceholderHelp": "N連用: '{'draws'}'=抽選回数, '{'rarityCounts'}'=レアリティ別枚数（例: レアx3、コモンx3）, '{'cards'}'=カード名一覧",
       "previewLength": "プレビュー文字数: {current} / {max}文字"
     },
     "buttons": {
@@ -418,6 +423,8 @@
     "demo": {
       "title": "チャットメッセージプレビュー",
       "description": "実際に送信されるメッセージのプレビューです（サンプルデータ使用）",
+      "singleTitle": "通常ガチャ",
+      "multiTitle": "N連ガチャ",
       "close": "閉じる"
     },
     "bot": {

--- a/src/app/api/overlay/[streamerId]/events/route.ts
+++ b/src/app/api/overlay/[streamerId]/events/route.ts
@@ -25,6 +25,7 @@ interface OverlayHistoryCard {
 
 interface OverlayHistoryRow {
   id: string;
+  event_id: string | null;
   redeemed_at: string;
   user_twitch_username: string | null;
   cards: OverlayHistoryCard | OverlayHistoryCard[] | null;
@@ -120,7 +121,7 @@ export async function GET(
         supabaseAdmin
           .from("gacha_history")
           .select(
-            "id, redeemed_at, user_twitch_username, cards(id, name, description, image_url, rarity)"
+            "id, event_id, redeemed_at, user_twitch_username, cards(id, name, description, image_url, rarity)"
           )
           .eq("streamer_id", streamerId)
           .gt("redeemed_at", since)
@@ -140,6 +141,7 @@ export async function GET(
         if (!card) return null;
         return {
           id: row.id,
+          eventId: row.event_id,
           redeemedAt: row.redeemed_at,
           userTwitchUsername: row.user_twitch_username ?? "Unknown",
           card,

--- a/src/app/api/streamer/settings/route.ts
+++ b/src/app/api/streamer/settings/route.ts
@@ -92,6 +92,8 @@ export async function POST(request: NextRequest) {
       // Chat announcement settings (optional)
       chatAnnouncementEnabled,
       chatAnnouncementTemplate,
+      chatAnnouncementMultiTemplate,
+      chatAnnouncementMultiShowCards,
       // レアリティ別自動確率設定（オプション）
       rarityWeights,
       // 未所持カード表示設定（オプション、Issue #395）
@@ -120,6 +122,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
     }
     if (disconnectBot !== undefined && typeof disconnectBot !== "boolean") {
+      return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
+    }
+    if (
+      chatAnnouncementMultiShowCards !== undefined
+      && typeof chatAnnouncementMultiShowCards !== "boolean"
+    ) {
       return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
     }
 
@@ -166,6 +174,12 @@ export async function POST(request: NextRequest) {
     // chatAnnouncementTemplate: カスタムテンプレート（nullでデフォルト使用）
     if (chatAnnouncementTemplate !== undefined) {
       updateData.chat_announcement_template = chatAnnouncementTemplate;
+    }
+    if (chatAnnouncementMultiTemplate !== undefined) {
+      updateData.chat_announcement_multi_template = chatAnnouncementMultiTemplate;
+    }
+    if (chatAnnouncementMultiShowCards !== undefined) {
+      updateData.chat_announcement_multi_show_cards = chatAnnouncementMultiShowCards;
     }
 
     // rarityWeights: レアリティ別目標確率（nullで自動モード無効）

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -8,8 +8,6 @@ import { checkRateLimit, rateLimits, getClientIp } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
 import { reportError } from "@/lib/sentry/error-handler";
 import { TwitchChatService, DEFAULT_CHAT_TEMPLATE, type ChatMessagePlaceholders } from "@/lib/twitch/chat-service";
-import { hasScope } from "@/lib/twitch/token-manager";
-import { ADDITIONAL_SCOPES } from "@/lib/twitch/scopes";
 import type { GachaCard, EventSubStreamerInfo } from "@/lib/services/gacha";
 import { countCharacters } from "@/lib/text-utils";
 
@@ -17,6 +15,7 @@ const MESSAGE_TYPE_VERIFICATION = "webhook_callback_verification";
 const MESSAGE_TYPE_NOTIFICATION = "notification";
 const MESSAGE_TYPE_REVOCATION = "revocation";
 const CARD_LIST_SEPARATOR = "、";
+const DEFAULT_MULTI_DRAW_CHAT_TEMPLATE = '@{user} が{draws}連ガチャで {rarityCounts} を獲得しました！{cards}';
 
 function formatCardNamesForChat(cardNames: string[], maxCharacters: number): string {
   if (cardNames.length === 0) return "";
@@ -66,6 +65,33 @@ function fitCardNamesForMessage(
   }
 
   return { cardsText, message };
+}
+
+function formatRarityCountsForChat(cardNamesByRarity: string[]): string {
+  if (cardNamesByRarity.length === 0) return "";
+
+  const counts = new Map<string, number>();
+  for (const rarity of cardNamesByRarity) {
+    counts.set(rarity, (counts.get(rarity) ?? 0) + 1);
+  }
+
+  const rarityOrder = ["legendary", "epic", "rare", "common"];
+  const rarityMap: Record<string, string> = {
+    common: 'コモン',
+    rare: 'レア',
+    epic: 'エピック',
+    legendary: 'レジェンダリー',
+  };
+
+  return [...counts.entries()]
+    .sort(([a], [b]) => {
+      const aIndex = rarityOrder.indexOf(a);
+      const bIndex = rarityOrder.indexOf(b);
+      return (aIndex === -1 ? rarityOrder.length : aIndex)
+        - (bIndex === -1 ? rarityOrder.length : bIndex);
+    })
+    .map(([rarity, count]) => `${rarityMap[rarity] ?? rarity}x${count}`)
+    .join(CARD_LIST_SEPARATOR);
 }
 
 /**
@@ -553,6 +579,8 @@ async function sendChatAnnouncement(
     id: string;
     chat_announcement_enabled: boolean;
     chat_announcement_template: string | null;
+    chat_announcement_multi_template: string | null;
+    chat_announcement_multi_show_cards: boolean;
   },
   card: GachaCard,
   userName: string,
@@ -562,6 +590,7 @@ async function sendChatAnnouncement(
   const drawnCards = cards && cards.length > 0 ? cards : [card];
   const isMultiDraw = drawnCards.length > 1;
   const cardNames = drawnCards.map((drawnCard) => drawnCard.name);
+  const rarityCounts = formatRarityCountsForChat(drawnCards.map((drawnCard) => drawnCard.rarity));
 
   // 関数呼び出しを記録（デバッグ用：この関数が呼ばれたことを確認するため）
   // Log function entry to confirm this function is being called
@@ -586,17 +615,6 @@ async function sendChatAnnouncement(
     return;
   }
 
-  // user:write:chatスコープが付与されているかチェック
-  // Check if user:write:chat scope is granted
-  const hasChatScope = await hasScope(broadcasterTwitchUserId, ADDITIONAL_SCOPES.CHAT_WRITE);
-  if (!hasChatScope) {
-    logger.info('Chat announcement skipped - missing scope', {
-      broadcasterTwitchUserId,
-      streamerId: streamer.id,
-    });
-    return;
-  }
-
   // レアリティの日本語/英語変換マップ
   // Rarity translation map
   const rarityMap: Record<string, string> = {
@@ -609,9 +627,10 @@ async function sendChatAnnouncement(
   // テンプレートに含まれるプレースホルダーに応じてのみDBクエリを実行
   // waitUntil内のwall time短縮のため、不要なDBクエリをスキップ
   // Run DB queries only for placeholders that appear in the template to keep waitUntil wall-time short
-  const messageTemplate = streamer.chat_announcement_template
-    || (isMultiDraw ? '@{user} が{draws}連ガチャで {cards} を獲得しました！' : DEFAULT_CHAT_TEMPLATE);
-  const usesMultiDrawPlaceholders = /\{cards\}|\{draws\}/.test(messageTemplate);
+  const messageTemplate = isMultiDraw
+    ? streamer.chat_announcement_multi_template || DEFAULT_MULTI_DRAW_CHAT_TEMPLATE
+    : streamer.chat_announcement_template || DEFAULT_CHAT_TEMPLATE;
+  const usesMultiDrawPlaceholders = /\{cards\}|\{draws\}|\{rarityCounts\}/.test(messageTemplate);
   const effectiveTemplate = messageTemplate;
   const needsCardCount = /\{num\}/.test(effectiveTemplate);
   const needsUniqueCount = /\{unique\}/.test(effectiveTemplate);
@@ -723,8 +742,11 @@ async function sendChatAnnouncement(
   const placeholders: ChatMessagePlaceholders = {
     user: userName,
     card: card.name,
-    cards: isMultiDraw ? cardNames.join(CARD_LIST_SEPARATOR) : undefined,
+    cards: isMultiDraw && streamer.chat_announcement_multi_show_cards
+      ? cardNames.join(CARD_LIST_SEPARATOR)
+      : undefined,
     draws: isMultiDraw ? drawnCards.length : undefined,
+    rarityCounts: isMultiDraw ? rarityCounts : undefined,
     rarity: rarityMap[card.rarity] || card.rarity,
     detail: card.description || undefined,
     num: cardCount,
@@ -738,7 +760,7 @@ async function sendChatAnnouncement(
   const chatService = new TwitchChatService();
   let message: string;
 
-  if (isMultiDraw && usesMultiDrawPlaceholders) {
+  if (isMultiDraw && streamer.chat_announcement_multi_show_cards && usesMultiDrawPlaceholders) {
     const fitted = fitCardNamesForMessage(cardNames, (cardsText) =>
       chatService.buildMessage(messageTemplate, { ...placeholders, cards: cardsText })
     );
@@ -746,7 +768,7 @@ async function sendChatAnnouncement(
     message = fitted.message;
   } else {
     const baseMessage = chatService.buildMessage(messageTemplate, placeholders);
-    if (isMultiDraw) {
+    if (isMultiDraw && streamer.chat_announcement_multi_show_cards && !usesMultiDrawPlaceholders) {
       message = fitCardNamesForMessage(
         cardNames,
         (cardsText) => `${baseMessage}（全${drawnCards.length}枚: ${cardsText}）`

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -120,6 +120,8 @@ export default async function SettingsPage() {
               streamerId={streamerData.streamer.id}
               currentEnabled={streamerData.streamer.chat_announcement_enabled ?? false}
               currentTemplate={streamerData.streamer.chat_announcement_template ?? null}
+              currentMultiTemplate={streamerData.streamer.chat_announcement_multi_template ?? null}
+              currentMultiShowCards={streamerData.streamer.chat_announcement_multi_show_cards ?? true}
               botAccount={botAccount}
             />
             {/* 未所持カード表示設定（Issue #395） */}

--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -31,10 +31,13 @@ interface GachaResult {
   cards?: Card[];
   userTwitchUsername: string;
   historyId?: string;
+  soundGroupId?: string;
+  shouldPlaySound?: boolean;
 }
 
 interface OverlayPollingEvent {
   id: string;
+  eventId: string | null;
   redeemedAt: string;
   userTwitchUsername: string;
   card: Pick<Card, "id" | "name" | "description" | "image_url" | "rarity">;
@@ -157,6 +160,7 @@ export default function OverlayPage() {
   // 連続引き換え時に前のカードが消えて最後の1件しか表示されない問題を解消
   const queueRef = useRef<GachaResult[]>([]);
   const isDisplayingRef = useRef(false);
+  const playedSoundGroupIdsRef = useRef<Set<string>>(new Set());
   // processQueueの再帰呼び出し用ref（useCallback内で自身を参照するため）
   const processQueueRef = useRef<() => void>(() => {});
   // displayResultとaddDebugLogをrefで保持することで、
@@ -377,7 +381,16 @@ export default function OverlayPage() {
     // Show card after brief delay
     animationTimeoutRef.current = setTimeout(() => {
       setShowCard(true);
-      playGachaSound();
+      if (next.shouldPlaySound !== false) {
+        if (next.soundGroupId) {
+          if (!playedSoundGroupIdsRef.current.has(next.soundGroupId)) {
+            playedSoundGroupIdsRef.current.add(next.soundGroupId);
+            playGachaSound();
+          }
+        } else {
+          playGachaSound();
+        }
+      }
 
       // Hide after display, then process next queued item
       animationTimeoutRef.current = setTimeout(() => {
@@ -403,10 +416,11 @@ export default function OverlayPage() {
   const enqueueResult = useCallback((data: GachaResult) => {
     const cards = data.cards?.length ? data.cards : [data.card];
     queueRef.current.push(
-      ...cards.map((card) => ({
+      ...cards.map((card, index) => ({
         ...data,
         card,
         cards: undefined,
+        shouldPlaySound: data.shouldPlaySound !== false && index === 0,
       }))
     );
     if (!isDisplayingRef.current) {
@@ -450,6 +464,7 @@ export default function OverlayPage() {
           card: event.card as Card,
           userTwitchUsername: event.userTwitchUsername,
           historyId: event.id,
+          soundGroupId: event.eventId?.replace(/:\d+$/, "") ?? event.id,
         });
       }
     } catch (error) {
@@ -503,6 +518,8 @@ export default function OverlayPage() {
   // 依存配列は streamerId のみ。displayResult/addDebugLog は ref 経由で参照し、
   // callback の再生成（soundSettings 変更等）で subscription が破棄・再作成されないようにする
   useEffect(() => {
+    const playedSoundGroupIds = playedSoundGroupIdsRef.current;
+
     queueMicrotask(() => {
       addDebugLogRef.current(`Starting subscription for streamer: ${streamerId}`);
       addDebugLogRef.current(`Supabase URL: ${process.env.NEXT_PUBLIC_SUPABASE_URL ? 'configured' : 'missing'}`);
@@ -557,6 +574,7 @@ export default function OverlayPage() {
       // キューをクリアして未再生アイテムを破棄
       queueRef.current = [];
       isDisplayingRef.current = false;
+      playedSoundGroupIds.clear();
       if (connectionTimeoutRef.current) {
         clearTimeout(connectionTimeoutRef.current);
       }

--- a/src/components/ChatAnnouncementSettings.tsx
+++ b/src/components/ChatAnnouncementSettings.tsx
@@ -14,6 +14,8 @@ interface ChatAnnouncementSettingsProps {
   // カスタムテンプレート（nullの場合はデフォルト）
   // Custom template (null for default)
   currentTemplate: string | null;
+  currentMultiTemplate: string | null;
+  currentMultiShowCards: boolean;
   botAccount?: {
     username: string | null;
     displayName: string | null;
@@ -21,6 +23,7 @@ interface ChatAnnouncementSettingsProps {
 }
 
 const DEFAULT_CHAT_TEMPLATE = "@{user} が【{rarity}】{card} を獲得しました！";
+const DEFAULT_MULTI_DRAW_CHAT_TEMPLATE = "@{user} が{draws}連ガチャで {rarityCounts} を獲得しました！{cards}";
 
 const MAX_TEMPLATE_PLACEHOLDER_LENGTHS = {
   user: 25,
@@ -42,6 +45,7 @@ function buildChatPreviewMessage(
     card: string;
     cards: string;
     draws: string;
+    rarityCounts: string;
     rarity: string;
     num: string;
     unique: string;
@@ -55,6 +59,7 @@ function buildChatPreviewMessage(
     .replace(/\{card\}/g, placeholders.card)
     .replace(/\{cards\}/g, placeholders.cards)
     .replace(/\{draws\}/g, placeholders.draws)
+    .replace(/\{rarityCounts\}/g, placeholders.rarityCounts)
     .replace(/\{rarity\}/g, placeholders.rarity)
     .replace(/\{num\}/g, placeholders.num)
     .replace(/\{unique\}/g, placeholders.unique)
@@ -74,6 +79,8 @@ export default function ChatAnnouncementSettings({
   streamerId,
   currentEnabled,
   currentTemplate,
+  currentMultiTemplate,
+  currentMultiShowCards,
   botAccount,
 }: ChatAnnouncementSettingsProps) {
   const t = useTranslations("chatAnnouncementSettings");
@@ -81,6 +88,11 @@ export default function ChatAnnouncementSettings({
   // State管理
   const [enabled, setEnabled] = useState(currentEnabled);
   const [template, setTemplate] = useState(currentTemplate || "");
+  const [multiTemplate, setMultiTemplate] = useState(currentMultiTemplate || "");
+  const [multiShowCards, setMultiShowCards] = useState(currentMultiShowCards);
+  const [showAdvanced, setShowAdvanced] = useState(
+    Boolean(currentTemplate || currentMultiTemplate || !currentMultiShowCards || botAccount)
+  );
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState("");
   const [isError, setIsError] = useState(false);
@@ -99,6 +111,7 @@ export default function ChatAnnouncementSettings({
   const [botConnecting, setBotConnecting] = useState(false);
   const [botDisconnecting, setBotDisconnecting] = useState(false);
   const activeTemplate = template || DEFAULT_CHAT_TEMPLATE;
+  const activeMultiTemplate = multiTemplate || DEFAULT_MULTI_DRAW_CHAT_TEMPLATE;
   const canSendChat = hasScope || botConnected;
 
   const demoMessage = useMemo(() => {
@@ -107,6 +120,7 @@ export default function ChatAnnouncementSettings({
       card: "レジェンダリーカード",
       cards: "レジェンダリーカード、レアカード、コモンカード",
       draws: "3",
+      rarityCounts: "レジェンダリーx1、レアx1、コモンx1",
       rarity: "レジェンダリー",
       num: "3",
       unique: "5",
@@ -115,6 +129,22 @@ export default function ChatAnnouncementSettings({
       url: `https://twica.live/collection/${streamerId}`,
     });
   }, [activeTemplate, streamerId]);
+
+  const multiDemoMessage = useMemo(() => {
+    return buildChatPreviewMessage(activeMultiTemplate, {
+      user: "SampleUser",
+      card: "レジェンダリーカード",
+      cards: multiShowCards ? "（レジェンダリーカード、レアカード、コモンカード）" : "",
+      draws: "3",
+      rarityCounts: "レジェンダリーx1、レアx1、コモンx1",
+      rarity: "レジェンダリー",
+      num: "3",
+      unique: "5",
+      all: "10",
+      detail: "特別なカードの説明文です",
+      url: `https://twica.live/collection/${streamerId}`,
+    });
+  }, [activeMultiTemplate, multiShowCards, streamerId]);
 
   const demoMessageCharacterCount = useMemo(
     () => countCharacters(demoMessage),
@@ -128,6 +158,7 @@ export default function ChatAnnouncementSettings({
         card: "カ".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.card),
         cards: "カ".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.cards),
         draws: "10",
+        rarityCounts: "レジェンダリーx10",
         rarity: "レ".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.rarity),
         num: "9".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.num),
         unique: "9".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.unique),
@@ -289,7 +320,12 @@ export default function ChatAnnouncementSettings({
    * 設定を保存
    * Save settings
    */
-  const saveSettings = useCallback(async (newEnabled: boolean, newTemplate: string) => {
+  const saveSettings = useCallback(async (
+    newEnabled: boolean,
+    newTemplate: string,
+    newMultiTemplate: string,
+    newMultiShowCards: boolean
+  ) => {
     setSaving(true);
     setMessage("");
     setIsError(false);
@@ -305,6 +341,8 @@ export default function ChatAnnouncementSettings({
           streamerId,
           chatAnnouncementEnabled: newEnabled,
           chatAnnouncementTemplate: newTemplate || null,
+          chatAnnouncementMultiTemplate: newMultiTemplate || null,
+          chatAnnouncementMultiShowCards: newMultiShowCards,
         }),
       });
 
@@ -336,21 +374,21 @@ export default function ChatAnnouncementSettings({
     const newEnabled = !enabled;
     setEnabled(newEnabled);
 
-    const success = await saveSettings(newEnabled, template);
+    const success = await saveSettings(newEnabled, template, multiTemplate, multiShowCards);
     if (!success) {
       // 失敗した場合は元に戻す
       // Revert on failure
       setEnabled(!newEnabled);
     }
-  }, [enabled, saveSettings, template]);
+  }, [enabled, multiShowCards, multiTemplate, saveSettings, template]);
 
   /**
    * テンプレートを保存
    * Save template
    */
   const handleSaveTemplate = useCallback(async () => {
-    await saveSettings(enabled, template);
-  }, [enabled, saveSettings, template]);
+    await saveSettings(enabled, template, multiTemplate, multiShowCards);
+  }, [enabled, multiShowCards, multiTemplate, saveSettings, template]);
 
   /**
    * デモ用のサンプルメッセージを生成
@@ -419,6 +457,17 @@ export default function ChatAnnouncementSettings({
         </div>
       )}
 
+      <label className="mb-4 flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-900/40 p-3">
+        <input
+          type="checkbox"
+          checked={showAdvanced}
+          onChange={(e) => setShowAdvanced(e.target.checked)}
+          className="h-4 w-4 rounded border-gray-600 bg-gray-700 text-purple-600 focus:ring-purple-500"
+        />
+        <span className="text-sm text-gray-200">{t("form.showAdvanced")}</span>
+      </label>
+
+      {showAdvanced && (
       <div className="mb-4 rounded-lg border border-gray-700 bg-gray-900/40 p-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div>
@@ -450,6 +499,7 @@ export default function ChatAnnouncementSettings({
           )}
         </div>
       </div>
+      )}
 
       <div className={`space-y-4 ${!canSendChat ? "opacity-50 pointer-events-none" : ""}`}>
         {/* 有効/無効切り替え */}
@@ -471,58 +521,89 @@ export default function ChatAnnouncementSettings({
           </span>
         </div>
 
-        {/* カスタムテンプレート入力 */}
-        <div>
-          <label className="mb-1 block text-sm text-gray-300">
-            {t("form.customTemplate")}
-          </label>
-          <textarea
-            value={template}
-            onChange={(e) => setTemplate(e.target.value)}
-            placeholder={t("form.templatePlaceholder")}
-            disabled={!canSendChat}
-            rows={3}
-            className="w-full rounded-lg border border-gray-600 bg-gray-700 px-3 py-2 text-sm text-white placeholder-gray-500 focus:border-purple-500 focus:outline-none disabled:opacity-50"
-          />
-          <p className="mt-1 text-xs text-gray-500">
-            {t("form.placeholderHelp")}
-          </p>
-          <p className={`mt-1 text-xs ${demoMessageCharacterCount > TWITCH_CHAT_MESSAGE_MAX_CHARACTERS ? "text-yellow-400" : "text-gray-500"}`}>
-            {t("form.previewLength", {
-              current: demoMessageCharacterCount,
-              max: TWITCH_CHAT_MESSAGE_MAX_CHARACTERS,
-            })}
-          </p>
-          {mayExceedChatLimit && (
-            <div className="mt-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3 text-xs text-yellow-300">
-              {t("messages.lengthWarning", {
-                estimated: estimatedMaxMessageCharacterCount,
-                max: TWITCH_CHAT_MESSAGE_MAX_CHARACTERS,
-              })}
+        {showAdvanced && (
+          <>
+            {/* カスタムテンプレート入力 */}
+            <div>
+              <label className="mb-1 block text-sm text-gray-300">
+                {t("form.customTemplate")}
+              </label>
+              <textarea
+                value={template}
+                onChange={(e) => setTemplate(e.target.value)}
+                placeholder={t("form.templatePlaceholder")}
+                disabled={!canSendChat}
+                rows={3}
+                className="w-full rounded-lg border border-gray-600 bg-gray-700 px-3 py-2 text-sm text-white placeholder-gray-500 focus:border-purple-500 focus:outline-none disabled:opacity-50"
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                {t("form.placeholderHelp")}
+              </p>
+              <p className={`mt-1 text-xs ${demoMessageCharacterCount > TWITCH_CHAT_MESSAGE_MAX_CHARACTERS ? "text-yellow-400" : "text-gray-500"}`}>
+                {t("form.previewLength", {
+                  current: demoMessageCharacterCount,
+                  max: TWITCH_CHAT_MESSAGE_MAX_CHARACTERS,
+                })}
+              </p>
+              {mayExceedChatLimit && (
+                <div className="mt-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3 text-xs text-yellow-300">
+                  {t("messages.lengthWarning", {
+                    estimated: estimatedMaxMessageCharacterCount,
+                    max: TWITCH_CHAT_MESSAGE_MAX_CHARACTERS,
+                  })}
+                </div>
+              )}
             </div>
-          )}
-        </div>
 
-        {/* ボタン群 */}
-        <div className="flex gap-2">
-          {/* テンプレート保存ボタン */}
-          <button
-            onClick={handleSaveTemplate}
-            disabled={saving || !canSendChat}
-            className="rounded-lg bg-purple-600 px-4 py-2 text-sm text-white hover:bg-purple-700 disabled:opacity-50"
-          >
-            {saving ? t("buttons.saving") : t("buttons.saveTemplate")}
-          </button>
+            <div className="rounded-lg border border-gray-700 bg-gray-900/40 p-4">
+              <label className="mb-1 block text-sm text-gray-300">
+                {t("form.multiTemplate")}
+              </label>
+              <textarea
+                value={multiTemplate}
+                onChange={(e) => setMultiTemplate(e.target.value)}
+                placeholder={t("form.multiTemplatePlaceholder")}
+                disabled={!canSendChat}
+                rows={3}
+                className="w-full rounded-lg border border-gray-600 bg-gray-700 px-3 py-2 text-sm text-white placeholder-gray-500 focus:border-purple-500 focus:outline-none disabled:opacity-50"
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                {t("form.multiPlaceholderHelp")}
+              </p>
+              <label className="mt-3 flex items-center gap-2 text-sm text-gray-300">
+                <input
+                  type="checkbox"
+                  checked={multiShowCards}
+                  onChange={(e) => setMultiShowCards(e.target.checked)}
+                  disabled={!canSendChat}
+                  className="h-4 w-4 rounded border-gray-600 bg-gray-700 text-purple-600 focus:ring-purple-500 disabled:opacity-50"
+                />
+                {t("form.multiShowCards")}
+              </label>
+            </div>
 
-          {/* チャットデモボタン */}
-          <button
-            onClick={() => setShowDemoModal(true)}
-            disabled={!canSendChat}
-            className="rounded-lg bg-gray-600 px-4 py-2 text-sm text-white hover:bg-gray-500 disabled:opacity-50"
-          >
-            {t("buttons.chatDemo")}
-          </button>
-        </div>
+            {/* ボタン群 */}
+            <div className="flex gap-2">
+              {/* テンプレート保存ボタン */}
+              <button
+                onClick={handleSaveTemplate}
+                disabled={saving || !canSendChat}
+                className="rounded-lg bg-purple-600 px-4 py-2 text-sm text-white hover:bg-purple-700 disabled:opacity-50"
+              >
+                {saving ? t("buttons.saving") : t("buttons.saveTemplate")}
+              </button>
+
+              {/* チャットデモボタン */}
+              <button
+                onClick={() => setShowDemoModal(true)}
+                disabled={!canSendChat}
+                className="rounded-lg bg-gray-600 px-4 py-2 text-sm text-white hover:bg-gray-500 disabled:opacity-50"
+              >
+                {t("buttons.chatDemo")}
+              </button>
+            </div>
+          </>
+        )}
 
         {/* ステータスメッセージ */}
         {message && (
@@ -545,8 +626,15 @@ export default function ChatAnnouncementSettings({
             </p>
             {/* プレビューメッセージ */}
             <div className="mb-4 rounded-lg bg-gray-700 p-4">
+              <p className="mb-2 text-xs text-gray-400">{t("demo.singleTitle")}</p>
               <p className="break-words text-sm text-white">
                 {demoMessage}
+              </p>
+            </div>
+            <div className="mb-4 rounded-lg bg-gray-700 p-4">
+              <p className="mb-2 text-xs text-gray-400">{t("demo.multiTitle")}</p>
+              <p className="break-words text-sm text-white">
+                {multiDemoMessage}
               </p>
             </div>
             <button

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -23,6 +23,8 @@ export interface EventSubStreamerInfo {
   id: string
   chat_announcement_enabled: boolean
   chat_announcement_template: string | null
+  chat_announcement_multi_template: string | null
+  chat_announcement_multi_show_cards: boolean
 }
 
 export interface GachaResult {
@@ -40,11 +42,13 @@ function isRaidOptionsSchemaError(error: { message?: string; code?: string } | n
 
 const ADDITIONAL_REWARD_OPTIONS_UNAVAILABLE = 'Additional reward options unavailable'
 
-function isRaidStateSchemaError(error: { message?: string; code?: string } | null | undefined) {
+function isStreamerSettingsSchemaError(error: { message?: string; code?: string } | null | undefined) {
   const message = error?.message ?? ''
   return error?.code === 'PGRST204'
     || message.includes('raid_gacha_active_until')
     || message.includes('raid_gacha_draw_count')
+    || message.includes('chat_announcement_multi_template')
+    || message.includes('chat_announcement_multi_show_cards')
 }
 
 function isRaidGachaActive(activeUntil: string | null | undefined, now = new Date()): boolean {
@@ -269,17 +273,24 @@ export class GachaService {
       // chat_announcement_enabled/template も同時取得してクエリ統合（CPU時間削減）
       let { data: streamer, error: streamerError } = await this.supabase
         .from('streamers')
-        .select('id, channel_point_reward_id, chat_announcement_enabled, chat_announcement_template, raid_gacha_active_until')
+        .select('id, channel_point_reward_id, chat_announcement_enabled, chat_announcement_template, chat_announcement_multi_template, chat_announcement_multi_show_cards, raid_gacha_active_until')
         .eq('twitch_user_id', event.broadcaster_user_id)
         .maybeSingle()
 
-      if (isRaidStateSchemaError(streamerError)) {
+      if (isStreamerSettingsSchemaError(streamerError)) {
         const fallbackResult = await this.supabase
           .from('streamers')
           .select('id, channel_point_reward_id, chat_announcement_enabled, chat_announcement_template')
           .eq('twitch_user_id', event.broadcaster_user_id)
           .maybeSingle()
-        streamer = fallbackResult.data ? { ...fallbackResult.data, raid_gacha_active_until: null } : fallbackResult.data
+        streamer = fallbackResult.data
+          ? {
+              ...fallbackResult.data,
+              chat_announcement_multi_template: null,
+              chat_announcement_multi_show_cards: true,
+              raid_gacha_active_until: null,
+            }
+          : fallbackResult.data
         streamerError = fallbackResult.error
       }
 
@@ -304,6 +315,8 @@ export class GachaService {
             id: streamer.id,
             chat_announcement_enabled: streamer.chat_announcement_enabled,
             chat_announcement_template: streamer.chat_announcement_template,
+            chat_announcement_multi_template: streamer.chat_announcement_multi_template,
+            chat_announcement_multi_show_cards: streamer.chat_announcement_multi_show_cards ?? true,
           },
         })
       }
@@ -376,17 +389,24 @@ export class GachaService {
     try {
       let { data: streamer, error: streamerError } = await this.supabase
         .from('streamers')
-        .select('id, chat_announcement_enabled, chat_announcement_template, raid_gacha_draw_count')
+        .select('id, chat_announcement_enabled, chat_announcement_template, chat_announcement_multi_template, chat_announcement_multi_show_cards, raid_gacha_draw_count')
         .eq('twitch_user_id', event.to_broadcaster_user_id)
         .maybeSingle()
 
-      if (isRaidStateSchemaError(streamerError)) {
+      if (isStreamerSettingsSchemaError(streamerError)) {
         const fallbackResult = await this.supabase
           .from('streamers')
           .select('id, chat_announcement_enabled, chat_announcement_template')
           .eq('twitch_user_id', event.to_broadcaster_user_id)
           .maybeSingle()
-        streamer = fallbackResult.data ? { ...fallbackResult.data, raid_gacha_draw_count: 0 } : fallbackResult.data
+        streamer = fallbackResult.data
+          ? {
+              ...fallbackResult.data,
+              chat_announcement_multi_template: null,
+              chat_announcement_multi_show_cards: true,
+              raid_gacha_draw_count: 0,
+            }
+          : fallbackResult.data
         streamerError = fallbackResult.error
       }
 
@@ -417,6 +437,8 @@ export class GachaService {
           id: streamer.id,
           chat_announcement_enabled: streamer.chat_announcement_enabled,
           chat_announcement_template: streamer.chat_announcement_template,
+          chat_announcement_multi_template: streamer.chat_announcement_multi_template,
+          chat_announcement_multi_show_cards: streamer.chat_announcement_multi_show_cards ?? true,
         },
       })
     } catch (error) {

--- a/src/lib/twitch/chat-service.ts
+++ b/src/lib/twitch/chat-service.ts
@@ -38,6 +38,9 @@ export interface ChatMessagePlaceholders {
   // 複数枚ガチャ時の抽選回数（オプション）
   // Draw count for multi-draw announcements (optional)
   draws?: number
+  // 複数枚ガチャ時のレアリティ別枚数（例: レアx3、コモンx3）
+  // Rarity counts for multi-draw announcements (e.g. Rare x3, Common x3)
+  rarityCounts?: string
   // カードのレアリティ（日本語または英語）
   // Card rarity (Japanese or English)
   rarity: string
@@ -339,6 +342,12 @@ export class TwitchChatService {
       message = message.replace(/\{draws\}/g, String(placeholders.draws))
     } else {
       message = message.replace(/\{draws\}/g, '')
+    }
+
+    if (placeholders.rarityCounts) {
+      message = message.replace(/\{rarityCounts\}/g, placeholders.rarityCounts)
+    } else {
+      message = message.replace(/\{rarityCounts\}/g, '')
     }
 
     // 連続する空白を1つにまとめ、前後の空白を削除

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -36,6 +36,12 @@ export interface Database {
           // チャット通知のカスタムテンプレート（nullの場合はデフォルトテンプレートを使用）
           // Custom message template for chat announcements (null uses default)
           chat_announcement_template: string | null
+          // N連ガチャ向けチャット通知のカスタムテンプレート（nullの場合はN連デフォルト）
+          // Custom template for multi-draw chat announcements (null uses multi-draw default)
+          chat_announcement_multi_template: string | null
+          // N連ガチャ通知に個別カード名一覧を含めるか
+          // Whether multi-draw announcements include the individual card-name list
+          chat_announcement_multi_show_cards: boolean
           // レアリティ名をキーにした目標確率マップ（0-100）
           // Dynamic rarity-to-target-percentage map (0-100)
           rarity_weights: Record<string, number> | null
@@ -67,6 +73,8 @@ export interface Database {
           gacha_sound_enabled?: boolean
           chat_announcement_enabled?: boolean
           chat_announcement_template?: string | null
+          chat_announcement_multi_template?: string | null
+          chat_announcement_multi_show_cards?: boolean
           rarity_weights?: Record<string, number> | null
           show_unowned_cards?: boolean
           show_unowned_card_details?: boolean
@@ -88,6 +96,8 @@ export interface Database {
           gacha_sound_enabled?: boolean
           chat_announcement_enabled?: boolean
           chat_announcement_template?: string | null
+          chat_announcement_multi_template?: string | null
+          chat_announcement_multi_show_cards?: boolean
           rarity_weights?: Record<string, number> | null
           show_unowned_cards?: boolean
           show_unowned_card_details?: boolean

--- a/supabase/migrations/00044_add_multi_draw_chat_settings.sql
+++ b/supabase/migrations/00044_add_multi_draw_chat_settings.sql
@@ -1,0 +1,12 @@
+-- N連ガチャ向けのチャット通知設定を streamers テーブルに追加
+-- Add chat announcement settings dedicated to multi-draw gacha redemptions.
+
+ALTER TABLE streamers
+ADD COLUMN IF NOT EXISTS chat_announcement_multi_template TEXT DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS chat_announcement_multi_show_cards BOOLEAN DEFAULT TRUE NOT NULL;
+
+COMMENT ON COLUMN streamers.chat_announcement_multi_template IS
+  'Custom message template for multi-draw chat announcements. Null uses the built-in multi-draw default.';
+
+COMMENT ON COLUMN streamers.chat_announcement_multi_show_cards IS
+  'Whether multi-draw chat announcements include the individual card-name list in {cards}.';

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -66,60 +66,77 @@ describe('OverlayPage', () => {
     expect(screen.queryByText('接続エラー')).not.toBeInTheDocument()
   })
 
-  it('RealtimeのN連ガチャpayloadを1枚ずつ順番に表示する', async () => {
-    window.history.replaceState({}, '', '/overlay/streamer-1?duration=2')
-    let realtimeCallback: ((payload: GachaBroadcastPayload) => void) | undefined
+  it('RealtimeのN連ガチャを全カード表示し、効果音は一度だけ再生する', async () => {
+    vi.useFakeTimers()
+
+    const playMock = vi.fn().mockResolvedValue(undefined)
+    const pauseMock = vi.fn()
+    class MockAudio {
+      currentTime = 0
+      preload = ''
+
+      constructor(public src: string) {}
+
+      play = playMock
+      pause = pauseMock
+    }
+
+    vi.stubGlobal('Audio', MockAudio)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ soundUrl: 'https://example.com/gacha.mp3', soundEnabled: true }),
+    }))
+
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+
     subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
-      realtimeCallback = callback as (payload: GachaBroadcastPayload) => void
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
       options.onSuccess?.()
       return vi.fn()
     })
 
     render(<OverlayPage />)
 
-    await waitFor(() => {
-      expect(realtimeCallback).toBeDefined()
-    })
     await act(async () => {
+      await Promise.resolve()
       await Promise.resolve()
     })
 
+    expect(onGachaResult).toBeDefined()
+    expect(playMock).toHaveBeenCalledTimes(1)
+    playMock.mockClear()
+
+    const cards = [
+      { id: 'card-1', name: 'Alpha', description: null, image_url: null, rarity: 'rare' },
+      { id: 'card-2', name: 'Beta', description: null, image_url: null, rarity: 'common' },
+      { id: 'card-3', name: 'Gamma', description: null, image_url: null, rarity: 'legendary' },
+    ]
+
     act(() => {
-      realtimeCallback?.({
+      onGachaResult?.({
         type: 'gacha',
-        card: {
-          id: 'card-1',
-          name: 'Alpha',
-          description: null,
-          image_url: null,
-          rarity: 'rare',
-        },
-        cards: [
-          {
-            id: 'card-1',
-            name: 'Alpha',
-            description: null,
-            image_url: null,
-            rarity: 'rare',
-          },
-          {
-            id: 'card-2',
-            name: 'Beta',
-            description: null,
-            image_url: null,
-            rarity: 'common',
-          },
-        ],
+        card: cards[0],
+        cards,
         userTwitchUsername: 'Viewer',
       })
     })
 
-    expect(await screen.findByText('Alpha')).toBeInTheDocument()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+    expect(playMock).toHaveBeenCalledTimes(1)
 
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 3200))
+      await vi.advanceTimersByTimeAsync(6600)
     })
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+    expect(playMock).toHaveBeenCalledTimes(1)
 
-    expect(await screen.findByText('Beta')).toBeInTheDocument()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6600)
+    })
+    expect(screen.getByText('Gamma')).toBeInTheDocument()
+    expect(playMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/unit/eventsub-reward-mismatch.test.ts
+++ b/tests/unit/eventsub-reward-mismatch.test.ts
@@ -5,18 +5,18 @@ import { reportError } from '@/lib/sentry/error-handler'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { broadcastGachaResult } from '@/lib/realtime'
 import { TwitchChatService } from '@/lib/twitch/chat-service'
-import { hasScope } from '@/lib/twitch/token-manager'
 
 const mocks = vi.hoisted(() => ({
   executeGachaForEventSub: vi.fn(),
   executeGachaForRaidEvent: vi.fn(),
-  buildMessage: vi.fn((template: string | null, placeholders: { user: string; card: string; cards?: string; draws?: number }) => {
+  buildMessage: vi.fn((template: string | null, placeholders: { user: string; card: string; cards?: string; draws?: number; rarityCounts?: string }) => {
     const messageTemplate = template || '{user} got {card}'
     return messageTemplate
       .replace(/\{user\}/g, placeholders.user)
       .replace(/\{card\}/g, placeholders.card)
       .replace(/\{cards\}/g, placeholders.cards ?? '')
       .replace(/\{draws\}/g, placeholders.draws === undefined ? '' : String(placeholders.draws))
+      .replace(/\{rarityCounts\}/g, placeholders.rarityCounts ?? '')
       .replace(/\s+/g, ' ')
       .trim()
   }),
@@ -51,10 +51,6 @@ vi.mock('@/lib/realtime', () => ({
   broadcastGachaResult: vi.fn(),
 }))
 
-vi.mock('@/lib/twitch/token-manager', () => ({
-  hasScope: vi.fn().mockResolvedValue(true),
-}))
-
 vi.mock('@/lib/twitch/chat-service', () => ({
   DEFAULT_CHAT_TEMPLATE: '{user} got {card}',
   TwitchChatService: vi.fn().mockImplementation(() => ({
@@ -75,7 +71,6 @@ const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin)
 const mockReportError = vi.mocked(reportError)
 const mockBroadcastGachaResult = vi.mocked(broadcastGachaResult)
 const mockTwitchChatService = vi.mocked(TwitchChatService)
-const mockHasScope = vi.mocked(hasScope)
 
 async function signEventSubBody(secret: string, messageId: string, timestamp: string, body: string): Promise<string> {
   const encoder = new TextEncoder()
@@ -130,14 +125,14 @@ async function createNotificationRequest(gachaError: string): Promise<NextReques
 describe('EventSub reward mismatch handling', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockHasScope.mockResolvedValue(true)
-    mocks.buildMessage.mockImplementation((template: string | null, placeholders: { user: string; card: string; cards?: string; draws?: number }) => {
+    mocks.buildMessage.mockImplementation((template: string | null, placeholders: { user: string; card: string; cards?: string; draws?: number; rarityCounts?: string }) => {
       const messageTemplate = template || '{user} got {card}'
       return messageTemplate
         .replace(/\{user\}/g, placeholders.user)
         .replace(/\{card\}/g, placeholders.card)
         .replace(/\{cards\}/g, placeholders.cards ?? '')
         .replace(/\{draws\}/g, placeholders.draws === undefined ? '' : String(placeholders.draws))
+        .replace(/\{rarityCounts\}/g, placeholders.rarityCounts ?? '')
         .replace(/\s+/g, ' ')
         .trim()
     })
@@ -203,6 +198,8 @@ describe('EventSub reward mismatch handling', () => {
           id: 'streamer-1',
           chat_announcement_enabled: false,
           chat_announcement_template: null,
+          chat_announcement_multi_template: null,
+          chat_announcement_multi_show_cards: true,
         },
       },
     })
@@ -287,6 +284,8 @@ describe('EventSub reward mismatch handling', () => {
           id: 'streamer-1',
           chat_announcement_enabled: false,
           chat_announcement_template: null,
+          chat_announcement_multi_template: null,
+          chat_announcement_multi_show_cards: true,
         },
       },
     })
@@ -347,7 +346,9 @@ describe('EventSub reward mismatch handling', () => {
         streamer: {
           id: 'streamer-1',
           chat_announcement_enabled: true,
-          chat_announcement_template: '{user}: first={card} all={cards} count={draws}',
+          chat_announcement_template: null,
+          chat_announcement_multi_template: '{user}: first={card} all={cards} count={draws} rarity={rarityCounts}',
+          chat_announcement_multi_show_cards: true,
         },
       },
     })
@@ -373,21 +374,22 @@ describe('EventSub reward mismatch handling', () => {
     )
     expect(mockTwitchChatService).toHaveBeenCalled()
     expect(mocks.buildMessage).toHaveBeenCalledWith(
-      '{user}: first={card} all={cards} count={draws}',
+      '{user}: first={card} all={cards} count={draws} rarity={rarityCounts}',
       expect.objectContaining({
         user: 'Viewer',
         card: 'Alpha',
         cards: 'Alpha、Beta、Gamma',
         draws: 3,
+        rarityCounts: 'レジェンダリーx1、レアx1、コモンx1',
       }),
     )
     expect(mocks.sendChatMessage).toHaveBeenCalledWith(
       'broadcaster-1',
-      'Viewer: first=Alpha all=Alpha、Beta、Gamma count=3',
+      'Viewer: first=Alpha all=Alpha、Beta、Gamma count=3 rarity=レジェンダリーx1、レアx1、コモンx1',
     )
   })
 
-  it('adds all multi-draw cards to existing single-card chat templates', async () => {
+  it('uses the default multi-draw template when no dedicated template is configured', async () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret
     const messageId = 'eventsub-multi-draw-single-template'
@@ -420,6 +422,8 @@ describe('EventSub reward mismatch handling', () => {
           id: 'streamer-1',
           chat_announcement_enabled: true,
           chat_announcement_template: '@{user} が {card} を獲得しました！',
+          chat_announcement_multi_template: null,
+          chat_announcement_multi_show_cards: true,
         },
       },
     })
@@ -439,7 +443,7 @@ describe('EventSub reward mismatch handling', () => {
     expect(response.status).toBe(200)
     expect(mocks.sendChatMessage).toHaveBeenCalledWith(
       'broadcaster-1',
-      '@Viewer が Alpha を獲得しました！（全3枚: Alpha、Beta、Gamma）',
+      '@Viewer が3連ガチャで レジェンダリーx1、レアx1、コモンx1 を獲得しました！Alpha、Beta、Gamma',
     )
   })
 
@@ -478,7 +482,9 @@ describe('EventSub reward mismatch handling', () => {
         streamer: {
           id: 'streamer-1',
           chat_announcement_enabled: true,
-          chat_announcement_template: '@{user} が{draws}連ガチャで {cards} を獲得しました！',
+          chat_announcement_template: null,
+          chat_announcement_multi_template: '@{user} が{draws}連ガチャで {cards} を獲得しました！',
+          chat_announcement_multi_show_cards: true,
         },
       },
     })
@@ -502,5 +508,71 @@ describe('EventSub reward mismatch handling', () => {
     const sentMessage = mocks.sendChatMessage.mock.calls.at(-1)?.[1] as string
     expect(sentMessage.length).toBeLessThanOrEqual(500)
     expect(sentMessage).toContain('10連ガチャ')
+  })
+
+  it('can send a rarity-count-only multi-draw chat announcement when card lists are disabled', async () => {
+    const secret = 'eventsub-test-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = secret
+    const messageId = 'eventsub-multi-draw-rarity-summary'
+    const timestamp = '2026-05-11T10:00:00Z'
+    const body = JSON.stringify({
+      subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
+      event: {
+        broadcaster_user_id: 'broadcaster-1',
+        user_id: 'viewer-1',
+        user_login: 'viewer',
+        user_name: 'Viewer',
+        reward: { id: 'raid-gacha', title: 'Raid Gacha', cost: 500 },
+      },
+    })
+    const signature = await signEventSubBody(secret, messageId, timestamp, body)
+
+    const cards = [
+      { id: 'card-1', name: 'Rare A', description: null, image_url: null, rarity: 'rare', drop_rate: 1 },
+      { id: 'card-2', name: 'Rare B', description: null, image_url: null, rarity: 'rare', drop_rate: 1 },
+      { id: 'card-3', name: 'Common A', description: null, image_url: null, rarity: 'common', drop_rate: 1 },
+    ] as const
+
+    mocks.executeGachaForEventSub.mockResolvedValue({
+      success: true,
+      data: {
+        card: cards[0],
+        cards: [...cards],
+        userTwitchUsername: 'Viewer',
+        streamer: {
+          id: 'streamer-1',
+          chat_announcement_enabled: true,
+          chat_announcement_template: null,
+          chat_announcement_multi_template: '@{user}: {draws}連 {rarityCounts} {cards}',
+          chat_announcement_multi_show_cards: false,
+        },
+      },
+    })
+
+    const response = await POST(new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'twitch-eventsub-message-id': messageId,
+        'twitch-eventsub-message-timestamp': timestamp,
+        'twitch-eventsub-message-type': 'notification',
+        'twitch-eventsub-message-signature': signature,
+      },
+      body,
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.buildMessage).toHaveBeenCalledWith(
+      '@{user}: {draws}連 {rarityCounts} {cards}',
+      expect.objectContaining({
+        cards: undefined,
+        draws: 3,
+        rarityCounts: 'レアx2、コモンx1',
+      }),
+    )
+    expect(mocks.sendChatMessage).toHaveBeenCalledWith(
+      'broadcaster-1',
+      '@Viewer: 3連 レアx2、コモンx1',
+    )
   })
 })

--- a/tests/unit/streamer-settings-api.test.ts
+++ b/tests/unit/streamer-settings-api.test.ts
@@ -84,6 +84,43 @@ describe('POST /api/streamer/settings', () => {
     expect(getSupabaseAdmin).toHaveBeenCalled()
   })
 
+  it('should update multi-draw chat announcement settings', async () => {
+    const builder = createSupabaseMock()
+      .withMaybeSingleResponse({
+        id: 'streamer123',
+        twitch_user_id: 'streamer123',
+      })
+    const mockSupabase = builder.build()
+    const query = builder.getQueryBuilder()
+
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        streamerId: 'streamer123',
+        chatAnnouncementEnabled: true,
+        chatAnnouncementTemplate: '@{user} got {card}',
+        chatAnnouncementMultiTemplate: '@{user}: {draws}連 {rarityCounts} {cards}',
+        chatAnnouncementMultiShowCards: false,
+      }),
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    expect(query.update).toHaveBeenCalledWith(expect.objectContaining({
+      chat_announcement_enabled: true,
+      chat_announcement_template: '@{user} got {card}',
+      chat_announcement_multi_template: '@{user}: {draws}連 {rarityCounts} {cards}',
+      chat_announcement_multi_show_cards: false,
+    }))
+  })
+
   it('should reject rarity weights when total is not 100%', async () => {
     const mockSupabase = createSupabaseMock().build()
 


### PR DESCRIPTION
## Summary
- Fix multi-draw gacha notifications so overlay receives all drawn cards and plays sound only once per draw set
- Add dedicated multi-draw chat announcement settings with `{draws}`, `{cards}`, and `{rarityCounts}` placeholders plus a card-list toggle
- Hide advanced chat settings behind an advanced-settings toggle and add DB fields for the new multi-draw options

## Validation
- `npx vitest run tests/unit/eventsub-reward-mismatch.test.ts tests/unit/components/overlay-page.test.tsx tests/unit/gacha-service.test.ts tests/unit/streamer-settings-api.test.ts`
- `npx eslint src/components/ChatAnnouncementSettings.tsx src/app/api/twitch/eventsub/route.ts src/lib/services/gacha.ts src/lib/twitch/chat-service.ts src/app/api/streamer/settings/route.ts src/app/dashboard/settings/page.tsx tests/unit/eventsub-reward-mismatch.test.ts tests/unit/streamer-settings-api.test.ts tests/unit/components/overlay-page.test.tsx`
- `npx tsc --noEmit --pretty false` still fails on existing unrelated unit-test type errors in `additional-rewards-api.test.ts`, `auth-scope-preservation.test.ts`, `battle.test.ts`, `cards-get-api.test.ts`, and `open-next-config.test.ts`
