### PR TITLE
feat: announce new cards in multi-draw chat (#502)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -394,7 +394,7 @@
       "multiTemplatePlaceholder": "@'{'user'}' got '{'rarityCounts'}' from a '{'draws'}'-draw gacha! '{'cards'}'",
       "multiShowCards": "Include card-name list in multi-draw announcements",
       "placeholderHelp": "Available placeholders: '{'user'}'=username, '{'card'}'=first card name, '{'rarity'}'=rarity, '{'num'}'=owned count, '{'unique'}'=unique types owned, '{'all'}'=total types, '{'detail'}'=card description, '{'url'}'=collection URL",
-      "multiPlaceholderHelp": "Multi-draw only: '{'draws'}'=draw count, '{'rarityCounts'}'=rarity counts (e.g. Rare x3, Common x3), '{'cards'}'=card-name list",
+      "multiPlaceholderHelp": "Multi-draw only: '{'draws'}'=draw count, '{'rarityCounts'}'=rarity counts (e.g. Rare x3, Common x3), '{'cards'}'=card-name list, '{'newCards'}'=newly obtained card names this draw, '{'newCardCount'}'=count of newly obtained card types this draw",
       "previewLength": "Preview length: {current} / {max} characters"
     },
     "buttons": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -394,7 +394,7 @@
       "multiTemplatePlaceholder": "@'{'user'}' が'{'draws'}'連ガチャで '{'rarityCounts'}' を獲得しました！'{'cards'}'",
       "multiShowCards": "N連通知にカード名一覧を含める",
       "placeholderHelp": "使用可能なプレースホルダー: '{'user'}'=ユーザー名, '{'card'}'=先頭カード名, '{'rarity'}'=レアリティ, '{'num'}'=所持枚数, '{'unique'}'=所持種類数, '{'all'}'=全種類数, '{'detail'}'=カード説明, '{'url'}'=コレクションURL",
