### PR TITLE
fix: stop endless overlay realtime retries

### DIFF
--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -605,6 +605,10 @@ export default function OverlayPage() {
         });
       }
     }, {
+      // Overlay has polling fallback, so endlessly reopening failed WebSockets only
+      // creates noisy preview logs and unnecessary Supabase Realtime traffic. Try a
+      // few times for low-latency delivery, then let polling carry the session.
+      maxRetries: 3,
       onError: (error) => {
         addDebugLogRef.current(`Connection error: ${error.message} (expected: ${error.isExpected})`);
         if (error.isExpected) {

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -52,6 +52,9 @@ describe('OverlayPage', () => {
       expect(subscribeMock).toHaveBeenCalled()
     })
 
+    expect(subscribeMock.mock.calls[0][2]).toEqual(expect.objectContaining({
+      maxRetries: 3,
+    }))
     expect(screen.queryByText('接続エラー')).not.toBeInTheDocument()
     expect(screen.queryByText(connectionError.message)).not.toBeInTheDocument()
   })


### PR DESCRIPTION
## Summary
- Limit OBS overlay Supabase Realtime reconnect attempts to 3 because polling fallback is already available.
- Avoid endless WebSocket retries/noisy preview logs when Supabase Realtime is asleep or unavailable.

## Verification
- `./node_modules/.bin/vitest run tests/unit/components/overlay-page.test.tsx tests/unit/realtime.test.ts`
- `npm run lint`
- `npm run build`