### PR TITLE
Add per-card drawer stats and all-time owner statistics

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1031,11 +1031,17 @@
     "tabs": {
       "7d": "7 Days",
       "30d": "30 Days",
-      "channelPoints": "Channel Points"
+      "channelPoints": "Channel Points",
+      "byCard": "By Card"
     },
     "totalDraws": "Total Draws",
     "draws": "draws",
+    "period": {
+      "7d": "7 Days",
+      "30d": "30 Days"
+    },
     "noData": "No gacha data for this period.",
+    "noCardData": "No cards.",
     "channelPointRanking": {
       "title": "Channel Point Usage Ranking (Since Tracking Started)",
       "total": "Total since tracking started: {points} points",
@@ -1052,6 +1058,9 @@
       "configuredRate": "Configured Rate",
       "actualRate": "Actual Rate",
       "drawCount": "Draw Count",
+      "drawers": "Players Who Drew",
+      "drawerCount": "{count} users",
+      "noDrawers": "No players drew this",
       "owners": "Owners",
       "ownerCount": "{count} users",
       "noOwners": "No owners"

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1028,11 +1028,17 @@
     "tabs": {
       "7d": "7日間",
       "30d": "30日間",
-      "channelPoints": "チャネルポイント"
+      "channelPoints": "チャネルポイント",
+      "byCard": "カード別"
     },
     "totalDraws": "総ガチャ回数",
     "draws": "回",
+    "period": {
+      "7d": "7日間",
+      "30d": "30日間"
+    },
     "noData": "この期間にはガチャデータがありません。",
+    "noCardData": "カードがありません。",
     "channelPointRanking": {
       "title": "チャネルポイント使用ランキング（記録開始後）",
       "total": "記録開始後合計: {points} ポイント",
@@ -1049,6 +1055,9 @@
       "configuredRate": "設定排出率",
       "actualRate": "実際の排出率",
       "drawCount": "排出回数",
+      "drawers": "引いたユーザー",
+      "drawerCount": "{count}人",
+      "noDrawers": "引いたユーザーなし",
       "owners": "所持ユーザー",
       "ownerCount": "{count}人",
       "noOwners": "所持ユーザーなし"

--- a/src/app/api/gacha-stats/route.ts
+++ b/src/app/api/gacha-stats/route.ts
@@ -8,7 +8,7 @@ import {
   getRateLimitIdentifier,
 } from "@/lib/rate-limit";
 import { ERROR_MESSAGES } from "@/lib/constants";
-import { getGachaStats } from "@/lib/dashboard-data";
+import { getGachaStats, getGachaCardOwnerStats } from "@/lib/dashboard-data";
 
 /**
  * GET /api/gacha-stats
@@ -65,9 +65,10 @@ export async function GET(request: NextRequest) {
 
     // Validate period parameter
     // period パラメータのバリデーション
-    if (period !== "7d" && period !== "30d") {
+    // "byCard": 全期間のカード別所持ユーザー統計（「カード別」タブ用）
+    if (period !== "7d" && period !== "30d" && period !== "byCard") {
       return NextResponse.json(
-        { error: "Invalid period. Must be '7d' or '30d'." },
+        { error: "Invalid period. Must be '7d', '30d', or 'byCard'." },
         { status: 400 }
       );
     }
@@ -84,6 +85,11 @@ export async function GET(request: NextRequest) {
         { error: ERROR_MESSAGES.STREAMER_NOT_FOUND },
         { status: 404 }
       );
+    }
+
+    if (period === "byCard") {
+      const cardOwnerStats = await getGachaCardOwnerStats(streamer.id);
+      return NextResponse.json(cardOwnerStats);
     }
 
     const stats = await getGachaStats(streamer.id, period);

--- a/src/components/DropRateTable.tsx
+++ b/src/components/DropRateTable.tsx
@@ -14,6 +14,21 @@ interface CardStat {
   configuredRate: number;
   actualCount: number;
   actualRate: number;
+  // 期間内にそのカードを引いたユーザー（所持ユーザーではない）
+  drawerCount: number;
+  drawers: Array<{
+    userTwitchId: string;
+    username: string;
+    drawCount: number;
+    lastDrawnAt: string;
+  }>;
+}
+
+interface CardOwnerStat {
+  cardId: string;
+  cardName: string;
+  rarity: string;
+  imageUrl: string | null;
   ownerCount: number;
   owners: Array<{
     userTwitchId: string;
@@ -46,7 +61,11 @@ interface GachaStatsData {
   rarityStats: RarityStat[];
 }
 
-type StatsTab = "7d" | "30d" | "channelPoints";
+interface CardOwnerStatsData {
+  cardStats: CardOwnerStat[];
+}
+
+type StatsTab = "7d" | "30d" | "channelPoints" | "byCard";
 
 /**
  * Drop rate comparison table for streamer statistics page
@@ -60,12 +79,24 @@ export default function DropRateTable() {
 
   const [activeTab, setActiveTab] = useState<StatsTab>("7d");
   const [stats, setStats] = useState<GachaStatsData | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [cardOwnerStats, setCardOwnerStats] =
+    useState<CardOwnerStatsData | null>(null);
+  // 期間統計とカード別統計は独立して非同期取得するため、
+  // スピナー状態を分離する（一方のフェッチ中に他方タブへ戻っても
+  // スピナーが残らないようにする）。
+  const [periodLoading, setPeriodLoading] = useState(true);
+  const [cardOwnerLoading, setCardOwnerLoading] = useState(false);
+  // 期間統計の取得期間。channelPoints タブは 7d 取得分の
+  // channelPointStats を流用するため 7d 扱いとする。
   const period = activeTab === "30d" ? "30d" : "7d";
+  const loading = activeTab === "byCard" ? cardOwnerLoading : periodLoading;
 
+  // 期間統計（7日/30日、およびチャネルポイントランキングの土台）。
+  // 「カード別」タブは期間に依存しないため別エフェクトで取得する。
   useEffect(() => {
+    if (activeTab === "byCard") return;
     const fetchStats = async () => {
-      setLoading(true);
+      setPeriodLoading(true);
       try {
         const res = await fetch(`/api/gacha-stats?period=${period}`);
         if (res.ok) {
@@ -73,11 +104,34 @@ export default function DropRateTable() {
           setStats(data);
         }
       } finally {
-        setLoading(false);
+        setPeriodLoading(false);
       }
     };
     fetchStats();
+    // 依存は period のみ。activeTab を含めると 7日↔ランキング 等の
+    // 同一 period 間タブ切替でも RPC を二重に叩き、DB負荷低減の目的に
+    // 反するため。period が変わらない限り取得済み stats を再利用する。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [period]);
+
+  // 「カード別」タブ用: 全期間のカード別所持ユーザー統計を遅延取得。
+  // 一度取得したらタブ切替で再フェッチしない（DB負荷低減）。
+  useEffect(() => {
+    if (activeTab !== "byCard" || cardOwnerStats) return;
+    const fetchCardOwnerStats = async () => {
+      setCardOwnerLoading(true);
+      try {
+        const res = await fetch(`/api/gacha-stats?period=byCard`);
+        if (res.ok) {
+          const data = await res.json();
+          setCardOwnerStats(data);
+        }
+      } finally {
+        setCardOwnerLoading(false);
+      }
+    };
+    fetchCardOwnerStats();
+  }, [activeTab, cardOwnerStats]);
 
   /**
    * Highlight rows where actual rate deviates significantly from configured rate
@@ -212,7 +266,7 @@ export default function DropRateTable() {
                 <th className="p-3 text-right">
                   {t("dropRateTable.drawCount")}
                 </th>
-                <th className="p-3">{t("dropRateTable.owners")}</th>
+                <th className="p-3">{t("dropRateTable.drawers")}</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-700">
@@ -266,28 +320,28 @@ export default function DropRateTable() {
                   <td className="p-3">
                     <div className="min-w-48 max-w-xs">
                       <div className="text-sm font-medium text-white">
-                        {t("dropRateTable.ownerCount", {
-                          count: card.ownerCount,
+                        {t("dropRateTable.drawerCount", {
+                          count: card.drawerCount,
                         })}
                       </div>
-                      {card.owners.length > 0 ? (
+                      {card.drawers.length > 0 ? (
                         <div className="mt-1 flex flex-wrap gap-1">
-                          {card.owners.map((owner) => (
+                          {card.drawers.map((drawer) => (
                             <span
-                              key={owner.userTwitchId}
+                              key={drawer.userTwitchId}
                               className="rounded bg-gray-700 px-2 py-0.5 text-xs text-gray-200"
-                              title={owner.userTwitchId}
+                              title={drawer.userTwitchId}
                             >
-                              {owner.displayName || owner.username}
-                              {owner.ownedCount > 1
-                                ? ` x${owner.ownedCount}`
+                              {drawer.username}
+                              {drawer.drawCount > 1
+                                ? ` x${drawer.drawCount}`
                                 : ""}
                             </span>
                           ))}
                         </div>
                       ) : (
                         <div className="mt-1 text-xs text-gray-500">
-                          {t("dropRateTable.noOwners")}
+                          {t("dropRateTable.noDrawers")}
                         </div>
                       )}
                     </div>
@@ -301,11 +355,103 @@ export default function DropRateTable() {
     );
   };
 
+  // 「カード別」タブ: 全期間のカード別所持ユーザー一覧
+  const renderCardOwnerStats = () => {
+    if (!cardOwnerStats) return null;
+
+    if (cardOwnerStats.cardStats.length === 0) {
+      return (
+        <div className="py-12 text-center text-gray-400">
+          {t("noCardData")}
+        </div>
+      );
+    }
+
+    return (
+      <div className="overflow-x-auto rounded-xl bg-gray-800">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-700 text-left text-gray-400">
+              <th className="p-3">{t("dropRateTable.cardName")}</th>
+              <th className="p-3">{t("dropRateTable.rarity")}</th>
+              <th className="p-3">{t("dropRateTable.owners")}</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-700">
+            {cardOwnerStats.cardStats.map((card) => (
+              <tr key={card.cardId}>
+                <td className="p-3">
+                  <div className="flex items-center gap-2">
+                    <div className="h-8 w-8 flex-shrink-0 overflow-hidden rounded bg-gray-700">
+                      {card.imageUrl ? (
+                        <Image
+                          src={getOptimizedImageUrl(card.imageUrl, "icon")}
+                          alt={card.cardName}
+                          width={32}
+                          height={32}
+                          className="h-full w-full object-cover"
+                          unoptimized
+                        />
+                      ) : (
+                        <div className="flex h-full items-center justify-center text-sm">
+                          🎴
+                        </div>
+                      )}
+                    </div>
+                    <span className="text-white">{card.cardName}</span>
+                  </div>
+                </td>
+                <td className="p-3">
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-xs text-white ${getRarityColorClass(
+                      card.rarity
+                    )}`}
+                  >
+                    {formatRarityLabel(card.rarity, tRarity)}
+                  </span>
+                </td>
+                <td className="p-3">
+                  <div className="min-w-48 max-w-xs">
+                    <div className="text-sm font-medium text-white">
+                      {t("dropRateTable.ownerCount", {
+                        count: card.ownerCount,
+                      })}
+                    </div>
+                    {card.owners.length > 0 ? (
+                      <div className="mt-1 flex flex-wrap gap-1">
+                        {card.owners.map((owner) => (
+                          <span
+                            key={owner.userTwitchId}
+                            className="rounded bg-gray-700 px-2 py-0.5 text-xs text-gray-200"
+                            title={owner.userTwitchId}
+                          >
+                            {owner.displayName || owner.username}
+                            {owner.ownedCount > 1
+                              ? ` x${owner.ownedCount}`
+                              : ""}
+                          </span>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="mt-1 text-xs text-gray-500">
+                        {t("dropRateTable.noOwners")}
+                      </div>
+                    )}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  };
+
   return (
     <div>
       {/* Period tabs / 期間タブ */}
       <div className="mb-6 flex flex-wrap gap-2">
-        {(["7d", "30d", "channelPoints"] as const).map((tab) => (
+        {(["7d", "30d", "channelPoints", "byCard"] as const).map((tab) => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}
@@ -324,6 +470,12 @@ export default function DropRateTable() {
         <div className="py-12 text-center text-gray-400">
           <div className="inline-block h-6 w-6 animate-spin rounded-full border-2 border-gray-500 border-t-purple-500" />
         </div>
+      ) : activeTab === "byCard" ? (
+        cardOwnerStats ? (
+          renderCardOwnerStats()
+        ) : (
+          <div className="py-12 text-center text-gray-400">{t("noData")}</div>
+        )
       ) : !stats ? (
         <div className="py-12 text-center text-gray-400">{t("noData")}</div>
       ) : activeTab === "channelPoints" ? (
@@ -332,13 +484,19 @@ export default function DropRateTable() {
         renderPeriodStats()
       )}
 
-      {/* Full period stats notice / 全期間統計についてのお知らせ */}
-      <div className="mt-8 rounded-xl border border-gray-700 bg-gray-800/50 p-4">
-        <h4 className="mb-2 text-sm font-semibold text-gray-300">
-          {t("fullPeriodStats.title")}
-        </h4>
-        <p className="text-sm text-gray-400">{t("fullPeriodStats.message")}</p>
-      </div>
+      {/* Full period stats notice / 全期間統計についてのお知らせ
+          「カード別」タブは全期間の所持統計そのものなので、
+          「全期間統計は未実装」という告知と矛盾するため非表示にする。 */}
+      {activeTab !== "byCard" && (
+        <div className="mt-8 rounded-xl border border-gray-700 bg-gray-800/50 p-4">
+          <h4 className="mb-2 text-sm font-semibold text-gray-300">
+            {t("fullPeriodStats.title")}
+          </h4>
+          <p className="text-sm text-gray-400">
+            {t("fullPeriodStats.message")}
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -573,6 +573,33 @@ export interface GachaStatsResult {
     configuredRate: number;
     actualCount: number;
     actualRate: number;
+    // 期間内にそのカードを引いたユニークユーザー数とその一覧
+    // (所持ユーザーではなく、当該期間の排出履歴ベース)
+    drawerCount: number;
+    drawers: Array<{
+      userTwitchId: string;
+      username: string;
+      drawCount: number;
+      lastDrawnAt: string;
+    }>;
+  }>;
+  rarityStats: Array<{
+    rarity: string;
+    count: number;
+    rate: number;
+  }>;
+}
+
+/**
+ * Per-card all-time owner statistics for the "by card" tab.
+ * 「カード別」タブ用: 全期間のカード別所持ユーザー統計
+ */
+export interface GachaCardOwnerStatsResult {
+  cardStats: Array<{
+    cardId: string;
+    cardName: string;
+    rarity: string;
+    imageUrl: string | null;
     ownerCount: number;
     owners: Array<{
       userTwitchId: string;
@@ -581,11 +608,6 @@ export interface GachaStatsResult {
       ownedCount: number;
       lastObtainedAt: string;
     }>;
-  }>;
-  rarityStats: Array<{
-    rarity: string;
-    count: number;
-    rate: number;
   }>;
 }
 
@@ -604,6 +626,13 @@ interface ChannelPointUsageHistoryRow {
   redeemed_at: string | null;
 }
 
+interface GachaDropStatsRpcDrawerRow {
+  user_twitch_id: string;
+  username: string | null;
+  draw_count: number | string;
+  last_drawn_at: string | null;
+}
+
 interface GachaDropStatsRpcCardRow {
   card_id: string;
   card_name: string;
@@ -612,6 +641,8 @@ interface GachaDropStatsRpcCardRow {
   configured_rate: number | string;
   actual_count: number | string;
   actual_rate: number | string;
+  drawer_count?: number | string | null;
+  drawers?: GachaDropStatsRpcDrawerRow[] | null;
 }
 
 interface GachaDropStatsRpcRarityRow {
@@ -620,9 +651,29 @@ interface GachaDropStatsRpcRarityRow {
   rate: number | string;
 }
 
-type GachaStatsOwner = GachaStatsResult["cardStats"][number]["owners"][number];
+type GachaStatsDrawer = GachaStatsResult["cardStats"][number]["drawers"][number];
 
-type GachaStatsOwnerRow = {
+type GachaCardOwner =
+  GachaCardOwnerStatsResult["cardStats"][number]["owners"][number];
+
+interface CardOwnerStatsRpcOwnerRow {
+  user_twitch_id: string;
+  username: string | null;
+  display_name: string | null;
+  owned_count: number | string;
+  last_obtained_at: string | null;
+}
+
+interface CardOwnerStatsRpcCardRow {
+  card_id: string;
+  card_name: string;
+  rarity: string;
+  image_url: string | null;
+  owner_count: number | string;
+  owners?: CardOwnerStatsRpcOwnerRow[] | null;
+}
+
+type GachaCardOwnerStatsOwnerRow = {
   card_id: string;
   obtained_at: string;
   users:
@@ -639,6 +690,11 @@ type GachaStatsOwnerRow = {
     | null;
 };
 
+// 1カードあたりに返すユーザー（引いた/所持）件数の上限。
+// JSONBペイロード肥大を防ぐためRPCと履歴フォールバックで共通化する
+// (RPC: get_gacha_drop_stats / get_card_owner_stats の p_limit_per_card 既定値と一致)。
+const STATS_USERS_PER_CARD_LIMIT = 100;
+
 function parseGachaDropStatsRpc(rpcResult: unknown): Omit<GachaStatsResult, "channelPointStats"> | null {
   if (!rpcResult || typeof rpcResult !== "object") return null;
 
@@ -648,6 +704,20 @@ function parseGachaDropStatsRpc(rpcResult: unknown): Omit<GachaStatsResult, "cha
     rarity_stats?: GachaDropStatsRpcRarityRow[] | null;
   };
   if (!Array.isArray(payload.card_stats) || !Array.isArray(payload.rarity_stats)) {
+    return null;
+  }
+
+  // デプロイ過渡期対策: 旧 get_gacha_drop_stats(2引数, migration 00050)が
+  // まだ稼働している場合、payload は有効だが drawers/drawer_count を欠く。
+  // この場合に成功扱いすると 7日/30日 タブの「引いたユーザー」が恒久的に
+  // 空表示になるため、スキーマが古いとみなして null を返し、呼び出し側で
+  // 履歴フォールバック(fetchGachaDropStatsFromHistory)に切り替えさせる。
+  // card_stats が空(=カード未登録)の場合は表示対象が無く判別不能なので
+  // そのまま空結果として返す（フォールバックも同じく空を返す）。
+  if (
+    payload.card_stats.length > 0 &&
+    !("drawer_count" in payload.card_stats[0])
+  ) {
     return null;
   }
 
@@ -661,8 +731,13 @@ function parseGachaDropStatsRpc(rpcResult: unknown): Omit<GachaStatsResult, "cha
       configuredRate: Number(row.configured_rate || 0),
       actualCount: Number(row.actual_count || 0),
       actualRate: Number(row.actual_rate || 0),
-      ownerCount: 0,
-      owners: [],
+      drawerCount: Number(row.drawer_count || 0),
+      drawers: (Array.isArray(row.drawers) ? row.drawers : []).map((d) => ({
+        userTwitchId: d.user_twitch_id,
+        username: d.username || d.user_twitch_id,
+        drawCount: Number(d.draw_count || 0),
+        lastDrawnAt: d.last_drawn_at || "",
+      })),
     })),
     rarityStats: payload.rarity_stats.map((row) => ({
       rarity: row.rarity,
@@ -800,7 +875,9 @@ async function fetchGachaDropStatsFromHistory(
       .gte("redeemed_at", fromDateIso),
     supabaseAdmin
       .from("gacha_history")
-      .select("card_id, cards(rarity)")
+      .select(
+        "card_id, user_twitch_id, user_twitch_username, redeemed_at, cards(rarity)"
+      )
       .eq("streamer_id", streamerId)
       .gte("redeemed_at", fromDateIso)
       .limit(10000),
@@ -830,6 +907,9 @@ async function fetchGachaDropStatsFromHistory(
   // Supabase の型推論が select('card_id, cards(rarity)') に対して不完全なため明示キャスト
   const history = (historyResult.data || []) as unknown as Array<{
     card_id: string;
+    user_twitch_id: string;
+    user_twitch_username: string | null;
+    redeemed_at: string | null;
     cards: { rarity: string } | null;
   }>;
   const cards = (cardsResult.data || []) as Array<{
@@ -842,8 +922,32 @@ async function fetchGachaDropStatsFromHistory(
   }>;
 
   const drawCounts = new Map<string, number>();
+  // 期間内にそのカードを引いたユーザーをカード×ユーザーで集計。
+  // RPC(get_gacha_drop_stats)と同じく1カードあたり上限件数で打ち切る。
+  const drawersByCard = new Map<string, Map<string, GachaStatsDrawer>>();
   for (const row of history) {
     drawCounts.set(row.card_id, (drawCounts.get(row.card_id) || 0) + 1);
+
+    if (!row.user_twitch_id) continue;
+    const cardDrawers = drawersByCard.get(row.card_id) || new Map();
+    const existing = cardDrawers.get(row.user_twitch_id);
+    if (existing) {
+      existing.drawCount += 1;
+      if (row.redeemed_at && row.redeemed_at > existing.lastDrawnAt) {
+        existing.lastDrawnAt = row.redeemed_at;
+      }
+      if (row.user_twitch_username) {
+        existing.username = row.user_twitch_username;
+      }
+    } else {
+      cardDrawers.set(row.user_twitch_id, {
+        userTwitchId: row.user_twitch_id,
+        username: row.user_twitch_username || row.user_twitch_id,
+        drawCount: 1,
+        lastDrawnAt: row.redeemed_at || "",
+      });
+    }
+    drawersByCard.set(row.card_id, cardDrawers);
   }
 
   const totalWeight = cards.reduce(
@@ -853,6 +957,15 @@ async function fetchGachaDropStatsFromHistory(
 
   const cardStats = cards.map((card) => {
     const actualCount = drawCounts.get(card.id) || 0;
+    const allDrawers = Array.from(
+      drawersByCard.get(card.id)?.values() || []
+    ).sort(
+      (a, b) =>
+        b.drawCount - a.drawCount ||
+        // redeemed_at が NULL のとき lastDrawnAt は "" になりうる。
+        // Date.parse("") は NaN でソート比較が不定になるため 0 にフォールバック。
+        ((Date.parse(b.lastDrawnAt) || 0) - (Date.parse(a.lastDrawnAt) || 0))
+    );
     return {
       cardId: card.id,
       cardName: card.name,
@@ -862,8 +975,8 @@ async function fetchGachaDropStatsFromHistory(
         totalWeight > 0 ? (Number(card.drop_rate || 0) / totalWeight) * 100 : 0,
       actualCount,
       actualRate: totalDraws > 0 ? (actualCount / totalDraws) * 100 : 0,
-      ownerCount: 0,
-      owners: [] as GachaStatsOwner[],
+      drawerCount: allDrawers.length,
+      drawers: allDrawers.slice(0, STATS_USERS_PER_CARD_LIMIT),
     };
   });
 
@@ -906,23 +1019,16 @@ export async function getGachaStats(
   const fromDate = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000);
   const fromDateIso = fromDate.toISOString();
 
-  const [dropStatsResult, ownerResult, channelPointResult] = await Promise.all([
+  // 所持ユーザーの全件フェッチ(user_cards .range(0,9999))は廃止。
+  // 期間タブでは「その期間にそのカードを引いたユーザー」を
+  // get_gacha_drop_stats が gacha_history からDB側で集計して返す。
+  // 全期間の所持ユーザーは「カード別」タブ(getGachaCardOwnerStats)に分離。
+  const [dropStatsResult, channelPointResult] = await Promise.all([
     supabaseAdmin
       .rpc("get_gacha_drop_stats", {
         p_streamer_id: streamerId,
         p_from_date: fromDateIso,
       }),
-    supabaseAdmin
-      .from("user_cards")
-      .select(`
-        card_id,
-        obtained_at,
-        users!inner(twitch_user_id, twitch_username, twitch_display_name),
-        cards!inner(streamer_id, is_active)
-      `)
-      .eq("cards.streamer_id", streamerId)
-      .eq("cards.is_active", true)
-      .range(0, 9999),
     supabaseAdmin
       .rpc("get_channel_point_usage_stats", {
         p_streamer_id: streamerId,
@@ -946,6 +1052,12 @@ export async function getGachaStats(
           `get_gacha_drop_stats RPC failed: ${dropStatsResult.error.message}`
         )
       );
+    } else {
+      // エラーは無いが parse が null = 旧スキーマ(drawers 欠落)。
+      // 00052 デプロイ完了までの過渡期。履歴集計でドロワーを補う。
+      logger.warn(
+        "get_gacha_drop_stats returned stale schema (no drawers), falling back to history aggregation"
+      );
     }
     dropStats = await fetchGachaDropStatsFromHistory(
       supabaseAdmin,
@@ -965,9 +1077,125 @@ export async function getGachaStats(
     }
   }
 
-  const ownersByCard = new Map<string, Map<string, GachaStatsOwner>>();
+  return { ...dropStats, channelPointStats };
+}
 
-  for (const row of (ownerResult.data || []) as GachaStatsOwnerRow[]) {
+/**
+ * Get all-time per-card owner statistics for a streamer ("by card" tab).
+ * Reads the trigger-maintained card_owner_stats aggregation table via RPC
+ * instead of fetching every user_cards row on each request.
+ * 配信者向け: 「カード別」タブ用の全期間カード別所持ユーザー統計を取得。
+ * リクエストごとに user_cards を全件フェッチせず、トリガーで維持される
+ * 集計テーブル card_owner_stats を RPC 経由で読むことでDB負荷を下げる。
+ */
+export async function getGachaCardOwnerStats(
+  streamerId: string
+): Promise<GachaCardOwnerStatsResult> {
+  const supabaseAdmin = getSupabaseAdmin();
+
+  const rpcResult = await supabaseAdmin.rpc("get_card_owner_stats", {
+    p_streamer_id: streamerId,
+  });
+
+  const parsed = parseCardOwnerStatsRpc(rpcResult.data);
+  if (parsed) {
+    return parsed;
+  }
+
+  // RPC が未デプロイ(42883)/実行時エラーの場合は、旧来の user_cards 集計に
+  // フォールバックして「データなし」の誤表示を防ぐ。
+  if (rpcResult.error?.code === "42883") {
+    logger.warn(
+      "get_card_owner_stats not deployed, falling back to user_cards aggregation"
+    );
+  } else if (rpcResult.error) {
+    reportError(
+      new Error(`get_card_owner_stats RPC failed: ${rpcResult.error.message}`)
+    );
+  }
+  return fetchCardOwnerStatsFromUserCards(supabaseAdmin, streamerId);
+}
+
+function parseCardOwnerStatsRpc(
+  rpcResult: unknown
+): GachaCardOwnerStatsResult | null {
+  if (!rpcResult || typeof rpcResult !== "object") return null;
+
+  const payload = rpcResult as {
+    card_stats?: CardOwnerStatsRpcCardRow[] | null;
+  };
+  if (!Array.isArray(payload.card_stats)) return null;
+
+  return {
+    cardStats: payload.card_stats.map((row) => ({
+      cardId: row.card_id,
+      cardName: row.card_name,
+      rarity: row.rarity,
+      imageUrl: row.image_url,
+      ownerCount: Number(row.owner_count || 0),
+      owners: (Array.isArray(row.owners) ? row.owners : []).map((o) => ({
+        userTwitchId: o.user_twitch_id,
+        username: o.username || o.user_twitch_id,
+        displayName: o.display_name || o.username || o.user_twitch_id,
+        ownedCount: Number(o.owned_count || 0),
+        lastObtainedAt: o.last_obtained_at || "",
+      })),
+    })),
+  };
+}
+
+/**
+ * Fallback all-time owner aggregation computed directly from user_cards.
+ * Mirrors the pre-aggregation-table behavior so the "by card" tab keeps
+ * working when get_card_owner_stats (00051) is not yet deployed.
+ * get_card_owner_stats 未デプロイ時のフォールバック。集計テーブル導入前と
+ * 同じく user_cards から直接集計する（PostgREST 行上限対策で上限1万件）。
+ */
+async function fetchCardOwnerStatsFromUserCards(
+  supabaseAdmin: ReturnType<typeof getSupabaseAdmin>,
+  streamerId: string
+): Promise<GachaCardOwnerStatsResult> {
+  const [cardsResult, ownerResult] = await Promise.all([
+    supabaseAdmin
+      .from("cards")
+      .select("id, name, rarity, image_url, rarity_order, created_at")
+      .eq("streamer_id", streamerId)
+      .eq("is_active", true)
+      .order("rarity_order", { ascending: true })
+      .order("created_at", { ascending: false }),
+    supabaseAdmin
+      .from("user_cards")
+      .select(`
+        card_id,
+        obtained_at,
+        users!inner(twitch_user_id, twitch_username, twitch_display_name),
+        cards!inner(streamer_id, is_active)
+      `)
+      .eq("cards.streamer_id", streamerId)
+      .eq("cards.is_active", true)
+      .range(0, 9999),
+  ]);
+
+  if (cardsResult.error || ownerResult.error) {
+    reportError(
+      new Error(
+        `card owner stats fallback query failed: ${
+          cardsResult.error?.message || ownerResult.error?.message
+        }`
+      )
+    );
+    return { cardStats: [] };
+  }
+
+  const cards = (cardsResult.data || []) as Array<{
+    id: string;
+    name: string;
+    rarity: string;
+    image_url: string | null;
+  }>;
+
+  const ownersByCard = new Map<string, Map<string, GachaCardOwner>>();
+  for (const row of (ownerResult.data || []) as GachaCardOwnerStatsOwnerRow[]) {
     const user = Array.isArray(row.users) ? row.users[0] : row.users;
     if (!user) continue;
 
@@ -981,8 +1209,11 @@ export async function getGachaStats(
     } else {
       cardOwners.set(user.twitch_user_id, {
         userTwitchId: user.twitch_user_id,
-        username: user.twitch_username || "",
-        displayName: user.twitch_display_name || user.twitch_username || "",
+        username: user.twitch_username || user.twitch_user_id,
+        displayName:
+          user.twitch_display_name ||
+          user.twitch_username ||
+          user.twitch_user_id,
         ownedCount: 1,
         lastObtainedAt: row.obtained_at,
       });
@@ -990,20 +1221,29 @@ export async function getGachaStats(
     ownersByCard.set(row.card_id, cardOwners);
   }
 
-  const cardStats = dropStats.cardStats.map((card) => {
-    const owners = Array.from(ownersByCard.get(card.cardId)?.values() || []).sort(
-      (a, b) =>
-        b.ownedCount - a.ownedCount ||
-        new Date(b.lastObtainedAt).getTime() - new Date(a.lastObtainedAt).getTime()
-    );
-    return {
-      ...card,
-      ownerCount: owners.length,
-      owners,
-    };
-  });
-
-  return { ...dropStats, cardStats, channelPointStats };
+  return {
+    cardStats: cards.map((card) => {
+      const owners = Array.from(
+        ownersByCard.get(card.id)?.values() || []
+      ).sort(
+        (a, b) =>
+          b.ownedCount - a.ownedCount ||
+          // obtained_at が NULL のとき lastObtainedAt は "" になりうるため
+          // Date.parse の NaN を 0 にフォールバックして比較を安定させる。
+          ((Date.parse(b.lastObtainedAt) || 0) -
+            (Date.parse(a.lastObtainedAt) || 0))
+      );
+      return {
+        cardId: card.id,
+        cardName: card.name,
+        rarity: card.rarity,
+        imageUrl: card.image_url,
+        // ownerCount は総数（打ち切り前）、owners はRPCと同じく上限件数で打ち切る
+        ownerCount: owners.length,
+        owners: owners.slice(0, STATS_USERS_PER_CARD_LIMIT),
+      };
+    }),
+  };
 }
 
 /**

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -660,6 +660,14 @@ export interface Database {
         Args: {
           p_streamer_id: string
           p_from_date: string
+          p_limit_per_card?: number
+        }
+        Returns: Json
+      }
+      get_card_owner_stats: {
+        Args: {
+          p_streamer_id: string
+          p_limit_per_card?: number
         }
         Returns: Json
       }

--- a/supabase/migrations/00051_add_card_owner_stats.sql
+++ b/supabase/migrations/00051_add_card_owner_stats.sql
@@ -1,0 +1,275 @@
+-- 「カード別」統計タブ用: カード所持ユーザーを全期間で集計する累積テーブル。
+--
+-- 旧実装は getGachaStats() のたびに user_cards を最大1万件フェッチして
+-- アプリ側で (card_id, user) ごとに集計していた。これは所持レコードが
+-- 増えるほどDB I/O とアプリのメモリ負荷が線形に増大し、PostgREST の
+-- 行上限（1万件）に達すると集計が欠落する問題もあった。
+--
+-- channel_point_usage_stats（00039）と同じ「トリガー維持の集計テーブル」
+-- パターンを踏襲し、user_cards への INSERT/UPDATE/DELETE のたびに
+-- 該当 (card_id, user) の1行だけを再集計する。読み取り時は
+-- card_owner_stats を card_id で引くだけになり、DB負荷を大幅に下げる。
+--
+-- 既知の制約: users 行が削除されると user_cards は ON DELETE CASCADE で
+-- 消えるが、その時点で users 行も消えているためトリガーから twitch_user_id
+-- を解決できず、card_owner_stats に孤児行が残りうる。これは
+-- channel_point_usage_stats と同じ best-effort な制約で、配信者向け
+-- 分析用途では許容する（アカウント削除は稀で実害が小さいため）。
+
+CREATE TABLE IF NOT EXISTS card_owner_stats (
+  streamer_id UUID NOT NULL REFERENCES streamers(id) ON DELETE CASCADE,
+  card_id UUID NOT NULL REFERENCES cards(id) ON DELETE CASCADE,
+  user_twitch_id TEXT NOT NULL,
+  username TEXT,
+  display_name TEXT,
+  owned_count INTEGER NOT NULL DEFAULT 0 CHECK (owned_count >= 0),
+  last_obtained_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (streamer_id, card_id, user_twitch_id)
+);
+
+-- カード別の所持ランキング読み出し（owned_count 降順 → 取得日時降順）を
+-- インデックスのみで解決するための複合インデックス。
+CREATE INDEX IF NOT EXISTS idx_card_owner_stats_card_rank
+  ON card_owner_stats(
+    streamer_id,
+    card_id,
+    owned_count DESC,
+    last_obtained_at DESC
+  );
+
+-- refresh_card_owner_stat はガチャ排出のたび（user_cards INSERT のホットパス）
+-- に発火し、WHERE card_id=? AND user_id=? で COUNT(*)/MAX(obtained_at) する。
+-- 00001 の単一列インデックス2本では BitmapAnd になり所持数が多いカード/
+-- ユーザーで遅くなるため、複合インデックスでインデックスオンリースキャン化する
+-- (00039 が gacha_history(streamer_id,user_twitch_id) 複合索引を用意したのと同様)。
+CREATE INDEX IF NOT EXISTS idx_user_cards_user_card
+  ON user_cards(user_id, card_id, obtained_at DESC);
+
+-- 指定 (card_id, user_id) の所持状況を user_cards から再集計し、
+-- card_owner_stats を1行だけ upsert/delete する。
+CREATE OR REPLACE FUNCTION refresh_card_owner_stat(
+  p_card_id UUID,
+  p_user_id UUID
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_streamer_id UUID;
+  v_twitch_user_id TEXT;
+  v_username TEXT;
+  v_display_name TEXT;
+  v_owned_count INTEGER;
+  v_last_obtained_at TIMESTAMPTZ;
+BEGIN
+  IF p_card_id IS NULL OR p_user_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT streamer_id INTO v_streamer_id
+  FROM cards
+  WHERE id = p_card_id;
+
+  SELECT twitch_user_id, twitch_username, twitch_display_name
+  INTO v_twitch_user_id, v_username, v_display_name
+  FROM users
+  WHERE id = p_user_id;
+
+  -- カード or ユーザーが解決できない場合は集計不能なのでスキップ。
+  IF v_streamer_id IS NULL OR v_twitch_user_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  SELECT COUNT(*)::INTEGER, MAX(obtained_at)
+  INTO v_owned_count, v_last_obtained_at
+  FROM user_cards
+  WHERE card_id = p_card_id
+    AND user_id = p_user_id;
+
+  IF v_owned_count = 0 THEN
+    DELETE FROM card_owner_stats
+    WHERE streamer_id = v_streamer_id
+      AND card_id = p_card_id
+      AND user_twitch_id = v_twitch_user_id;
+    RETURN;
+  END IF;
+
+  INSERT INTO card_owner_stats (
+    streamer_id,
+    card_id,
+    user_twitch_id,
+    username,
+    display_name,
+    owned_count,
+    last_obtained_at
+  )
+  VALUES (
+    v_streamer_id,
+    p_card_id,
+    v_twitch_user_id,
+    v_username,
+    v_display_name,
+    v_owned_count,
+    v_last_obtained_at
+  )
+  ON CONFLICT (streamer_id, card_id, user_twitch_id) DO UPDATE SET
+    username = EXCLUDED.username,
+    display_name = EXCLUDED.display_name,
+    owned_count = EXCLUDED.owned_count,
+    last_obtained_at = EXCLUDED.last_obtained_at,
+    updated_at = NOW();
+END;
+$$;
+
+-- user_cards の変更を card_owner_stats に反映するトリガー本体。
+-- UPDATE で card_id/user_id が変わるケースも考慮し、OLD/NEW 双方を再集計する。
+CREATE OR REPLACE FUNCTION sync_card_owner_stat()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF TG_OP IN ('UPDATE', 'DELETE') THEN
+    PERFORM refresh_card_owner_stat(OLD.card_id, OLD.user_id);
+  END IF;
+
+  IF TG_OP IN ('INSERT', 'UPDATE') THEN
+    PERFORM refresh_card_owner_stat(NEW.card_id, NEW.user_id);
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_sync_card_owner_stat ON user_cards;
+CREATE TRIGGER trg_sync_card_owner_stat
+AFTER INSERT OR UPDATE OR DELETE ON user_cards
+FOR EACH ROW
+EXECUTE FUNCTION sync_card_owner_stat();
+
+-- 既存 user_cards からの初期バックフィル。
+-- user_cards が大規模な場合に supabase db push の statement_timeout で
+-- マイグレーション全体がロールバックされるのを防ぐ。マイグレーションは
+-- トランザクション内なので SET LOCAL はこのトランザクション内に限定される。
+-- ON CONFLICT DO UPDATE により再実行は冪等。
+SET LOCAL statement_timeout = 0;
+
+INSERT INTO card_owner_stats (
+  streamer_id,
+  card_id,
+  user_twitch_id,
+  username,
+  display_name,
+  owned_count,
+  last_obtained_at
+)
+SELECT
+  c.streamer_id,
+  uc.card_id,
+  u.twitch_user_id,
+  MAX(u.twitch_username) AS username,
+  MAX(u.twitch_display_name) AS display_name,
+  COUNT(*)::INTEGER AS owned_count,
+  MAX(uc.obtained_at) AS last_obtained_at
+FROM user_cards uc
+JOIN cards c ON c.id = uc.card_id
+JOIN users u ON u.id = uc.user_id
+GROUP BY c.streamer_id, uc.card_id, u.twitch_user_id
+ON CONFLICT (streamer_id, card_id, user_twitch_id) DO UPDATE SET
+  username = EXCLUDED.username,
+  display_name = EXCLUDED.display_name,
+  owned_count = EXCLUDED.owned_count,
+  last_obtained_at = EXCLUDED.last_obtained_at,
+  updated_at = NOW();
+
+-- 「カード別」タブ用: 配信者のアクティブカードごとに所持ユーザーを返す。
+-- 所持者が1人もいないカードも LEFT JOIN で表示する（排出率テーブルと同様、
+-- カード一覧として欠落させない）。owners はカードごとに p_limit_per_card
+-- 件で打ち切り、JSONB ペイロードが青天井に膨らむのを防ぐ。
+CREATE OR REPLACE FUNCTION get_card_owner_stats(
+  p_streamer_id UUID,
+  p_limit_per_card INTEGER DEFAULT 100
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_card_stats JSONB;
+BEGIN
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'card_id', c.id,
+      'card_name', c.name,
+      'rarity', c.rarity,
+      'image_url', c.image_url,
+      'owner_count', COALESCE(oc.owner_count, 0),
+      'owners', COALESCE(ow.owners, '[]'::JSONB)
+    )
+    ORDER BY c.rarity_order ASC, c.created_at DESC
+  ), '[]'::JSONB)
+  INTO v_card_stats
+  FROM cards c
+  LEFT JOIN LATERAL (
+    SELECT COUNT(*)::BIGINT AS owner_count
+    FROM card_owner_stats s
+    WHERE s.streamer_id = p_streamer_id
+      AND s.card_id = c.id
+  ) oc ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT jsonb_agg(
+      jsonb_build_object(
+        'user_twitch_id', t.user_twitch_id,
+        'username', t.username,
+        'display_name', t.display_name,
+        'owned_count', t.owned_count,
+        'last_obtained_at', t.last_obtained_at
+      )
+      ORDER BY t.owned_count DESC, t.last_obtained_at DESC
+    ) AS owners
+    FROM (
+      SELECT
+        s.user_twitch_id,
+        s.username,
+        s.display_name,
+        s.owned_count,
+        s.last_obtained_at
+      FROM card_owner_stats s
+      WHERE s.streamer_id = p_streamer_id
+        AND s.card_id = c.id
+      ORDER BY s.owned_count DESC, s.last_obtained_at DESC
+      LIMIT GREATEST(1, p_limit_per_card)
+    ) t
+  ) ow ON TRUE
+  WHERE c.streamer_id = p_streamer_id
+    AND c.is_active = TRUE;
+
+  RETURN jsonb_build_object('card_stats', v_card_stats);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION refresh_card_owner_stat(UUID, UUID) FROM PUBLIC;
+REVOKE ALL ON FUNCTION sync_card_owner_stat() FROM PUBLIC;
+REVOKE ALL ON FUNCTION get_card_owner_stats(UUID, INTEGER) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_card_owner_stats(UUID, INTEGER) TO service_role;
+
+-- card_owner_stats は get_card_owner_stats() 経由でのみ参照する
+-- サーバーサイド集計テーブル。channel_point_usage_stats（00045/00047）と
+-- 同様に直接アクセスを閉じ、service_role のみ許可する。
+ALTER TABLE card_owner_stats ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Service role can manage card owner stats" ON card_owner_stats;
+CREATE POLICY "Service role can manage card owner stats"
+ON card_owner_stats
+FOR ALL
+TO service_role
+USING (true)
+WITH CHECK (true);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.card_owner_stats TO service_role;

--- a/supabase/migrations/00052_add_drawers_to_gacha_drop_stats.sql
+++ b/supabase/migrations/00052_add_drawers_to_gacha_drop_stats.sql
@@ -1,0 +1,176 @@
+-- get_gacha_drop_stats に「期間内にそのカードを引いたユーザー」を追加。
+--
+-- 旧来の統計ページは 7日/30日 タブにも全期間の「所持ユーザー」を表示して
+-- いたが、期間統計の文脈では「その期間にそのカードを引いたユーザー」を
+-- 見たいという要望のため、card_stats の各カードに drawers/drawer_count を
+-- 付与する。所持(user_cards)ではなく排出履歴(gacha_history)を期間で集計する。
+--
+-- 所持ユーザーは別途「カード別」タブ（get_card_owner_stats, 00051）で
+-- 全期間集計として表示するため、本RPCからは所持情報を返さない。
+--
+-- drawers はカードごとに p_limit_per_card 件で打ち切り、JSONB ペイロードが
+-- 青天井に膨らむのを防ぐ。total_draws / card_stats のレート計算と
+-- rarity_stats のロジックは 00050 から変更なし。
+
+CREATE OR REPLACE FUNCTION get_gacha_drop_stats(
+  p_streamer_id UUID,
+  p_from_date TIMESTAMPTZ,
+  p_limit_per_card INTEGER DEFAULT 100
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_total_draws BIGINT;
+  v_total_weight NUMERIC;
+  v_card_stats JSONB;
+  v_rarity_stats JSONB;
+BEGIN
+  SELECT COUNT(*)::BIGINT
+  INTO v_total_draws
+  FROM gacha_history
+  WHERE streamer_id = p_streamer_id
+    AND redeemed_at >= p_from_date;
+
+  SELECT COALESCE(SUM(drop_rate), 0)::NUMERIC
+  INTO v_total_weight
+  FROM cards
+  WHERE streamer_id = p_streamer_id
+    AND is_active = TRUE;
+
+  -- カードごとに gacha_history を引き直す N+1 な LATERAL を避け、
+  -- 期間内の履歴を一度だけ (card_id, user_twitch_id) で集計し、
+  -- ウィンドウ関数で「カード内の引いた回数ランキング」を付与する。
+  -- これにより gacha_history へのアクセスはカード数に依らず一定回数。
+  WITH draw_counts AS (
+    SELECT card_id, COUNT(*)::BIGINT AS draw_count
+    FROM gacha_history
+    WHERE streamer_id = p_streamer_id
+      AND redeemed_at >= p_from_date
+    GROUP BY card_id
+  ),
+  drawer_agg AS (
+    SELECT
+      gh.card_id,
+      gh.user_twitch_id,
+      COALESCE(MAX(gh.user_twitch_username), gh.user_twitch_id) AS username,
+      COUNT(*)::BIGINT AS draw_count,
+      MAX(gh.redeemed_at) AS last_drawn_at
+    FROM gacha_history gh
+    WHERE gh.streamer_id = p_streamer_id
+      AND gh.redeemed_at >= p_from_date
+    GROUP BY gh.card_id, gh.user_twitch_id
+  ),
+  drawer_ranked AS (
+    SELECT
+      da.*,
+      ROW_NUMBER() OVER (
+        PARTITION BY da.card_id
+        ORDER BY da.draw_count DESC, da.last_drawn_at DESC
+      ) AS rn
+    FROM drawer_agg da
+  ),
+  -- drawer_count はカード内の全ユニークユーザー数（打ち切り前）、
+  -- drawers は rn <= p_limit_per_card のみを JSONB 化（上位N件）。
+  drawer_by_card AS (
+    SELECT
+      dr.card_id,
+      COUNT(*)::BIGINT AS drawer_count,
+      jsonb_agg(
+        jsonb_build_object(
+          'user_twitch_id', dr.user_twitch_id,
+          'username', dr.username,
+          'draw_count', dr.draw_count,
+          'last_drawn_at', dr.last_drawn_at
+        )
+        ORDER BY dr.draw_count DESC, dr.last_drawn_at DESC
+      ) FILTER (WHERE dr.rn <= GREATEST(1, p_limit_per_card)) AS drawers
+    FROM drawer_ranked dr
+    GROUP BY dr.card_id
+  )
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'card_id', c.id,
+      'card_name', c.name,
+      'rarity', c.rarity,
+      'image_url', c.image_url,
+      'configured_rate', CASE
+        WHEN v_total_weight > 0 THEN (c.drop_rate / v_total_weight) * 100
+        ELSE 0
+      END,
+      'actual_count', COALESCE(dc.draw_count, 0),
+      'actual_rate', CASE
+        WHEN v_total_draws > 0 THEN (COALESCE(dc.draw_count, 0)::NUMERIC / v_total_draws) * 100
+        ELSE 0
+      END,
+      'drawer_count', COALESCE(dbc.drawer_count, 0),
+      'drawers', COALESCE(dbc.drawers, '[]'::JSONB)
+    )
+    ORDER BY c.rarity_order ASC, c.created_at DESC
+  ), '[]'::JSONB)
+  INTO v_card_stats
+  FROM cards c
+  LEFT JOIN draw_counts dc ON dc.card_id = c.id
+  LEFT JOIN drawer_by_card dbc ON dbc.card_id = c.id
+  WHERE c.streamer_id = p_streamer_id
+    AND c.is_active = TRUE;
+
+  WITH rarity_counts AS (
+    SELECT c.rarity, COUNT(*)::BIGINT AS draw_count
+    FROM gacha_history gh
+    JOIN cards c ON c.id = gh.card_id
+    WHERE gh.streamer_id = p_streamer_id
+      AND gh.redeemed_at >= p_from_date
+    GROUP BY c.rarity
+  ),
+  default_order AS (
+    SELECT *
+    FROM (VALUES
+      ('legendary'::TEXT, 1),
+      ('epic'::TEXT, 2),
+      ('rare'::TEXT, 3),
+      ('common'::TEXT, 4)
+    ) AS r(rarity, sort_order)
+  ),
+  -- デフォルト4種（排出0でも常に表示）＋ 実際に排出されたカスタムレアリティ。
+  -- カスタムは sort_order=5 でデフォルトの後ろ、名前順で安定整列する。
+  rarity_universe AS (
+    SELECT rarity, sort_order FROM default_order
+    UNION
+    SELECT rc.rarity, 5
+    FROM rarity_counts rc
+    WHERE rc.rarity NOT IN (SELECT rarity FROM default_order)
+  )
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'rarity', ru.rarity,
+      'count', COALESCE(rc.draw_count, 0),
+      'rate', CASE
+        WHEN v_total_draws > 0 THEN (COALESCE(rc.draw_count, 0)::NUMERIC / v_total_draws) * 100
+        ELSE 0
+      END
+    )
+    ORDER BY ru.sort_order, ru.rarity
+  )
+  INTO v_rarity_stats
+  FROM rarity_universe ru
+  LEFT JOIN rarity_counts rc ON rc.rarity = ru.rarity;
+
+  RETURN jsonb_build_object(
+    'total_draws', v_total_draws,
+    'card_stats', v_card_stats,
+    'rarity_stats', v_rarity_stats
+  );
+END;
+$$;
+
+-- 旧シグネチャ get_gacha_drop_stats(UUID, TIMESTAMPTZ) は本マイグレーションで
+-- 追加した3引数版に置き換わる。デフォルト引数付きで定義したため2引数呼び出し
+-- とも互換だが、PostgreSQL はデフォルト値の異なる同名関数を別関数として
+-- 保持するため、曖昧さ回避のため旧2引数版を明示的に削除する。
+DROP FUNCTION IF EXISTS get_gacha_drop_stats(UUID, TIMESTAMPTZ);
+
+REVOKE ALL ON FUNCTION get_gacha_drop_stats(UUID, TIMESTAMPTZ, INTEGER) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_gacha_drop_stats(UUID, TIMESTAMPTZ, INTEGER) TO service_role;

--- a/tests/unit/gacha-stats-api.test.ts
+++ b/tests/unit/gacha-stats-api.test.ts
@@ -76,7 +76,7 @@ describe("GET /api/gacha-stats", () => {
     expect(res.status).toBe(403);
   });
 
-  it("returns 400 for invalid period", async () => {
+  it("returns 400 for unknown period value", async () => {
     mockGetSession.mockResolvedValue({
       twitchUserId: "streamer1",
       twitchUsername: "streamer1",
@@ -126,6 +126,15 @@ describe("GET /api/gacha-stats", () => {
                 configured_rate: 100,
                 actual_count: 1001,
                 actual_rate: 100,
+                drawer_count: 1,
+                drawers: [
+                  {
+                    user_twitch_id: "viewer1",
+                    username: "alice",
+                    draw_count: 1001,
+                    last_drawn_at: "2026-01-02T00:00:00Z",
+                  },
+                ],
               },
             ],
             rarity_stats: [
@@ -156,41 +165,9 @@ describe("GET /api/gacha-stats", () => {
       });
     });
 
-    const ownersQuery = createMockQueryBuilder();
-    const ownersResponse = {
-      data: [
-        {
-          card_id: "c1",
-          obtained_at: "2026-01-01T00:00:00Z",
-          users: {
-            twitch_user_id: "viewer1",
-            twitch_username: "alice",
-            twitch_display_name: "Alice",
-          },
-        },
-        {
-          card_id: "c1",
-          obtained_at: "2026-01-02T00:00:00Z",
-          users: {
-            twitch_user_id: "viewer1",
-            twitch_username: "alice",
-            twitch_display_name: "Alice",
-          },
-        },
-      ],
-      error: null,
-    };
-    (ownersQuery as unknown as Record<string, unknown>).then = (
-      resolve: (value: unknown) => void
-    ) => {
-      resolve(ownersResponse);
-      return ownersQuery;
-    };
-
     mockGetSupabaseAdmin.mockReturnValue({
       from: vi.fn((table: string) => {
         if (table === "streamers") return streamerQuery;
-        if (table === "user_cards") return ownersQuery;
         return createMockQueryBuilder();
       }),
       rpc,
@@ -205,14 +182,13 @@ describe("GET /api/gacha-stats", () => {
     expect(body.cardStats[0].cardName).toBe("Card1");
     expect(body.cardStats[0].actualCount).toBe(1001);
     expect(body.cardStats[0].actualRate).toBe(100);
-    expect(body.cardStats[0].ownerCount).toBe(1);
-    expect(body.cardStats[0].owners).toEqual([
+    expect(body.cardStats[0].drawerCount).toBe(1);
+    expect(body.cardStats[0].drawers).toEqual([
       {
         userTwitchId: "viewer1",
         username: "alice",
-        displayName: "Alice",
-        ownedCount: 2,
-        lastObtainedAt: "2026-01-02T00:00:00Z",
+        drawCount: 1001,
+        lastDrawnAt: "2026-01-02T00:00:00Z",
       },
     ]);
     expect(body.rarityStats).toHaveLength(4);
@@ -354,6 +330,88 @@ describe("GET /api/gacha-stats", () => {
     expect(legendary.count).toBe(1);
   });
 
+  it("returns per-card owner stats for period=byCard", async () => {
+    const session = {
+      twitchUserId: "streamer1",
+      twitchUsername: "streamer1",
+      twitchDisplayName: "Streamer 1",
+      twitchProfileImageUrl: "",
+      broadcasterType: "affiliate",
+      expiresAt: Date.now() + 100000,
+      version: 1,
+    };
+    mockGetSession.mockResolvedValue(session);
+    mockCanUseStreamerFeatures.mockReturnValue(true);
+
+    const streamerQuery = createMockQueryBuilder();
+    (streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue(
+      createMockResponse({ id: "streamer-id-1" })
+    );
+
+    const rpc = vi.fn((functionName: string) => {
+      if (functionName === "get_card_owner_stats") {
+        return Promise.resolve({
+          data: {
+            card_stats: [
+              {
+                card_id: "c1",
+                card_name: "Card1",
+                rarity: "common",
+                image_url: null,
+                owner_count: 1,
+                owners: [
+                  {
+                    user_twitch_id: "viewer1",
+                    username: "alice",
+                    display_name: "Alice",
+                    owned_count: 2,
+                    last_obtained_at: "2026-01-02T00:00:00Z",
+                  },
+                ],
+              },
+            ],
+          },
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: null, error: null });
+    });
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "streamers") return streamerQuery;
+        return createMockQueryBuilder();
+      }),
+      rpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await GET(createRequest({ period: "byCard" }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.cardStats).toEqual([
+      {
+        cardId: "c1",
+        cardName: "Card1",
+        rarity: "common",
+        imageUrl: null,
+        ownerCount: 1,
+        owners: [
+          {
+            userTwitchId: "viewer1",
+            username: "alice",
+            displayName: "Alice",
+            ownedCount: 2,
+            lastObtainedAt: "2026-01-02T00:00:00Z",
+          },
+        ],
+      },
+    ]);
+    expect(rpc).toHaveBeenCalledWith("get_card_owner_stats", {
+      p_streamer_id: "streamer-id-1",
+    });
+  });
+
   it("falls back to history aggregation when the channel point stats RPC is not deployed", async () => {
     const session = {
       twitchUserId: "streamer1",
@@ -436,5 +494,224 @@ describe("GET /api/gacha-stats", () => {
         },
       ],
     });
+  });
+
+  it("falls back to user_cards aggregation for byCard when get_card_owner_stats is not deployed", async () => {
+    const session = {
+      twitchUserId: "streamer1",
+      twitchUsername: "streamer1",
+      twitchDisplayName: "Streamer 1",
+      twitchProfileImageUrl: "",
+      broadcasterType: "affiliate",
+      expiresAt: Date.now() + 100000,
+      version: 1,
+    };
+    mockGetSession.mockResolvedValue(session);
+    mockCanUseStreamerFeatures.mockReturnValue(true);
+
+    const streamerQuery = createMockQueryBuilder();
+    (streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue(
+      createMockResponse({ id: "streamer-id-1" })
+    );
+
+    const thenable = (response: unknown) => {
+      const q = createMockQueryBuilder();
+      Object.assign(q, {
+        then: Promise.resolve(response).then.bind(Promise.resolve(response)),
+      });
+      return q;
+    };
+
+    const cardsQuery = thenable({
+      data: [
+        {
+          id: "c1",
+          name: "Card1",
+          rarity: "common",
+          image_url: null,
+          rarity_order: 4,
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      error: null,
+    });
+    const userCardsQuery = thenable({
+      data: [
+        {
+          card_id: "c1",
+          obtained_at: "2026-01-01T00:00:00Z",
+          users: {
+            twitch_user_id: "viewer1",
+            twitch_username: "alice",
+            twitch_display_name: "Alice",
+          },
+        },
+        {
+          card_id: "c1",
+          obtained_at: "2026-01-03T00:00:00Z",
+          users: {
+            twitch_user_id: "viewer1",
+            twitch_username: "alice",
+            twitch_display_name: "Alice",
+          },
+        },
+      ],
+      error: null,
+    });
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "streamers") return streamerQuery;
+        if (table === "cards") return cardsQuery;
+        if (table === "user_cards") return userCardsQuery;
+        return createMockQueryBuilder();
+      }),
+      rpc: vi.fn().mockResolvedValue({
+        data: null,
+        error: { code: "42883", message: "function not found" },
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await GET(createRequest({ period: "byCard" }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.cardStats).toEqual([
+      {
+        cardId: "c1",
+        cardName: "Card1",
+        rarity: "common",
+        imageUrl: null,
+        ownerCount: 1,
+        owners: [
+          {
+            userTwitchId: "viewer1",
+            username: "alice",
+            displayName: "Alice",
+            ownedCount: 2,
+            lastObtainedAt: "2026-01-03T00:00:00Z",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("aggregates period drawers from history when get_gacha_drop_stats RPC errors", async () => {
+    const session = {
+      twitchUserId: "streamer1",
+      twitchUsername: "streamer1",
+      twitchDisplayName: "Streamer 1",
+      twitchProfileImageUrl: "",
+      broadcasterType: "affiliate",
+      expiresAt: Date.now() + 100000,
+      version: 1,
+    };
+    mockGetSession.mockResolvedValue(session);
+    mockCanUseStreamerFeatures.mockReturnValue(true);
+
+    const streamerQuery = createMockQueryBuilder();
+    (streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue(
+      createMockResponse({ id: "streamer-id-1" })
+    );
+
+    const thenable = (response: unknown) => {
+      const q = createMockQueryBuilder();
+      Object.assign(q, {
+        then: Promise.resolve(response).then.bind(Promise.resolve(response)),
+      });
+      return q;
+    };
+
+    const countQuery = thenable({ count: 3, error: null });
+    const historySampleQuery = thenable({
+      data: [
+        {
+          card_id: "c1",
+          user_twitch_id: "viewer1",
+          user_twitch_username: "alice",
+          redeemed_at: "2026-01-01T00:00:00Z",
+          cards: { rarity: "common" },
+        },
+        {
+          card_id: "c1",
+          user_twitch_id: "viewer1",
+          user_twitch_username: "alice",
+          redeemed_at: "2026-01-02T00:00:00Z",
+          cards: { rarity: "common" },
+        },
+        {
+          card_id: "c1",
+          user_twitch_id: "viewer2",
+          user_twitch_username: "bob",
+          redeemed_at: "2026-01-03T00:00:00Z",
+          cards: { rarity: "common" },
+        },
+      ],
+      error: null,
+    });
+    const cardsQuery = thenable({
+      data: [
+        {
+          id: "c1",
+          name: "Card1",
+          rarity: "common",
+          image_url: null,
+          drop_rate: 10,
+          rarity_order: 4,
+          created_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+      error: null,
+    });
+
+    let gachaHistoryCalls = 0;
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "streamers") return streamerQuery;
+        if (table === "cards") return cardsQuery;
+        if (table === "gacha_history") {
+          gachaHistoryCalls += 1;
+          return gachaHistoryCalls === 1 ? countQuery : historySampleQuery;
+        }
+        return createMockQueryBuilder();
+      }),
+      rpc: vi.fn((functionName: string) => {
+        if (functionName === "get_gacha_drop_stats") {
+          return Promise.resolve({
+            data: null,
+            error: { code: "P0001", message: "boom" },
+          });
+        }
+        return Promise.resolve({
+          data: { total_points: 0, ranking: [] },
+          error: null,
+        });
+      }),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await GET(createRequest({ period: "7d" }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.totalDraws).toBe(3);
+    expect(body.cardStats).toHaveLength(1);
+    const c1 = body.cardStats[0];
+    expect(c1.actualCount).toBe(3);
+    expect(c1.drawerCount).toBe(2);
+    // 引いた回数の多い順 → viewer1(2回) が先頭、viewer2(1回) が次
+    expect(c1.drawers).toEqual([
+      {
+        userTwitchId: "viewer1",
+        username: "alice",
+        drawCount: 2,
+        lastDrawnAt: "2026-01-02T00:00:00Z",
+      },
+      {
+        userTwitchId: "viewer2",
+        username: "bob",
+        drawCount: 1,
+        lastDrawnAt: "2026-01-03T00:00:00Z",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

This PR introduces two new statistics features for the gacha dashboard:

1. **Period-based drawer statistics**: The 7-day and 30-day tabs now display users who drew specific cards during that period (from `gacha_history`), replacing the previous all-time owner display.
2. **All-time card owner statistics**: A new "By Card" tab shows which users own each card across all time, with ownership counts and last obtained dates.

The changes separate period-based analytics (who drew in the last 7/30 days) from all-time ownership analytics (who owns what cards), providing clearer insights into both short-term gacha activity and long-term card distribution.

## Key Changes

### Database Migrations
- **`00051_add_card_owner_stats.sql`**: Creates a trigger-maintained aggregation table (`card_owner_stats`) that tracks all-time card ownership per user. Includes:
  - `card_owner_stats` table with composite primary key (streamer_id, card_id, user_twitch_id)
  - `refresh_card_owner_stat()` function to maintain aggregations on user_cards changes
  - `get_card_owner_stats()` RPC function to fetch owner statistics with per-card user limits
  - Backfill logic for existing user_cards data

- **`00052_add_drawers_to_gacha_drop_stats.sql`**: Extends the `get_gacha_drop_stats()` RPC to include drawer information:
  - Adds `drawer_count` and `drawers` fields to card stats
  - Aggregates drawers from `gacha_history` within the specified date range
  - Uses window functions to efficiently rank drawers by draw count per card
  - Maintains per-card user limit (default 100) to prevent payload bloat

### Backend Logic (`src/lib/dashboard-data.ts`)
- **New `GachaCardOwnerStatsResult` interface**: Defines the structure for all-time owner statistics
- **New `getGachaCardOwnerStats()` function**: Fetches all-time owner stats via RPC with fallback to user_cards aggregation
- **Updated `parseGachaDropStatsRpc()`**: Parses drawer information from RPC response; includes schema version detection to handle migration period where old RPC lacks drawers
- **Updated `fetchGachaDropStatsFromHistory()`**: Fallback aggregation now computes drawer statistics from gacha_history, including per-user draw counts and last drawn timestamps
- **New `fetchCardOwnerStatsFromUserCards()`**: Fallback aggregation for all-time owner stats when RPC is unavailable
- **New `STATS_USERS_PER_CARD_LIMIT` constant**: Shared limit (100) for users per card across RPC and fallback paths

### Frontend (`src/components/DropRateTable.tsx`)
- **New `CardOwnerStat` interface**: Represents all-time owner statistics structure
- **New `CardOwnerStatsData` interface**: Container for card owner stats response
- **Updated `StatsTab` type**: Added "byCard" option
- **Separated loading states**: `periodLoading` and `cardOwnerLoading` to prevent spinner artifacts when switching between tabs
- **New `renderCardOwnerStats()` method**: Renders the "By Card" tab with owner information
- **Updated period stats rendering**: Changed "owners" to "drawers" with draw counts instead of ownership counts
- **Lazy loading for card owner stats**: Fetches only when "By Card" tab is first accessed, then caches result

### API Route (`src/app/api/gacha-stats/route.ts`)
- Added support for `period=byCard` query parameter
- Routes to `getGachaCardOwnerStats()` for all-time owner statistics
- Maintains backward compatibility with existing period parameters (7d, 30d, channelPoints)

### Localization
- Added "By Card" tab label in both English and Japanese
- Added "drawers" terminology for period-based user lists
- Added "noCardData" message for empty card owner stats

### Tests
- Updated test descriptions for clarity ("unknown period value" instead

https://claude.ai/code/session_01WMq8y2wG9CEwuTGACMY9yv