### PR TITLE
Reduce dashboard network latency

### DIFF
--- a/src/app/api/twitch/channel-point-bootstrap/route.ts
+++ b/src/app/api/twitch/channel-point-bootstrap/route.ts
@@ -1,0 +1,245 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSession, canUseStreamerFeatures } from "@/lib/session";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
+import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { ERROR_MESSAGES } from "@/lib/constants";
+import { ADDITIONAL_SCOPES } from "@/lib/twitch/scopes";
+import { getTwitchAccessToken, hasScope } from "@/lib/twitch/token-manager";
+import {
+  deriveEventSubStatus,
+  type EventSubSubscriptionForStatus,
+} from "@/lib/twitch/eventsub-status";
+import { logPerf, perfStart } from "@/lib/perf";
+
+const TWITCH_API_URL = "https://api.twitch.tv/helix";
+
+interface TwitchReward {
+  id: string;
+  title: string;
+  cost: number;
+  is_enabled: boolean;
+}
+
+function isRaidOptionsSchemaError(error: { message?: string; code?: string } | null | undefined) {
+  const message = error?.message ?? "";
+  return error?.code === "PGRST204" || message.includes("draw_count") || message.includes("is_raid_limited");
+}
+
+function isRaidStateSchemaError(error: { message?: string; code?: string } | null | undefined) {
+  const message = error?.message ?? "";
+  return error?.code === "PGRST204"
+    || message.includes("raid_gacha_active_until")
+    || message.includes("raid_gacha_draw_count");
+}
+
+async function getTwitchRewards(twitchUserId: string): Promise<{ rewards: TwitchReward[]; requiresReauth?: boolean; error?: string }> {
+  const accessToken = await getTwitchAccessToken(twitchUserId);
+  if (!accessToken) {
+    return { rewards: [], requiresReauth: true };
+  }
+
+  const response = await fetch(
+    `${TWITCH_API_URL}/channel_points/custom_rewards?broadcaster_id=${twitchUserId}`,
+    {
+      headers: {
+        "Authorization": `Bearer ${accessToken}`,
+        "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
+      },
+    }
+  );
+
+  if (response.status === 401) {
+    return { rewards: [], requiresReauth: true };
+  }
+
+  if (response.status === 403) {
+    return { rewards: [], error: "affiliateRequired" };
+  }
+
+  if (!response.ok) {
+    return { rewards: [], error: "fetchFailed" };
+  }
+
+  const data = await response.json();
+  return { rewards: data.data || [] };
+}
+
+async function getAppAccessToken(): Promise<string> {
+  const response = await fetch("https://id.twitch.tv/oauth2/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
+      client_secret: process.env.TWITCH_CLIENT_SECRET!,
+      grant_type: "client_credentials",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to get app access token");
+  }
+
+  const data = await response.json();
+  return data.access_token;
+}
+
+async function getSubscriptionsByUserId(
+  appAccessToken: string,
+  userId: string,
+): Promise<EventSubSubscriptionForStatus[]> {
+  const allData: EventSubSubscriptionForStatus[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const url = new URL(`${TWITCH_API_URL}/eventsub/subscriptions`);
+    url.searchParams.set("user_id", userId);
+    url.searchParams.set("first", "100");
+    if (cursor) url.searchParams.set("after", cursor);
+
+    const response = await fetch(url, {
+      headers: {
+        "Authorization": `Bearer ${appAccessToken}`,
+        "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch EventSub subscriptions: status=${response.status}`);
+    }
+
+    const data = await response.json();
+    allData.push(...(data.data || []));
+    cursor = data.pagination?.cursor;
+  } while (cursor);
+
+  return allData;
+}
+
+async function getAdditionalRewards(streamerId: string) {
+  const supabaseAdmin = getSupabaseAdmin();
+  let { data: rewards, error } = await supabaseAdmin
+    .from("streamer_additional_gacha_rewards")
+    .select("id, reward_id, reward_name, draw_count, is_raid_limited, created_at")
+    .eq("streamer_id", streamerId)
+    .order("created_at", { ascending: true });
+
+  if (isRaidOptionsSchemaError(error)) {
+    const fallbackResult = await supabaseAdmin
+      .from("streamer_additional_gacha_rewards")
+      .select("id, reward_id, reward_name, created_at")
+      .eq("streamer_id", streamerId)
+      .order("created_at", { ascending: true });
+    rewards = (fallbackResult.data || []).map((reward) => ({
+      ...reward,
+      draw_count: 1,
+      is_raid_limited: false,
+    }));
+    error = fallbackResult.error;
+  }
+
+  if (error) {
+    throw error;
+  }
+
+  return rewards || [];
+}
+
+async function getOwnedStreamer(twitchUserId: string) {
+  const supabaseAdmin = getSupabaseAdmin();
+  let { data: streamer, error } = await supabaseAdmin
+    .from("streamers")
+    .select("id, channel_point_reward_id, raid_gacha_draw_count")
+    .eq("twitch_user_id", twitchUserId)
+    .maybeSingle();
+
+  if (isRaidStateSchemaError(error)) {
+    const fallbackResult = await supabaseAdmin
+      .from("streamers")
+      .select("id, channel_point_reward_id")
+      .eq("twitch_user_id", twitchUserId)
+      .maybeSingle();
+    streamer = fallbackResult.data
+      ? { ...fallbackResult.data, raid_gacha_draw_count: 0 }
+      : fallbackResult.data;
+    error = fallbackResult.error;
+  }
+
+  return { streamer, error };
+}
+
+export async function GET(request: NextRequest) {
+  const startedAt = perfStart();
+  const diagnostics = request.nextUrl.searchParams.get("diagnostics") === "1";
+
+  try {
+    const session = await getSession();
+    const identifier = await getRateLimitIdentifier(request, session?.twitchUserId);
+    const rateLimitResult = await checkRateLimit(rateLimits.twitchRewardsGet, identifier);
+
+    if (!rateLimitResult.success) {
+      return NextResponse.json(
+        { error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
+        { status: 429 },
+      );
+    }
+
+    if (!session || !canUseStreamerFeatures(session)) {
+      return NextResponse.json({ error: ERROR_MESSAGES.UNAUTHORIZED }, { status: 401 });
+    }
+
+    const hasRequiredScope = await hasScope(
+      session.twitchUserId,
+      ADDITIONAL_SCOPES.CHANNEL_READ_REDEMPTIONS,
+    );
+
+    if (!hasRequiredScope) {
+      return NextResponse.json({
+        hasRequiredScope: false,
+        rewards: [],
+        requiresReauth: true,
+      });
+    }
+
+    const { rewards, requiresReauth, error } = await getTwitchRewards(session.twitchUserId);
+    const responsePayload: Record<string, unknown> = {
+      hasRequiredScope: true,
+      rewards,
+      requiresReauth,
+      error,
+    };
+
+    if (diagnostics && !requiresReauth) {
+      const { streamer, error: streamerError } = await getOwnedStreamer(session.twitchUserId);
+      if (streamerError) return handleDatabaseError(streamerError, "Channel Point Bootstrap API");
+      if (!streamer) return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
+
+      const appAccessToken = await getAppAccessToken();
+      const subscriptions = await getSubscriptionsByUserId(appAccessToken, session.twitchUserId);
+      const expectedCallbackUrl = `${process.env.NEXT_PUBLIC_APP_URL}/api/twitch/eventsub`;
+      const subscriptionsWithDebug = subscriptions.map((sub) => ({
+        ...sub,
+        debug: {
+          expectedCallbackUrl,
+          callbackMatch: sub.transport?.callback === expectedCallbackUrl,
+        },
+      }));
+      const status = deriveEventSubStatus(
+        subscriptionsWithDebug,
+        streamer.channel_point_reward_id || "",
+      );
+
+      responsePayload.subscriptions = subscriptionsWithDebug;
+      responsePayload.eventSubStatus = status.rewardStatus;
+      responsePayload.raidEventSubStatus = status.raidStatus;
+      responsePayload.additionalRewards = await getAdditionalRewards(streamer.id);
+      responsePayload.raidGiftDrawCount = streamer.raid_gacha_draw_count ?? 0;
+    }
+
+    return NextResponse.json(responsePayload);
+  } catch (error) {
+    return handleApiError(error, "Channel Point Bootstrap API");
+  } finally {
+    logPerf("api", "channel-point-bootstrap", startedAt, { diagnostics });
+  }
+}

--- a/src/app/dashboard/collection/page.tsx
+++ b/src/app/dashboard/collection/page.tsx
@@ -1,5 +1,5 @@
 import { getSession } from "@/lib/session";
-import { getUserCards, getActiveCardsForStreamer } from "@/lib/dashboard-data";
+import { getUserCards, getActiveCardCountsForStreamers } from "@/lib/dashboard-data";
 import { countOwnedActiveCardTypes, sortCollectedCards } from "@/lib/collection-utils";
 import Collection from "@/components/Collection";
 import type { Card, Streamer } from "@/types/database";
@@ -63,18 +63,17 @@ export default async function CollectionPage() {
   // getUserCards() は非アクティブカードも含むため、進捗には
   // アクティブカードとの交差で正確な所持数を算出する
   const streamerIds = Object.keys(cardsByStreamer);
-  const activeCardData = await Promise.all(
-    streamerIds.map(async (streamerId) => {
-      const activeCards = await getActiveCardsForStreamer(streamerId);
-      const activeCardIds = new Set(activeCards.map((c) => c.id));
-      return {
-        streamerId,
-        totalActive: activeCards.length,
-        ownedActive: countOwnedActiveCardTypes(cardsByStreamer[streamerId].cards, activeCardIds),
-      };
-    })
-  );
-  for (const { streamerId, totalActive, ownedActive } of activeCardData) {
+  const activeCardCounts = await getActiveCardCountsForStreamers(streamerIds);
+  for (const streamerId of streamerIds) {
+    const activeCardData = activeCardCounts.get(streamerId) ?? {
+      totalActive: 0,
+      activeCardIds: new Set<string>(),
+    };
+    const totalActive = activeCardData.totalActive;
+    const ownedActive = countOwnedActiveCardTypes(
+      cardsByStreamer[streamerId].cards,
+      activeCardData.activeCardIds
+    );
     cardsByStreamer[streamerId].totalActive = totalActive;
     cardsByStreamer[streamerId].ownedActive = ownedActive;
 

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,6 +1,7 @@
 import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { getUnreadAnnouncements } from "@/lib/announcements";
-import { getUserPlan } from "@/lib/plan";
+import { getUserPlanSnapshot } from "@/lib/plan";
+import { logPerf, perfStart } from "@/lib/perf";
 import Header from "@/components/Header";
 import DashboardNav from "@/components/DashboardNav";
 import { TwitchLoginRedirect } from "@/components/TwitchLoginRedirect";
@@ -21,6 +22,7 @@ export default async function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const startedAt = perfStart();
   // Get session for authentication check
   // 認証確認のためにセッションを取得
   const session = await getSession();
@@ -37,13 +39,13 @@ export default async function DashboardLayout({
 
   // Check if user has a supporter plan (support/patron) for inquiry access
   // 問い合わせ機能アクセス用に支援者プランを確認
-  const plan = await getUserPlan(session.twitchUserId);
+  const [plan, unreadAnnouncements] = await Promise.all([
+    getUserPlanSnapshot(session.twitchUserId),
+    getUnreadAnnouncements(session.twitchUserId),
+  ]);
   const isSupporter = plan !== 'basic';
-
-  // Get unread announcements count for header badge
-  // ヘッダーのバッジ表示用に未読お知らせ数を取得
-  const unreadAnnouncements = await getUnreadAnnouncements(session.twitchUserId);
   const unreadAnnouncementsCount = unreadAnnouncements.length;
+  logPerf("dashboard-layout", "load", startedAt, { isStreamer, isSupporter });
 
   return (
     <div className="min-h-screen bg-gray-900">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { getUnreadAnnouncements } from "@/lib/announcements";
 import { getOptimizedImageUrl } from "@/lib/image-utils";
 import { getStorageUsage, formatBytes } from "@/lib/storage-usage";
 import { sha256Prefix } from "@/lib/crypto-utils";
+import { logPerf, perfStart } from "@/lib/perf";
 import Stats from "@/components/Stats";
 import VoteCampaignButton from "@/components/VoteCampaignButton";
 import AnnouncementBanner from "@/components/AnnouncementBanner";
@@ -25,6 +26,7 @@ import AnnouncementBanner from "@/components/AnnouncementBanner";
  * 統計概要、最近のカード、他のセクションへのクイックリンクを表示
  */
 export default async function DashboardPage() {
+  const startedAt = perfStart();
   const t = await getTranslations("dashboard");
   const tCards = await getTranslations("cardsPage");
   const tSettings = await getTranslations("settingsPage");
@@ -52,6 +54,11 @@ export default async function DashboardPage() {
     getUnreadAnnouncements(session.twitchUserId),
     storagePromise,
   ]);
+  logPerf("dashboard-page", "load-data", startedAt, {
+    cardCount: userCards.length,
+    unreadAnnouncements: unreadAnnouncements.length,
+    isStreamer,
+  });
 
   // Sort cards by rarity (legendary first)
   // レアリティでソート（レジェンダリーが先頭）

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -4,7 +4,14 @@ import { useState, useEffect, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { logger } from "@/lib/logger";
 import { CHANNEL_POINT_SCOPES } from "@/lib/twitch/scopes";
+import {
+  deriveEventSubStatus,
+  RAID_EVENTSUB_TYPE,
+  type EventSubStatus,
+  type EventSubSubscriptionForStatus,
+} from "@/lib/twitch/eventsub-status";
 
+export { deriveEventSubStatus } from "@/lib/twitch/eventsub-status";
 
 interface TwitchReward {
   id: string;
@@ -24,36 +31,6 @@ interface AdditionalReward {
   created_at: string;
 }
 
-interface EventSubSubscription {
-  id: string;
-  status: string;
-  type: string;
-  condition: {
-    broadcaster_user_id?: string;
-    reward_id?: string;
-    to_broadcaster_user_id?: string;
-  };
-  transport?: {
-    callback?: string;
-  };
-  debug?: {
-    expectedCallbackUrl: string;
-    callbackMatch: boolean;
-  };
-}
-
-type EventSubStatus = "none" | "pending" | "active" | "error";
-
-const CHANNEL_POINTS_EVENTSUB_TYPE = "channel.channel_points_custom_reward_redemption.add";
-const RAID_EVENTSUB_TYPE = "channel.raid";
-const FAILED_EVENTSUB_STATUSES = [
-  "webhook_callback_verification_failed",
-  "notification_failures_exceeded",
-  "authorization_revoked",
-];
-
-const matchesExpectedCallback = (sub: EventSubSubscription) => sub.debug?.callbackMatch ?? true;
-
 const getRaidSubscriptionWarning = (data: unknown): string => {
   const raidSubscription = (data as { raidSubscription?: { warning?: unknown } })?.raidSubscription;
   return typeof raidSubscription?.warning === "string" ? raidSubscription.warning : "";
@@ -65,46 +42,6 @@ const getRaidSubscriptionStatus = (data: unknown): EventSubStatus | null => {
     ? status
     : null;
 };
-
-export function deriveEventSubStatus(
-  subs: EventSubSubscription[],
-  rewardIdToCheck: string,
-): { rewardStatus: EventSubStatus; raidStatus: EventSubStatus } {
-  const rewardSubscriptions = subs.filter(
-    (sub) => sub.type === CHANNEL_POINTS_EVENTSUB_TYPE && matchesExpectedCallback(sub)
-  );
-  const raidSubscriptions = subs.filter(
-    (sub) => sub.type === RAID_EVENTSUB_TYPE && matchesExpectedCallback(sub)
-  );
-
-  const hasActiveRewardSub = rewardSubscriptions.some(
-    (sub) => sub.status === "enabled" && sub.condition.reward_id === rewardIdToCheck
-  );
-  const hasFailedRewardSub = rewardSubscriptions.some(
-    (sub) => FAILED_EVENTSUB_STATUSES.includes(sub.status)
-  );
-  const hasActiveRaidSub = raidSubscriptions.some((sub) => sub.status === "enabled");
-  const hasFailedRaidSub = raidSubscriptions.some(
-    (sub) => FAILED_EVENTSUB_STATUSES.includes(sub.status)
-  );
-
-  return {
-    rewardStatus: hasActiveRewardSub
-      ? "active"
-      : hasFailedRewardSub
-        ? "error"
-        : rewardSubscriptions.length > 0
-          ? "pending"
-          : "none",
-    raidStatus: hasActiveRaidSub
-      ? "active"
-      : hasFailedRaidSub
-        ? "error"
-        : raidSubscriptions.length > 0
-          ? "pending"
-          : "none",
-  };
-}
 
 interface ChannelPointSettingsProps {
   streamerId: string;
@@ -146,7 +83,7 @@ export default function ChannelPointSettings({
   const [eventSubStatus, setEventSubStatus] = useState<EventSubStatus>("none");
   const [raidEventSubStatus, setRaidEventSubStatus] = useState<EventSubStatus>("none");
   const [raidEventSubWarning, setRaidEventSubWarning] = useState("");
-  const [subscriptions, setSubscriptions] = useState<EventSubSubscription[]>([]);
+  const [subscriptions, setSubscriptions] = useState<EventSubSubscriptionForStatus[]>([]);
   // チャネルポイント用スコープ不足でstep-up再認証が必要かどうか
   // Whether step-up reauth is needed because channel point scopes are missing
   const [needsReauth, setNeedsReauth] = useState(false);
@@ -171,84 +108,54 @@ export default function ChannelPointSettings({
   // 連携未設定のユーザーはここで step-up 再認証の導線に誘導される。
   // Pre-check Channel Points scope grant. Initial login omits these scopes,
   // so users who haven't opted in are redirected to step-up reauth via the CTA.
-  const checkChannelPointScope = useCallback(async (): Promise<boolean> => {
+  const fetchChannelPointBootstrap = useCallback(async (includeDiagnostics: boolean) => {
     try {
       const response = await fetch(
-        `/api/auth/check-scope?scope=${encodeURIComponent(
-          "channel:read:redemptions"
-        )}`,
-        { credentials: "include" }
+        `/api/twitch/channel-point-bootstrap?diagnostics=${includeDiagnostics ? "1" : "0"}`,
+        { credentials: "include" },
       );
       if (!response.ok) {
-        // 一時的な障害（rate limit等）: reauth CTAを出さずrewards APIに任せる。
-        // Transient failure (e.g. rate limit): fall through to rewards API.
-        return true;
+        setError(t("messages.fetchFailed"));
+        return;
       }
       const data = await response.json();
-      return Boolean(data.hasScope);
+      if (!data.hasRequiredScope || data.requiresReauth) {
+        setNeedsReauth(true);
+        return;
+      }
+
+      setNeedsReauth(false);
+      if (data.error === "affiliateRequired") {
+        setError(t("messages.affiliateRequired"));
+      } else if (data.error) {
+        setError(t("messages.fetchFailed"));
+      }
+      setRewards(Array.isArray(data.rewards) ? data.rewards : []);
+
+      if (includeDiagnostics) {
+        setSubscriptions(Array.isArray(data.subscriptions) ? data.subscriptions : []);
+        if (data.eventSubStatus) setEventSubStatus(data.eventSubStatus);
+        if (data.raidEventSubStatus) setRaidEventSubStatus(data.raidEventSubStatus);
+        if (Array.isArray(data.additionalRewards)) {
+          setAdditionalRewards(data.additionalRewards);
+          logger.info("[AdditionalRewards] Bootstrapped additional rewards", { count: data.additionalRewards.length });
+        }
+        if (typeof data.raidGiftDrawCount !== "undefined") {
+          setRaidGiftDrawCount(Math.min(10, Math.max(0, Number(data.raidGiftDrawCount ?? 0))));
+        }
+      }
     } catch (err) {
-      logger.error("Failed to check channel point scope:", err);
-      return true;
+      logger.error("Failed to bootstrap channel point settings:", err);
+      setError(t("messages.fetchFailed"));
     }
-  }, []);
+  }, [t]);
 
   const fetchRewards = async () => {
     setLoading(true);
     setError("");
 
     try {
-      // スコープ未付与なら rewards API を呼ぶ前に CTA へ切替える。
-      // これにより Twitch 401 の汎用エラーに埋もれないようにする。
-      // Short-circuit to the reauth CTA before calling the rewards API when
-      // scopes are missing, so users never see a generic 401 error instead.
-      const hasScope = await checkChannelPointScope();
-      if (!hasScope) {
-        setNeedsReauth(true);
-        setLoading(false);
-        return;
-      }
-
-      const response = await fetch("/api/twitch/rewards", {
-        credentials: "include",
-      });
-
-      if (response.status === 401) {
-        const errorData = await response.json();
-        // requiresReauth はトークン自体が失われたケース。
-        // スコープ不足は事前チェックで拾うため、ここではログイン誘導のみ。
-        // requiresReauth here means the token itself is gone; scope gaps are
-        // already handled by the pre-check above.
-        if (errorData.requiresReauth) {
-          setNeedsReauth(true);
-        } else {
-          setError(t("messages.fetchFailed"));
-        }
-        setLoading(false);
-        return;
-      }
-
-      if (response.status === 403) {
-        setError(t("messages.affiliateRequired"));
-        setLoading(false);
-        return;
-      }
-
-      if (response.status === 429) {
-        const errorData = await response.json();
-        setError(errorData.error || t("messages.rateLimit"));
-        setLoading(false);
-        return;
-      }
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        setError(errorData.error || "報酬の取得に失敗しました");
-        setLoading(false);
-        return;
-      }
-
-      const data = await response.json();
-      setRewards(data);
+      await fetchChannelPointBootstrap(!compact);
     } catch (err) {
       logger.error("Failed to fetch rewards:", err);
       setError(t("messages.fetchFailed"));
@@ -330,7 +237,7 @@ export default function ChannelPointSettings({
       });
       if (response.ok) {
         const subs = await response.json();
-        logger.info("[EventSub] API response", { subsCount: subs.length, subs: subs.map((s: EventSubSubscription) => ({ id: s.id, status: s.status, reward_id: s.condition.reward_id })) });
+        logger.info("[EventSub] API response", { subsCount: subs.length, subs: subs.map((s: EventSubSubscriptionForStatus) => ({ id: s.id, status: s.status, reward_id: s.condition.reward_id })) });
         setSubscriptions(subs);
 
         const derivedStatus = deriveEventSubStatus(subs, rewardIdToCheck);
@@ -349,14 +256,7 @@ export default function ChannelPointSettings({
   // 依存配列を空にすることで、保存後の再実行を防ぐ
   useEffect(() => {
     fetchRewards();
-    // 初期ロード時はpropsのcurrentRewardIdを使用
-    fetchEventSubStatus(currentRewardId || undefined);
-    // Fetch additional rewards if main reward is set
-    // メイン報酬が設定されている場合は追加報酬も取得
-    if (currentRewardId) {
-      fetchAdditionalRewards();
-      fetchRaidGachaStatus();
-    }
+    // compact modeでは初期表示の外部診断APIを避け、詳細表示時のみbootstrapでまとめて取得する。
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -825,7 +725,7 @@ export default function ChannelPointSettings({
     }
   };
 
-  const getSubscriptionLabel = (sub: EventSubSubscription) => {
+  const getSubscriptionLabel = (sub: EventSubSubscriptionForStatus) => {
     if (sub.type === RAID_EVENTSUB_TYPE) {
       return t("form.raidEventSubStatus");
     }
@@ -1240,7 +1140,7 @@ export default function ChannelPointSettings({
              </button>
              {!compact && (
              <button
-               onClick={() => { fetchRewards(); fetchEventSubStatus(); fetchAdditionalRewards(); setRegistrationFailed(false); }}
+               onClick={() => { fetchRewards(); fetchEventSubStatus(); fetchAdditionalRewards(); fetchRaidGachaStatus(); setRegistrationFailed(false); }}
                className="inline-flex h-10 items-center justify-center rounded-md border border-gray-500 bg-transparent px-4 text-sm font-medium text-gray-200 transition-colors hover:border-gray-400 hover:bg-gray-700/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-800"
              >
                {tCommon("refresh")}

--- a/src/components/SettingsViewMode.tsx
+++ b/src/components/SettingsViewMode.tsx
@@ -244,9 +244,22 @@ const STATUS_DOT_CLASS: Record<NonNullable<SettingsSection["status"]>, string> =
 export function AdvancedSettingsLayout({ sections }: { sections: SettingsSection[] }) {
   const t = useTranslations("settingsPage.advanced");
   const [activeId, setActiveId] = useState<string>(sections[0]?.id ?? "");
+  const [visitedIds, setVisitedIds] = useState<Set<string>>(
+    () => new Set(sections[0]?.id ? [sections[0].id] : [])
+  );
   const active = sections.find((s) => s.id === activeId) ?? sections[0];
 
   if (!active) return null;
+
+  const selectSection = (sectionId: string) => {
+    setActiveId(sectionId);
+    setVisitedIds((prev) => {
+      if (prev.has(sectionId)) return prev;
+      const next = new Set(prev);
+      next.add(sectionId);
+      return next;
+    });
+  };
 
   return (
     <div className="grid gap-6 lg:grid-cols-[260px_minmax(0,1fr)]">
@@ -262,7 +275,7 @@ export function AdvancedSettingsLayout({ sections }: { sections: SettingsSection
               <button
                 key={section.id}
                 type="button"
-                onClick={() => setActiveId(section.id)}
+                onClick={() => selectSection(section.id)}
                 aria-current={isActive ? "true" : undefined}
                 className={`group flex shrink-0 items-center gap-3 rounded-xl border px-4 py-3 text-left text-sm transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-400 lg:w-full lg:shrink ${
                   isActive
@@ -305,12 +318,14 @@ export function AdvancedSettingsLayout({ sections }: { sections: SettingsSection
 
       {/* Content pane */}
       <div className="min-w-0">
-        {/* 全セクションを DOM に保持し、非アクティブを hidden で隠す。
-            入力中の値や子コンポーネントの fetch 状態がタブ切り替えで失われないようにする。 */}
+        {/* 訪問済みセクションだけを DOM に保持する。
+            初期表示では非表示セクションの fetch を発火させず、訪問後は入力状態を保つ。 */}
         {sections.map((section) => (
-          <div key={section.id} hidden={section.id !== active.id} aria-hidden={section.id !== active.id ? true : undefined}>
-            {section.content}
-          </div>
+          visitedIds.has(section.id) ? (
+            <div key={section.id} hidden={section.id !== active.id} aria-hidden={section.id !== active.id ? true : undefined}>
+              {section.content}
+            </div>
+          ) : null
         ))}
       </div>
     </div>

--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -5,6 +5,7 @@ import { logger } from "@/lib/logger";
 import { normalizeDropRate } from "@/lib/card-utils";
 import { reportError } from "@/lib/sentry/error-handler";
 import { withRetry } from "@/lib/supabase/retry";
+import { logPerf, perfStart } from "@/lib/perf";
 import type { Card, Streamer, GachaHistory } from "@/types/database";
 
 interface CardWithDetails extends Card {
@@ -912,6 +913,59 @@ export const getActiveCardsForStreamer = cache(async (
   logger.info(`[Perf] getActiveCardsForStreamer (with cache): ${Date.now() - start}ms`);
   return result;
 });
+
+export interface ActiveCardCountForStreamer {
+  totalActive: number;
+  activeCardIds: Set<string>;
+}
+
+export async function getActiveCardCountsForStreamers(
+  streamerIds: string[]
+): Promise<Map<string, ActiveCardCountForStreamer>> {
+  const startedAt = perfStart();
+  const uniqueStreamerIds = Array.from(new Set(streamerIds.filter(Boolean)));
+  const counts = new Map<string, ActiveCardCountForStreamer>();
+  for (const streamerId of uniqueStreamerIds) {
+    counts.set(streamerId, { totalActive: 0, activeCardIds: new Set() });
+  }
+
+  if (uniqueStreamerIds.length === 0) {
+    logPerf("dashboard-data", "getActiveCardCountsForStreamers", startedAt, { streamerCount: 0 });
+    return counts;
+  }
+
+  const supabaseAdmin = getSupabaseAdmin();
+  const { data, error } = await withRetry(
+    () => supabaseAdmin
+      .from("cards")
+      .select("id, streamer_id")
+      .in("streamer_id", uniqueStreamerIds)
+      .eq("is_active", true),
+    "getActiveCardCountsForStreamers",
+  );
+
+  if (error) {
+    reportError(new Error(`active card count batch query failed: ${error.message}`));
+    logPerf("dashboard-data", "getActiveCardCountsForStreamers", startedAt, {
+      streamerCount: uniqueStreamerIds.length,
+      failed: true,
+    });
+    return counts;
+  }
+
+  for (const row of (data || []) as Array<{ id: string; streamer_id: string }>) {
+    const entry = counts.get(row.streamer_id);
+    if (!entry) continue;
+    entry.totalActive += 1;
+    entry.activeCardIds.add(row.id);
+  }
+
+  logPerf("dashboard-data", "getActiveCardCountsForStreamers", startedAt, {
+    streamerCount: uniqueStreamerIds.length,
+    activeCardCount: data?.length ?? 0,
+  });
+  return counts;
+}
 
 /**
  * Internal function to fetch user cards for a specific streamer from database

--- a/src/lib/perf.ts
+++ b/src/lib/perf.ts
@@ -1,0 +1,26 @@
+import { logger } from "@/lib/logger";
+
+type PerfContext = Record<string, string | number | boolean | null | undefined>;
+
+export function perfStart(): number {
+  return Date.now();
+}
+
+export function logPerf(surface: string, operation: string, startedAt: number, context?: PerfContext): void {
+  const durationMs = Date.now() - startedAt;
+  logger.info(`[Perf] ${surface} ${operation} ${durationMs}ms`, context ?? {});
+}
+
+export async function measurePerf<T>(
+  surface: string,
+  operation: string,
+  task: () => Promise<T>,
+  context?: PerfContext,
+): Promise<T> {
+  const startedAt = perfStart();
+  try {
+    return await task();
+  } finally {
+    logPerf(surface, operation, startedAt, context);
+  }
+}

--- a/src/lib/plan.ts
+++ b/src/lib/plan.ts
@@ -18,6 +18,7 @@ import { withRetry } from '@/lib/supabase/retry'
 import { logger } from '@/lib/logger'
 import { hasTwitchSub } from '@/lib/twitch/sub-check'
 import { PLAN_PRIORITY, PLAN_STORAGE_BONUS } from '@/lib/plan-constants'
+import { logPerf, perfStart } from '@/lib/perf'
 import type { PlanType } from '@/lib/plan-constants'
 
 // サーバー側コードからの既存 import を壊さないよう re-export
@@ -34,6 +35,7 @@ export { PLAN_STORAGE_BONUS, PLAN_MAX_IMAGE_WIDTH, PLAN_MAX_UPLOAD_SIZE, PLAN_AV
  * @returns 現在の有効プラン（ライセンスなしの場合は 'basic'）
  */
 export const getUserPlan = cache(async function getUserPlan(twitchUserId: string): Promise<PlanType> {
+  const startedAt = perfStart()
   try {
     // DBライセンス判定・Twitchサブスク判定を並列実行
     // hasTwitchSub は環境変数未設定時に即座に false を返すため、未設定環境でも安全
@@ -54,6 +56,32 @@ export const getUserPlan = cache(async function getUserPlan(twitchUserId: string
     // プラン判定失敗時はbasicとする（ユーザーに不利にしない方が安全）
     logger.error('[Plan] Error getting user plan:', error)
     return 'basic'
+  } finally {
+    logPerf('plan', 'getUserPlan', startedAt)
+  }
+})
+
+/**
+ * Dashboard navigation用の軽量プラン判定。
+ * 外部Twitch APIへ再検証に行かず、DBに保存済みのライセンス/サブスク状態だけを見る。
+ */
+export const getUserPlanSnapshot = cache(async function getUserPlanSnapshot(twitchUserId: string): Promise<PlanType> {
+  const startedAt = perfStart()
+  try {
+    const [licensePlan, cachedSubPlan] = await Promise.all([
+      getLicensePlan(twitchUserId),
+      getCachedTwitchSubPlan(twitchUserId),
+    ])
+
+    if (PLAN_PRIORITY[cachedSubPlan] > PLAN_PRIORITY[licensePlan]) {
+      return cachedSubPlan
+    }
+    return licensePlan
+  } catch (error) {
+    logger.error('[Plan] Error getting user plan snapshot:', error)
+    return 'basic'
+  } finally {
+    logPerf('plan', 'getUserPlanSnapshot', startedAt)
   }
 })
 
@@ -96,6 +124,29 @@ async function getLicensePlan(twitchUserId: string): Promise<PlanType> {
     return highestPlan
   } catch (error) {
     logger.error('[Plan] Error getting license plan:', error)
+    return 'basic'
+  }
+}
+
+async function getCachedTwitchSubPlan(twitchUserId: string): Promise<PlanType> {
+  try {
+    const supabaseAdmin = getSupabaseAdmin()
+    const { data, error } = await withRetry(
+      () => supabaseAdmin
+        .from('users')
+        .select('twitch_has_sub')
+        .eq('twitch_user_id', twitchUserId)
+        .maybeSingle(),
+      'getCachedTwitchSubPlan',
+    )
+
+    if (error || !data) {
+      return 'basic'
+    }
+
+    return data.twitch_has_sub === true ? 'twitch_sub' : 'basic'
+  } catch (error) {
+    logger.error('[Plan] Error getting cached Twitch sub plan:', error)
     return 'basic'
   }
 }

--- a/src/lib/twitch/eventsub-status.ts
+++ b/src/lib/twitch/eventsub-status.ts
@@ -1,0 +1,69 @@
+export interface EventSubSubscriptionForStatus {
+  id: string;
+  status: string;
+  type: string;
+  condition: {
+    broadcaster_user_id?: string;
+    reward_id?: string;
+    to_broadcaster_user_id?: string;
+  };
+  transport?: {
+    callback?: string;
+  };
+  debug?: {
+    expectedCallbackUrl: string;
+    callbackMatch: boolean;
+  };
+}
+
+export type EventSubStatus = "none" | "pending" | "active" | "error";
+
+export const CHANNEL_POINTS_EVENTSUB_TYPE = "channel.channel_points_custom_reward_redemption.add";
+export const RAID_EVENTSUB_TYPE = "channel.raid";
+export const FAILED_EVENTSUB_STATUSES = [
+  "webhook_callback_verification_failed",
+  "notification_failures_exceeded",
+  "authorization_revoked",
+];
+
+const matchesExpectedCallback = (sub: EventSubSubscriptionForStatus) => sub.debug?.callbackMatch ?? true;
+
+export function deriveEventSubStatus(
+  subs: EventSubSubscriptionForStatus[],
+  rewardIdToCheck: string,
+): { rewardStatus: EventSubStatus; raidStatus: EventSubStatus } {
+  const rewardSubscriptions = subs.filter(
+    (sub) => sub.type === CHANNEL_POINTS_EVENTSUB_TYPE && matchesExpectedCallback(sub)
+  );
+  const raidSubscriptions = subs.filter(
+    (sub) => sub.type === RAID_EVENTSUB_TYPE && matchesExpectedCallback(sub)
+  );
+
+  const hasActiveRewardSub = rewardSubscriptions.some(
+    (sub) => sub.status === "enabled" && sub.condition.reward_id === rewardIdToCheck
+  );
+  const hasFailedRewardSub = rewardSubscriptions.some(
+    (sub) => FAILED_EVENTSUB_STATUSES.includes(sub.status)
+  );
+  const hasActiveRaidSub = raidSubscriptions.some((sub) => sub.status === "enabled");
+  const hasFailedRaidSub = raidSubscriptions.some(
+    (sub) => FAILED_EVENTSUB_STATUSES.includes(sub.status)
+  );
+
+  return {
+    rewardStatus: hasActiveRewardSub
+      ? "active"
+      : hasFailedRewardSub
+        ? "error"
+        : rewardSubscriptions.length > 0
+          ? "pending"
+          : "none",
+    raidStatus: hasActiveRaidSub
+      ? "active"
+      : hasFailedRaidSub
+        ? "error"
+        : raidSubscriptions.length > 0
+          ? "pending"
+          : "none",
+  };
+}

--- a/tests/unit/channel-point-bootstrap-api.test.ts
+++ b/tests/unit/channel-point-bootstrap-api.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('@/lib/session', () => ({
+  getSession: vi.fn(),
+  canUseStreamerFeatures: vi.fn(),
+}))
+vi.mock('@/lib/rate-limit', () => ({
+  getRateLimitIdentifier: vi.fn().mockResolvedValue('user:test'),
+  checkRateLimit: vi.fn(),
+  rateLimits: { twitchRewardsGet: { windowMs: 60000, max: 30 } },
+}))
+vi.mock('@/lib/twitch/token-manager', () => ({
+  hasScope: vi.fn(),
+  getTwitchAccessToken: vi.fn(),
+}))
+vi.mock('@/lib/supabase/admin', () => ({
+  getSupabaseAdmin: vi.fn(),
+}))
+
+const session = {
+  twitchUserId: 'streamer-1',
+  twitchUsername: 'streamer',
+  twitchDisplayName: 'Streamer',
+  twitchProfileImageUrl: null,
+  broadcasterType: 'affiliate',
+  expiresAt: Date.now() + 10000,
+  version: 1,
+}
+
+function request(url = 'http://localhost:3000/api/twitch/channel-point-bootstrap') {
+  return new NextRequest(url)
+}
+
+describe('GET /api/twitch/channel-point-bootstrap', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    process.env.NEXT_PUBLIC_APP_URL = 'https://example.com'
+    vi.stubGlobal('fetch', vi.fn())
+    const { getSession, canUseStreamerFeatures } = await import('@/lib/session')
+    const { checkRateLimit } = await import('@/lib/rate-limit')
+    vi.mocked(getSession).mockResolvedValue(session as any)
+    vi.mocked(canUseStreamerFeatures).mockReturnValue(true)
+    vi.mocked(checkRateLimit).mockResolvedValue({
+      success: true,
+      limit: 30,
+      remaining: 29,
+      reset: Date.now() + 60000,
+    })
+  })
+
+  it('scope不足ならTwitch rewardsを呼ばずreauthを返す', async () => {
+    const { hasScope } = await import('@/lib/twitch/token-manager')
+    vi.mocked(hasScope).mockResolvedValue(false)
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    const response = await GET(request())
+    const body = await response.json()
+
+    expect(body).toMatchObject({ hasRequiredScope: false, rewards: [], requiresReauth: true })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('diagnostics=0ではscope確認とrewards取得だけを返す', async () => {
+    const { hasScope, getTwitchAccessToken } = await import('@/lib/twitch/token-manager')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(getTwitchAccessToken).mockResolvedValue('token-1')
+    vi.mocked(global.fetch).mockResolvedValue(new Response(JSON.stringify({
+      data: [{ id: 'reward-1', title: 'Reward', cost: 100, is_enabled: true }],
+    }), { status: 200 }) as any)
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    const response = await GET(request())
+    const body = await response.json()
+
+    expect(body.hasRequiredScope).toBe(true)
+    expect(body.rewards).toHaveLength(1)
+    expect(body.subscriptions).toBeUndefined()
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('diagnostics=1ではEventSubと追加報酬状態も返す', async () => {
+    const { hasScope, getTwitchAccessToken } = await import('@/lib/twitch/token-manager')
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(getTwitchAccessToken).mockResolvedValue('token-1')
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(new Response(JSON.stringify({ data: [] }), { status: 200 }) as any)
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'app-token' }), { status: 200 }) as any)
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        data: [
+          {
+            id: 'sub-1',
+            status: 'enabled',
+            type: 'channel.channel_points_custom_reward_redemption.add',
+            condition: { reward_id: 'reward-1' },
+            transport: { callback: 'https://example.com/api/twitch/eventsub' },
+          },
+          {
+            id: 'sub-2',
+            status: 'enabled',
+            type: 'channel.raid',
+            condition: { to_broadcaster_user_id: 'streamer-1' },
+            transport: { callback: 'https://example.com/api/twitch/eventsub' },
+          },
+        ],
+        pagination: {},
+      }), { status: 200 }) as any)
+
+    const streamerQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({
+        data: { id: 'streamer-db-1', channel_point_reward_id: 'reward-1', raid_gacha_draw_count: 3 },
+        error: null,
+      }),
+    }
+    const rewardsQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [{ id: 'extra-1', reward_id: 'reward-2' }], error: null }),
+    }
+    vi.mocked(getSupabaseAdmin).mockReturnValue({
+      from: vi.fn((table: string) => table === 'streamers' ? streamerQuery : rewardsQuery),
+    } as any)
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    const response = await GET(request('http://localhost:3000/api/twitch/channel-point-bootstrap?diagnostics=1'))
+    const body = await response.json()
+
+    expect(body.eventSubStatus).toBe('active')
+    expect(body.raidEventSubStatus).toBe('active')
+    expect(body.additionalRewards).toHaveLength(1)
+    expect(body.raidGiftDrawCount).toBe(3)
+  })
+})

--- a/tests/unit/components/settings-view-mode.test.tsx
+++ b/tests/unit/components/settings-view-mode.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, act } from '@testing-library/react'
 import { NextIntlClientProvider } from 'next-intl'
 import {
   AdvancedSettings,
+  AdvancedSettingsLayout,
   SettingsViewModeProvider,
   SettingsViewToggle,
   __resetSettingsViewModeSubscribersForTest,
@@ -13,6 +14,9 @@ const STORAGE_KEY = 'twica.settingsViewMode'
 
 const messages = {
   settingsPage: {
+    advanced: {
+      navAria: '詳細設定ナビゲーション',
+    },
     viewMode: {
       simple: 'シンプル',
       advanced: '詳細',
@@ -209,6 +213,27 @@ describe('SettingsViewMode', () => {
       const wrapper = screen.getByTestId('advanced-settings')
       expect(wrapper).not.toHaveAttribute('hidden')
       expect(wrapper).not.toHaveAttribute('aria-hidden')
+    })
+  })
+
+  describe('AdvancedSettingsLayout', () => {
+    it('初期表示ではactive sectionだけをmountし、選択後は訪問済みsectionを保持する', () => {
+      renderWithProvider(
+        <AdvancedSettingsLayout
+          sections={[
+            { id: 'first', label: 'First', content: <div data-testid="first-panel">first</div> },
+            { id: 'second', label: 'Second', content: <div data-testid="second-panel">second</div> },
+          ]}
+        />
+      )
+
+      expect(screen.getByTestId('first-panel')).toBeInTheDocument()
+      expect(screen.queryByTestId('second-panel')).toBeNull()
+
+      fireEvent.click(screen.getByRole('button', { name: /Second/ }))
+
+      expect(screen.getByTestId('first-panel').parentElement).toHaveAttribute('hidden')
+      expect(screen.getByTestId('second-panel')).toBeInTheDocument()
     })
   })
 })

--- a/tests/unit/dashboard-active-card-counts.test.ts
+++ b/tests/unit/dashboard-active-card-counts.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('@/lib/sentry/error-handler', () => ({
+  reportError: vi.fn(),
+}))
+vi.mock('@/lib/supabase/admin', () => ({
+  getSupabaseAdmin: vi.fn(),
+}))
+
+describe('getActiveCardCountsForStreamers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  it('複数streamerのactive card countを1回のbatch queryで返す', async () => {
+    const eq = vi.fn().mockResolvedValue({
+      data: [
+        { id: 'card-1', streamer_id: 'streamer-a' },
+        { id: 'card-2', streamer_id: 'streamer-a' },
+        { id: 'card-3', streamer_id: 'streamer-b' },
+      ],
+      error: null,
+    })
+    const query = {
+      select: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      eq,
+    }
+    const from = vi.fn(() => query)
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from } as any)
+
+    const { getActiveCardCountsForStreamers } = await import('@/lib/dashboard-data')
+    const result = await getActiveCardCountsForStreamers(['streamer-a', 'streamer-b', 'streamer-a'])
+
+    expect(from).toHaveBeenCalledTimes(1)
+    expect(query.in).toHaveBeenCalledWith('streamer_id', ['streamer-a', 'streamer-b'])
+    expect(result.get('streamer-a')?.totalActive).toBe(2)
+    expect(result.get('streamer-a')?.activeCardIds.has('card-2')).toBe(true)
+    expect(result.get('streamer-b')?.totalActive).toBe(1)
+  })
+})

--- a/tests/unit/plan.test.ts
+++ b/tests/unit/plan.test.ts
@@ -5,6 +5,7 @@ import {
   PLAN_MAX_UPLOAD_SIZE,
   type PlanType,
 } from '@/lib/plan'
+import { hasTwitchSub } from '@/lib/twitch/sub-check'
 
 vi.mock('@/lib/logger')
 vi.mock('@/lib/twitch/sub-check', () => ({
@@ -108,6 +109,37 @@ describe('getUserPlan', () => {
     const { getUserPlan } = await import('@/lib/plan')
     const result = await getUserPlan('user-throw')
     expect(result).toBe('basic')
+  })
+
+  it('getUserPlanSnapshot uses DB state without calling Twitch subscription API', async () => {
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    const from = vi.fn((table: string) => {
+      if (table === 'user_licenses') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          in: vi.fn().mockResolvedValue({
+            data: [{ plan_type: 'support', support_codes: { status: 'active' } }],
+            error: null,
+          }),
+        }
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: { twitch_has_sub: true },
+          error: null,
+        }),
+      }
+    })
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from } as any)
+
+    const { getUserPlanSnapshot } = await import('@/lib/plan')
+    const result = await getUserPlanSnapshot('user-snapshot')
+
+    expect(result).toBe('twitch_sub')
+    expect(hasTwitchSub).not.toHaveBeenCalled()
   })
 })
 
@@ -213,4 +245,3 @@ describe('getPlanStorageBytes', () => {
     expect(result).toBe(500 * 1024 * 1024)
   })
 })
-


### PR DESCRIPTION
## Summary
- add lightweight `[Perf]` logging around dashboard surfaces and key data helpers
- remove initial dashboard/settings network blockers by using DB-only plan snapshots, parallel layout data loading, lazy advanced settings sections, and a unified channel point bootstrap API
- batch collection active-card counts with one Supabase query instead of streamer-by-streamer calls

## Validation
- `npx vitest run tests/unit/plan.test.ts tests/unit/components/settings-view-mode.test.tsx tests/unit/dashboard-active-card-counts.test.ts tests/unit/channel-point-bootstrap-api.test.ts tests/unit/channel-point-settings-eventsub.test.ts`
- `npx eslint src/lib/perf.ts src/lib/twitch/eventsub-status.ts src/app/api/twitch/channel-point-bootstrap/route.ts src/app/dashboard/layout.tsx src/app/dashboard/page.tsx src/app/dashboard/collection/page.tsx src/components/SettingsViewMode.tsx src/components/ChannelPointSettings.tsx src/lib/dashboard-data.ts src/lib/plan.ts tests/unit/plan.test.ts tests/unit/components/settings-view-mode.test.tsx tests/unit/channel-point-bootstrap-api.test.ts tests/unit/dashboard-active-card-counts.test.ts`
- `npm run test:unit`

## Notes
- `npm run build` reached Next.js compilation successfully, then failed on an unrelated untracked worktree file: `twica-maker-476/analysis/src/App.tsx` cannot resolve `react-router-dom`.
- Full `npm run lint` hung locally; targeted eslint over the changed files passed.
