### PR TITLE
fix: reduce Supabase Realtime egress for gacha overlay

### DIFF
--- a/src/app/api/gacha/demo/route.ts
+++ b/src/app/api/gacha/demo/route.ts
@@ -130,7 +130,12 @@ export async function POST(request: NextRequest) {
         };
 
         try {
-          await broadcastGachaResult(targetStreamerId, payload);
+          // 新overlayはv2 channel、旧OBSソースはlegacy channelを購読している。
+          // デモ通知は低頻度なので、移行期間中はfull payloadを両方に送って互換性を優先する。
+          await Promise.allSettled([
+            broadcastGachaResult(targetStreamerId, payload, { channelVersion: "v2" }),
+            broadcastGachaResult(targetStreamerId, payload, { channelVersion: "legacy" }),
+          ]);
           logger.info(`Demo broadcast sent to streamer ${targetStreamerId}`);
         } catch (broadcastError) {
           // ブロードキャストエラーはログに記録するが、レスポンスは返す

--- a/src/app/api/gacha/route.ts
+++ b/src/app/api/gacha/route.ts
@@ -119,10 +119,13 @@ export async function POST(request: NextRequest) {
       userTwitchUsername: result.data.userTwitchUsername,
     };
 
-    // broadcastGachaResult は内部でリトライし、失敗時も throw しない設計
-    // （OBSオーバーレイへの通知のみで、ガチャ処理の成否に影響しないため Issue #359-#365）
-    // 失敗ログは broadcastGachaResult 内で warn として出力される
-    await broadcastGachaResult(streamerId, payload);
+    // 新overlayはv2 channel、旧OBSソースはlegacy channelを購読している。
+    // 手動ガチャ/デモは低頻度でfull payloadのままなので、移行期間中は両方に送って
+    // リロード済み/未リロードのOBSソースを同時に壊さない。
+    await Promise.allSettled([
+      broadcastGachaResult(streamerId, payload, { channelVersion: "v2" }),
+      broadcastGachaResult(streamerId, payload, { channelVersion: "legacy" }),
+    ]);
     logger.info(`Gacha result broadcast attempted for streamer ${streamerId}`);
 
     return NextResponse.json<GachaSuccessResponse>({

--- a/src/app/api/overlay/[streamerId]/events/route.ts
+++ b/src/app/api/overlay/[streamerId]/events/route.ts
@@ -62,6 +62,33 @@ function resolveCard(cards: OverlayHistoryRow["cards"]): OverlayHistoryCard | nu
   return cards;
 }
 
+const MAX_BATCH_IDS = 25;
+
+function parseHistoryIdsParam(value: string | null): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean)
+    .slice(0, MAX_BATCH_IDS);
+}
+
+function mapHistoryRows(rows: OverlayHistoryRow[]) {
+  return rows
+    .map((row) => {
+      const card = resolveCard(row.cards);
+      if (!card) return null;
+      return {
+        id: row.id,
+        eventId: row.event_id,
+        redeemedAt: row.redeemed_at,
+        userTwitchUsername: row.user_twitch_username ?? "Unknown",
+        card,
+      };
+    })
+    .filter((event): event is NonNullable<typeof event> => event !== null);
+}
+
 /**
  * GET /api/overlay/[streamerId]/events
  *
@@ -83,6 +110,73 @@ export async function GET(
     }
 
     const { searchParams } = new URL(request.url);
+    const requestedIds = parseHistoryIdsParam(searchParams.get("ids"));
+
+    if (requestedIds.length > 0) {
+      const uniqueRequestedIds = Array.from(new Set(requestedIds));
+      const identifier = await getRateLimitIdentifier(request);
+      const rateLimitResult = await checkRateLimit(
+        rateLimits.overlayEventsGet,
+        identifier
+      );
+
+      if (!rateLimitResult.success) {
+        return NextResponse.json<ApiRateLimitResponse>(
+          {
+            error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+            retryAfter:
+              (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000),
+          },
+          {
+            status: 429,
+            headers: {
+              "X-RateLimit-Limit": String(rateLimitResult.limit),
+              "X-RateLimit-Remaining": String(rateLimitResult.remaining),
+              "X-RateLimit-Reset": String(rateLimitResult.reset),
+            },
+          }
+        );
+      }
+
+      const supabaseAdmin = getSupabaseAdmin();
+      const { data, error } = await withRetry(
+        () =>
+          supabaseAdmin
+            .from("gacha_history")
+            .select(
+              "id, event_id, redeemed_at, user_twitch_username, cards(id, name, description, image_url, rarity)"
+            )
+            .eq("streamer_id", streamerId)
+            .in("id", uniqueRequestedIds),
+        "overlayEventsByIds",
+        { maxRetries: 1 }
+      );
+
+      if (error) {
+        return handleDatabaseError(error, "Overlay Events API");
+      }
+
+      const eventsById = new Map(mapHistoryRows((data ?? []) as OverlayHistoryRow[]).map((event) => [event.id, event]));
+      const events = requestedIds
+        .map((id) => eventsById.get(id))
+        .filter((event): event is NonNullable<typeof event> => event !== undefined);
+      const complete = events.length === requestedIds.length;
+
+      // ID指定はRealtime受信直後の詳細補完に使う。DB反映レースで欠けた応答を
+      // キャッシュすると、全OBSソースが同じ欠落を踏むため完全一致時だけ短TTLにする。
+      // Only complete batches are cacheable; partial batches must be retried by clients.
+      return NextResponse.json(
+        { events, complete },
+        {
+          headers: {
+            "Cache-Control": complete
+              ? "public, max-age=5, stale-while-revalidate=10"
+              : "no-store",
+          },
+        }
+      );
+    }
+
     const since = normalizeDateParam(searchParams.get("since"));
     if (!since) {
       return NextResponse.json(
@@ -135,19 +229,7 @@ export async function GET(
       return handleDatabaseError(error, "Overlay Events API");
     }
 
-    const events = ((data ?? []) as OverlayHistoryRow[])
-      .map((row) => {
-        const card = resolveCard(row.cards);
-        if (!card) return null;
-        return {
-          id: row.id,
-          eventId: row.event_id,
-          redeemedAt: row.redeemed_at,
-          userTwitchUsername: row.user_twitch_username ?? "Unknown",
-          card,
-        };
-      })
-      .filter((event): event is NonNullable<typeof event> => event !== null);
+    const events = mapHistoryRows((data ?? []) as OverlayHistoryRow[]);
 
     return NextResponse.json({ events });
   } catch (error) {

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -3,7 +3,7 @@ import { getSupabaseAdmin, getSupabaseAdminNoCache } from "@/lib/supabase/admin"
 import { GachaService } from "@/lib/services/gacha";
 import { TWITCH_CHAT_MESSAGE_MAX_CHARACTERS, TWITCH_SUBSCRIPTION_TYPE, ERROR_MESSAGES } from "@/lib/constants";
 import { handleApiError } from "@/lib/error-handler";
-import { broadcastGachaResult } from "@/lib/realtime";
+import { broadcastGachaResult, type GachaBroadcastPayload } from "@/lib/realtime";
 import { checkRateLimit, rateLimits, getClientIp } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
 import { reportError } from "@/lib/sentry/error-handler";
@@ -420,6 +420,8 @@ async function handleRaidNotification(messageId: string, event: {
       type: "gacha",
       card: result.data.card,
       cards: result.data.cards,
+      historyId: result.data.historyId,
+      historyIds: result.data.historyIds,
       userTwitchUsername: result.data.userTwitchUsername,
     },
     broadcasterTwitchUserId: toBroadcasterUserId,
@@ -434,11 +436,50 @@ interface RedemptionNotifyData {
     type: "gacha";
     card: GachaCard;
     cards?: GachaCard[];
+    historyId?: string;
+    historyIds?: string[];
     userTwitchUsername: string;
   };
   broadcasterTwitchUserId: string;
   streamer: EventSubStreamerInfo;
   userId: string;
+}
+
+function buildRealtimePayload(gachaResult: RedemptionNotifyData["gachaResult"]): GachaBroadcastPayload {
+  const drawnCards = gachaResult.cards?.length ? gachaResult.cards : [gachaResult.card];
+  const historyIds = gachaResult.historyIds?.length
+    ? gachaResult.historyIds
+    : gachaResult.historyId
+      ? [gachaResult.historyId]
+      : undefined;
+
+  if (historyIds && historyIds.length === drawnCards.length) {
+    return {
+      type: "gacha",
+      historyIds,
+      cardIds: drawnCards.map((drawnCard) => drawnCard.id),
+      drawCount: drawnCards.length,
+      soundGroupId: historyIds[0],
+      userTwitchUsername: gachaResult.userTwitchUsername,
+    };
+  }
+
+  // RPC未適用やlegacy fallbackではgacha_history.idを安全に特定できないため、
+  // 既存のfull payloadを維持してoverlay表示とチャット通知の互換性を優先する。
+  // Keep the full payload only when the ID-only contract is unavailable.
+  return buildLegacyRealtimePayload(gachaResult);
+}
+
+function buildLegacyRealtimePayload(gachaResult: RedemptionNotifyData["gachaResult"]): GachaBroadcastPayload {
+  const drawnCards = gachaResult.cards?.length ? gachaResult.cards : [gachaResult.card];
+
+  return {
+    type: "gacha",
+    card: gachaResult.card,
+    cards: gachaResult.cards,
+    drawCount: drawnCards.length,
+    userTwitchUsername: gachaResult.userTwitchUsername,
+  };
 }
 
 /**
@@ -451,10 +492,19 @@ interface RedemptionNotifyData {
  */
 async function postRedemptionNotify(data: RedemptionNotifyData): Promise<void> {
   const results = await Promise.allSettled([
-    // Realtime通知: waitUntil内でもCPU時間は有限のためリトライを1回に制限
-    broadcastGachaResult(data.streamer.id, data.gachaResult, {
+    // 新しいoverlayはv2 channelでID-only payloadを受け、詳細をAPIで補完する。
+    // 旧OBSブラウザソースは長時間リロードされないため、移行期間はlegacy channelにも
+    // full payloadを送って表示欠落を避ける。v2へ移行済みのソースからegress削減が効く。
+    broadcastGachaResult(data.streamer.id, buildRealtimePayload(data.gachaResult), {
       maxRetries: 1,
       retryDelay: 500,
+      channelVersion: "v2",
+    }),
+    // Realtime通知: waitUntil内でもCPU時間は有限のためリトライを1回に制限
+    broadcastGachaResult(data.streamer.id, buildLegacyRealtimePayload(data.gachaResult), {
+      maxRetries: 1,
+      retryDelay: 500,
+      channelVersion: "legacy",
     }),
     sendChatAnnouncement(
       data.broadcasterTwitchUserId,
@@ -467,12 +517,12 @@ async function postRedemptionNotify(data: RedemptionNotifyData): Promise<void> {
   ]);
 
   // 通知失敗をログ出力 + エラー追跡
-  // Note: broadcastGachaResult (i=0) は内部でリトライし失敗時も throw しない設計 (Issue #359-#365)
+  // Note: broadcastGachaResult (i=0,1) は内部でリトライし失敗時も throw しない設計 (Issue #359-#365)
   // そのため broadcast は 'rejected' にならず、失敗ログは broadcastGachaResult 内で warn として出力される
-  // chatAnnouncement (i=1) は引き続きエラー時に throw するため、こちらのみ reportError が機能する
+  // chatAnnouncement (i=2) は引き続きエラー時に throw するため、こちらのみ reportError が機能する
   for (const [i, result] of results.entries()) {
     if (result.status === 'rejected') {
-      const label = i === 0 ? 'broadcast' : 'chatAnnouncement';
+      const label = i < 2 ? 'broadcast' : 'chatAnnouncement';
       logger.warn(`[postRedemptionNotify] ${label} failed`, {
         error: result.reason instanceof Error ? result.reason.message : String(result.reason),
         streamerId: data.streamer.id,
@@ -592,6 +642,8 @@ async function handleRedemption(messageId: string, event: {
       type: "gacha" as const,
       card: result.data.card,
       cards: result.data.cards,
+      historyId: result.data.historyId,
+      historyIds: result.data.historyIds,
       userTwitchUsername: result.data.userTwitchUsername,
     };
 

--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -42,6 +42,11 @@ interface OverlayPollingEvent {
   card: Pick<Card, "id" | "name" | "description" | "image_url" | "rarity">;
 }
 
+interface OverlayEventsResponse {
+  events?: OverlayPollingEvent[];
+  complete?: boolean;
+}
+
 function fetchJsonWithXhrFallback<T>(url: string): Promise<T> {
   return fetch(url)
     .then((response) => {
@@ -499,6 +504,63 @@ export default function OverlayPage() {
     };
   }, [pollOverlayEvents]);
 
+  const fetchOverlayEventsByIds = useCallback(async (
+    historyIds: string[],
+    options: { maxRetries?: number; retryDelayMs?: number } = {}
+  ): Promise<OverlayPollingEvent[]> => {
+    const { maxRetries = 2, retryDelayMs = 250 } = options;
+    const ids = historyIds.filter(Boolean);
+
+    for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+      const url = new URL(`/api/overlay/${streamerId}/events`, window.location.origin);
+      url.searchParams.set("ids", ids.join(","));
+      // Cache key is already the ids list; this timestamp is intentionally not
+      // added so complete responses can be shared by multiple OBS sources.
+      const data = await fetchJsonWithXhrFallback<OverlayEventsResponse>(url.toString());
+      const events = data.events ?? [];
+      if (data.complete !== false && events.length === ids.length) {
+        return events;
+      }
+
+      if (attempt < maxRetries) {
+        await new Promise((resolve) => setTimeout(resolve, retryDelayMs * (attempt + 1)));
+      }
+    }
+
+    throw new Error("Overlay detail fetch returned an incomplete batch");
+  }, [streamerId]);
+
+  const displayRealtimeIdPayload = useCallback(async (payload: { historyIds?: string[]; userTwitchUsername: string; soundGroupId?: string }) => {
+    const historyIds = payload.historyIds?.filter(Boolean) ?? [];
+    if (historyIds.length === 0) {
+      return;
+    }
+
+    try {
+      const events = await fetchOverlayEventsByIds(historyIds);
+      for (const event of events) {
+        if (seenHistoryIdsRef.current.has(event.id)) {
+          continue;
+        }
+        seenHistoryIdsRef.current.add(event.id);
+        const redeemedAtMs = Date.parse(event.redeemedAt);
+        pollCursorRef.current = Number.isFinite(redeemedAtMs)
+          ? new Date(redeemedAtMs).toISOString()
+          : new Date().toISOString();
+        displayResultRef.current({
+          card: event.card as Card,
+          userTwitchUsername: event.userTwitchUsername || payload.userTwitchUsername,
+          historyId: event.id,
+          soundGroupId: payload.soundGroupId ?? historyIds[0],
+        });
+      }
+    } catch (error) {
+      logger.warn("Overlay detail fetch failed for Realtime payload:", error);
+      addDebugLogRef.current("Realtime detail fetch failed; polling fallback will retry");
+      setConnectionStatus("disconnected");
+    }
+  }, [fetchOverlayEventsByIds]);
+
   // デバッグログを追加するヘルパー関数
   // OBSブラウザソースでの接続問題を調査するために使用
   const addDebugLog = useCallback((message: string) => {
@@ -526,13 +588,20 @@ export default function OverlayPage() {
 
     const cleanup = subscribeToGachaResults(streamerId, (payload) => {
       addDebugLogRef.current(`Received payload: ${payload.type}`);
-      if (payload.type === 'gacha' && payload.card) {
+      if (payload.type === 'gacha' && payload.historyIds?.length) {
+        // ID-only payloadは詳細APIの補完が成功するまで表示済みとは扱わない。
+        // 先にcursorを進めると、partial/429/ネットワーク失敗時にpolling fallbackも
+        // gacha_history.redeemed_atを取り逃がすため、displayRealtimeIdPayload内で
+        // 実際に表示できたevent.redeemedAtまでだけ進める。
+        void displayRealtimeIdPayload(payload);
+      } else if (payload.type === 'gacha' && payload.card) {
         // Avoid replaying the same event through polling if Realtime later drops.
         pollCursorRef.current = new Date().toISOString();
         displayResultRef.current({
           card: payload.card as unknown as Card,
           cards: payload.cards as unknown as Card[] | undefined,
           userTwitchUsername: payload.userTwitchUsername,
+          soundGroupId: payload.soundGroupId,
         });
       }
     }, {
@@ -584,7 +653,7 @@ export default function OverlayPage() {
         clearTimeout(animationTimeoutRef.current);
       }
     };
-  }, [streamerId]);
+  }, [displayRealtimeIdPayload, streamerId]);
 
   // Demo function for testing
   // デモ機能 - 配信者のカードがあればそれを、なければデモカードを表示

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -34,6 +34,12 @@ const GACHA_CHANNEL_CONFIG = {
   },
 } as const
 
+type GachaChannelVersion = 'legacy' | 'v2'
+
+function getGachaChannelName(streamerId: string, version: GachaChannelVersion): string {
+  return version === 'v2' ? `gacha:v2:${streamerId}` : `gacha:${streamerId}`
+}
+
 function getSupabaseRealtimeClient(): SupabaseClient {
   if (supabaseRealtime) {
     return supabaseRealtime
@@ -69,7 +75,7 @@ function getSupabaseRealtimeClient(): SupabaseClient {
 
 export interface GachaBroadcastPayload {
   type: 'gacha'
-  card: {
+  card?: {
     id: string
     name: string
     description: string | null
@@ -83,6 +89,13 @@ export interface GachaBroadcastPayload {
     image_url: string | null
     rarity: string
   }>
+  /** Ordered gacha_history IDs. Preferred for EventSub multi-draw to avoid fanning out full card payloads. */
+  historyIds?: string[]
+  /** Ordered card IDs for diagnostics and clients that only need identity. */
+  cardIds?: string[]
+  drawCount?: number
+  /** Stable group ID so the overlay plays one sound for an N-draw event after fetching details. */
+  soundGroupId?: string
   userTwitchUsername: string
 }
 
@@ -91,6 +104,12 @@ export interface RealtimeError {
   message: string
   error: unknown
   isExpected?: boolean
+}
+
+export interface BroadcastOptions {
+  maxRetries?: number
+  retryDelay?: number
+  channelVersion?: GachaChannelVersion
 }
 
 // 接続中の一時的なステータス（エラーではない）
@@ -104,9 +123,10 @@ const EXPECTED_CLOSE_STATUSES = ['CLOSED', 'TIMED_OUT', 'CHANNEL_ERROR']
 export async function broadcastGachaResult(
   streamerId: string,
   payload: GachaBroadcastPayload,
-  options: { maxRetries?: number; retryDelay?: number } = {}
+  options: BroadcastOptions = {}
 ): Promise<void> {
-  const { maxRetries = 3, retryDelay = 1000 } = options
+  const { maxRetries = 3, retryDelay = 1000, channelVersion = 'legacy' } = options
+  const channelName = getGachaChannelName(streamerId, channelVersion)
 
   // getSupabaseRealtimeClient() や client.channel() がリトライループ前に throw する可能性がある
   // （環境変数不正、クライアント初期化失敗など）。これらのエラーも try/catch 内に含め、
@@ -117,7 +137,7 @@ export async function broadcastGachaResult(
   let channel: ReturnType<ReturnType<typeof getSupabaseRealtimeClient>['channel']>
   try {
     client = getSupabaseRealtimeClient()
-    channel = client.channel(`gacha:${streamerId}`, GACHA_CHANNEL_CONFIG)
+    channel = client.channel(channelName, GACHA_CHANNEL_CONFIG)
   } catch (initError) {
     logger.warn(`[Broadcast] Failed to initialize realtime client for streamer ${streamerId}`, {
       error: initError instanceof Error ? initError.message : String(initError),
@@ -146,7 +166,7 @@ export async function broadcastGachaResult(
           // ブロードキャスト失敗はガチャ処理自体に影響しない（OBSオーバーレイへの通知のみ）
           // 一時的な502/タイムアウトで大量のGitHub Issueが作成されるのを防ぐため、
           // reportRealtimeError ではなく warn ログに留める (Issue #359-#365)
-          logger.warn(`[Broadcast] Failed after ${maxRetries} retries for streamer ${streamerId}`, {
+          logger.warn(`[Broadcast] Failed after ${maxRetries} retries for ${channelName}`, {
             error: error instanceof Error ? error.message : String(error),
             retryCount: attemptCount - 1,
           })
@@ -163,7 +183,7 @@ export async function broadcastGachaResult(
     try {
       client.removeChannel(channel)
     } catch {
-      logger.info(`Channel cleanup completed for streamer ${streamerId}`)
+      logger.info(`Channel cleanup completed for ${channelName}`)
     }
   }
 }
@@ -184,6 +204,10 @@ export interface SubscribeOptions {
   // デバッグ用：接続ステータスの変化を追跡するコールバック
   // OBSブラウザソースでの接続問題を調査するために使用
   onStatusChange?: (status: string) => void
+  // v2 is the ID-only overlay channel. The legacy channel remains available
+  // during rollout because already-open OBS browser sources keep their old JS
+  // and still need full payloads until the scene is refreshed.
+  channelVersion?: GachaChannelVersion
 }
 
 export function subscribeToGachaResults(
@@ -197,8 +221,10 @@ export function subscribeToGachaResults(
     onError,
     onSuccess,
     onStatusChange,
+    channelVersion = 'v2',
   } = options
 
+  const channelName = getGachaChannelName(streamerId, channelVersion)
   let client: SupabaseClient | null = null
   let channel: ReturnType<SupabaseClient['channel']> | null = null
   let retryCount = 0
@@ -243,7 +269,7 @@ export function subscribeToGachaResults(
         client.removeChannel(channel)
       } catch {
         // クリーンアップ失敗は非致命的、ログのみ
-        logger.info(`Previous channel cleanup for gacha:${streamerId}`)
+        logger.info(`Previous channel cleanup for ${channelName}`)
       }
       channel = null
     }
@@ -254,7 +280,7 @@ export function subscribeToGachaResults(
     try {
       client = getSupabaseRealtimeClient()
       onStatusChange?.('CLIENT_CREATED')
-      channel = client.channel(`gacha:${streamerId}`, GACHA_CHANNEL_CONFIG)
+      channel = client.channel(channelName, GACHA_CHANNEL_CONFIG)
       onStatusChange?.('CHANNEL_CREATED')
 
       channel
@@ -286,12 +312,12 @@ export function subscribeToGachaResults(
 
           if (status === 'SUBSCRIBED') {
             retryCount = 0
-            logger.info(`Successfully subscribed to gacha:${streamerId}`)
+            logger.info(`Successfully subscribed to ${channelName}`)
             onSuccess?.()
           } else if (CONNECTING_STATUSES.includes(status)) {
             // 接続中の一時的なステータス（リトライカウントを増やさない）
             // Temporary connecting status - don't count as error
-            logger.info(`Connection in progress for gacha:${streamerId}, status: ${status}`)
+            logger.info(`Connection in progress for ${channelName}, status: ${status}`)
             onStatusChange?.(`CONNECTING: ${status}`)
           } else {
             const isExpected = EXPECTED_CLOSE_STATUSES.includes(status)
@@ -304,9 +330,9 @@ export function subscribeToGachaResults(
             }
 
             if (isExpected) {
-              logger.info(`Expected connection closure for gacha:${streamerId}, status: ${status}`)
+              logger.info(`Expected connection closure for ${channelName}, status: ${status}`)
             } else {
-              logger.warn(`Connection issue for gacha:${streamerId}, status: ${status}`)
+              logger.warn(`Connection issue for ${channelName}, status: ${status}`)
               // クライアントサイドの同期コールバック内のため await 不可
               void reportRealtimeError(err, {
                 action: 'subscribe',
@@ -325,7 +351,7 @@ export function subscribeToGachaResults(
               logger.info(`Retrying connection (attempt ${retryLabel}) in ${Math.round(delay)}ms...`)
               retryTimeout = setTimeout(subscribe, delay)
             } else {
-              logger.warn(`Max retries (${maxRetries}) reached for gacha:${streamerId}`)
+              logger.warn(`Max retries (${maxRetries}) reached for ${channelName}`)
               const maxRetriesError: RealtimeError = {
                 type: 'connection',
                 message: 'Max retries reached. Please refresh the page to reconnect.',
@@ -337,7 +363,7 @@ export function subscribeToGachaResults(
           }
         })
     } catch (error) {
-      logger.error(`Failed to subscribe to gacha:${streamerId}:`, error)
+      logger.error(`Failed to subscribe to ${channelName}:`, error)
       // 同期関数 subscribe() 内のため await 不可
       void reportRealtimeError(error, {
         action: 'subscribe',

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -30,6 +30,10 @@ export interface EventSubStreamerInfo {
 export interface GachaResult {
   card: GachaCard
   cards?: GachaCard[]
+  /** gacha_history.id for the first draw when the transactional RPC returns it. */
+  historyId?: string
+  /** Ordered gacha_history IDs for multi-draw results. Omitted when legacy fallback cannot return IDs. */
+  historyIds?: string[]
   userTwitchUsername: string
   /** EventSub経由の場合のみ設定。クエリ統合のためガチャ結果と一緒に返す */
   streamer?: EventSubStreamerInfo
@@ -131,6 +135,7 @@ export class GachaService {
 
       return ok({
         card: selectedCard,
+        historyId: typeof rpcResult?.history_id === 'string' ? rpcResult.history_id : undefined,
         userTwitchUsername,
       })
     } catch (error) {
@@ -147,6 +152,7 @@ export class GachaService {
     rewardCost?: number
   ): Promise<Result<GachaResult>> {
     const cards: GachaCard[] = []
+    const historyIds: string[] = []
     let firstResult: GachaResult | null = null
 
     for (let index = 0; index < drawCount; index += 1) {
@@ -176,6 +182,9 @@ export class GachaService {
       }
 
       cards.push(result.data.card)
+      if (result.data.historyId) {
+        historyIds.push(result.data.historyId)
+      }
       firstResult ??= result.data
     }
 
@@ -186,6 +195,7 @@ export class GachaService {
     return ok({
       ...firstResult,
       cards,
+      historyIds: historyIds.length === cards.length ? historyIds : undefined,
     })
   }
 

--- a/tasks/plans/issue-515-realtime-id-payload.md
+++ b/tasks/plans/issue-515-realtime-id-payload.md
@@ -1,0 +1,57 @@
+# Issue 515 Realtime ID Payload Plan
+
+## Goal
+
+Reduce Supabase Realtime egress caused by multi-draw overlay broadcasts without regressing overlay display or chat announcements.
+
+## Industry Guidance
+
+- Supabase Broadcast counts one sent message plus one message for each subscribed client, so payload size and subscriber count both matter for egress and billing.
+- Supabase Realtime is suitable for low-latency notifications, but large display payloads should be kept out of fanout channels when they can be fetched separately.
+- Cloudflare Workers/Durable Objects are the long-term fit for persistent fanout, while short-lived HTTP detail fetches can be cached and retried more predictably.
+- Cloudflare cache is edge-local and best used as a short TTL absorber for repeated identical detail fetches from multiple OBS sources/tabs.
+
+## Implementation
+
+1. Change the Realtime payload contract in `src/lib/realtime.ts` to support lightweight draw result notifications:
+   - keep legacy `card` / `cards` support for compatibility
+   - add `historyIds`, `cardIds`, `drawCount`, and optional `soundGroupId`
+2. Plumb history IDs through the gacha service:
+   - `execute_gacha_transaction` already returns `history_id`; preserve it in `GachaResult`
+   - `executeGachaDraws()` must return ordered history IDs per draw, including duplicate card IDs
+   - legacy fallback can omit history IDs and should keep full-card Realtime compatibility rather than pretending IDs are available
+3. Change EventSub broadcasts in `src/app/api/twitch/eventsub/route.ts`:
+   - broadcast only IDs/order metadata for multi-draw EventSub results
+   - keep full card objects available inside the same process for chat notifications
+   - preserve single-card API/manual gacha compatibility unless the route has history IDs available
+4. Add/extend an overlay detail API:
+   - support `ids=` batch lookup of `gacha_history.id` values on `/api/overlay/[streamerId]/events`
+   - handle `ids=` in a separate branch that does not require `since`
+   - keep the existing `since` polling behavior unchanged
+   - return full card display data ordered like requested IDs
+   - include conservative cache headers only when all requested IDs were found
+   - return `Cache-Control: no-store` for partial/empty batches so a write/read race is not pinned in cache
+5. Update overlay client:
+   - if Realtime payload contains full cards, use existing path
+   - if Realtime payload contains IDs only, fetch details once in batch, retry lightly for write/read race, then enqueue cards in order
+   - preserve image, description, sound-once behavior, and polling fallback
+6. Add focused tests:
+   - EventSub broadcast no longer includes full `cards` objects for multi-draw
+   - chat announcement still receives full cards and preserves `{cards}` / `{newCards}` behavior
+   - overlay fetches detail payload for ID-only Realtime and displays all cards in order
+   - overlay details API orders batch responses by requested IDs
+   - overlay details API accepts `ids=` without `since`, filters by `streamerId`, and avoids caching partial batches
+
+## Validation
+
+- `npx vitest run tests/unit/eventsub-reward-mismatch.test.ts tests/unit/components/overlay-page.test.tsx`
+- Add and run a focused route test for `/api/overlay/[streamerId]/events?ids=...`.
+- `npm run lint`
+- `npm run build` or `npm run workers:build` if the change reaches Next/Worker boundaries.
+
+## Review Focus
+
+- No visible overlay regression for `image_url`, `description`, display order, or sound-once behavior.
+- No chat notification regression for multi-draw placeholders or new-card detection.
+- No N+1 detail fetches per card.
+- No new unauthenticated broad data exposure beyond the existing public overlay endpoint scoped by `streamerId`.

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,6 +2,34 @@ import { vi } from 'vitest'
 import '@testing-library/jest-dom'
 import { createMockSupabaseClient } from './utils/supabase-mock'
 
+const localStorageStore = new Map<string, string>()
+const localStorageMock: Storage = {
+  get length() {
+    return localStorageStore.size
+  },
+  clear: vi.fn(() => localStorageStore.clear()),
+  getItem: vi.fn((key: string) => localStorageStore.get(key) ?? null),
+  key: vi.fn((index: number) => Array.from(localStorageStore.keys())[index] ?? null),
+  removeItem: vi.fn((key: string) => {
+    localStorageStore.delete(key)
+  }),
+  setItem: vi.fn((key: string, value: string) => {
+    localStorageStore.set(key, String(value))
+  }),
+}
+
+// Node 25 exposes an experimental global localStorage that is separate from
+// happy-dom and lacks clear(). Keep bare localStorage and window.localStorage
+// on the same browser-like Storage object for component tests.
+Object.defineProperty(window, 'localStorage', {
+  configurable: true,
+  value: localStorageMock,
+})
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: localStorageMock,
+})
+
 // Setup environment variables
 process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
 process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co'

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -139,4 +139,178 @@ describe('OverlayPage', () => {
     expect(screen.getByText('Gamma')).toBeInTheDocument()
     expect(playMock).toHaveBeenCalledTimes(1)
   })
+
+  it('IDのみのRealtime payloadでは詳細APIをbatch取得して全カードを順番に表示する', async () => {
+    vi.useFakeTimers()
+
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes('/api/streamer/streamer-1/sound-settings')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ soundUrl: null, soundEnabled: false }),
+        })
+      }
+      if (url.includes('/api/overlay/streamer-1/events')) {
+        expect(url).toContain('ids=history-1%2Chistory-2%2Chistory-3')
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            complete: true,
+            events: [
+              {
+                id: 'history-1',
+                eventId: 'event-1',
+                redeemedAt: '2026-05-14T00:00:00.000Z',
+                userTwitchUsername: 'Viewer',
+                card: { id: 'card-1', name: 'Alpha', description: 'A', image_url: null, rarity: 'rare' },
+              },
+              {
+                id: 'history-2',
+                eventId: 'event-1:2',
+                redeemedAt: '2026-05-14T00:00:01.000Z',
+                userTwitchUsername: 'Viewer',
+                card: { id: 'card-2', name: 'Beta', description: 'B', image_url: null, rarity: 'common' },
+              },
+              {
+                id: 'history-3',
+                eventId: 'event-1:3',
+                redeemedAt: '2026-05-14T00:00:02.000Z',
+                userTwitchUsername: 'Viewer',
+                card: { id: 'card-3', name: 'Gamma', description: 'C', image_url: null, rarity: 'legendary' },
+              },
+            ],
+          }),
+        })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
+      options.onSuccess?.()
+      return vi.fn()
+    })
+
+    render(<OverlayPage />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        historyIds: ['history-1', 'history-2', 'history-3'],
+        cardIds: ['card-1', 'card-2', 'card-3'],
+        drawCount: 3,
+        soundGroupId: 'history-1',
+        userTwitchUsername: 'Viewer',
+      })
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6600)
+    })
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6600)
+    })
+    expect(screen.getByText('Gamma')).toBeInTheDocument()
+  })
+
+  it('IDのみのRealtime詳細取得が失敗してもpolling cursorを先送りせずfallbackで表示する', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-14T00:00:00.000Z'))
+
+    const pollingSinceValues: string[] = []
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes('/api/streamer/streamer-1/sound-settings')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ soundUrl: null, soundEnabled: false }),
+        })
+      }
+      if (url.includes('/api/overlay/streamer-1/events')) {
+        const parsedUrl = new URL(url)
+        if (parsedUrl.searchParams.has('ids')) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({
+              complete: false,
+              events: [],
+            }),
+          })
+        }
+
+        pollingSinceValues.push(parsedUrl.searchParams.get('since') ?? '')
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            events: [
+              {
+                id: 'history-1',
+                eventId: 'event-1',
+                redeemedAt: '2026-05-14T00:00:01.000Z',
+                userTwitchUsername: 'Viewer',
+                card: { id: 'card-1', name: 'Alpha', description: 'A', image_url: null, rarity: 'rare' },
+              },
+            ],
+          }),
+        })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
+      options.onSuccess?.()
+      return vi.fn()
+    })
+
+    render(<OverlayPage />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    vi.setSystemTime(new Date('2026-05-14T00:00:02.000Z'))
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        historyIds: ['history-1'],
+        cardIds: ['card-1'],
+        drawCount: 1,
+        soundGroupId: 'history-1',
+        userTwitchUsername: 'Viewer',
+      })
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(800)
+      await Promise.resolve()
+    })
+    expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+    expect(pollingSinceValues.at(-1)).toBe('2026-05-14T00:00:00.000Z')
+  })
 })

