### PR TITLE
feat: 配信設定ページのシンプル/詳細表示の UX 改善

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -616,6 +616,34 @@
       "simple": "Simple",
       "advanced": "Advanced",
       "ariaLabel": "Toggle stream settings display mode"
+    },
+    "simple": {
+      "heroEyebrow": "Quick start",
+      "heroTitle": "Start streaming in two steps",
+      "heroDescription": "Only the two settings you need to go live. Switch to Advanced for full customization.",
+      "step1": "1",
+      "step1Label": "Add the overlay to OBS",
+      "step2": "2",
+      "step2Label": "Pick a redemption reward",
+      "switchToAdvanced": "Show all settings →",
+      "collectionLink": "Viewer collection page"
+    },
+    "advanced": {
+      "navAria": "Settings sections",
+      "section": {
+        "overlay": "Overlay",
+        "overlayDesc": "OBS URL & effects",
+        "reward": "Reward",
+        "rewardDesc": "Channel-point link",
+        "sound": "Sound",
+        "soundDesc": "Gacha sound effect",
+        "announcement": "Chat alert",
+        "announcementDesc": "Auto chat message",
+        "visibility": "Visibility",
+        "visibilityDesc": "Unowned card display",
+        "share": "Share",
+        "shareDesc": "Collection page URL"
+      }
     }
   },
   "cardsPage": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -616,6 +616,34 @@
       "simple": "シンプル",
       "advanced": "詳細",
       "ariaLabel": "配信設定の表示モードを切り替え"
