### PR TITLE
fix: カード作成フォームのレアリティ選択をセレクトボックスに変更

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -188,6 +188,28 @@
       "confirmSwitchToAuto": "Rarity-based probability will be enabled and all card rates will be recalculated. Switch?",
       "switchFailed": "Failed to switch mode"
     },
+    "customRarity": {
+      "button": "Custom Rarities",
+      "title": "Custom Rarities",
+      "description": "Manage the rarities selectable when creating cards. Default rarities are always available and cannot be removed.",
+      "defaultSection": "Default (always available)",
+      "customSection": "Custom rarities",
+      "addPlaceholder": "New rarity name",
+      "add": "Add",
+      "empty": "No custom rarities yet",
+      "deleteNote": "Removing a custom rarity does not change existing cards (it is only removed from the card-creation suggestions).",
+      "save": "Save",
+      "saving": "Saving...",
+      "saved": "Saved",
+      "saveFailed": "Failed to save",
+      "confirmClose": "You have unsaved changes. Close anyway?",
+      "errorEmpty": "Enter a rarity name",
+      "errorTooLong": "Rarity name must be 40 characters or fewer",
+      "errorInvalidChars": "Contains characters that cannot be used",
+      "errorDuplicate": "That rarity already exists",
+      "errorDefault": "Default rarities cannot be added (they are always available)",
+      "errorMax": "Up to {max} custom rarities allowed"
+    },
     "batchDropRate": {
       "button": "Batch Drop Rate",
       "title": "Batch Drop Rate Adjustment",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -188,6 +188,28 @@
       "confirmSwitchToAuto": "レアリティ別確率設定が有効になり、全カードの確率が再計算されます。切り替えますか？",
       "switchFailed": "モードの切り替えに失敗しました"
     },
+    "customRarity": {
+      "button": "レアリティカスタム",
+      "title": "カスタムレアリティ",
+      "description": "カード作成時に選べるレアリティを管理します。デフォルトのレアリティは常に選択でき、削除できません。",
+      "defaultSection": "デフォルト（常に選択可能）",
+      "customSection": "カスタムレアリティ",
+      "addPlaceholder": "新しいレアリティ名",
+      "add": "追加",
+      "empty": "カスタムレアリティはまだありません",
+      "deleteNote": "削除しても既存カードのレアリティは変わりません（カード作成時の候補から外れるだけです）。",
+      "save": "保存",
+      "saving": "保存中...",
+      "saved": "保存しました",
+      "saveFailed": "保存に失敗しました",
+      "confirmClose": "未保存の変更があります。閉じますか？",
+      "errorEmpty": "レアリティ名を入力してください",
+      "errorTooLong": "レアリティ名は40文字以内で入力してください",
+      "errorInvalidChars": "使用できない文字が含まれています",
+      "errorDuplicate": "同じレアリティが既に存在します",
+      "errorDefault": "デフォルトのレアリティは追加できません（常に選択可能です）",
+      "errorMax": "カスタムレアリティは最大{max}件までです"
+    },
     "batchDropRate": {
       "button": "確率一括調整",
       "title": "確率一括調整",

--- a/src/app/api/streamer/settings/route.ts
+++ b/src/app/api/streamer/settings/route.ts
@@ -4,18 +4,18 @@ import { getSupabaseAdmin } from "@/lib/supabase/admin";
 import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
 import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
-import { ERROR_MESSAGES } from "@/lib/constants";
+import {
+  ERROR_MESSAGES,
+  RARITIES,
+  MAX_RARITY_KEY_LENGTH,
+  MAX_CUSTOM_RARITIES,
+  RARITY_CONTROL_CHAR_REGEX as CONTROL_CHAR_REGEX,
+  RARITY_BIDI_OVERRIDE_REGEX as BIDI_OVERRIDE_REGEX,
+} from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
 import { recalculateIfAutoMode } from "@/lib/recalculate-drop-rates";
 
-// レアリティキーの最大長。DB側のレアリティ列(varchar)と整合する保守的な上限。
-const MAX_RARITY_KEY_LENGTH = 40;
-// 制御文字(C0 範囲 \u0000-\u001F・DEL \u007F・C1 範囲 \u0080-\u009F)。
-// 表示崩れや不可視キー注入を防ぐため禁止。
-const CONTROL_CHAR_REGEX = /[\u0000-\u001F\u007F-\u009F]/;
-// Bidi override/embedding/isolate 文字。UI上で他キーへのなりすましを防ぐため禁止。
-const BIDI_OVERRIDE_REGEX = /[\u202A-\u202E\u2066-\u2069]/;
 
 type RarityWeightsValidation =
   | { ok: true; value: Record<string, number> | null }
@@ -58,6 +58,57 @@ function validateRarityWeightsInput(value: unknown): RarityWeightsValidation {
       return { ok: false };
     }
     normalized[key] = rate;
+  }
+
+  return { ok: true, value: normalized };
+}
+
+// デフォルトレアリティの value 集合。カスタム一覧へ重複登録させないために使用。
+const DEFAULT_RARITY_VALUES = new Set<string>(RARITIES.map((r) => r.value));
+
+type CustomRaritiesValidation =
+  | { ok: true; value: string[] }
+  | { ok: false };
+
+/**
+ * customRarities 入力を検証し、正規化済みの文字列配列を返す。
+ *
+ * rarity_weights のキー検証と同じ規則を適用する:
+ * - 配列であること（要素は文字列のみ）。
+ * - 各要素は trim + Unicode NFC 正規化後、長さ 1〜40。
+ * - 制御文字 / Bidi override を禁止。
+ * - 正規化後にデフォルトレアリティと一致するものは拒否
+ *   （デフォルトは常に選択可能なため、カスタム一覧に持たせると二重表示になる）。
+ * - 正規化後に重複するものは拒否（黙ってマージするとUI表示が崩れるため）。
+ * - 件数上限は MAX_CUSTOM_RARITIES。
+ */
+function validateCustomRaritiesInput(value: unknown): CustomRaritiesValidation {
+  if (!Array.isArray(value)) {
+    return { ok: false };
+  }
+  if (value.length > MAX_CUSTOM_RARITIES) {
+    return { ok: false };
+  }
+
+  const normalized: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of value) {
+    if (typeof raw !== "string") {
+      return { ok: false };
+    }
+    const key = raw.trim().normalize("NFC");
+    if (
+      key.length < 1
+      || key.length > MAX_RARITY_KEY_LENGTH
+      || CONTROL_CHAR_REGEX.test(key)
+      || BIDI_OVERRIDE_REGEX.test(key)
+      || DEFAULT_RARITY_VALUES.has(key)
+      || seen.has(key)
+    ) {
+      return { ok: false };
+    }
+    seen.add(key);
+    normalized.push(key);
   }
 
   return { ok: true, value: normalized };
