### PR TITLE
[codex] Add explicit Supabase public table grants

### DIFF
--- a/supabase/migrations/00047_explicit_public_table_grants.sql
+++ b/supabase/migrations/00047_explicit_public_table_grants.sql
@@ -1,0 +1,38 @@
+-- Supabase Data API privilege hardening
+--
+-- Supabase no longer implicitly exposes newly-created public-schema tables to
+-- PostgREST/GraphQL roles. Keep table privileges explicit and aligned with the
+-- existing RLS policies.
+
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+
+-- Public read surfaces. RLS still limits rows to active records.
+GRANT SELECT ON TABLE public.streamers TO anon, authenticated;
+GRANT SELECT ON TABLE public.cards TO anon, authenticated;
+
+-- Existing authenticated-only RLS policy for streamer-owned reward settings.
+GRANT SELECT ON TABLE public.streamer_additional_gacha_rewards TO authenticated;
+
+-- Server-side application access through the elevated Supabase key.
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamers TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.cards TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.users TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.user_cards TO service_role;
+GRANT SELECT, INSERT ON TABLE public.gacha_history TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.battles TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.battle_stats TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.storage_usage TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.blob_files TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamer_additional_gacha_rewards TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.errors TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamer_storage_bonus TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.announcements TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.announcement_reads TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.support_codes TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.user_licenses TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.support_inquiries TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.support_inquiry_messages TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.collection_completions TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.channel_point_usage_stats TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.twitch_bot_accounts TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamer_chat_sender_settings TO service_role;

--- a/tests/unit/migration-rls.test.ts
+++ b/tests/unit/migration-rls.test.ts
@@ -9,6 +9,12 @@ const normalizeIdentifier = (identifier: string) => identifier.replaceAll('"', '
 const tableKey = (schema: string | undefined, table: string) =>
   `${normalizeIdentifier(schema ?? 'public')}.${normalizeIdentifier(table)}`
 
+const tableGrantPattern = (table: string, role: string) =>
+  new RegExp(
+    `GRANT\\s+[^;]+\\s+ON\\s+TABLE\\s+public\\.${table}\\s+TO\\s+${role}\\b`,
+    'i',
+  )
+
 describe('Supabase migration RLS coverage', () => {
   it('enables row-level security for every public table created by migrations', () => {
     const createdPublicTables = new Map<string, string>()
@@ -35,6 +41,51 @@ describe('Supabase migration RLS coverage', () => {
       .map(([table, file]) => `${table} created in ${file}`)
 
     expect(missingRls).toEqual([])
+  })
+
+  it('grants service_role Data API access explicitly for every public table', () => {
+    const createdPublicTables = new Map<string, string>()
+    const allMigrationsSql = readdirSync(migrationsDir)
+      .filter(file => file.endsWith('.sql'))
+      .sort()
+      .map(file => {
+        const sql = readFileSync(resolve(migrationsDir, file), 'utf-8')
+
+        for (const match of sql.matchAll(/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:(\w+|"\w+")\.)?(\w+|"\w+")/gi)) {
+          const key = tableKey(match[1], match[2])
+
+          if (key.startsWith('public.')) {
+            createdPublicTables.set(key, file)
+          }
+        }
+
+        return sql
+      })
+      .join('\n')
+
+    const missingGrants = [...createdPublicTables.entries()]
+      .filter(([table]) => {
+        const [, tableName] = table.split('.')
+
+        return !tableGrantPattern(tableName, 'service_role').test(allMigrationsSql)
+      })
+      .map(([table, file]) => `${table} created in ${file}`)
+
+    expect(missingGrants).toEqual([])
+  })
+
+  it('keeps browser-visible table grants limited to intended read-only surfaces', () => {
+    const migration = readFileSync(
+      resolve(migrationsDir, '00047_explicit_public_table_grants.sql'),
+      'utf-8',
+    )
+
+    expect(migration).toMatch(/GRANT\s+SELECT\s+ON\s+TABLE\s+public\.streamers\s+TO\s+anon,\s*authenticated/i)
+    expect(migration).toMatch(/GRANT\s+SELECT\s+ON\s+TABLE\s+public\.cards\s+TO\s+anon,\s*authenticated/i)
+    expect(migration).toMatch(/GRANT\s+SELECT\s+ON\s+TABLE\s+public\.streamer_additional_gacha_rewards\s+TO\s+authenticated/i)
+    expect(migration).not.toMatch(/GRANT\s+[^;]*INSERT[^;]*TO\s+anon/i)
+    expect(migration).not.toMatch(/GRANT\s+[^;]*UPDATE[^;]*TO\s+anon/i)
+    expect(migration).not.toMatch(/GRANT\s+[^;]*DELETE[^;]*TO\s+anon/i)
   })
 
   it('keeps channel point usage stats restricted to service role table access', () => {


### PR DESCRIPTION
## Summary

- Add a forward-only Supabase migration that explicitly grants Data API table privileges for public-schema tables.
- Keep browser-visible grants limited to existing read-only surfaces while preserving server-side `service_role` access.
- Extend migration tests so future public tables need an explicit `service_role` table grant and browser grants stay read-only.

## Why

Supabase is removing the implicit Data API exposure for newly-created `public` tables. TwiCa already relied on RLS policies, but the table-level grants were not explicit, so future projects or enforcement dates could make PostgREST/supabase-js access fail with `42501`.

## Validation

- `./node_modules/.bin/vitest run tests/unit/migration-filenames.test.ts tests/unit/migration-rls.test.ts`
