### PR TITLE
fix: enable RLS for channel point usage stats

### DIFF
--- a/supabase/migrations/00045_enable_channel_point_usage_stats_rls.sql
+++ b/supabase/migrations/00045_enable_channel_point_usage_stats_rls.sql
@@ -1,0 +1,11 @@
+-- channel_point_usage_stats is a server-side aggregate table used through
+-- get_channel_point_usage_stats(). Keep direct table access closed.
+ALTER TABLE channel_point_usage_stats ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role can manage channel point usage stats" ON channel_point_usage_stats;
+CREATE POLICY "Service role can manage channel point usage stats"
+ON channel_point_usage_stats
+FOR ALL
+TO service_role
+USING (true)
+WITH CHECK (true);

--- a/tests/unit/migration-rls.test.ts
+++ b/tests/unit/migration-rls.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync, readdirSync } from 'fs'
+import { resolve } from 'path'
+
+const migrationsDir = resolve(__dirname, '../../supabase/migrations')
+
+const normalizeIdentifier = (identifier: string) => identifier.replaceAll('"', '').toLowerCase()
+
+const tableKey = (schema: string | undefined, table: string) =>
+  `${normalizeIdentifier(schema ?? 'public')}.${normalizeIdentifier(table)}`
+
+describe('Supabase migration RLS coverage', () => {
+  it('enables row-level security for every public table created by migrations', () => {
+    const createdPublicTables = new Map<string, string>()
+    const rlsEnabledTables = new Set<string>()
+
+    for (const file of readdirSync(migrationsDir).filter(file => file.endsWith('.sql')).sort()) {
+      const sql = readFileSync(resolve(migrationsDir, file), 'utf-8')
+
+      for (const match of sql.matchAll(/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:(\w+|"\w+")\.)?(\w+|"\w+")/gi)) {
+        const key = tableKey(match[1], match[2])
+
+        if (key.startsWith('public.')) {
+          createdPublicTables.set(key, file)
+        }
+      }
+
+      for (const match of sql.matchAll(/ALTER\s+TABLE\s+(?:(\w+|"\w+")\.)?(\w+|"\w+")\s+ENABLE\s+ROW\s+LEVEL\s+SECURITY/gi)) {
+        rlsEnabledTables.add(tableKey(match[1], match[2]))
+      }
+    }
+
+    const missingRls = [...createdPublicTables.entries()]
+      .filter(([table]) => !rlsEnabledTables.has(table))
+      .map(([table, file]) => `${table} created in ${file}`)
+
+    expect(missingRls).toEqual([])
+  })
+
+  it('keeps channel point usage stats restricted to service role table access', () => {
+    const migration = readFileSync(
+      resolve(migrationsDir, '00045_enable_channel_point_usage_stats_rls.sql'),
+      'utf-8',
+    )
+
+    expect(migration).toContain('ALTER TABLE channel_point_usage_stats ENABLE ROW LEVEL SECURITY')
+    expect(migration).toMatch(/ON\s+channel_point_usage_stats\s+FOR\s+ALL\s+TO\s+service_role/i)
+    expect(migration).toMatch(/WITH\s+CHECK\s+\(true\)/i)
+  })
+})


### PR DESCRIPTION
## Summary
- Enable row-level security on the public channel_point_usage_stats aggregate table.
- Add a service_role-only table policy for direct table access.
- Add a migration regression test that fails when a public table is created without RLS being enabled anywhere in the migration set.

## Context
Supabase reported rls_disabled_in_public for TwiCa and TwiCa-DEV on 2026-05-11. Scanning origin/main migrations found channel_point_usage_stats as the only public table created without an ENABLE ROW LEVEL SECURITY migration.

## Validation
- ./node_modules/.bin/vitest run tests/unit/migration-rls.test.ts tests/unit/migration-filenames.test.ts
- npm run lint

Note: npm run test:unit -- tests/unit/migration-rls.test.ts tests/unit/migration-filenames.test.ts runs the whole unit suite because the script already includes tests/unit; the new RLS test passed, but existing tests/unit/components/overlay-preview.test.tsx currently fails with localStorage.clear is not a function.