### PR TITLE
Build: Enable webpack for Next.js production builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "npx wrangler dev",
     "dev:next": "TURBOPACK=0 next dev",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint",
     "test:unit": "vitest run tests/unit",


### PR DESCRIPTION
## 概要
Next.js のプロダクションビルドコマンドに `--webpack` フラグを追加し、ビルドプロセスで Webpack を明示的に使用するように変更しました。

## 変更内容
- `package.json` の `build` スクリプトを `next build` から `next build --webpack` に更新

## 実装の詳細
この変更により、Next.js のビルドプロセスで Turbopack ではなく Webpack を使用するよう強制します。これは以下の場合に有効です：

- 開発環境では Turbopack を使用（`dev:next` スクリプト）しながら、本番ビルドでは安定性の高い Webpack を使用する必要がある場合
- Turbopack との互換性の問題がある依存関係やプラグインがある場合
- ビルド出力の一貫性を確保する必要がある場合

**注記**: このフラグの追加により、ビルド時間やメモリ使用量に影響が生じる可能性があります。本番環境でのビルドパフォーマンスを検証してください。

https://claude.ai/code/session_01W8zLQLNnXhFia76rSkbCrt