+    },
+    "simple": {
+      "heroEyebrow": "クイックスタート",
+      "heroTitle": "最短で配信を始める",
+      "heroDescription": "必要な2つの設定だけを表示しています。細かいカスタマイズは『詳細』に切り替えてください。",
+      "step1": "1",
+      "step1Label": "OBSにオーバーレイを追加",
+      "step2": "2",
+      "step2Label": "視聴者の引換ポイントを選ぶ",
+      "switchToAdvanced": "すべての設定を表示する →",
+      "collectionLink": "視聴者向けコレクションページ"
+    },
+    "advanced": {
+      "navAria": "設定セクション",
+      "section": {
+        "overlay": "オーバーレイ",
+        "overlayDesc": "OBS表示URLと演出",
+        "reward": "報酬",
+        "rewardDesc": "チャネルポイント連携",
+        "sound": "効果音",
+        "soundDesc": "ガチャ演出のサウンド",
+        "announcement": "チャット通知",
+        "announcementDesc": "獲得時の自動メッセージ",
+        "visibility": "公開設定",
+        "visibilityDesc": "未所持カードの見せ方",
+        "share": "共有",
+        "shareDesc": "コレクションページのURL"
+      }
     }
   },
   "cardsPage": {

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,168 +1,70 @@
 import { redirect } from "next/navigation";
-import dynamic from "next/dynamic";
-import { getTranslations } from "next-intl/server";
 import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { getStreamerData } from "@/lib/dashboard-data";
 import { getCustomBotAccountDisplayForStreamer } from "@/lib/twitch/token-manager";
 import { shouldShowVoteCampaign } from "@/lib/storage-db";
-import { VOTE_CAMPAIGN_CONFIG } from "@/lib/constants";
-import VoteCampaignButton from "@/components/VoteCampaignButton";
-import {
-  AdvancedSettings,
-  SettingsViewModeProvider,
-  SettingsViewToggle,
-} from "@/components/SettingsViewMode";
-
-const OverlayPreview = dynamic(() => import("@/components/OverlayPreview"), {
-  loading: () => (
-    <div className="rounded-lg border border-gray-700 bg-gray-800 p-6 text-sm text-gray-400">
-      Loading overlay preview...
-    </div>
-  ),
-});
-
-const ChannelPointSettings = dynamic(() => import("@/components/ChannelPointSettings"), {
-  loading: () => <SettingsPanelSkeleton />,
-});
-const GachaSoundSettings = dynamic(() => import("@/components/GachaSoundSettings"), {
-  loading: () => <SettingsPanelSkeleton />,
-});
-const ChatAnnouncementSettings = dynamic(() => import("@/components/ChatAnnouncementSettings"), {
-  loading: () => <SettingsPanelSkeleton />,
-});
-const CardVisibilitySettings = dynamic(() => import("@/components/CardVisibilitySettings"), {
-  loading: () => <SettingsPanelSkeleton />,
-});
-
-function SettingsPanelSkeleton() {
-  return (
-    <div className="rounded-lg border border-gray-700 bg-gray-800 p-4">
-      <div className="h-4 w-1/3 rounded bg-gray-700" />
-      <div className="mt-3 h-3 w-2/3 rounded bg-gray-700" />
-    </div>
-  );
-}
+import SettingsLayout from "@/components/SettingsLayout";
 
 // Note: Page is automatically dynamic due to cookies() usage in getSession()
 // cookies()使用により自動的に動的ページになるため、force-dynamicは不要
 
 /**
  * Settings page for streamers
- * Includes OBS overlay URL and channel point reward configuration
  * 配信者向け設定ページ
- * OBSオーバーレイURLとチャネルポイント報酬の設定を含む
+ *
+ * UX: Progressive disclosure with two modes.
+ * - Simple = quick-start 2-step layout (OBS URL + reward picker compact)
+ * - Advanced = sidebar nav with one section visible at a time
+ * 既存ユーザーで詳細機能が有効化済みの場合は初期モードを "advanced" にして、
+ * 設定が消えたように見える混乱を避ける。localStorage の選択が優先。
  */
 export default async function SettingsPage() {
-  const t = await getTranslations("settingsPage");
   const session = await getSession();
+  if (!session) redirect("/");
 
-  // Session check is handled by layout, but double-check for safety
-  // セッションチェックはレイアウトで行われるが、安全のため再確認
-  if (!session) {
-    redirect("/");
-  }
-
-  // Redirect non-streamers to main dashboard
-  // 非配信者はメインダッシュボードにリダイレクト
   const isStreamer = canUseStreamerFeatures(session);
-  if (!isStreamer) {
-    redirect("/dashboard");
-  }
+  if (!isStreamer) redirect("/dashboard");
 
-  // 配信者データ取得とキャンペーン判定を並列実行してレイテンシ削減
   const [streamerData, showVoteCampaign] = await Promise.all([
     getStreamerData(session.twitchUserId),
     shouldShowVoteCampaign(session.twitchUserId),
   ]);
-
-  if (!streamerData) {
-    redirect("/dashboard");
-  }
+  if (!streamerData) redirect("/dashboard");
 
   const botAccount = await getCustomBotAccountDisplayForStreamer(streamerData.streamer.id);
 
-  // 既存ユーザーで詳細機能 (ガチャ効果音/チャット通知/未所持カード表示) を一つでも有効化済みなら
-  // 初回デフォルトを "advanced" にし、トグル導入で設定が消えたように見える混乱を避ける。
-  // localStorage に明示的な選択が保存されていれば、そちらが優先される。
   const hasAdvancedSettingsInUse =
     Boolean(streamerData.streamer.gacha_sound_enabled) ||
     Boolean(streamerData.streamer.chat_announcement_enabled) ||
     Boolean(streamerData.streamer.show_unowned_cards) ||
     Boolean(streamerData.streamer.show_unowned_card_details);
-  const initialModeHint = hasAdvancedSettingsInUse ? "advanced" : "simple";
 
   return (
-    // 配信設定ページを Provider でラップし、シンプル/詳細トグルを画面全体に適用。
-    // Wrap entire page with the view-mode provider so toggle + advanced sections share state.
-    <SettingsViewModeProvider initialModeHint={initialModeHint}>
-      {/* 投票キャンペーンボタン（期間内かつ未適用の場合のみ表示） */}
-      <VoteCampaignButton visible={showVoteCampaign} bonusMb={VOTE_CAMPAIGN_CONFIG.BONUS_MB} />
-
-      {/* Page header */}
-      {/* ページヘッダー */}
-      {/* 表示モード切替トグルをタイトル右側に配置 (狭幅では下に回り込み) */}
-      <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-white">
-            {t("title")}
-          </h1>
-          <p className="mt-2 text-gray-400">
-            {t("description")}
-          </p>
-        </div>
-        <SettingsViewToggle />
-      </div>
-
-      {/* OBSブラウザソースURLとカード引換設定を横並びに配置、プレビューは下に全幅で表示 */}
-      {/* URL settings and channel point settings side by side, preview below full width */}
-      {/* cardsを渡してセレクトボックスでカードを選択可能にする */}
-      {/* Pass cards prop to enable card selection in dropdown */}
-      <OverlayPreview
-        streamerId={streamerData.streamer.id}
-        baseUrl={process.env.NEXT_PUBLIC_APP_URL || ""}
-        cards={streamerData.cards}
-        sideContent={
-          <>
-            {/* シンプル表示でも必須の設定: チャネルポイント報酬 */}
-            {/* Always-visible essential setting: channel point reward */}
-            <ChannelPointSettings
-              streamerId={streamerData.streamer.id}
-              currentRewardId={streamerData.streamer.channel_point_reward_id}
-              currentRewardName={streamerData.streamer.channel_point_reward_name}
-            />
-            {/* 詳細表示モードでのみ露出する追加設定群 */}
-            {/* Sections shown only in advanced mode */}
-            <AdvancedSettings>
-              {/* ガチャ効果音設定 */}
-              {/* Gacha sound effect settings */}
-              <GachaSoundSettings
-                streamerId={streamerData.streamer.id}
-                currentSoundUrl={streamerData.streamer.gacha_sound_url ?? null}
-                currentSoundEnabled={streamerData.streamer.gacha_sound_enabled ?? false}
-              />
-              {/* チャット通知設定 */}
-              {/* Chat announcement settings */}
-              <ChatAnnouncementSettings
-                streamerId={streamerData.streamer.id}
-                currentEnabled={streamerData.streamer.chat_announcement_enabled ?? false}
-                currentTemplate={streamerData.streamer.chat_announcement_template ?? null}
-                currentMultiTemplate={streamerData.streamer.chat_announcement_multi_template ?? null}
-                currentMultiShowCards={streamerData.streamer.chat_announcement_multi_show_cards ?? true}
-                botAccount={botAccount}
-              />
-              {/* 未所持カード表示設定（Issue #395） */}
-              {/* Unowned-card visibility settings (Issue #395) */}
-              <CardVisibilitySettings
-                streamerId={streamerData.streamer.id}
-                currentShowUnowned={streamerData.streamer.show_unowned_cards ?? false}
-                currentShowUnownedDetails={
-                  streamerData.streamer.show_unowned_card_details ?? false
-                }
-              />
-            </AdvancedSettings>
-          </>
-        }
-      />
-    </SettingsViewModeProvider>
+    <SettingsLayout
+      streamerId={streamerData.streamer.id}
+      baseUrl={process.env.NEXT_PUBLIC_APP_URL || ""}
+      cards={streamerData.cards}
+      showVoteCampaign={showVoteCampaign}
+      botAccount={botAccount}
+      channelPoint={{
+        rewardId: streamerData.streamer.channel_point_reward_id,
+        rewardName: streamerData.streamer.channel_point_reward_name,
+      }}
+      gachaSound={{
+        soundUrl: streamerData.streamer.gacha_sound_url ?? null,
+        soundEnabled: streamerData.streamer.gacha_sound_enabled ?? false,
+      }}
+      chatAnnouncement={{
+        enabled: streamerData.streamer.chat_announcement_enabled ?? false,
+        template: streamerData.streamer.chat_announcement_template ?? null,
+        multiTemplate: streamerData.streamer.chat_announcement_multi_template ?? null,
+        multiShowCards: streamerData.streamer.chat_announcement_multi_show_cards ?? true,
+      }}
+      visibility={{
+        showUnowned: streamerData.streamer.show_unowned_cards ?? false,
+        showUnownedDetails: streamerData.streamer.show_unowned_card_details ?? false,
+      }}
+      initialModeHint={hasAdvancedSettingsInUse ? "advanced" : "simple"}
+    />
   );
 }

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -110,6 +110,14 @@ interface ChannelPointSettingsProps {
   streamerId: string;
   currentRewardId: string | null;
   currentRewardName: string | null;
+  /**
+   * compact: シンプル表示モード用の縮約レンダリング。
+   * EventSub 診断パネル / 追加報酬セクション / 詳細エラーリストを隠し、
+   * 報酬選択 + ステータスピル + 保存ボタンの最小構成にする。
+   * Hide diagnostic panel, additional rewards, and verbose error states
+   * to give beginners a focused, low-noise reward picker.
+   */
+  compact?: boolean;
 }
 
 /**
@@ -121,6 +129,7 @@ export default function ChannelPointSettings({
   streamerId,
   currentRewardId,
   currentRewardName,
+  compact = false,
 }: ChannelPointSettingsProps) {
   const t = useTranslations("channelPointSettings");
   const tCommon = useTranslations("common");
@@ -916,7 +925,7 @@ export default function ChannelPointSettings({
              </div>
            )}
 
-           {selectedRewardId && (
+           {selectedRewardId && !compact && (
              <div className="rounded-lg bg-gray-700 p-3">
                <p className="text-sm text-gray-400">
                  {t("form.selected")} <span className="text-white">{selectedRewardName}</span>
@@ -927,7 +936,8 @@ export default function ChannelPointSettings({
              </div>
            )}
 
-           {/* EventSub Info */}
+           {/* EventSub Info — compact mode では診断ノイズを隠す */}
+           {!compact && (
            <div className="rounded-lg bg-gray-700/50 p-4">
              <h3 className="mb-2 text-sm font-medium text-gray-300">{t("form.eventsubStatus")}</h3>
              <div className="mb-3 rounded bg-gray-800/60 p-3 text-xs">
@@ -1078,10 +1088,11 @@ export default function ChannelPointSettings({
               </p>
             )}
            </div>
+           )}
 
            {/* Additional Rewards Section - Only shown when main reward is active */}
            {/* 追加報酬セクション - メイン報酬がアクティブな場合のみ表示 */}
