### PR TITLE
[codex] Make Supabase grant migration tolerant

### DIFF
--- a/supabase/migrations/00047_explicit_public_table_grants.sql
+++ b/supabase/migrations/00047_explicit_public_table_grants.sql
@@ -7,32 +7,91 @@
 GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
 
 -- Public read surfaces. RLS still limits rows to active records.
-GRANT SELECT ON TABLE public.streamers TO anon, authenticated;
-GRANT SELECT ON TABLE public.cards TO anon, authenticated;
-
 -- Existing authenticated-only RLS policy for streamer-owned reward settings.
-GRANT SELECT ON TABLE public.streamer_additional_gacha_rewards TO authenticated;
+DO $$
+BEGIN
+  IF to_regclass('public.streamers') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT ON TABLE public.streamers TO anon, authenticated';
+  END IF;
+  IF to_regclass('public.cards') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT ON TABLE public.cards TO anon, authenticated';
+  END IF;
+  IF to_regclass('public.streamer_additional_gacha_rewards') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT ON TABLE public.streamer_additional_gacha_rewards TO authenticated';
+  END IF;
+END
+$$;
 
 -- Server-side application access through the elevated Supabase key.
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamers TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.cards TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.users TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.user_cards TO service_role;
-GRANT SELECT, INSERT ON TABLE public.gacha_history TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.battles TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.battle_stats TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.storage_usage TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.blob_files TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamer_additional_gacha_rewards TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.errors TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamer_storage_bonus TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.announcements TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.announcement_reads TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.support_codes TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.user_licenses TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.support_inquiries TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.support_inquiry_messages TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.collection_completions TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.channel_point_usage_stats TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.twitch_bot_accounts TO service_role;
-GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamer_chat_sender_settings TO service_role;
+-- Some long-lived environments do not have every historical table, so make
+-- these grants conditional while keeping the intended privileges explicit.
+DO $$
+BEGIN
+  IF to_regclass('public.streamers') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamers TO service_role';
+  END IF;
+  IF to_regclass('public.cards') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.cards TO service_role';
+  END IF;
+  IF to_regclass('public.users') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.users TO service_role';
+  END IF;
+  IF to_regclass('public.user_cards') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.user_cards TO service_role';
+  END IF;
+  IF to_regclass('public.gacha_history') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT ON TABLE public.gacha_history TO service_role';
+  END IF;
+  IF to_regclass('public.battles') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.battles TO service_role';
+  END IF;
+  IF to_regclass('public.battle_stats') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.battle_stats TO service_role';
+  END IF;
+  IF to_regclass('public.storage_usage') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.storage_usage TO service_role';
+  END IF;
+  IF to_regclass('public.blob_files') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.blob_files TO service_role';
+  END IF;
+  IF to_regclass('public.streamer_additional_gacha_rewards') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamer_additional_gacha_rewards TO service_role';
+  END IF;
+  IF to_regclass('public.errors') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.errors TO service_role';
+  END IF;
+  IF to_regclass('public.streamer_storage_bonus') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamer_storage_bonus TO service_role';
+  END IF;
+  IF to_regclass('public.announcements') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.announcements TO service_role';
+  END IF;
+  IF to_regclass('public.announcement_reads') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.announcement_reads TO service_role';
+  END IF;
+  IF to_regclass('public.support_codes') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.support_codes TO service_role';
+  END IF;
+  IF to_regclass('public.user_licenses') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.user_licenses TO service_role';
+  END IF;
+  IF to_regclass('public.support_inquiries') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.support_inquiries TO service_role';
+  END IF;
+  IF to_regclass('public.support_inquiry_messages') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.support_inquiry_messages TO service_role';
+  END IF;
+  IF to_regclass('public.collection_completions') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.collection_completions TO service_role';
+  END IF;
+  IF to_regclass('public.channel_point_usage_stats') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.channel_point_usage_stats TO service_role';
+  END IF;
+  IF to_regclass('public.twitch_bot_accounts') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.twitch_bot_accounts TO service_role';
+  END IF;
+  IF to_regclass('public.streamer_chat_sender_settings') IS NOT NULL THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamer_chat_sender_settings TO service_role';
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Summary

- Make the explicit Supabase grants migration tolerate long-lived databases that do not have every historical table.
- Preserve the same intended grants, but run each table grant only when the table exists.

## Root Cause

Production deploy failed while applying `00047_explicit_public_table_grants.sql` because the production database does not currently have `public.battles`. The migration used unconditional `GRANT ... ON TABLE public.battles`, so `supabase db push` stopped with SQLSTATE `42P01`.

## Validation

- `./node_modules/.bin/vitest run tests/unit/migration-filenames.test.ts tests/unit/migration-rls.test.ts`
