### PR TITLE
Default card management sort to created_at desc

### DIFF
--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -143,8 +143,10 @@ export default function CardManager({
 
   // Sorting and filtering state
   // 並び替えとフィルタリングの状態
-  const [sortField, setSortField] = useState<SortField>("display_order");
-  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+  // Default sort: 設定日（created_at）降順
+  // 初期表示は最新の設定（作成）日順とし、サーバー側 initialCards のソートと一致させる
+  const [sortField, setSortField] = useState<SortField>("created_at");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [titleSearchQuery, setTitleSearchQuery] = useState("");
   // Track if this is the first render to skip initial reload


### PR DESCRIPTION
カード管理画面を開いた時のデフォルト並び替えを「設定日（created_at）降順」に変更。
サーバーサイドで取得する initialCards も同順にソート済みのため、初回表示と一致する。