--- a/tests/unit/eventsub-reward-mismatch.test.ts
+++ b/tests/unit/eventsub-reward-mismatch.test.ts
@@ -261,7 +261,7 @@ describe('EventSub reward mismatch handling', () => {
     )
   })
 
-  it('broadcasts all cards returned by a multi-draw EventSub redemption', async () => {
+  it('broadcasts only ordered history IDs for a multi-draw EventSub redemption', async () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret
     const messageId = 'eventsub-multi-draw'
@@ -282,11 +282,13 @@ describe('EventSub reward mismatch handling', () => {
       { id: 'card-2', name: 'Card 2', description: null, image_url: null, rarity: 'rare' },
       { id: 'card-3', name: 'Card 3', description: null, image_url: null, rarity: 'epic' },
     ]
+    const historyIds = ['history-1', 'history-2', 'history-3']
     mocks.executeGachaForEventSub.mockResolvedValue({
       success: true,
       data: {
         card: cards[0],
         cards,
+        historyIds,
         userTwitchUsername: 'Viewer',
         streamer: {
           id: 'streamer-1',
@@ -311,15 +313,29 @@ describe('EventSub reward mismatch handling', () => {
     }))
 
     expect(response.status).toBe(200)
-    expect(mockBroadcastGachaResult).toHaveBeenCalledWith(
-      'streamer-1',
-      expect.objectContaining({
-        card: cards[0],
-        cards,
-        userTwitchUsername: 'Viewer',
-      }),
-      expect.any(Object),
+    const v2Call = mockBroadcastGachaResult.mock.calls.find(
+      (call) => call[2]?.channelVersion === 'v2',
     )
+    expect(v2Call?.[0]).toBe('streamer-1')
+    expect(v2Call?.[1]).toEqual(expect.objectContaining({
+      historyIds,
+      cardIds: ['card-1', 'card-2', 'card-3'],
+      drawCount: 3,
+      soundGroupId: 'history-1',
+      userTwitchUsername: 'Viewer',
+    }))
+    expect(v2Call?.[1].card).toBeUndefined()
+    expect(v2Call?.[1].cards).toBeUndefined()
+
+    const legacyCall = mockBroadcastGachaResult.mock.calls.find(
+      (call) => call[2]?.channelVersion === 'legacy',
+    )
+    expect(legacyCall?.[1]).toEqual(expect.objectContaining({
+      card: cards[0],
+      cards: [...cards],
+      drawCount: 3,
+      userTwitchUsername: 'Viewer',
+    }))
   })
 
   it('sends multi-draw chat announcements with all cards while preserving {card} as the first card', async () => {
@@ -350,6 +366,7 @@ describe('EventSub reward mismatch handling', () => {
       data: {
         card: cards[0],
         cards: [...cards],
+        historyIds: ['history-1', 'history-2', 'history-3'],
         userTwitchUsername: 'Viewer',
         streamer: {
           id: 'streamer-1',
@@ -375,11 +392,15 @@ describe('EventSub reward mismatch handling', () => {
 
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ received: true })
-    expect(mockBroadcastGachaResult).toHaveBeenCalledWith(
-      'streamer-1',
-      expect.objectContaining({ card: cards[0], cards: [...cards] }),
-      expect.any(Object),
+    const v2Call = mockBroadcastGachaResult.mock.calls.find(
+      (call) => call[2]?.channelVersion === 'v2',
     )
+    expect(v2Call?.[0]).toBe('streamer-1')
+    expect(v2Call?.[1]).toEqual(expect.objectContaining({
+      historyIds: ['history-1', 'history-2', 'history-3'],
+      cardIds: ['card-1', 'card-2', 'card-3'],
+      drawCount: 3,
+    }))
     expect(mockTwitchChatService).toHaveBeenCalled()
     expect(mocks.buildMessage).toHaveBeenCalledWith(
       '{user}: first={card} all={cards} count={draws} rarity={rarityCounts}',

--- a/tests/unit/overlay-events-api.test.ts
+++ b/tests/unit/overlay-events-api.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '@/app/api/overlay/[streamerId]/events/route'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { checkRateLimit } from '@/lib/rate-limit'
+
+vi.mock('@/lib/supabase/admin', () => ({
+  getSupabaseAdmin: vi.fn(),
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn().mockResolvedValue({
+    success: true,
+    limit: 120,
+    remaining: 119,
+    reset: 0,
+  }),
+  getRateLimitIdentifier: vi.fn().mockResolvedValue('ip:127.0.0.1'),
+  rateLimits: { overlayEventsGet: {} },
+}))
+
+vi.mock('@/lib/supabase/retry', () => ({
+  withRetry: vi.fn((operation: () => unknown) => operation()),
+}))
+
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin)
+const mockCheckRateLimit = vi.mocked(checkRateLimit)
+
+function createSupabaseRows(rows: unknown[]) {
+  const query = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockResolvedValue({ data: rows, error: null }),
+  }
+  mockGetSupabaseAdmin.mockReturnValue({
+    from: vi.fn((table: string) => {
+      if (table !== 'gacha_history') throw new Error(`Unexpected table: ${table}`)
+      return query
+    }),
+  } as unknown as ReturnType<typeof getSupabaseAdmin>)
+  return query
+}
+
+describe('Overlay events API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 120,
+      remaining: 119,
+      reset: 0,
+    } as Awaited<ReturnType<typeof checkRateLimit>>)
+  })
+
+  it('fetches requested gacha_history IDs without requiring since and preserves request order', async () => {
+    const query = createSupabaseRows([
+      {
+        id: 'history-2',
+        event_id: 'event-1:2',
+        redeemed_at: '2026-05-14T00:00:01.000Z',
+        user_twitch_username: 'Viewer',
+        cards: { id: 'card-2', name: 'Beta', description: 'B', image_url: null, rarity: 'rare' },
+      },
+      {
+        id: 'history-1',
+        event_id: 'event-1',
+        redeemed_at: '2026-05-14T00:00:00.000Z',
+        user_twitch_username: 'Viewer',
+        cards: { id: 'card-1', name: 'Alpha', description: 'A', image_url: null, rarity: 'common' },
+      },
+    ])
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/overlay/streamer-1/events?ids=history-1,history-2,history-1'),
+      { params: Promise.resolve({ streamerId: 'streamer-1' }) },
+    )
+
+    expect(response.status).toBe(200)
+    expect(query.eq).toHaveBeenCalledWith('streamer_id', 'streamer-1')
+    expect(query.in).toHaveBeenCalledWith('id', ['history-1', 'history-2'])
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=5, stale-while-revalidate=10')
+    await expect(response.json()).resolves.toMatchObject({
+      complete: true,
+      events: [
+        { id: 'history-1', card: { name: 'Alpha' } },
+        { id: 'history-2', card: { name: 'Beta' } },
+        { id: 'history-1', card: { name: 'Alpha' } },
+      ],
+    })
+  })
+
+  it('marks partial ID batches as no-store so clients can retry write/read races', async () => {
+    createSupabaseRows([
+      {
+        id: 'history-1',
+        event_id: 'event-1',
+        redeemed_at: '2026-05-14T00:00:00.000Z',
+        user_twitch_username: 'Viewer',
+        cards: { id: 'card-1', name: 'Alpha', description: null, image_url: null, rarity: 'common' },
+      },
+    ])
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/overlay/streamer-1/events?ids=history-1,history-missing'),
+      { params: Promise.resolve({ streamerId: 'streamer-1' }) },
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Cache-Control')).toBe('no-store')
+    await expect(response.json()).resolves.toMatchObject({
+      complete: false,
+      events: [{ id: 'history-1' }],
+    })
+  })
+})

--- a/tests/unit/realtime.test.ts
+++ b/tests/unit/realtime.test.ts
@@ -103,7 +103,7 @@ describe('subscribeToGachaResults', () => {
 
     expect(channels).toHaveLength(2)
     expect(loggerMock.warn).toHaveBeenCalledWith(
-      'Max retries (1) reached for gacha:streamer-1',
+      'Max retries (1) reached for gacha:v2:streamer-1',
     )
     expect(onError).toHaveBeenLastCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
## Summary
- Reduce Supabase Realtime payload size by sending ordered `historyIds` / `cardIds` on the new `gacha:v2:*` channel.
- Keep legacy `gacha:*` full-payload broadcasts during rollout so already-open OBS browser sources do not lose cards.
- Add `ids=` support to the overlay events API so overlays can fetch display data (`description`, `image_url`, etc.) by `gacha_history.id`.
- Update the overlay to batch-fetch details, retry partial batches, avoid cursor advancement on fetch failure, and fall back to polling.

Closes #515

## Verification
- `./node_modules/.bin/vitest run tests/unit/eventsub-reward-mismatch.test.ts tests/unit/components/overlay-page.test.tsx tests/unit/overlay-events-api.test.ts`
- `./node_modules/.bin/vitest run tests/unit/realtime.test.ts tests/unit/eventsub-reward-mismatch.test.ts tests/unit/components/overlay-page.test.tsx tests/unit/overlay-events-api.test.ts`
- `./node_modules/.bin/vitest run`
- `npm run lint`
- `npm run build`
- `npm run workers:build`

## Review
- Strict self-review subagent: blockingなし
- Final team review (backend/perf/cost, frontend/OBS, test/release): blockingなし