-           {selectedRewardId && eventSubStatus === "active" && (
+           {!compact && selectedRewardId && eventSubStatus === "active" && (
              <div className="rounded-lg bg-gray-700/50 p-4">
                <h3 className="mb-2 text-sm font-medium text-gray-300">
                  {t("additionalRewards.title")}
@@ -1227,15 +1238,16 @@ export default function ChannelPointSettings({
              >
                {saving ? tCommon("loading") : t("buttons.saveEventSub")}
              </button>
+             {!compact && (
              <button
                onClick={() => { fetchRewards(); fetchEventSubStatus(); fetchAdditionalRewards(); setRegistrationFailed(false); }}
                className="inline-flex h-10 items-center justify-center rounded-md border border-gray-500 bg-transparent px-4 text-sm font-medium text-gray-200 transition-colors hover:border-gray-400 hover:bg-gray-700/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800"
              >
                {tCommon("refresh")}
              </button>
-             {/* 設定解除ボタン: EventSubが設定されている場合のみ表示 */}
-             {/* Disconnect button: Only shown when EventSub is configured */}
-             {(eventSubStatus === "active" || eventSubStatus === "pending" || subscriptions.length > 0) && (
+             )}
+             {/* 設定解除ボタン: EventSubが設定されている場合のみ表示 (compact 時は省略) */}
+             {!compact && (eventSubStatus === "active" || eventSubStatus === "pending" || subscriptions.length > 0) && (
                <button
                  onClick={handleDisconnect}
                  disabled={disconnecting}

--- a/src/components/OverlayPreview.tsx
+++ b/src/components/OverlayPreview.tsx
@@ -87,6 +87,8 @@ interface OverlayPreviewProps {
   streamerId: string;
   baseUrl: string;
   showPreview?: boolean;  // プレビューセクションを表示するかどうか（デフォルト: true）
+  showCustomization?: boolean;  // カスタマイズ折りたたみセクションを表示するか（デフォルト: true）
+  showCollectionUrl?: boolean;  // コレクションURLセクションを表示するか（デフォルト: true）
   sideContent?: React.ReactNode;  // URLセクションの横に表示するコンテンツ（横並びレイアウト用）
   cards?: Card[];  // デバッグ用：配信者のカード一覧（セレクトボックスで選択可能）
 }
@@ -107,7 +109,15 @@ const isPreviewEnvironment = process.env.NEXT_PUBLIC_VERCEL_ENV === "preview";
  * - iframeでのプレビュー表示
  * - DEMOボタンで配信者のカードを表示
  */
-export default function OverlayPreview({ streamerId, baseUrl, showPreview = true, sideContent, cards = [] }: OverlayPreviewProps) {
+export default function OverlayPreview({
+  streamerId,
+  baseUrl,
+  showPreview = true,
+  showCustomization = true,
+  showCollectionUrl = true,
+  sideContent,
+  cards = [],
+}: OverlayPreviewProps) {
   const t = useTranslations("overlaySettings");
   const tDashboard = useTranslations("dashboard");
   const storageKey = `${OVERLAY_OPTIONS_STORAGE_KEY_PREFIX}${streamerId}`;
@@ -368,6 +378,7 @@ export default function OverlayPreview({ streamerId, baseUrl, showPreview = true
 
       {/* オーバーレイカスタマイズオプション（折りたたみ可能） */}
       {/* Overlay customization options (collapsible section) */}
+      {showCustomization && (
       <div className="mt-6 pt-6 border-t border-gray-700">
         {/* 折りたたみヘッダー - クリックで展開/折りたたみ */}
         {/* Collapsible header - click to expand/collapse */}
@@ -554,6 +565,7 @@ export default function OverlayPreview({ streamerId, baseUrl, showPreview = true
           </>
         )}
       </div>
+      )}
     </div>
   );
 
@@ -726,28 +738,20 @@ export default function OverlayPreview({ streamerId, baseUrl, showPreview = true
   if (sideContent) {
     return (
       <div className="space-y-8">
-        {/* URLセクションとsideContentを横並びに配置 */}
-        {/* Place URL section and sideContent side by side */}
         <div className="grid gap-8 lg:grid-cols-2">
           {urlSection}
           {sideContent}
         </div>
-        {/* コレクションページURLセクション（別欄として表示） */}
-        {/* Collection page URL section (displayed as separate section) */}
-        {collectionUrlSection}
-        {/* プレビューは全幅で下に配置 */}
-        {/* Preview section spans full width below */}
+        {showCollectionUrl && collectionUrlSection}
         {previewSection}
       </div>
     );
   }
 
   return (
-    <div className={showPreview ? "space-y-8" : ""}>
+    <div className={showPreview || showCollectionUrl ? "space-y-8" : ""}>
       {urlSection}
-      {/* コレクションページURLセクション（別欄として表示） */}
-      {/* Collection page URL section (displayed as separate section) */}
-      {collectionUrlSection}
+      {showCollectionUrl && collectionUrlSection}
       {previewSection}
     </div>
   );

--- a/src/components/SettingsLayout.tsx
+++ b/src/components/SettingsLayout.tsx
@@ -1,0 +1,418 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useTranslations } from "next-intl";
+import {
+  AdvancedSettingsLayout,
+  SettingsViewModeProvider,
+  SettingsViewToggle,
+  useSetSettingsViewMode,
+  useSettingsViewMode,
+  type SettingsSection,
+} from "@/components/SettingsViewMode";
+import CopyButton from "@/components/CopyButton";
+import VoteCampaignButton from "@/components/VoteCampaignButton";
+import { VOTE_CAMPAIGN_CONFIG } from "@/lib/constants";
+import type { Card } from "@/types/database";
+
+// token-manager のサーバー専用モジュールに依存しないよう、戻り値型を inline 宣言。
+// 形状は getCustomBotAccountDisplayForStreamer の戻り値と一致させる。
+type BotAccountDisplay = { username: string | null; displayName: string | null };
+
+// 配信設定ページのレイアウト切替クライアントコンポーネント。
+// Simple = 集中度の高いクイックスタート 2 ステップ表示。
+// Advanced = sticky 左サイドバー + 右コンテンツの単一セクション表示。
+// 各モードで実コンポーネント (OverlayPreview / ChannelPointSettings 等) を
+// 個別にマウントするため、トグル時は子の内部状態がリセットされる。
+// これは fetch 重複を避けるため意図的にした設計判断。
+// (双方を常時マウントすると初回ロードで API が 2 倍呼ばれるトレードオフがあった)
+
+const OverlayPreview = dynamic(() => import("@/components/OverlayPreview"), {
+  ssr: false,
+  loading: () => <SettingsPanelSkeleton />,
+});
+const ChannelPointSettings = dynamic(() => import("@/components/ChannelPointSettings"), {
+  ssr: false,
+  loading: () => <SettingsPanelSkeleton />,
+});
+const GachaSoundSettings = dynamic(() => import("@/components/GachaSoundSettings"), {
+  ssr: false,
+  loading: () => <SettingsPanelSkeleton />,
+});
+const ChatAnnouncementSettings = dynamic(() => import("@/components/ChatAnnouncementSettings"), {
+  ssr: false,
+  loading: () => <SettingsPanelSkeleton />,
+});
+const CardVisibilitySettings = dynamic(() => import("@/components/CardVisibilitySettings"), {
+  ssr: false,
+  loading: () => <SettingsPanelSkeleton />,
+});
+
+function SettingsPanelSkeleton() {
+  return (
+    <div className="animate-pulse rounded-2xl border border-white/5 bg-gray-900/40 p-6">
+      <div className="h-4 w-1/3 rounded bg-white/10" />
+      <div className="mt-3 h-3 w-2/3 rounded bg-white/10" />
+      <div className="mt-6 h-10 w-full rounded bg-white/10" />
+    </div>
+  );
+}
+
+export interface SettingsLayoutData {
+  streamerId: string;
+  baseUrl: string;
+  cards: Card[];
+  showVoteCampaign: boolean;
+  botAccount: BotAccountDisplay | null;
+  channelPoint: {
+    rewardId: string | null;
+    rewardName: string | null;
+  };
+  gachaSound: {
+    soundUrl: string | null;
+    soundEnabled: boolean;
+  };
+  chatAnnouncement: {
+    enabled: boolean;
+    template: string | null;
+    multiTemplate: string | null;
+    multiShowCards: boolean;
+  };
+  visibility: {
+    showUnowned: boolean;
+    showUnownedDetails: boolean;
+  };
+  initialModeHint: "simple" | "advanced";
+}
+
+export default function SettingsLayout(props: SettingsLayoutData) {
+  return (
+    <SettingsViewModeProvider initialModeHint={props.initialModeHint}>
+      <VoteCampaignButton visible={props.showVoteCampaign} bonusMb={VOTE_CAMPAIGN_CONFIG.BONUS_MB} />
+      <ModeSwitch data={props} />
+    </SettingsViewModeProvider>
+  );
+}
+
+function ModeSwitch({ data }: { data: SettingsLayoutData }) {
+  const mode = useSettingsViewMode();
+  return mode === "simple" ? <SimpleLayout data={data} /> : <AdvancedLayout data={data} />;
+}
+
+// ---------------------------------------------------------------------------
+// Simple layout
+// ---------------------------------------------------------------------------
+
+function SimpleLayout({ data }: { data: SettingsLayoutData }) {
+  const t = useTranslations("settingsPage");
+  const collectionUrl = `${data.baseUrl}/collection/${data.streamerId}`;
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6">
+      <PageHeader title={t("title")} />
+
+      {/* Hero ribbon — explains the focused mode and orients the user */}
+      <section
+        aria-labelledby="simple-hero-title"
+        className="relative overflow-hidden rounded-3xl border border-violet-500/20 bg-gradient-to-br from-violet-600/15 via-indigo-700/10 to-transparent p-6 sm:p-8"
+      >
+        {/* decorative orb — pure CSS, no asset cost */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute -right-16 -top-16 h-48 w-48 rounded-full bg-violet-500/20 blur-3xl"
+        />
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-violet-300/80">
+          {t("simple.heroEyebrow")}
+        </p>
+        <h2 id="simple-hero-title" className="mt-2 text-2xl font-semibold text-white sm:text-3xl">
+          {t("simple.heroTitle")}
+        </h2>
+        <p className="mt-3 max-w-lg text-sm leading-relaxed text-gray-300">
+          {t("simple.heroDescription")}
+        </p>
+      </section>
+
+      {/* Step 1: OBS URL */}
+      <StepCard step={t("simple.step1")} label={t("simple.step1Label")}>
+        <OverlayPreview
+          streamerId={data.streamerId}
+          baseUrl={data.baseUrl}
+          cards={data.cards}
+          showPreview={false}
+          showCustomization={false}
+          showCollectionUrl={false}
+        />
+      </StepCard>
+
+      {/* Step 2: Reward picker — compact, no diagnostics */}
+      <StepCard step={t("simple.step2")} label={t("simple.step2Label")}>
+        <ChannelPointSettings
+          streamerId={data.streamerId}
+          currentRewardId={data.channelPoint.rewardId}
+          currentRewardName={data.channelPoint.rewardName}
+          compact
+        />
+      </StepCard>
+
+      {/* Collection URL — secondary share link */}
+      <div className="rounded-2xl border border-white/5 bg-gray-900/40 p-5">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-gray-200">{t("simple.collectionLink")}</p>
+            <p className="mt-0.5 truncate text-xs text-gray-500">{collectionUrl}</p>
+          </div>
+          <CopyButton text={collectionUrl} />
+        </div>
+      </div>
+
+      {/* CTA: switch to advanced */}
+      <div className="flex justify-center pt-2">
+        <SwitchToAdvancedLink />
+      </div>
+    </div>
+  );
+}
+
+function StepCard({
+  step,
+  label,
+  children,
+}: {
+  step: string;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section
+      aria-label={label}
+      className="overflow-hidden rounded-2xl border border-white/5 bg-gray-900/40 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"
+    >
+      <header className="flex items-center gap-3 border-b border-white/5 bg-white/[0.02] px-5 py-3">
+        <span className="flex h-7 w-7 items-center justify-center rounded-full bg-violet-500/20 text-xs font-semibold text-violet-200 ring-1 ring-inset ring-violet-400/20">
+          {step}
+        </span>
+        <h3 className="text-sm font-semibold tracking-wide text-gray-200">{label}</h3>
+      </header>
+      {/* 子コンポーネントは独自スタイル (rounded-xl bg-gray-800) を持つため、
+          ここでは padding のみ与えて入れ子カードとして自然に見せる。
+          以前は属性セレクタで子の class を打ち消していたが、Tailwind class が
+          変わった瞬間に静かに壊れる脆さがあったため廃止。 */}
+      <div className="p-3 sm:p-4">{children}</div>
+    </section>
+  );
+}
+
+function SwitchToAdvancedLink() {
+  const t = useTranslations("settingsPage.simple");
+  const setMode = useSetSettingsViewMode();
+  return (
+    <button
+      type="button"
+      onClick={() => setMode("advanced")}
+      className="group inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-5 py-2 text-sm text-gray-300 transition-all hover:border-violet-400/40 hover:bg-violet-500/10 hover:text-white"
+    >
+      {t("switchToAdvanced")}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Advanced layout
+// ---------------------------------------------------------------------------
+
+function AdvancedLayout({ data }: { data: SettingsLayoutData }) {
+  const t = useTranslations("settingsPage");
+  const collectionUrl = `${data.baseUrl}/collection/${data.streamerId}`;
+
+  const rewardStatus: SettingsSection["status"] = data.channelPoint.rewardId ? "active" : "empty";
+  const soundStatus: SettingsSection["status"] = data.gachaSound.soundEnabled
+    ? "active"
+    : data.gachaSound.soundUrl
+      ? "configured"
+      : "empty";
+  const announcementStatus: SettingsSection["status"] = data.chatAnnouncement.enabled
+    ? "active"
+    : "empty";
+  const visibilityStatus: SettingsSection["status"] = data.visibility.showUnowned
+    ? "active"
+    : "empty";
+
+  const sections: SettingsSection[] = [
+    {
+      id: "overlay",
+      label: t("advanced.section.overlay"),
+      description: t("advanced.section.overlayDesc"),
+      icon: <SectionIcon name="overlay" />,
+      status: "configured",
+      content: (
+        <OverlayPreview
+          streamerId={data.streamerId}
+          baseUrl={data.baseUrl}
+          cards={data.cards}
+          showCollectionUrl={false}
+        />
+      ),
+    },
+    {
+      id: "reward",
+      label: t("advanced.section.reward"),
+      description: t("advanced.section.rewardDesc"),
+      icon: <SectionIcon name="reward" />,
+      status: rewardStatus,
+      content: (
+        <ChannelPointSettings
+          streamerId={data.streamerId}
+          currentRewardId={data.channelPoint.rewardId}
+          currentRewardName={data.channelPoint.rewardName}
+        />
+      ),
+    },
+    {
+      id: "sound",
+      label: t("advanced.section.sound"),
+      description: t("advanced.section.soundDesc"),
+      icon: <SectionIcon name="sound" />,
+      status: soundStatus,
+      content: (
+        <GachaSoundSettings
+          streamerId={data.streamerId}
+          currentSoundUrl={data.gachaSound.soundUrl}
+          currentSoundEnabled={data.gachaSound.soundEnabled}
+        />
+      ),
+    },
+    {
+      id: "announcement",
+      label: t("advanced.section.announcement"),
+      description: t("advanced.section.announcementDesc"),
+      icon: <SectionIcon name="chat" />,
+      status: announcementStatus,
+      content: (
+        <ChatAnnouncementSettings
+          streamerId={data.streamerId}
+          currentEnabled={data.chatAnnouncement.enabled}
+          currentTemplate={data.chatAnnouncement.template}
+          currentMultiTemplate={data.chatAnnouncement.multiTemplate}
+          currentMultiShowCards={data.chatAnnouncement.multiShowCards}
+          botAccount={data.botAccount}
+        />
+      ),
+    },
+    {
+      id: "visibility",
+      label: t("advanced.section.visibility"),
+      description: t("advanced.section.visibilityDesc"),
+      icon: <SectionIcon name="eye" />,
+      status: visibilityStatus,
+      content: (
+        <CardVisibilitySettings
+          streamerId={data.streamerId}
+          currentShowUnowned={data.visibility.showUnowned}
+          currentShowUnownedDetails={data.visibility.showUnownedDetails}
+        />
+      ),
+    },
+    {
+      id: "share",
+      label: t("advanced.section.share"),
+      description: t("advanced.section.shareDesc"),
+      icon: <SectionIcon name="share" />,
+      status: "configured",
+      content: <ShareSection url={collectionUrl} />,
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title={t("title")} description={t("description")} />
+      <AdvancedSettingsLayout sections={sections} />
+    </div>
+  );
+}
+
+function ShareSection({ url }: { url: string }) {
+  const t = useTranslations("overlaySettings");
+  return (
+    <div className="rounded-xl bg-gray-800 p-6">
+      <h2 className="mb-4 text-xl font-semibold text-white">{t("collectionUrl")}</h2>
+      <p className="mb-4 text-sm text-gray-400">{t("collectionUrlDescription")}</p>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          readOnly
+          value={url}
+          className="flex-1 rounded-lg bg-gray-700 px-4 py-2 text-gray-200"
+        />
+        <CopyButton text={url} />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared header
+// ---------------------------------------------------------------------------
+
+function PageHeader({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight text-white">{title}</h1>
+        {description && <p className="mt-2 text-sm text-gray-400">{description}</p>}
+      </div>
+      <SettingsViewToggle />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Icons — inline SVG path data only (no asset dependency).
+// 一つの <SectionIcon> でラップし、共通の svg 属性を共有することで boilerplate を削減。
+// ---------------------------------------------------------------------------
+
+type IconName = "overlay" | "reward" | "sound" | "chat" | "eye" | "share";
+
+const ICON_PATHS: Record<IconName, React.ReactNode> = {
+  overlay: (
+    <>
+      <rect x="3" y="5" width="18" height="14" rx="2" />
+      <path d="M3 9h18" />
+      <circle cx="7" cy="7" r="0.6" fill="currentColor" />
+    </>
+  ),
+  reward: (
+    <>
+      <circle cx="12" cy="9" r="5" />
+      <path d="M8.5 13.5 7 21l5-3 5 3-1.5-7.5" />
+    </>
+  ),
+  sound: (
+    <>
+      <path d="M5 10v4h3l4 3V7L8 10H5z" />
+      <path d="M16 8a5 5 0 0 1 0 8" />
+    </>
+  ),
+  chat: <path d="M4 5h16v11H8l-4 4V5z" />,
+  eye: (
+    <>
+      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z" />
+      <circle cx="12" cy="12" r="3" />
+    </>
+  ),
+  share: (
+    <>
+      <circle cx="18" cy="5" r="2.5" />
+      <circle cx="6" cy="12" r="2.5" />
+      <circle cx="18" cy="19" r="2.5" />
+      <path d="M8.2 10.7 15.8 6.3M8.2 13.3l7.6 4.4" />
+    </>
+  ),
+};
+
+function SectionIcon({ name }: { name: IconName }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" className="h-4 w-4">
+      {ICON_PATHS[name]}
+    </svg>
+  );
+}

--- a/src/components/SettingsViewMode.tsx
+++ b/src/components/SettingsViewMode.tsx
@@ -5,14 +5,18 @@ import {
   useCallback,
   useContext,
   useMemo,
+  useState,
   useSyncExternalStore,
   type ReactNode,
 } from "react";
 import { useTranslations } from "next-intl";
 
 // 配信設定ページの表示モード切り替え用コンポーネント群。
-// Progressive disclosure パターン (Gmail Basic/Standard, Stripe Advanced 等の業界標準) に倣い、
-// 初心者向けの最小構成 ("simple") と全設定を露出する "advanced" を切り替える。
+// Progressive disclosure パターン (Gmail Basic/Standard, Stripe Advanced, GitHub Settings 等の業界標準)
+// に倣い、初心者向けの最小構成 ("simple") と全設定を露出する "advanced" を切り替える。
+// 詳細モードは sidebar nav パターンで section を一つずつ表示し情報過多を回避する。
+// Simple mode = 最小限のクイックセットアップカード。
+// Advanced mode = 左 sticky sidebar + 右ペインの単一セクション表示。
 // 保存先は localStorage 限定 (DB 変更なし、ブラウザ毎)。
 
 type SettingsViewMode = "simple" | "advanced";
@@ -31,7 +35,6 @@ function notifyStorageSubscribers(): void {
 }
 
 // テスト用: 内部購読者集合をクリア。本番コードからは呼ばない。
-// Exported for tests only — production code should not depend on this.
 export function __resetSettingsViewModeSubscribersForTest(): void {
   storageSubscribers.clear();
   transientMode = null;
@@ -48,8 +51,6 @@ function isValidMode(value: unknown): value is SettingsViewMode {
   return value === "simple" || value === "advanced";
 }
 
-// useSyncExternalStore に渡す subscribe 関数。
-// React docs: https://react.dev/reference/react/useSyncExternalStore
 function subscribeStorage(callback: () => void): () => void {
   storageSubscribers.add(callback);
   if (typeof window !== "undefined") {
@@ -64,14 +65,12 @@ function subscribeStorage(callback: () => void): () => void {
 }
 
 function readStoredMode(): SettingsViewMode | null {
-  if (typeof window === "undefined") {
-    return null;
-  }
+  if (typeof window === "undefined") return null;
   try {
     const stored = window.localStorage.getItem(STORAGE_KEY);
     return isValidMode(stored) ? stored : null;
   } catch {
-    // Safari プライベートモード等で localStorage がアクセス不能な場合は null (=未保存扱い)。
+    // Safari プライベートモード等で localStorage がアクセス不能な場合は null。
     return null;
   }
 }
@@ -80,16 +79,6 @@ function readCurrentMode(fallbackMode: SettingsViewMode): SettingsViewMode {
   return transientMode ?? readStoredMode() ?? fallbackMode;
 }
 
-/**
- * Provider — Context + localStorage 永続化。
- * useSyncExternalStore で localStorage を購読し、SSR/CSR の整合性を保つ。
- *
- * initialModeHint:
- *   サーバー側でユーザーの既存設定状況から推奨初期モードを判断し渡す。
- *   localStorage に明示的保存がない場合のフォールバックとして使用される。
- *   既存ユーザーが詳細機能を有効化済みなら "advanced" を渡すことで、
- *   トグル導入時に設定が消えたように見える混乱を回避できる。
- */
 export function SettingsViewModeProvider({
   children,
   initialModeHint,
@@ -97,17 +86,17 @@ export function SettingsViewModeProvider({
   children: ReactNode;
   initialModeHint?: SettingsViewMode;
 }) {
-  // SSR snapshot は initialModeHint または DEFAULT_MODE 固定。
-  // ハイドレーション不整合を避けるためサーバとクライアントの初期描画で同じ値を返す。
   const fallbackMode: SettingsViewMode = initialModeHint ?? DEFAULT_MODE;
 
-  const getClientSnapshot = useCallback((): SettingsViewMode => {
-    return readCurrentMode(fallbackMode);
-  }, [fallbackMode]);
+  const getClientSnapshot = useCallback(
+    (): SettingsViewMode => readCurrentMode(fallbackMode),
+    [fallbackMode],
+  );
 
-  const getServerSnapshot = useCallback((): SettingsViewMode => {
-    return fallbackMode;
-  }, [fallbackMode]);
+  const getServerSnapshot = useCallback(
+    (): SettingsViewMode => fallbackMode,
+    [fallbackMode],
+  );
 
   const mode = useSyncExternalStore(
     subscribeStorage,
@@ -116,10 +105,7 @@ export function SettingsViewModeProvider({
   );
 
   const setMode = useCallback((next: SettingsViewMode) => {
-    if (typeof window === "undefined") {
-      // SSR で誤って呼ばれた場合は no-op (本来到達しない)。
-      return;
-    }
+    if (typeof window === "undefined") return;
     transientMode = next;
     try {
       window.localStorage.setItem(STORAGE_KEY, next);
@@ -139,41 +125,60 @@ export function SettingsViewModeProvider({
   );
 }
 
-function useSettingsViewMode(): SettingsViewModeContextValue {
+/**
+ * Hook for child components to react to the current view mode.
+ * Provider 外で呼ばれた場合は安全側に倒し "advanced" を返す
+ * (= 全機能を表示する) ことで、テスト / 単体表示時の破損を避ける。
+ */
+export function useSettingsViewMode(): SettingsViewMode {
+  const ctx = useContext(SettingsViewModeContext);
+  return ctx?.mode ?? "advanced";
+}
+
+/**
+ * Hook to imperatively change the view mode (e.g. from an inline CTA link).
+ * Provider 外では no-op を返し、安全側に倒す。
+ */
+export function useSetSettingsViewMode(): (mode: SettingsViewMode) => void {
+  const ctx = useContext(SettingsViewModeContext);
+  return ctx?.setMode ?? (() => {});
+}
+
+function useSettingsViewModeStrict(): SettingsViewModeContextValue {
   const ctx = useContext(SettingsViewModeContext);
   if (!ctx) {
-    throw new Error(
-      "useSettingsViewMode must be used within SettingsViewModeProvider",
-    );
+    throw new Error("must be used within SettingsViewModeProvider");
   }
   return ctx;
 }
 
 /**
- * 表示モード切替トグル UI (2 つのセグメントボタン)。
- * 視覚的に現在モードがハイライトされ、クリックでもう片方へ切替。
+ * View-mode セグメントトグル。Apple Settings 風のピル状デザイン。
  */
 export function SettingsViewToggle() {
   const t = useTranslations("settingsPage.viewMode");
-  const { mode, setMode } = useSettingsViewMode();
-
-  // 共通の trigger スタイル。aria-pressed で選択状態を伝える。
-  const baseClass =
-    "px-3 py-1.5 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400";
-  const activeClass = "bg-purple-600 text-white";
-  const inactiveClass = "bg-gray-800 text-gray-300 hover:bg-gray-700";
+  const { mode, setMode } = useSettingsViewModeStrict();
 
   return (
     <div
       role="group"
       aria-label={t("ariaLabel")}
-      className="inline-flex overflow-hidden rounded-lg border border-gray-700"
+      className="relative inline-flex rounded-full border border-white/10 bg-gray-900/60 p-1 shadow-inner shadow-black/40 backdrop-blur"
     >
+      {/* スライドする選択ハイライト */}
+      <span
+        aria-hidden="true"
+        className={`pointer-events-none absolute top-1 bottom-1 w-[calc(50%-0.25rem)] rounded-full bg-gradient-to-br from-violet-500 to-indigo-600 shadow-lg shadow-violet-900/40 transition-transform duration-300 ease-out ${
+          mode === "advanced" ? "translate-x-[calc(100%+0.25rem)]" : "translate-x-0"
+        }`}
+      />
       <button
         type="button"
         aria-pressed={mode === "simple"}
         onClick={() => setMode("simple")}
-        className={`${baseClass} ${mode === "simple" ? activeClass : inactiveClass}`}
+        className={`relative z-10 px-4 py-1.5 text-xs font-medium tracking-wide transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 ${
+          mode === "simple" ? "text-white" : "text-gray-400 hover:text-gray-200"
+        }`}
       >
         {t("simple")}
       </button>
@@ -181,7 +186,9 @@ export function SettingsViewToggle() {
         type="button"
         aria-pressed={mode === "advanced"}
         onClick={() => setMode("advanced")}
-        className={`${baseClass} ${mode === "advanced" ? activeClass : inactiveClass}`}
+        className={`relative z-10 px-4 py-1.5 text-xs font-medium tracking-wide transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 ${
+          mode === "advanced" ? "text-white" : "text-gray-400 hover:text-gray-200"
+        }`}
       >
         {t("advanced")}
       </button>
@@ -190,16 +197,13 @@ export function SettingsViewToggle() {
 }
 
 /**
- * 詳細設定ラッパー。mode === "advanced" のときだけ children を表示。
- * 非表示時は `hidden` 属性を付け、DOM ノードは保持して内部状態 (入力中の値など) を失わない。
- *
- * aria-hidden は true のときだけ明示。false 明示は WAI-ARIA 仕様上意味が曖昧で
- * 一部支援技術で誤動作する可能性があるため、undefined にすることで属性自体を除外する。
+ * 詳細設定ラッパー (互換性のため残す)。
+ * mode === "advanced" のときだけ children を表示。
+ * 非表示時は `hidden` 属性 + DOM 保持で内部状態 (入力中の値など) を失わない。
  */
 export function AdvancedSettings({ children }: { children: ReactNode }) {
-  const { mode } = useSettingsViewMode();
+  const mode = useSettingsViewMode();
   const isAdvanced = mode === "advanced";
-
   return (
     <div
       data-testid="advanced-settings"
@@ -207,6 +211,109 @@ export function AdvancedSettings({ children }: { children: ReactNode }) {
       hidden={!isAdvanced}
     >
       {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Advanced mode: sidebar navigation
+// ---------------------------------------------------------------------------
+
+export interface SettingsSection {
+  id: string;
+  label: string;
+  description?: string;
+  icon?: ReactNode;
+  /** active/configured/empty — controls the right-side status dot color */
+  status?: "active" | "configured" | "empty";
+  content: ReactNode;
+}
+
+const STATUS_DOT_CLASS: Record<NonNullable<SettingsSection["status"]>, string> = {
+  active: "bg-emerald-400 shadow-[0_0_8px_rgba(52,211,153,0.65)]",
+  configured: "bg-violet-400 shadow-[0_0_8px_rgba(167,139,250,0.55)]",
+  empty: "bg-gray-600",
+};
+
+/**
+ * AdvancedSettingsLayout
+ *
+ * sticky 左サイドバー + 右コンテンツの 2 カラムレイアウト。
+ * 一度に 1 セクションだけ表示することで、情報過多を解消する。
+ * モバイル (lg 未満) では横スクロールするピル型タブとして折り畳まれる。
+ */
+export function AdvancedSettingsLayout({ sections }: { sections: SettingsSection[] }) {
+  const t = useTranslations("settingsPage.advanced");
+  const [activeId, setActiveId] = useState<string>(sections[0]?.id ?? "");
+  const active = sections.find((s) => s.id === activeId) ?? sections[0];
+
+  if (!active) return null;
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[260px_minmax(0,1fr)]">
+      {/* Sidebar — desktop = vertical sticky list, mobile = horizontal scroll */}
+      <aside className="lg:sticky lg:top-6 lg:self-start">
+        <nav
+          aria-label={t("navAria")}
+          className="-mx-1 flex gap-1 overflow-x-auto px-1 pb-2 lg:mx-0 lg:flex-col lg:gap-0.5 lg:overflow-visible lg:pb-0"
+        >
+          {sections.map((section) => {
+            const isActive = section.id === active.id;
+            return (
+              <button
+                key={section.id}
+                type="button"
+                onClick={() => setActiveId(section.id)}
+                aria-current={isActive ? "true" : undefined}
+                className={`group flex shrink-0 items-center gap-3 rounded-xl border px-4 py-3 text-left text-sm transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 lg:w-full lg:shrink ${
+                  isActive
+                    ? "border-violet-500/40 bg-gradient-to-br from-violet-500/15 to-indigo-500/5 text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
+                    : "border-transparent text-gray-400 hover:border-white/5 hover:bg-white/5 hover:text-gray-200"
+                }`}
+              >
+                {section.icon && (
+                  <span
+                    className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-colors ${
+                      isActive
+                        ? "bg-violet-500/20 text-violet-200"
+                        : "bg-white/5 text-gray-500 group-hover:text-gray-300"
+                    }`}
+                  >
+                    {section.icon}
+                  </span>
+                )}
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span className="flex items-center gap-2 font-medium">
+                    <span className="truncate">{section.label}</span>
+                    {section.status && (
+                      <span
+                        aria-hidden="true"
+                        className={`h-1.5 w-1.5 shrink-0 rounded-full ${STATUS_DOT_CLASS[section.status]}`}
+                      />
+                    )}
+                  </span>
+                  {section.description && (
+                    <span className="hidden truncate text-xs text-gray-500 lg:block">
+                      {section.description}
+                    </span>
+                  )}
+                </span>
+              </button>
+            );
+          })}
+        </nav>
+      </aside>
+
+      {/* Content pane */}
+      <div className="min-w-0">
+        {/* 全セクションを DOM に保持し、非アクティブを hidden で隠す。
+            入力中の値や子コンポーネントの fetch 状態がタブ切り替えで失われないようにする。 */}
+        {sections.map((section) => (
+          <div key={section.id} hidden={section.id !== active.id} aria-hidden={section.id !== active.id ? true : undefined}>
+            {section.content}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/tests/unit/components/settings-view-mode.test.tsx
+++ b/tests/unit/components/settings-view-mode.test.tsx
@@ -192,19 +192,23 @@ describe('SettingsViewMode', () => {
   })
 
   describe('useSettingsViewMode (Provider 未使用時)', () => {
-    it('Provider 外で AdvancedSettings を使うと例外', () => {
-      // テスト時の console.error を抑制するため、render を try/catch で囲む。
-      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
-      expect(() =>
-        render(
-          <NextIntlClientProvider locale="ja" messages={messages}>
-            <AdvancedSettings>
-              <p>x</p>
-            </AdvancedSettings>
-          </NextIntlClientProvider>
-        )
-      ).toThrow(/SettingsViewModeProvider/)
-      spy.mockRestore()
+    it('Provider 外でも AdvancedSettings は children を表示する (= advanced フォールバック)', () => {
+      // Provider 未使用時は安全側に倒し「advanced (= 全機能表示)」をフォールバックとして返す。
+      // これにより個別の設定コンポーネントを単独 (テスト/Storybook/エラーフォールバック等) で
+      // レンダリングしてもクラッシュしないことを保証する。
+      render(
+        <NextIntlClientProvider locale="ja" messages={messages}>
+          <AdvancedSettings>
+            <p>advanced-fallback-content</p>
+          </AdvancedSettings>
+        </NextIntlClientProvider>
+      )
+      // children が表示されていること
+      expect(screen.getByText('advanced-fallback-content')).toBeInTheDocument()
+      // hidden / aria-hidden が付与されていないこと (= advanced モードで可視)
+      const wrapper = screen.getByTestId('advanced-settings')
+      expect(wrapper).not.toHaveAttribute('hidden')
+      expect(wrapper).not.toHaveAttribute('aria-hidden')
     })
   })
 })


### PR DESCRIPTION
## Summary
- シンプル表示を「クイックスタート 2 ステップ」に集約。EventSub 診断パネルや追加報酬など中級者向け項目はすべて隠す
- 詳細表示を **左 sticky サイドバー + 単一セクション表示** (GitHub / Stripe / Linear 設定の業界標準) に変更し、見づらさを解消
- セクション毎の状態ドット (emerald=有効 / violet=設定済 / gray=未設定) で一目把握
- モード切替トグルを Apple 風スライドピルに刷新

## なぜ
ユーザーフィードバック: 「シンプルはまだ全然複雑、詳細はみづらい」
→ Simple は本当に最低限の 2 つだけ、Advanced は一度に 1 セクションだけ見せる形に再設計。

## 主な変更
- ` + "`ChannelPointSettings`" + ` に ` + "`compact`" + ` prop 追加 (診断ノイズ抑制)
- ` + "`OverlayPreview`" + ` に ` + "`showCustomization`" + ` / ` + "`showCollectionUrl`" + ` flag
- ` + "`AdvancedSettingsLayout`" + ` 新設: sticky sidebar + 単一セクション content pane
- ` + "`SettingsLayout`" + ` クライアントラッパ新設、モードで 2 レイアウト切替
- ` + "`useSettingsViewMode`" + ` / ` + "`useSetSettingsViewMode`" + ` hook を export (Provider 外でも安全)

## Test plan
- [x] ` + "`npm run test:unit -- settings-view-mode`" + ` (11/11 passing)
- [x] ` + "`npx tsc --noEmit`" + ` 該当ファイルでエラーなし
- [x] ` + "`npx eslint`" + ` 該当ファイル clean
- [x] ` + "`npm run dev:next`" + ` で /dashboard/settings が 200 OK
- [ ] 手動: Simple モードで OBS URL コピー + 報酬選択 + 保存が動作する
- [ ] 手動: Advanced モードでサイドバー各セクションが切替可能 (overlay / reward / sound / chat / visibility / share)
- [ ] 手動: モード切替後も localStorage に永続化される
- [ ] 手動: モバイル幅 (lg<) でサイドバーが横スクロールピルに変わる
- [ ] 手動: 既存ユーザー (詳細機能利用中) が初回表示で advanced になる

## 設計上のトレードオフ
モード切替時、Simple と Advanced はそれぞれ別の React 子ツリーで実コンポーネントを mount するため、未保存の選択 state はモード切替で失われる (Twitch rewards / EventSub status は再フェッチ)。
これは双方を hidden で常時 mount すると初回ロードで API が 2 倍叩かれるトレードオフがあったため、利用頻度の低い操作 (モード切替) を犠牲にしている。
将来 SWR 等で fetch state を hoist すれば両立可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)