-      "multiPlaceholderHelp": "N連用: '{'draws'}'=抽選回数, '{'rarityCounts'}'=レアリティ別枚数（例: レアx3、コモンx3）, '{'cards'}'=カード名一覧",
+      "multiPlaceholderHelp": "N連用: '{'draws'}'=抽選回数, '{'rarityCounts'}'=レアリティ別枚数（例: レアx3、コモンx3）, '{'cards'}'=カード名一覧, '{'newCards'}'=今回初めて獲得したカード名一覧, '{'newCardCount'}'=今回初めて獲得したカード種類数",
       "previewLength": "プレビュー文字数: {current} / {max}文字"
     },
     "buttons": {

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -52,13 +52,19 @@ function formatCardNamesForChat(cardNames: string[], maxCharacters: number): str
 
 function fitCardNamesForMessage(
   cardNames: string[],
-  renderMessage: (cardsText: string) => string
+  renderMessage: (cardsText: string) => string,
+  // 後段で必ず追記される接尾辞分の文字数を予約しておくことで、
+  // 「初出:」追記時の二段階圧縮で末尾切り（truncateCharacters）に陥るのを防ぐ。
+  // Reserve characters for a suffix that will be appended later (e.g., " 初出: ...").
+  // Without this, the second fit pass cannot shrink {cards} enough and the suffix gets truncated.
+  reservedSuffixCharacters: number = 0
 ): { cardsText: string; message: string } {
+  const effectiveLimit = Math.max(0, TWITCH_CHAT_MESSAGE_MAX_CHARACTERS - reservedSuffixCharacters);
   let cardsText = cardNames.join(CARD_LIST_SEPARATOR);
   let message = renderMessage(cardsText);
 
-  for (let i = 0; i < 3 && countCharacters(message) > TWITCH_CHAT_MESSAGE_MAX_CHARACTERS; i++) {
-    const overflow = countCharacters(message) - TWITCH_CHAT_MESSAGE_MAX_CHARACTERS;
+  for (let i = 0; i < 3 && countCharacters(message) > effectiveLimit; i++) {
+    const overflow = countCharacters(message) - effectiveLimit;
     const nextMaxCharacters = Math.max(0, countCharacters(cardsText) - overflow);
     cardsText = formatCardNamesForChat(cardNames, nextMaxCharacters);
     message = renderMessage(cardsText);
@@ -92,6 +98,49 @@ function formatRarityCountsForChat(cardNamesByRarity: string[]): string {
     })
     .map(([rarity, count]) => `${rarityMap[rarity] ?? rarity}x${count}`)
     .join(CARD_LIST_SEPARATOR);
+}
+
+function findNewCardNamesForCurrentDraw(
+  drawnCards: GachaCard[],
+  userCardCounts: Array<{ count: number; card: { id: string; is_active?: boolean } }>
+): string[] {
+  const drawnCounts = new Map<string, number>();
+  for (const drawnCard of drawnCards) {
+    drawnCounts.set(drawnCard.id, (drawnCounts.get(drawnCard.id) ?? 0) + 1);
+  }
+
+  const finalCounts = new Map<string, number>();
+  for (const row of userCardCounts) {
+    if (!row.card?.id) continue;
+    finalCounts.set(row.card.id, Number(row.count) || 0);
+  }
+
+  const seenInCurrentDraw = new Set<string>();
+  const newCardNames: string[] = [];
+
+  for (const drawnCard of drawnCards) {
+    if (seenInCurrentDraw.has(drawnCard.id)) continue;
+
+    const finalCount = finalCounts.get(drawnCard.id);
+    if (finalCount === undefined) {
+      seenInCurrentDraw.add(drawnCard.id);
+      continue;
+    }
+
+    const currentDrawCount = drawnCounts.get(drawnCard.id) ?? 0;
+    const previousCount = finalCount - currentDrawCount;
+    // legacy fallback で user_cards INSERT が失敗すると finalCount=0 のまま返り、
+    // previousCount が負値になって「初出」誤通知が発生する。
+    // 「初出」と判定するには「いま実際に所持している（finalCount > 0）」必要がある。
+    // If legacy fallback INSERT fails, finalCount stays 0 while currentDrawCount > 0,
+    // making previousCount negative. Treat as "new card" only when the user actually owns it.
+    if (finalCount > 0 && previousCount <= 0) {
+      newCardNames.push(drawnCard.name);
+    }
+    seenInCurrentDraw.add(drawnCard.id);
+  }
+
+  return newCardNames;
 }
 
 /**
@@ -630,17 +679,25 @@ async function sendChatAnnouncement(
   const messageTemplate = isMultiDraw
     ? streamer.chat_announcement_multi_template || DEFAULT_MULTI_DRAW_CHAT_TEMPLATE
     : streamer.chat_announcement_template || DEFAULT_CHAT_TEMPLATE;
-  const usesMultiDrawPlaceholders = /\{cards\}|\{draws\}|\{rarityCounts\}/.test(messageTemplate);
+  const usesMultiDrawPlaceholders = /\{cards\}|\{draws\}|\{rarityCounts\}|\{newCards\}|\{newCardCount\}/.test(messageTemplate);
   const effectiveTemplate = messageTemplate;
   const needsCardCount = /\{num\}/.test(effectiveTemplate);
   const needsUniqueCount = /\{unique\}/.test(effectiveTemplate);
   const needsAllCount = /\{all\}/.test(effectiveTemplate);
+  const usesNewCardPlaceholders = /\{newCards\}|\{newCardCount\}/.test(effectiveTemplate);
+  const shouldAppendDefaultNewCards = isMultiDraw
+    && streamer.chat_announcement_multi_show_cards
+    && !streamer.chat_announcement_multi_template;
+  const needsNewCardInfo = isMultiDraw
+    && streamer.chat_announcement_multi_show_cards
+    && (usesNewCardPlaceholders || shouldAppendDefaultNewCards);
 
   let cardCount: number | undefined;
   let uniqueCount: number | undefined;
   let allCount: number | undefined;
+  let newCardNames: string[] = [];
 
-  if (needsCardCount || needsUniqueCount || needsAllCount) {
+  if (needsCardCount || needsUniqueCount || needsAllCount || needsNewCardInfo) {
     const supabaseAdminNoCache = getSupabaseAdminNoCache();
 
     // {all} は配信者のアクティブカード総数のため、直接 cards テーブルを count クエリ
@@ -659,7 +716,7 @@ async function sendChatAnnouncement(
     // {num} / {unique}: use RPC returning pre-aggregated per-card counts.
     // The RPC handles GROUP BY server-side, avoiding PostgREST 1000-row cap.
     // RPC does not filter by is_active, so we filter on the client.
-    const userCardCountsPromise = (needsCardCount || needsUniqueCount)
+    const userCardCountsPromise = (needsCardCount || needsUniqueCount || needsNewCardInfo)
       ? supabaseAdminNoCache.rpc('get_user_card_counts', {
           p_twitch_user_id: userId,
           p_streamer_id: streamer.id,
@@ -688,14 +745,14 @@ async function sendChatAnnouncement(
         }
       }
 
-      if (needsCardCount || needsUniqueCount) {
+      if (needsCardCount || needsUniqueCount || needsNewCardInfo) {
         if (userCardCountsResult?.error) {
           logger.warn('Failed to fetch user card counts for chat announcement', {
             streamerId: streamer.id,
             userTwitchId: userId,
             error: userCardCountsResult.error.message,
           });
-          if (needsUniqueCount) {
+          if (needsUniqueCount || needsNewCardInfo) {
             // RPC 失敗時は 0 にフォールバックせず、未定義のままプレースホルダを空文字化
             // On RPC failure, leave placeholders undefined so buildMessage strips them
           }
@@ -718,6 +775,10 @@ async function sendChatAnnouncement(
             // アクティブカードのみ数えてコンプ進捗を算出
             // Count only active cards to match the progress definition in dashboard UI
             uniqueCount = rows.filter((row) => row.card?.is_active === true).length;
+          }
+
+          if (needsNewCardInfo) {
+            newCardNames = findNewCardNamesForCurrentDraw(drawnCards, rows);
           }
         }
       }
@@ -747,6 +808,10 @@ async function sendChatAnnouncement(
       : undefined,
     draws: isMultiDraw ? drawnCards.length : undefined,
     rarityCounts: isMultiDraw ? rarityCounts : undefined,
+    newCards: needsNewCardInfo && newCardNames.length > 0
+      ? newCardNames.join(CARD_LIST_SEPARATOR)
+      : undefined,
+    newCardCount: needsNewCardInfo ? newCardNames.length : undefined,
     rarity: rarityMap[card.rarity] || card.rarity,
     detail: card.description || undefined,
     num: cardCount,
@@ -760,9 +825,20 @@ async function sendChatAnnouncement(
   const chatService = new TwitchChatService();
   let message: string;
 
+  // 後段で「初出: {cardNames}」を追記する場合、{cards} 側の圧縮時に
+  // 接尾辞分の文字数を予約しておかないと、最終的な truncate で「初出:」部分が
+  // 切り落とされる可能性がある。事前に長さを見積もって reservedSuffixCharacters に渡す。
+  // Estimate the suffix length so {cards} fitting reserves space for the appended "初出: ..."
+  const willAppendDefaultNewCards = shouldAppendDefaultNewCards && newCardNames.length > 0;
+  const reservedSuffixCharacters = willAppendDefaultNewCards
+    ? countCharacters(' 初出: ') + countCharacters(newCardNames.join(CARD_LIST_SEPARATOR))
+    : 0;
+
   if (isMultiDraw && streamer.chat_announcement_multi_show_cards && usesMultiDrawPlaceholders) {
-    const fitted = fitCardNamesForMessage(cardNames, (cardsText) =>
-      chatService.buildMessage(messageTemplate, { ...placeholders, cards: cardsText })
+    const fitted = fitCardNamesForMessage(
+      cardNames,
+      (cardsText) => chatService.buildMessage(messageTemplate, { ...placeholders, cards: cardsText }),
+      reservedSuffixCharacters
     );
     placeholders.cards = fitted.cardsText;
     message = fitted.message;
@@ -771,11 +847,23 @@ async function sendChatAnnouncement(
     if (isMultiDraw && streamer.chat_announcement_multi_show_cards && !usesMultiDrawPlaceholders) {
       message = fitCardNamesForMessage(
         cardNames,
-        (cardsText) => `${baseMessage}（全${drawnCards.length}枚: ${cardsText}）`
+        (cardsText) => `${baseMessage}（全${drawnCards.length}枚: ${cardsText}）`,
+        reservedSuffixCharacters
       ).message;
     } else {
       message = baseMessage;
     }
+  }
+
+  if (willAppendDefaultNewCards) {
+    // ここでの fitCardNamesForMessage は newCardNames 側の圧縮を担う。
+    // 上で {cards} 側に余白を予約済みなので、通常はここでの圧縮は発生しない。
+    // The earlier pass reserved space, so this fit normally just appends as-is.
+    const fitted = fitCardNamesForMessage(
+      newCardNames,
+      (newCardsText) => `${message} 初出: ${newCardsText}`
+    );
+    message = fitted.message;
   }
 
   const success = await chatService.sendChatMessage(broadcasterTwitchUserId, message);

--- a/src/components/ChatAnnouncementSettings.tsx
+++ b/src/components/ChatAnnouncementSettings.tsx
@@ -36,6 +36,10 @@ const MAX_TEMPLATE_PLACEHOLDER_LENGTHS = {
   unique: 4,
   all: 4,
   detail: CARD_DESCRIPTION_MAX_CHARACTERS,
+  // newCards は cards と同等の上限（実装上は 「初出: 」付与時に予約される）
+  // newCards mirrors `cards` length; runtime reserves space for the "初出: " suffix
+  newCards: 300,
+  newCardCount: 4,
 } as const;
 
 function buildChatPreviewMessage(
@@ -52,6 +56,8 @@ function buildChatPreviewMessage(
     all: string;
     detail: string;
     url: string;
+    newCards: string;
+    newCardCount: string;
   }
 ): string {
   return template
@@ -66,6 +72,8 @@ function buildChatPreviewMessage(
     .replace(/\{all\}/g, placeholders.all)
     .replace(/\{detail\}/g, placeholders.detail)
     .replace(/\{url\}/g, placeholders.url)
+    .replace(/\{newCards\}/g, placeholders.newCards)
+    .replace(/\{newCardCount\}/g, placeholders.newCardCount)
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -127,6 +135,8 @@ export default function ChatAnnouncementSettings({
       all: "10",
       detail: "特別なカードの説明文です",
       url: `https://twica.live/collection/${streamerId}`,
+      newCards: "レジェンダリーカード、レアカード",
+      newCardCount: "2",
     });
   }, [activeTemplate, streamerId]);
 
@@ -143,6 +153,8 @@ export default function ChatAnnouncementSettings({
       all: "10",
       detail: "特別なカードの説明文です",
       url: `https://twica.live/collection/${streamerId}`,
+      newCards: multiShowCards ? "レジェンダリーカード、レアカード" : "",
+      newCardCount: multiShowCards ? "2" : "",
     });
   }, [activeMultiTemplate, multiShowCards, streamerId]);
 
@@ -165,6 +177,8 @@ export default function ChatAnnouncementSettings({
         all: "9".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.all),
         detail: "説".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.detail),
         url: `https://twica.live/collection/${streamerId}`,
+        newCards: "カ".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.newCards),
+        newCardCount: "9".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.newCardCount),
       })
     );
   }, [activeTemplate, streamerId]);

--- a/src/lib/twitch/chat-service.ts
+++ b/src/lib/twitch/chat-service.ts
@@ -41,6 +41,12 @@ export interface ChatMessagePlaceholders {
   // 複数枚ガチャ時のレアリティ別枚数（例: レアx3、コモンx3）
   // Rarity counts for multi-draw announcements (e.g. Rare x3, Common x3)
   rarityCounts?: string
+  // 複数枚ガチャで今回初めて獲得したカード名一覧（オプション）
+  // Newly obtained card names in the current multi-draw announcement (optional)
+  newCards?: string
+  // 複数枚ガチャで今回初めて獲得したカードの種類数（オプション）
+  // Count of newly obtained card types in the current multi-draw announcement (optional)
+  newCardCount?: number
   // カードのレアリティ（日本語または英語）
   // Card rarity (Japanese or English)
   rarity: string
@@ -348,6 +354,18 @@ export class TwitchChatService {
       message = message.replace(/\{rarityCounts\}/g, placeholders.rarityCounts)
     } else {
       message = message.replace(/\{rarityCounts\}/g, '')
+    }
+
+    if (placeholders.newCards) {
+      message = message.replace(/\{newCards\}/g, placeholders.newCards)
+    } else {
+      message = message.replace(/\{newCards\}/g, '')
+    }
+
+    if (placeholders.newCardCount !== undefined) {
+      message = message.replace(/\{newCardCount\}/g, String(placeholders.newCardCount))
+    } else {
+      message = message.replace(/\{newCardCount\}/g, '')
     }
 
     // 連続する空白を1つにまとめ、前後の空白を削除

--- a/tests/unit/chat-service.test.ts
+++ b/tests/unit/chat-service.test.ts
@@ -130,6 +130,55 @@ describe('TwitchChatService', () => {
     });
   });
 
+  describe('buildMessage - multi-draw new card placeholders', () => {
+    it('N連ガチャ用の {newCards} と {newCardCount} を値に置換する', () => {
+      const message = service.buildMessage(
+        '{user}: 初出 {newCardCount}種類 {newCards}',
+        {
+          user: 'viewer',
+          card: 'Alpha',
+          rarity: 'レア',
+          newCards: 'Alpha、Gamma',
+          newCardCount: 2,
+        },
+      );
+
+      expect(message).toBe('viewer: 初出 2種類 Alpha、Gamma');
+    });
+
+    it('N連ガチャ用の初出プレースホルダー未指定時は空文字に置換される', () => {
+      // newCards / newCardCount どちらも未指定なら空文字置換となり、
+      // 「種類」「初出」など接続詞は周辺の連続空白整形で1スペースに丸まる。
+      // 「初出」セクション全体を出さないかどうかは呼び出し側の責務（route.ts の
+      // shouldAppendDefaultNewCards 判定 / カスタムテンプレート設計）に委ねる。
+      // Whether to omit the "初出" section entirely is the caller's responsibility.
+      const message = service.buildMessage(
+        '{user}: 初出 {newCardCount}種類 {newCards}',
+        {
+          user: 'viewer',
+          card: 'Alpha',
+          rarity: 'レア',
+        },
+      );
+
+      expect(message).toBe('viewer: 初出 種類');
+    });
+
+    it('newCardCount=0 を明示的に渡すと "0" として置換される', () => {
+      const message = service.buildMessage(
+        '{user}: 初出 {newCardCount}種類',
+        {
+          user: 'viewer',
+          card: 'Alpha',
+          rarity: 'レア',
+          newCardCount: 0,
+        },
+      );
+
+      expect(message).toBe('viewer: 初出 0種類');
+    });
+  });
+
   describe('sendChatMessage - 401エラー時のDB保護', () => {
     it('401 + スコープエラーでもDBのスコープは削除されない（DB保護）', async () => {
       vi.mocked(getTwitchAccessToken).mockResolvedValue('test-token');

--- a/tests/unit/eventsub-reward-mismatch.test.ts
+++ b/tests/unit/eventsub-reward-mismatch.test.ts
@@ -2,14 +2,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { POST } from '@/app/api/twitch/eventsub/route'
 import { reportError } from '@/lib/sentry/error-handler'
-import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { getSupabaseAdmin, getSupabaseAdminNoCache } from '@/lib/supabase/admin'
 import { broadcastGachaResult } from '@/lib/realtime'
 import { TwitchChatService } from '@/lib/twitch/chat-service'
 
 const mocks = vi.hoisted(() => ({
   executeGachaForEventSub: vi.fn(),
   executeGachaForRaidEvent: vi.fn(),
-  buildMessage: vi.fn((template: string | null, placeholders: { user: string; card: string; cards?: string; draws?: number; rarityCounts?: string }) => {
+  buildMessage: vi.fn((template: string | null, placeholders: { user: string; card: string; cards?: string; draws?: number; rarityCounts?: string; newCards?: string; newCardCount?: number }) => {
     const messageTemplate = template || '{user} got {card}'
     return messageTemplate
       .replace(/\{user\}/g, placeholders.user)
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
       .replace(/\{cards\}/g, placeholders.cards ?? '')
       .replace(/\{draws\}/g, placeholders.draws === undefined ? '' : String(placeholders.draws))
       .replace(/\{rarityCounts\}/g, placeholders.rarityCounts ?? '')
+      .replace(/\{newCards\}/g, placeholders.newCards ?? '')
+      .replace(/\{newCardCount\}/g, placeholders.newCardCount === undefined ? '' : String(placeholders.newCardCount))
       .replace(/\s+/g, ' ')
       .trim()
   }),
@@ -68,6 +70,7 @@ vi.mock('@/lib/logger', () => ({
 }))
 
 const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin)
+const mockGetSupabaseAdminNoCache = vi.mocked(getSupabaseAdminNoCache)
 const mockReportError = vi.mocked(reportError)
 const mockBroadcastGachaResult = vi.mocked(broadcastGachaResult)
 const mockTwitchChatService = vi.mocked(TwitchChatService)
@@ -125,7 +128,7 @@ async function createNotificationRequest(gachaError: string): Promise<NextReques
 describe('EventSub reward mismatch handling', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mocks.buildMessage.mockImplementation((template: string | null, placeholders: { user: string; card: string; cards?: string; draws?: number; rarityCounts?: string }) => {
+    mocks.buildMessage.mockImplementation((template: string | null, placeholders: { user: string; card: string; cards?: string; draws?: number; rarityCounts?: string; newCards?: string; newCardCount?: number }) => {
       const messageTemplate = template || '{user} got {card}'
       return messageTemplate
         .replace(/\{user\}/g, placeholders.user)
@@ -133,6 +136,8 @@ describe('EventSub reward mismatch handling', () => {
         .replace(/\{cards\}/g, placeholders.cards ?? '')
         .replace(/\{draws\}/g, placeholders.draws === undefined ? '' : String(placeholders.draws))
         .replace(/\{rarityCounts\}/g, placeholders.rarityCounts ?? '')
+        .replace(/\{newCards\}/g, placeholders.newCards ?? '')
+        .replace(/\{newCardCount\}/g, placeholders.newCardCount === undefined ? '' : String(placeholders.newCardCount))
         .replace(/\s+/g, ' ')
         .trim()
     })
@@ -148,6 +153,9 @@ describe('EventSub reward mismatch handling', () => {
         throw new Error(`Unexpected table: ${table}`)
       }),
     } as unknown as ReturnType<typeof getSupabaseAdmin>)
+    mockGetSupabaseAdminNoCache.mockReturnValue({
+      rpc: vi.fn().mockResolvedValue({ data: [], error: null }),
+    } as unknown as ReturnType<typeof getSupabaseAdminNoCache>)
   })
 
   it('does not report stale EventSub notifications for unconfigured rewards', async () => {
@@ -447,6 +455,151 @@ describe('EventSub reward mismatch handling', () => {
     )
   })
 
+  it('appends newly obtained card names to the default multi-draw chat announcement', async () => {
+    const secret = 'eventsub-test-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = secret
+    const messageId = 'eventsub-multi-draw-new-cards'
+    const timestamp = '2026-05-11T10:00:00Z'
+    const body = JSON.stringify({
+      subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
+      event: {
+        broadcaster_user_id: 'broadcaster-1',
+        user_id: 'viewer-1',
+        user_login: 'viewer',
+        user_name: 'Viewer',
+        reward: { id: 'raid-gacha', title: 'Raid Gacha', cost: 500 },
+      },
+    })
+    const signature = await signEventSubBody(secret, messageId, timestamp, body)
+
+    const cards = [
+      { id: 'card-1', name: 'Alpha', description: null, image_url: null, rarity: 'rare', drop_rate: 1 },
+      { id: 'card-2', name: 'Beta', description: null, image_url: null, rarity: 'common', drop_rate: 1 },
+      { id: 'card-1', name: 'Alpha', description: null, image_url: null, rarity: 'rare', drop_rate: 1 },
+      { id: 'card-3', name: 'Gamma', description: null, image_url: null, rarity: 'legendary', drop_rate: 1 },
+    ] as const
+
+    mockGetSupabaseAdminNoCache.mockReturnValue({
+      rpc: vi.fn().mockResolvedValue({
+        data: [
+          { count: 2, card: { id: 'card-1', is_active: true } },
+          { count: 2, card: { id: 'card-2', is_active: true } },
+          { count: 1, card: { id: 'card-3', is_active: true } },
+        ],
+        error: null,
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdminNoCache>)
+
+    mocks.executeGachaForEventSub.mockResolvedValue({
+      success: true,
+      data: {
+        card: cards[0],
+        cards: [...cards],
+        userTwitchUsername: 'Viewer',
+        streamer: {
+          id: 'streamer-1',
+          chat_announcement_enabled: true,
+          chat_announcement_template: null,
+          chat_announcement_multi_template: null,
+          chat_announcement_multi_show_cards: true,
+        },
+      },
+    })
+
+    const response = await POST(new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'twitch-eventsub-message-id': messageId,
+        'twitch-eventsub-message-timestamp': timestamp,
+        'twitch-eventsub-message-type': 'notification',
+        'twitch-eventsub-message-signature': signature,
+      },
+      body,
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.sendChatMessage).toHaveBeenCalledWith(
+      'broadcaster-1',
+      '@Viewer が4連ガチャで レジェンダリーx1、レアx2、コモンx1 を獲得しました！Alpha、Beta、Alpha、Gamma 初出: Alpha、Gamma',
+    )
+  })
+
+  it('exposes newly obtained card placeholders for custom multi-draw templates', async () => {
+    const secret = 'eventsub-test-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = secret
+    const messageId = 'eventsub-multi-draw-new-placeholders'
+    const timestamp = '2026-05-11T10:00:00Z'
+    const body = JSON.stringify({
+      subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
+      event: {
+        broadcaster_user_id: 'broadcaster-1',
+        user_id: 'viewer-1',
+        user_login: 'viewer',
+        user_name: 'Viewer',
+        reward: { id: 'raid-gacha', title: 'Raid Gacha', cost: 500 },
+      },
+    })
+    const signature = await signEventSubBody(secret, messageId, timestamp, body)
+
+    const cards = [
+      { id: 'card-1', name: 'Alpha', description: null, image_url: null, rarity: 'rare', drop_rate: 1 },
+      { id: 'card-2', name: 'Beta', description: null, image_url: null, rarity: 'common', drop_rate: 1 },
+    ] as const
+
+    mockGetSupabaseAdminNoCache.mockReturnValue({
+      rpc: vi.fn().mockResolvedValue({
+        data: [
+          { count: 1, card: { id: 'card-1', is_active: true } },
+          { count: 3, card: { id: 'card-2', is_active: true } },
+        ],
+        error: null,
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdminNoCache>)
+
+    mocks.executeGachaForEventSub.mockResolvedValue({
+      success: true,
+      data: {
+        card: cards[0],
+        cards: [...cards],
+        userTwitchUsername: 'Viewer',
+        streamer: {
+          id: 'streamer-1',
+          chat_announcement_enabled: true,
+          chat_announcement_template: null,
+          chat_announcement_multi_template: '@{user}: new={newCards} count={newCardCount} all={cards}',
+          chat_announcement_multi_show_cards: true,
+        },
+      },
+    })
+
+    const response = await POST(new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'twitch-eventsub-message-id': messageId,
+        'twitch-eventsub-message-timestamp': timestamp,
+        'twitch-eventsub-message-type': 'notification',
+        'twitch-eventsub-message-signature': signature,
+      },
+      body,
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mocks.buildMessage).toHaveBeenCalledWith(
+      '@{user}: new={newCards} count={newCardCount} all={cards}',
+      expect.objectContaining({
+        newCards: 'Alpha',
+        newCardCount: 1,
+        cards: 'Alpha、Beta',
+      }),
+    )
+    expect(mocks.sendChatMessage).toHaveBeenCalledWith(
+      'broadcaster-1',
+      '@Viewer: new=Alpha count=1 all=Alpha、Beta',
+    )
+  })
+
   it('abbreviates long multi-draw card lists before sending chat announcements', async () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret
@@ -532,6 +685,10 @@ describe('EventSub reward mismatch handling', () => {
       { id: 'card-2', name: 'Rare B', description: null, image_url: null, rarity: 'rare', drop_rate: 1 },
       { id: 'card-3', name: 'Common A', description: null, image_url: null, rarity: 'common', drop_rate: 1 },
     ] as const
+    const rpc = vi.fn().mockResolvedValue({ data: [], error: null })
+    mockGetSupabaseAdminNoCache.mockReturnValue({
+      rpc,
+    } as unknown as ReturnType<typeof getSupabaseAdminNoCache>)
 
     mocks.executeGachaForEventSub.mockResolvedValue({
       success: true,
@@ -566,6 +723,8 @@ describe('EventSub reward mismatch handling', () => {
       '@{user}: {draws}連 {rarityCounts} {cards}',
       expect.objectContaining({
         cards: undefined,
+        newCards: undefined,
+        newCardCount: undefined,
         draws: 3,
         rarityCounts: 'レアx2、コモンx1',
       }),
@@ -574,5 +733,158 @@ describe('EventSub reward mismatch handling', () => {
       'broadcaster-1',
       '@Viewer: 3連 レアx2、コモンx1',
     )
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  // 「初出: ...」追記がメッセージ末尾切り（truncate）で消えないことを確認する。
+  // 旧実装では {cards} 圧縮時に接尾辞分の予約をしていなかったため、500文字に
+  // 張り付くと最終的に 「初出:」 部分が truncate で削られていた。
+  // Verifies that the appended "初出: ..." suffix survives even when {cards} fills the limit.
+  it('preserves the 「初出: ...」 suffix when card lists fill the message limit', async () => {
+    const secret = 'eventsub-test-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = secret
+    const messageId = 'eventsub-new-cards-suffix-preserved'
+    const timestamp = '2026-05-11T10:00:00Z'
+    const body = JSON.stringify({
+      subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
+      event: {
+        broadcaster_user_id: 'broadcaster-1',
+        user_id: 'viewer-1',
+        user_login: 'viewer',
+        user_name: 'Viewer',
+        reward: { id: 'raid-gacha', title: 'Raid Gacha', cost: 500 },
+      },
+    })
+    const signature = await signEventSubBody(secret, messageId, timestamp, body)
+
+    // 各カード名は十分長く、10連で全カードを並べると 500 文字を大幅に超える。
+    // すべてのカードが新規取得（finalCount=1, currentDrawCount=1）になるよう設定。
+    const cards = Array.from({ length: 10 }, (_, index) => ({
+      id: `card-${index + 1}`,
+      name: `NewCardName${String(index + 1).padStart(2, '0')}-${'B'.repeat(60)}`,
+      description: null,
+      image_url: null,
+      rarity: 'rare',
+      drop_rate: 1,
+    }))
+
+    mockGetSupabaseAdminNoCache.mockReturnValue({
+      rpc: vi.fn().mockResolvedValue({
+        data: cards.map((card) => ({ count: 1, card: { id: card.id, is_active: true } })),
+        error: null,
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdminNoCache>)
+
+    mocks.executeGachaForEventSub.mockResolvedValue({
+      success: true,
+      data: {
+        card: cards[0],
+        cards,
+        userTwitchUsername: 'Viewer',
+        streamer: {
+          id: 'streamer-1',
+          chat_announcement_enabled: true,
+          chat_announcement_template: null,
+          chat_announcement_multi_template: null,
+          chat_announcement_multi_show_cards: true,
+        },
+      },
+    })
+
+    const response = await POST(new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'twitch-eventsub-message-id': messageId,
+        'twitch-eventsub-message-timestamp': timestamp,
+        'twitch-eventsub-message-type': 'notification',
+        'twitch-eventsub-message-signature': signature,
+      },
+      body,
+    }))
+
+    expect(response.status).toBe(200)
+    const sentMessage = mocks.sendChatMessage.mock.calls.at(-1)?.[1] as string
+    expect(sentMessage.length).toBeLessThanOrEqual(500)
+    // 「初出:」セクションが truncate で末尾削除されていないこと
+    expect(sentMessage).toContain(' 初出: ')
+    // truncate サフィックス '...' で終わっていない（=「初出:」直後で打ち切られていない）
+    expect(sentMessage.endsWith('...')).toBe(false)
+  })
+
+  // legacy fallback で user_cards の INSERT に失敗すると finalCount が 0 のまま
+  // 返ってきて「初出」誤通知が起きるバグ。finalCount=0 のカードは「持っていない」ため
+  // 「初出」とは扱わない。
+  // Regression: when finalCount=0 the user does not actually own the card (legacy fallback
+  // INSERT failed); it must NOT be announced as "初出".
+  it('does not announce 「初出」 when finalCount is 0 due to legacy fallback insert failure', async () => {
+    const secret = 'eventsub-test-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = secret
+    const messageId = 'eventsub-new-cards-legacy-fallback-zero'
+    const timestamp = '2026-05-11T10:00:00Z'
+    const body = JSON.stringify({
+      subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
+      event: {
+        broadcaster_user_id: 'broadcaster-1',
+        user_id: 'viewer-1',
+        user_login: 'viewer',
+        user_name: 'Viewer',
+        reward: { id: 'raid-gacha', title: 'Raid Gacha', cost: 500 },
+      },
+    })
+    const signature = await signEventSubBody(secret, messageId, timestamp, body)
+
+    const cards = [
+      { id: 'card-1', name: 'Alpha', description: null, image_url: null, rarity: 'rare', drop_rate: 1 },
+      { id: 'card-2', name: 'Beta', description: null, image_url: null, rarity: 'common', drop_rate: 1 },
+    ] as const
+
+    // Beta は legacy fallback で INSERT 失敗 -> count=0 が返る想定。
+    // 旧実装では previousCount = 0 - 1 = -1 で「初出」誤通知。
+    mockGetSupabaseAdminNoCache.mockReturnValue({
+      rpc: vi.fn().mockResolvedValue({
+        data: [
+          { count: 1, card: { id: 'card-1', is_active: true } },
+          { count: 0, card: { id: 'card-2', is_active: true } },
+        ],
+        error: null,
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdminNoCache>)
+
+    mocks.executeGachaForEventSub.mockResolvedValue({
+      success: true,
+      data: {
+        card: cards[0],
+        cards: [...cards],
+        userTwitchUsername: 'Viewer',
+        streamer: {
+          id: 'streamer-1',
+          chat_announcement_enabled: true,
+          chat_announcement_template: null,
+          chat_announcement_multi_template: null,
+          chat_announcement_multi_show_cards: true,
+        },
+      },
+    })
+
+    const response = await POST(new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'twitch-eventsub-message-id': messageId,
+        'twitch-eventsub-message-timestamp': timestamp,
+        'twitch-eventsub-message-type': 'notification',
+        'twitch-eventsub-message-signature': signature,
+      },
+      body,
+    }))
+
+    expect(response.status).toBe(200)
+    const sentMessage = mocks.sendChatMessage.mock.calls.at(-1)?.[1] as string
+    // Alpha は finalCount=1 で「初出」対象、Beta は finalCount=0 なので除外。
+    expect(sentMessage).toContain(' 初出: Alpha')
+    // 末尾の「初出:」セクションに Beta が含まれていないことを厳密に確認
+    const newCardSection = sentMessage.slice(sentMessage.indexOf(' 初出: '))
+    expect(newCardSection).not.toContain('Beta')
   })
 })


### PR DESCRIPTION
* feat: announce new cards in multi-draw chat

* fix: protect 「初出:」 suffix and avoid false-positive new card announcements

- Reserve suffix character budget when fitting {cards} so the appended 「初出: ...」 section is not lost to truncate when the message hits the 500-character cap.
- Require finalCount > 0 in findNewCardNamesForCurrentDraw so legacy fallback INSERT failures (count stays 0) no longer falsely trigger 「初出」 announcements via negative previousCount.
- Document {newCards} / {newCardCount} in the multi-draw placeholder help and substitute them in the dashboard preview to match runtime behavior.
- Drop the dead-write to placeholders.newCards after the suffix fit.



---------