@@ -133,6 +184,9 @@ export async function POST(request: NextRequest) {
       chatAnnouncementMultiShowCards,
       // レアリティ別自動確率設定（オプション）
       rarityWeights,
+      // カスタムレアリティ名の一覧（オプション、ドロップ率設定とは独立）
+      // Custom rarity name catalog (optional, decoupled from drop-rate settings)
+      customRarities,
       // 未所持カード表示設定（オプション、Issue #395）
       // Unowned-card visibility settings (optional, Issue #395)
       showUnownedCards,
@@ -154,6 +208,17 @@ export async function POST(request: NextRequest) {
       if (!hasValidRarityWeightsTotal(normalizedRarityWeights)) {
         return NextResponse.json({ error: "Rarity weights total must be 100%" }, { status: 400 });
       }
+    }
+
+    // customRarities はレアリティ名の一覧のみを保持し、ドロップ率には影響しない。
+    // そのため再計算は行わず、独立した列にそのまま保存する。
+    let normalizedCustomRarities: string[] | undefined;
+    if (customRarities !== undefined) {
+      const validation = validateCustomRaritiesInput(customRarities);
+      if (!validation.ok) {
+        return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
+      }
+      normalizedCustomRarities = validation.value;
     }
 
     // 視聴者向け未所持カード表示の boolean 検証
@@ -228,6 +293,11 @@ export async function POST(request: NextRequest) {
     // rarityWeights: レアリティ別目標確率（nullで自動モード無効）
     if (rarityWeights !== undefined) {
       updateData.rarity_weights = normalizedRarityWeights;
+    }
+
+    // カスタムレアリティ名（ドロップ率の再計算は不要）
+    if (customRarities !== undefined) {
+      updateData.custom_rarities = normalizedCustomRarities;
     }
 
     // 未所持カードの視聴者向け表示設定

--- a/src/app/dashboard/cards/page.tsx
+++ b/src/app/dashboard/cards/page.tsx
@@ -60,6 +60,7 @@ export default async function CardsPage() {
       streamerId={streamerData.streamer.id}
       initialCards={initialCards}
       initialRarityWeights={streamerData.streamer.rarity_weights}
+      initialCustomRarities={streamerData.streamer.custom_rarities ?? []}
       viewMode="list"
       showViewToggle={true}
       maxImageWidth={maxImageWidth}

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -14,6 +14,7 @@ import ImageCropper, { type CropMode, getCropModes } from "./ImageCropper";
 import CardViewToggle, { type ViewMode } from "./CardViewToggle";
 import CardList from "./CardList";
 import DropRateSettingsModal from "./DropRateSettingsModal";
+import CustomRarityModal from "./CustomRarityModal";
 import ExpandableDescription from "./ExpandableDescription";
 
 /** Custom dropdown arrow style for appearance-none select boxes */
@@ -73,6 +74,9 @@ interface CardManagerProps {
   // Initial rarity weights: null/undefined = unset (auto mode with defaults), {} = explicit manual mode, {weights} = auto mode
   // レアリティ確率設定: null/undefined=未設定（自動モードデフォルト化）, {}=手動モード明示, {weights}=自動モード
   initialRarityWeights?: Record<string, number> | null;
+  // 配信者が定義したカスタムレアリティ名（rarity_weights とは独立）
+  // Streamer-defined custom rarity names (decoupled from rarity_weights)
+  initialCustomRarities?: string[];
 }
 
 // Sorting field options
@@ -117,6 +121,7 @@ export default function CardManager({
   maxImageWidth = 800,
   availableWidths = [800],
   initialRarityWeights = null,
+  initialCustomRarities = [],
 }: CardManagerProps) {
   // i18n translations
   // i18n翻訳
@@ -138,6 +143,8 @@ export default function CardManager({
     }
     return initialRarityWeights;
   });
+  // カスタムレアリティ名（ドロップ率設定とは独立。専用モーダルで管理）
+  const [customRarities, setCustomRarities] = useState<string[]>(initialCustomRarities);
   const rarityOptions = useMemo(() => {
     const values = new Set<string>(RARITIES.map((rarity) => rarity.value));
     cards.forEach((card) => {
@@ -146,8 +153,11 @@ export default function CardManager({
     Object.keys(rarityWeights ?? {}).forEach((rarity) => {
       if (rarity.trim()) values.add(rarity);
     });
+    customRarities.forEach((rarity) => {
+      if (rarity.trim()) values.add(rarity);
+    });
     return Array.from(values);
-  }, [cards, rarityWeights]);
+  }, [cards, rarityWeights, customRarities]);
   const [loading, setLoading] = useState(false);
   // Current view mode state (thumbnail or list)
   // 現在の表示モード状態（サムネイルまたはリスト）
@@ -338,6 +348,8 @@ export default function CardManager({
   // Batch drop rate modal state
   // 確率一括調整モーダルの状態
   const [showBatchDropRateModal, setShowBatchDropRateModal] = useState(false);
+  // カスタムレアリティ管理モーダルの状態
+  const [showCustomRarityModal, setShowCustomRarityModal] = useState(false);
   // Zoomed card image modal state (opened when user clicks a thumbnail)
   // Uses the original (pre-thumbnail) URL so users see the full-resolution image
   // サムネイルクリック時に表示する拡大画像モーダルの状態
@@ -1268,6 +1280,14 @@ export default function CardManager({
             className="rounded-lg border border-purple-600 px-4 py-2 text-purple-400 hover:bg-purple-600 hover:text-white transition whitespace-nowrap"
           >
             {t("dropRateSettings.button")}
+          </button>
+          {/* Custom rarity management button */}
+          {/* カスタムレアリティ管理ボタン */}
+          <button
+            onClick={() => setShowCustomRarityModal(true)}
+            className="rounded-lg border border-purple-600 px-4 py-2 text-purple-400 hover:bg-purple-600 hover:text-white transition whitespace-nowrap"
+          >
+            {t("customRarity.button")}
           </button>
           {/* Emote import button */}
           {/* エモートインポートボタン */}
@@ -2245,6 +2265,17 @@ export default function CardManager({
         onCardsSave={handleBatchDropRateSave}
         onRarityWeightsApply={handleRarityWeightsApply}
         rarityWeights={rarityWeights}
+        customRarities={customRarities}
+      />
+
+      {/* Custom Rarity Modal */}
+      {/* カスタムレアリティ管理モーダル */}
+      <CustomRarityModal
+        isOpen={showCustomRarityModal}
+        onClose={() => setShowCustomRarityModal(false)}
+        streamerId={streamerId}
+        customRarities={customRarities}
+        onSaved={setCustomRarities}
       />
 
       {/* Emote Import Modal */}

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -1398,24 +1398,32 @@ export default function CardManager({
                         <label className="mb-1 block text-sm text-gray-300">
                           {t("form.rarity")}
                         </label>
-                        <input
+                        {/*
+                          レアリティ選択は <select> を使用する。
+                          以前は <input list> + <datalist> だったが、datalist は
+                          入力欄の現在値に部分一致する候補のみを表示する仕様のため、
+                          初期値 "common" が入っている状態ではコモンしか候補に出ず
+                          実質的に他のレアリティを選べない不具合があった。
+                          <select> なら現在値に関わらず常に全選択肢を表示できる。
+                          rarityOptions はデフォルト4種＋既存カードのレアリティ＋
+                          カスタムレアリティ(rarity_weights)を含むため、デフォルトの
+                          レアリティは常に保持される。
+                        */}
+                        <select
                           name="rarity"
-                          list="card-rarity-options"
                           value={formData.rarity}
                           onChange={(e) =>
                             setFormData({ ...formData, rarity: e.target.value as Rarity })
                           }
-                          maxLength={40}
-                          placeholder={getRarityLabel("common")}
-                          className="w-full min-w-0 rounded-lg bg-gray-600 px-4 py-2 text-white"
-                        />
-                        <datalist id="card-rarity-options">
+                          className="w-full min-w-0 appearance-none rounded-lg bg-gray-600 px-4 py-2 pr-8 text-white"
+                          style={SELECT_ARROW_STYLE}
+                        >
                           {rarityOptions.map((rarity) => (
                             <option key={rarity} value={rarity}>
                               {getRarityLabel(rarity)}
                             </option>
                           ))}
-                        </datalist>
+                        </select>
                       </div>
                       <div className="min-w-0">
                         <label className="mb-1 block text-sm text-gray-300">

--- a/src/components/CustomRarityModal.tsx
+++ b/src/components/CustomRarityModal.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  RARITIES,
+  MAX_RARITY_KEY_LENGTH,
+  MAX_CUSTOM_RARITIES,
+  RARITY_CONTROL_CHAR_REGEX as CONTROL_CHAR_REGEX,
+  RARITY_BIDI_OVERRIDE_REGEX as BIDI_OVERRIDE_REGEX,
+} from "@/lib/constants";
+import { logger } from "@/lib/logger";
+
+// ここでの事前検証は UX 向上のためで、最終的な検証はサーバーが行う
+// (POST /api/streamer/settings)。検証規則は constants の共通定数を共有する。
+
+const DEFAULT_RARITY_VALUES = new Set<string>(RARITIES.map((r) => r.value));
+
+interface CustomRarityModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  streamerId: string;
+  customRarities: string[];
+  onSaved: (next: string[]) => void;
+}
+
+/**
+ * CustomRarityModal - カスタムレアリティ名の管理モーダル
+ *
+ * デフォルトレアリティ (RARITIES) は常に選択可能なため読み取り専用で表示し、
+ * 削除できない。カスタムレアリティ名のみ追加/削除でき、保存すると
+ * streamers.custom_rarities に永続化される。
+ *
+ * このモーダルはレアリティ「名」のみを扱い、ドロップ率設定 (rarity_weights)
+ * とは完全に独立している。そのため保存してもカードの排出確率は再計算されない。
+ */
+export default function CustomRarityModal({
+  isOpen,
+  onClose,
+  streamerId,
+  customRarities,
+  onSaved,
+}: CustomRarityModalProps) {
+  const t = useTranslations("cardManager");
+  const tRarity = useTranslations("rarity");
+
+  const [list, setList] = useState<string[]>(customRarities);
+  const [input, setInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  // モーダルを開くたびに、保存済みの最新値から編集を開始する。
+  // 閉じている間に親の customRarities が変わってもズレないようにする。
+  useEffect(() => {
+    if (isOpen) {
+      setList(customRarities);
+      setInput("");
+      setError(null);
+    }
+  }, [isOpen, customRarities]);
+
+  const hasChanges = useMemo(() => {
+    if (list.length !== customRarities.length) return true;
+    return list.some((v, i) => v !== customRarities[i]);
+  }, [list, customRarities]);
+
+  if (!isOpen) return null;
+
+  const handleClose = () => {
+    if (hasChanges && !confirm(t("customRarity.confirmClose"))) return;
+    // 次回開いたときに保存済みの値から再開できるよう破棄
+    setList(customRarities);
+    setInput("");
+    setError(null);
+    onClose();
+  };
+
+  const handleAdd = () => {
+    const key = input.trim().normalize("NFC");
+    if (key.length < 1) {
+      setError(t("customRarity.errorEmpty"));
+      return;
+    }
+    if (key.length > MAX_RARITY_KEY_LENGTH) {
+      setError(t("customRarity.errorTooLong"));
+      return;
+    }
+    if (CONTROL_CHAR_REGEX.test(key) || BIDI_OVERRIDE_REGEX.test(key)) {
+      setError(t("customRarity.errorInvalidChars"));
+      return;
+    }
+    if (DEFAULT_RARITY_VALUES.has(key)) {
+      setError(t("customRarity.errorDefault"));
+      return;
+    }
+    if (list.includes(key)) {
+      setError(t("customRarity.errorDuplicate"));
+      return;
+    }
+    if (list.length >= MAX_CUSTOM_RARITIES) {
+      setError(t("customRarity.errorMax", { max: MAX_CUSTOM_RARITIES }));
+      return;
+    }
+    setList([...list, key]);
+    setInput("");
+    setError(null);
+  };
+
+  const handleRemove = (value: string) => {
+    setList(list.filter((v) => v !== value));
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/streamer/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ streamerId, customRarities: list }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || t("customRarity.saveFailed"));
+      }
+      onSaved(list);
+      onClose();
+    } catch (err) {
+      logger.error("Failed to save custom rarities:", err);
+      setError(err instanceof Error ? err.message : t("customRarity.saveFailed"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4"
+      onClick={handleClose}
+    >
+      <div
+        className="max-h-[90vh] w-full max-w-lg overflow-hidden rounded-xl bg-gray-800 shadow-2xl flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ヘッダー */}
+        <div className="p-6 border-b border-gray-700">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-white">
+              {t("customRarity.title")}
+            </h3>
+            <button
+              onClick={handleClose}
+              className="text-gray-400 hover:text-white"
+              aria-label="Close"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-6 w-6"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+          <p className="mt-2 text-sm text-gray-400">
+            {t("customRarity.description")}
+          </p>
+        </div>
+
+        {/* 本文 */}
+        <div className="flex-1 overflow-y-auto p-6 space-y-6">
+          {/* デフォルト（読み取り専用・削除不可） */}
+          <div>
+            <h4 className="mb-2 text-sm font-medium text-gray-300">
+              {t("customRarity.defaultSection")}
+            </h4>
+            <div className="flex flex-wrap gap-2">
+              {RARITIES.map((r) => (
+                <span
+                  key={r.value}
+                  className={`rounded-full px-3 py-1 text-sm text-white ${r.color}`}
+                >
+                  {tRarity(r.value)}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* カスタム */}
+          <div>
+            <h4 className="mb-2 text-sm font-medium text-gray-300">
+              {t("customRarity.customSection")}
+            </h4>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={input}
+                maxLength={MAX_RARITY_KEY_LENGTH}
+                placeholder={t("customRarity.addPlaceholder")}
+                onChange={(e) => setInput(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    handleAdd();
+                  }
+                }}
+                className="w-full min-w-0 rounded-lg bg-gray-600 px-4 py-2 text-white placeholder:text-gray-400"
+              />
+              <button
+                type="button"
+                onClick={handleAdd}
+                className="rounded-lg border border-purple-600 px-4 py-2 text-purple-400 hover:bg-purple-600 hover:text-white transition whitespace-nowrap"
+              >
+                {t("customRarity.add")}
+              </button>
+            </div>
+            {error && (
+              <p className="mt-2 text-sm text-red-400">{error}</p>
+            )}
+
+            <div className="mt-4">
+              {list.length === 0 ? (
+                <p className="text-sm text-gray-500">
+                  {t("customRarity.empty")}
+                </p>
+              ) : (
+                <ul className="space-y-2">
+                  {list.map((value) => (
+                    <li
+                      key={value}
+                      className="flex items-center justify-between rounded-lg bg-gray-700 px-4 py-2"
+                    >
+                      <span className="text-white break-all">{value}</span>
+                      <button
+                        type="button"
+                        onClick={() => handleRemove(value)}
+                        className="ml-2 text-gray-400 hover:text-red-400"
+                        aria-label={`Remove ${value}`}
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="h-5 w-5"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M6 18L18 6M6 6l12 12"
+                          />
+                        </svg>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            <p className="mt-3 text-xs text-gray-500">
+              {t("customRarity.deleteNote")}
+            </p>
+          </div>
+        </div>
+
+        {/* フッター */}
+        <div className="p-6 border-t border-gray-700 flex justify-end">
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving || !hasChanges}
+            className="rounded-lg bg-purple-600 px-6 py-2 text-white hover:bg-purple-700 transition disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {saving ? t("customRarity.saving") : t("customRarity.save")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DropRateAutoModeContent.tsx
+++ b/src/components/DropRateAutoModeContent.tsx
@@ -13,6 +13,8 @@ interface DropRateAutoModeContentProps {
   cards: Card[];
   streamerId: string;
   rarityWeights: Record<string, number>;
+  // カスタムレアリティ名（カード未使用でも重み設定欄に表示するため）
+  customRarities: string[];
   onCardsSave: (updatedCards: Card[]) => void;
   onRarityWeightsApply: (
     w: Record<string, number> | null,
@@ -39,6 +41,7 @@ export default function DropRateAutoModeContent({
   cards,
   streamerId,
   rarityWeights,
+  customRarities,
   onCardsSave,
   onRarityWeightsApply,
   onSwitchToManualMode,
@@ -83,13 +86,14 @@ export default function DropRateAutoModeContent({
     for (const rarity of RARITIES) keys.add(rarity.value);
     for (const card of cards) keys.add(card.rarity);
     for (const key of Object.keys(rarityWeights)) keys.add(key);
+    for (const key of customRarities) keys.add(key);
 
     const baseOrder = RARITIES.map((rarity) => rarity.value) as string[];
     const extras = Array.from(keys)
       .filter((key) => !baseOrder.includes(key))
       .sort();
     return [...baseOrder.filter((key) => keys.has(key)), ...extras];
-  }, [cards, rarityWeights]);
+  }, [cards, rarityWeights, customRarities]);
 
   // アクティブカード数（レアリティ別）
   const activeCounts = useMemo(() => {

--- a/src/components/DropRateSettingsModal.tsx
+++ b/src/components/DropRateSettingsModal.tsx
@@ -19,6 +19,8 @@ interface DropRateSettingsModalProps {
     c: Card[] | null
   ) => void;
   rarityWeights: Record<string, number> | null;
+  // カスタムレアリティ名（自動モードで重みを割り当てられるよう一覧へ含める）
+  customRarities: string[];
 }
 
 /**
@@ -36,6 +38,7 @@ export default function DropRateSettingsModal({
   onCardsSave,
   onRarityWeightsApply,
   rarityWeights,
+  customRarities,
 }: DropRateSettingsModalProps) {
   const t = useTranslations("cardManager");
   const [switching, setSwitching] = useState(false);
@@ -110,6 +113,7 @@ export default function DropRateSettingsModal({
         cards={cards}
         streamerId={streamerId}
         rarityWeights={rarityWeights}
+        customRarities={customRarities}
         onCardsSave={onCardsSave}
         onRarityWeightsApply={onRarityWeightsApply}
         onSwitchToManualMode={() => switchMode(false)}

--- a/src/components/StreamerSettings.tsx
+++ b/src/components/StreamerSettings.tsx
@@ -68,6 +68,7 @@ export default async function StreamerSettings({ streamerData }: StreamerSetting
           streamerId={streamerData.streamer.id}
           initialCards={streamerData.cards as Card[]}
           initialRarityWeights={streamerData.streamer.rarity_weights}
+          initialCustomRarities={streamerData.streamer.custom_rarities ?? []}
         />
       </div>
     </section>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -62,6 +62,18 @@ export const SESSION_CONFIG = {
   COOKIE_PATH: '/',
 }
 
+// レアリティ名（rarity_weights のキー / cards.rarity / custom_rarities）の
+// 共通検証プリミティブ。クライアント(モーダル)とサーバー(API)で同一規則を使う。
+// レアリティ名の最大長。DB側のレアリティ列(varchar)と整合する保守的な上限。
+export const MAX_RARITY_KEY_LENGTH = 40;
+// 1配信者あたりのカスタムレアリティ数の上限。DB(00049 の CHECK)と整合させる。
+export const MAX_CUSTOM_RARITIES = 50;
+// 制御文字(C0 U+0000-U+001F・DEL U+007F・C1 U+0080-U+009F)。
+// 表示崩れや不可視キー注入を防ぐため禁止。
+export const RARITY_CONTROL_CHAR_REGEX = /[\u0000-\u001F\u007F-\u009F]/;
+// Bidi override/embedding/isolate 文字。UI上で他キーへのなりすましを防ぐため禁止。
+export const RARITY_BIDI_OVERRIDE_REGEX = /[\u202A-\u202E\u2066-\u2069]/;
+
 export const RARITIES = [
   { value: "common", label: "コモン", color: "bg-gray-500" },
   { value: "rare", label: "レア", color: "bg-blue-500" },

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -45,6 +45,9 @@ export interface Database {
           // レアリティ名をキーにした目標確率マップ（0-100）
           // Dynamic rarity-to-target-percentage map (0-100)
           rarity_weights: Record<string, number> | null
+          // 配信者が定義したカスタムレアリティ名の一覧（rarity_weights とは独立）
+          // List of streamer-defined custom rarity names (decoupled from rarity_weights)
+          custom_rarities: string[]
           // 視聴者向けコレクションページで未所持カードを表示するか（オプトイン、デフォルトfalse）
           // Whether unowned cards are visible on the viewer collection page (opt-in, default false)
           show_unowned_cards: boolean
@@ -76,6 +79,7 @@ export interface Database {
           chat_announcement_multi_template?: string | null
           chat_announcement_multi_show_cards?: boolean
           rarity_weights?: Record<string, number> | null
+          custom_rarities?: string[]
           show_unowned_cards?: boolean
           show_unowned_card_details?: boolean
           raid_gacha_active_until?: string | null
@@ -99,6 +103,7 @@ export interface Database {
           chat_announcement_multi_template?: string | null
           chat_announcement_multi_show_cards?: boolean
           rarity_weights?: Record<string, number> | null
+          custom_rarities?: string[]
           show_unowned_cards?: boolean
           show_unowned_card_details?: boolean
           raid_gacha_active_until?: string | null

--- a/supabase/migrations/00049_add_custom_rarities.sql
+++ b/supabase/migrations/00049_add_custom_rarities.sql
@@ -1,0 +1,38 @@
+-- Add a dedicated catalog of custom rarity names per streamer.
+--
+-- Why a separate column instead of reusing streamers.rarity_weights:
+--   rarity_weights is overloaded (null = auto mode w/ defaults, {} = manual mode
+--   sentinel, {...} = auto mode custom weights that must total 100% and trigger
+--   a full drop_rate recalculation of every card). Storing rarity *names* there
+--   would force auto mode and destructively recalculate drop rates just because
+--   a streamer added a label. custom_rarities is fully decoupled: it only holds
+--   the list of selectable custom rarity names and never affects drop rates.
+--
+-- Lock safety: a constant DEFAULT ('[]') means Postgres 11+ records the default
+-- in catalog metadata without rewriting existing rows, so this ADD COLUMN takes
+-- only a brief ACCESS EXCLUSIVE lock and needs no backfill.
+--
+-- Element-level validation (string, length 1-40, no control/Bidi chars, NFC,
+-- de-duplication, no collision with default rarities) is enforced in the
+-- application layer (POST /api/streamer/settings), consistent with how
+-- rarity_weights keys and cards.rarity (migration 00048) are only structurally
+-- constrained at the DB level.
+--
+-- Grants/RLS: migration 00047 grants SELECT on the streamers table to anon /
+-- authenticated, which automatically covers this new column; writes go through
+-- the service_role admin client only. No additional grants or RLS policies are
+-- required.
+
+ALTER TABLE streamers
+ADD COLUMN IF NOT EXISTS custom_rarities JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- 制約は再適用時に確実に張り直せるよう、一度落としてから追加する
+-- （migration 00048 と同じ冪等パターン）。
+ALTER TABLE streamers
+DROP CONSTRAINT IF EXISTS streamers_custom_rarities_valid;
+
+ALTER TABLE streamers
+ADD CONSTRAINT streamers_custom_rarities_valid CHECK (
+  jsonb_typeof(custom_rarities) = 'array'
+  AND jsonb_array_length(custom_rarities) <= 50
+);

--- a/tests/unit/card-manager-form-layout.test.ts
+++ b/tests/unit/card-manager-form-layout.test.ts
@@ -13,8 +13,21 @@ describe("CardManager form layout", () => {
     expect(source).toContain("md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]");
     expect(source).toContain("flex min-w-0 flex-col justify-between gap-4");
     expect(source).toContain("grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]");
-    expect(source).toContain('list="card-rarity-options"');
     expect(source).toContain("w-full min-w-0 rounded-lg bg-gray-600 px-4 py-2 text-white");
-    expect(source).toContain("w-full min-w-0 rounded-lg bg-gray-600");
+
+    // レアリティ欄は <input list> + <datalist> ではなく
+    // 全選択肢を常に表示できる <select> であること
+    expect(source).not.toContain('list="card-rarity-options"');
+    expect(source).not.toContain('id="card-rarity-options"');
+    expect(source).toContain('<select\n                          name="rarity"');
+    expect(source).toContain(
+      "w-full min-w-0 appearance-none rounded-lg bg-gray-600 px-4 py-2 pr-8 text-white",
+    );
+    expect(source).toContain("style={SELECT_ARROW_STYLE}");
+    // 選択肢は rarityOptions から動的に生成されていること
+    expect(source).toContain("{rarityOptions.map((rarity) => (");
+    expect(source).toContain(
+      "<option key={rarity} value={rarity}>",
+    );
   });
 });

--- a/tests/unit/streamer-settings-api.test.ts
+++ b/tests/unit/streamer-settings-api.test.ts
@@ -11,7 +11,10 @@ vi.mock('@/lib/session')
 vi.mock('@/lib/rate-limit')
 vi.mock('@/lib/csrf')
 vi.mock('@/lib/request-validation')
-vi.mock('@/lib/constants')
+// 本物の constants モジュールを保持する。RARITIES が空配列になると
+// route.ts の DEFAULT_RARITY_VALUES が空となり、デフォルトレアリティとの
+// 衝突検出ができなくなるため、ファクトリで実体をそのまま返す。
+vi.mock('@/lib/constants', async (importOriginal) => await importOriginal())
 vi.mock('@/lib/supabase/admin', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/supabase/admin')>()
   return {
@@ -239,6 +242,100 @@ describe('POST /api/streamer/settings', () => {
       expect(query.update).toHaveBeenCalledWith(
         expect.objectContaining({ rarity_weights: { common: 70, rare: 30 } })
       )
+    })
+  })
+
+  describe('custom rarities validation', () => {
+    const buildRequest = (customRarities: unknown) =>
+      new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ streamerId: 'streamer123', customRarities }),
+      })
+
+    const mockOk = async () => {
+      const mockSupabase = createSupabaseMock()
+        .withMaybeSingleResponse({ id: 'streamer123', twitch_user_id: 'streamer123' })
+      const built = mockSupabase.build()
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(
+        built as unknown as ReturnType<typeof getSupabaseAdmin>
+      )
+      return mockSupabase.getQueryBuilder()
+    }
+
+    it('rejects non-array value', async () => {
+      await mockOk()
+      const response = await POST(buildRequest({ super: 1 }))
+      expect(response.status).toBe(400)
+    })
+
+    it('rejects non-string element', async () => {
+      await mockOk()
+      const response = await POST(buildRequest(['super', 123]))
+      expect(response.status).toBe(400)
+    })
+
+    it('rejects empty / whitespace-only name', async () => {
+      await mockOk()
+      const response = await POST(buildRequest(['   ']))
+      expect(response.status).toBe(400)
+    })
+
+    it('rejects name longer than 40 chars', async () => {
+      await mockOk()
+      const response = await POST(buildRequest(['a'.repeat(41)]))
+      expect(response.status).toBe(400)
+    })
+
+    it('rejects control characters', async () => {
+      await mockOk()
+      const response = await POST(buildRequest(['super']))
+      expect(response.status).toBe(400)
+    })
+
+    it('rejects bidi override characters', async () => {
+      await mockOk()
+      const response = await POST(
+        buildRequest([`super${String.fromCharCode(0x202e)}`])
+      )
+      expect(response.status).toBe(400)
+    })
+
+    it('rejects collision with a default rarity', async () => {
+      await mockOk()
+      const response = await POST(buildRequest(['common']))
+      expect(response.status).toBe(400)
+    })
+
+    it('rejects duplicates after trim/NFC normalization', async () => {
+      await mockOk()
+      const response = await POST(buildRequest(['super', ' super ']))
+      expect(response.status).toBe(400)
+    })
+
+    it('rejects more than 50 entries', async () => {
+      await mockOk()
+      const many = Array.from({ length: 51 }, (_, i) => `r${i}`)
+      const response = await POST(buildRequest(many))
+      expect(response.status).toBe(400)
+    })
+
+    it('persists trimmed/NFC-normalized names when valid', async () => {
+      const query = await mockOk()
+      const response = await POST(buildRequest([' super ', 'ultra']))
+      expect(response.status).toBe(200)
+      expect(query.update).toHaveBeenCalledWith(
+        expect.objectContaining({ custom_rarities: ['super', 'ultra'] })
+      )
+    })
+
+    it('does not trigger drop-rate recalculation', async () => {
+      await mockOk()
+      const response = await POST(buildRequest(['super']))
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.recalculatedCards).toBeNull()
     })
   })
 


### PR DESCRIPTION
input+datalist は入力欄の現在値に部分一致する候補のみ表示する仕様のため、
初期値 "common" が入っているとコモンしか選べなかった。select に変更し、
デフォルト4種＋カスタムレアリティを常に全件表示できるようにした。

https://claude.ai/code/session_01KDPDzBdcfXZJaJLkbL4SrJ