### PR TITLE
Add gacha drop stats fallback aggregation from history

### DIFF
--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -767,6 +767,128 @@ async function fetchChannelPointUsageStatsFromHistory(
 
 
 /**
+ * Fallback drop-rate aggregation computed directly from gacha_history + cards.
+ *
+ * get_gacha_drop_stats（RPC, migration 00038）が本番に未デプロイ、または
+ * 実行時エラーで失敗した場合、getGachaStats はフォールバック無しだと
+ * totalDraws=0 を返し、配信者には毎日大量にガチャが回っていても
+ * 「この期間にはガチャデータがありません。」と誤表示されてしまう。
+ * channelPointStats が fetchChannelPointUsageStatsFromHistory で
+ * 同様に救済されているのと対称になるよう、ここでも履歴から直接集計する。
+ *
+ * ロジックは RPC（migration 00038）および analysis/DropRateStats.tsx と
+ * 同一: 総数は count-only クエリで正確に取得し、カード別/レアリティ別の
+ * 内訳は上限 10000 件の履歴サンプルから集計する（PostgREST の行上限対策）。
+ */
+async function fetchGachaDropStatsFromHistory(
+  supabaseAdmin: ReturnType<typeof getSupabaseAdmin>,
+  streamerId: string,
+  fromDateIso: string
+): Promise<Omit<GachaStatsResult, "channelPointStats">> {
+  const FIXED_RARITIES = ["legendary", "epic", "rare", "common"] as const;
+  const emptyRarityStats = FIXED_RARITIES.map((rarity) => ({
+    rarity,
+    count: 0,
+    rate: 0,
+  }));
+
+  const [countResult, historyResult, cardsResult] = await Promise.all([
+    supabaseAdmin
+      .from("gacha_history")
+      .select("id", { count: "exact", head: true })
+      .eq("streamer_id", streamerId)
+      .gte("redeemed_at", fromDateIso),
+    supabaseAdmin
+      .from("gacha_history")
+      .select("card_id, cards(rarity)")
+      .eq("streamer_id", streamerId)
+      .gte("redeemed_at", fromDateIso)
+      .limit(10000),
+    supabaseAdmin
+      .from("cards")
+      .select("id, name, rarity, image_url, drop_rate, rarity_order, created_at")
+      .eq("streamer_id", streamerId)
+      .eq("is_active", true)
+      .order("rarity_order", { ascending: true })
+      .order("created_at", { ascending: false }),
+  ]);
+
+  if (countResult.error || historyResult.error || cardsResult.error) {
+    reportError(
+      new Error(
+        `gacha drop stats fallback query failed: ${
+          countResult.error?.message ||
+          historyResult.error?.message ||
+          cardsResult.error?.message
+        }`
+      )
+    );
+    return { totalDraws: 0, cardStats: [], rarityStats: emptyRarityStats };
+  }
+
+  const totalDraws = countResult.count || 0;
+  // Supabase の型推論が select('card_id, cards(rarity)') に対して不完全なため明示キャスト
+  const history = (historyResult.data || []) as unknown as Array<{
+    card_id: string;
+    cards: { rarity: string } | null;
+  }>;
+  const cards = (cardsResult.data || []) as Array<{
+    id: string;
+    name: string;
+    rarity: string;
+    image_url: string | null;
+    drop_rate: number | string | null;
+    created_at: string;
+  }>;
+
+  const drawCounts = new Map<string, number>();
+  for (const row of history) {
+    drawCounts.set(row.card_id, (drawCounts.get(row.card_id) || 0) + 1);
+  }
+
+  const totalWeight = cards.reduce(
+    (sum, c) => sum + Number(c.drop_rate || 0),
+    0
+  );
+
+  const cardStats = cards.map((card) => {
+    const actualCount = drawCounts.get(card.id) || 0;
+    return {
+      cardId: card.id,
+      cardName: card.name,
+      rarity: card.rarity,
+      imageUrl: card.image_url,
+      configuredRate:
+        totalWeight > 0 ? (Number(card.drop_rate || 0) / totalWeight) * 100 : 0,
+      actualCount,
+      actualRate: totalDraws > 0 ? (actualCount / totalDraws) * 100 : 0,
+      ownerCount: 0,
+      owners: [] as GachaStatsOwner[],
+    };
+  });
+
+  // レアリティ別集計は履歴←cards の join から引く（RPC migration 00038 と同じく
+  // is_active 非依存）。非アクティブ化済みカードの過去排出も RPC と同様に計上される。
+  const rarityCounts = new Map<string, number>();
+  for (const row of history) {
+    const rarity = row.cards?.rarity;
+    if (rarity) {
+      rarityCounts.set(rarity, (rarityCounts.get(rarity) || 0) + 1);
+    }
+  }
+  const rarityStats = FIXED_RARITIES.map((rarity) => {
+    const count = rarityCounts.get(rarity) || 0;
+    return {
+      rarity,
+      count,
+      rate: totalDraws > 0 ? (count / totalDraws) * 100 : 0,
+    };
+  });
+
+  return { totalDraws, cardStats, rarityStats };
+}
+
+/**
  * Get gacha statistics for a streamer within a given period
  * Query gacha_history filtered by streamer_id and date range,
  * then compare actual draw counts against configured drop_rate
@@ -782,12 +904,13 @@ export async function getGachaStats(
   const now = new Date();
   const daysAgo = period === "7d" ? 7 : 30;
   const fromDate = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000);
+  const fromDateIso = fromDate.toISOString();
 
   const [dropStatsResult, ownerResult, channelPointResult] = await Promise.all([
     supabaseAdmin
       .rpc("get_gacha_drop_stats", {
         p_streamer_id: streamerId,
-        p_from_date: fromDate.toISOString(),
+        p_from_date: fromDateIso,
       }),
     supabaseAdmin
       .from("user_cards")
@@ -808,15 +931,28 @@ export async function getGachaStats(
       }),
   ]);
 
-  const dropStats = parseGachaDropStatsRpc(dropStatsResult.data) || {
-    totalDraws: 0,
-    cardStats: [],
-    rarityStats: ["legendary", "epic", "rare", "common"].map((rarity) => ({
-      rarity,
-      count: 0,
-      rate: 0,
-    })),
-  };
+  // RPC が使えない場合（未デプロイ=42883 や実行時エラー）は履歴から直接集計する。
+  // ここで握り潰すと配信者には恒久的に「データなし」と誤表示されるため、
+  // channelPointStats と同様にエラーを可観測化したうえでフォールバックする。
+  let dropStats = parseGachaDropStatsRpc(dropStatsResult.data);
+  if (!dropStats) {
+    if (dropStatsResult.error?.code === "42883") {
+      logger.warn(
+        "get_gacha_drop_stats not deployed, falling back to history aggregation"
+      );
+    } else if (dropStatsResult.error) {
+      reportError(
+        new Error(
+          `get_gacha_drop_stats RPC failed: ${dropStatsResult.error.message}`
+        )
+      );
+    }
+    dropStats = await fetchGachaDropStatsFromHistory(
+      supabaseAdmin,
+      streamerId,
+      fromDateIso
+    );
+  }
   const channelPointStats =
     parseChannelPointUsageStatsRpc(channelPointResult.data) ||
     await fetchChannelPointUsageStatsFromHistory(supabaseAdmin, streamerId, 10);

--- a/tests/unit/gacha-stats-api.test.ts
+++ b/tests/unit/gacha-stats-api.test.ts
@@ -237,6 +237,123 @@ describe("GET /api/gacha-stats", () => {
     });
   });
 
+  it("aggregates drop stats from history when get_gacha_drop_stats RPC errors", async () => {
+    const session = {
+      twitchUserId: "streamer1",
+      twitchUsername: "streamer1",
+      twitchDisplayName: "Streamer 1",
+      twitchProfileImageUrl: "",
+      broadcasterType: "affiliate",
+      expiresAt: Date.now() + 100000,
+      version: 1,
+    };
+    mockGetSession.mockResolvedValue(session);
+    mockCanUseStreamerFeatures.mockReturnValue(true);
+
+    const streamerQuery = createMockQueryBuilder();
+    (streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue(
+      createMockResponse({ id: "streamer-id-1" })
+    );
+
+    const thenable = (response: unknown) => {
+      const q = createMockQueryBuilder();
+      Object.assign(q, {
+        then: Promise.resolve(response).then.bind(Promise.resolve(response)),
+      });
+      return q;
+    };
+
+    // 1回目の gacha_history = count-only クエリ、2回目 = 履歴サンプル
+    const countQuery = thenable({ count: 3, error: null });
+    const historySampleQuery = thenable({
+      data: [
+        { card_id: "c1", cards: { rarity: "common" } },
+        { card_id: "c1", cards: { rarity: "common" } },
+        { card_id: "c2", cards: { rarity: "legendary" } },
+      ],
+      error: null,
+    });
+    const cardsQuery = thenable({
+      data: [
+        {
+          id: "c1",
+          name: "Card1",
+          rarity: "common",
+          image_url: null,
+          drop_rate: 7,
+          rarity_order: 4,
+          created_at: "2026-01-02T00:00:00Z",
+        },
+        {
+          id: "c2",
+          name: "Card2",
+          rarity: "legendary",
+          image_url: null,
+          drop_rate: 3,
+          rarity_order: 1,
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      error: null,
+    });
+    const ownersQuery = thenable({ data: [], error: null });
+
+    let gachaHistoryCalls = 0;
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "streamers") return streamerQuery;
+        if (table === "user_cards") return ownersQuery;
+        if (table === "cards") return cardsQuery;
+        if (table === "gacha_history") {
+          gachaHistoryCalls += 1;
+          return gachaHistoryCalls === 1 ? countQuery : historySampleQuery;
+        }
+        return createMockQueryBuilder();
+      }),
+      rpc: vi.fn((functionName: string) => {
+        if (functionName === "get_gacha_drop_stats") {
+          return Promise.resolve({
+            data: null,
+            error: { code: "P0001", message: "boom" },
+          });
+        }
+        return Promise.resolve({
+          data: { total_points: 0, ranking: [] },
+          error: null,
+        });
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await GET(createRequest({ period: "7d" }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.totalDraws).toBe(3);
+    expect(body.cardStats).toHaveLength(2);
+
+    const c1 = body.cardStats.find(
+      (c: { cardId: string }) => c.cardId === "c1"
+    );
+    const c2 = body.cardStats.find(
+      (c: { cardId: string }) => c.cardId === "c2"
+    );
+    expect(c1.actualCount).toBe(2);
+    expect(c1.configuredRate).toBeCloseTo(70);
+    expect(c1.actualRate).toBeCloseTo((2 / 3) * 100);
+    expect(c2.actualCount).toBe(1);
+    expect(c2.configuredRate).toBeCloseTo(30);
+    expect(c2.actualRate).toBeCloseTo((1 / 3) * 100);
+
+    const common = body.rarityStats.find(
+      (r: { rarity: string }) => r.rarity === "common"
+    );
+    const legendary = body.rarityStats.find(
+      (r: { rarity: string }) => r.rarity === "legendary"
+    );
+    expect(common.count).toBe(2);
+    expect(legendary.count).toBe(1);
+  });
+
   it("falls back to history aggregation when the channel point stats RPC is not deployed", async () => {
     const session = {
       twitchUserId: "streamer1",


### PR DESCRIPTION
## 概要

`get_gacha_drop_stats` RPC が本番環境に未デプロイまたは実行時エラーで失敗した場合に、ガチャ履歴から直接集計するフォールバック機能を追加しました。これにより、配信者が実際にはガチャを回していても「この期間にはガチャデータがありません」と誤表示される問題を解決します。

## 主な変更

- **`fetchGachaDropStatsFromHistory` 関数の追加**
  - `gacha_history` テーブルから直接ドロップ率統計を集計するフォールバック実装
  - 総数は count-only クエリで正確に取得し、カード別/レアリティ別の内訳は上限 10,000 件の履歴サンプルから集計（PostgREST の行上限対策）
  - RPC（migration 00038）および `analysis/DropRateStats.tsx` と同一のロジックを実装

- **`getGachaStats` 関数の改善**
  - RPC 実行結果が null の場合にフォールバック処理を実行
  - エラーコード `42883`（関数未定義）の場合は warn ログ、その他のエラーは `reportError` で可観測化
  - `channelPointStats` と同様の対称的なエラーハンドリングパターンを採用

- **テストケースの追加**
  - RPC エラー時に履歴から正確に集計されることを検証
  - カード別の実績数・設定レート・実績レートの計算正確性を確認
  - レアリティ別集計の正確性を確認

## 実装の詳細

- 非アクティブ化済みカードの過去排出も RPC と同様に計上される（`is_active` 非依存）
- Supabase の型推論が不完全な `select('card_id, cards(rarity)')` に対して明示的なキャストを実施
- エラーハンドリングは既存の `channelPointStats` フォールバックと一貫性を保つ

https://claude.ai/code/session_01CmsiANETxco7E7YbNHC2q7