### PR TITLE
fix: treat realtime retry exhaustion as overlay fallback

### DIFF
--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -231,6 +231,7 @@ export function subscribeToGachaResults(
   let isDisposed = false
   let retryTimeout: ReturnType<typeof setTimeout> | null = null
   let subscriptionGeneration = 0
+  let maxRetriesNotified = false
 
   const hasRetryLimit = Number.isFinite(maxRetries)
 
@@ -312,6 +313,7 @@ export function subscribeToGachaResults(
 
           if (status === 'SUBSCRIBED') {
             retryCount = 0
+            maxRetriesNotified = false
             logger.info(`Successfully subscribed to ${channelName}`)
             onSuccess?.()
           } else if (CONNECTING_STATUSES.includes(status)) {
@@ -321,6 +323,14 @@ export function subscribeToGachaResults(
             onStatusChange?.(`CONNECTING: ${status}`)
           } else {
             const isExpected = EXPECTED_CLOSE_STATUSES.includes(status)
+
+            // Supabase can emit the same terminal status more than once for a
+            // single channel failure. Once a reconnect is already scheduled,
+            // ignore duplicate terminal callbacks so one failure consumes only
+            // one retry budget and cleanup can still cancel the pending timer.
+            if (retryTimeout) {
+              return
+            }
 
             const error: RealtimeError = {
               type: 'connection',
@@ -346,17 +356,24 @@ export function subscribeToGachaResults(
 
             if (!hasRetryLimit || retryCount < maxRetries) {
               retryCount++
+              maxRetriesNotified = false
               const delay = getRetryDelay(retryCount, retryDelay)
               const retryLabel = hasRetryLimit ? `${retryCount}/${maxRetries}` : `${retryCount}`
               logger.info(`Retrying connection (attempt ${retryLabel}) in ${Math.round(delay)}ms...`)
               retryTimeout = setTimeout(subscribe, delay)
             } else {
-              logger.warn(`Max retries (${maxRetries}) reached for ${channelName}`)
+              if (maxRetriesNotified) {
+                return
+              }
+              maxRetriesNotified = true
+              logger.info(`Max retries (${maxRetries}) reached for ${channelName}; staying on fallback path`)
               const maxRetriesError: RealtimeError = {
                 type: 'connection',
-                message: 'Max retries reached. Please refresh the page to reconnect.',
+                message: 'Realtime reconnect limit reached; polling fallback is active.',
                 error: null,
-                isExpected: false,
+                // Finite maxRetries is used by overlays because polling fallback is available.
+                // Treat the handoff as expected so debug UI does not show a false failure.
+                isExpected: true,
               }
               onError?.(maxRetriesError)
             }

--- a/tests/unit/realtime.test.ts
+++ b/tests/unit/realtime.test.ts
@@ -102,15 +102,60 @@ describe('subscribeToGachaResults', () => {
     await vi.runOnlyPendingTimersAsync()
 
     expect(channels).toHaveLength(2)
-    expect(loggerMock.warn).toHaveBeenCalledWith(
-      'Max retries (1) reached for gacha:v2:streamer-1',
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      'Max retries (1) reached for gacha:v2:streamer-1; staying on fallback path',
     )
     expect(onError).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        message: 'Max retries reached. Please refresh the page to reconnect.',
-        isExpected: false,
+        message: 'Realtime reconnect limit reached; polling fallback is active.',
+        isExpected: true,
       }),
     )
+
+    cleanup()
+  })
+
+  it('reports max retries only once when Supabase repeats terminal statuses', async () => {
+    const onError = vi.fn()
+    const cleanup = subscribeToGachaResults('streamer-1', vi.fn(), {
+      maxRetries: 0,
+      retryDelay: 10,
+      onError,
+    })
+
+    statusCallbacks[0]('CHANNEL_ERROR')
+    statusCallbacks[0]('CHANNEL_ERROR')
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      'Max retries (0) reached for gacha:v2:streamer-1; staying on fallback path',
+    )
+    expect(onError.mock.calls.filter(([error]) => (
+      error.message === 'Realtime reconnect limit reached; polling fallback is active.'
+    ))).toHaveLength(1)
+
+    cleanup()
+  })
+
+  it('counts repeated terminal statuses with a pending retry as one failure', async () => {
+    const onError = vi.fn()
+    const cleanup = subscribeToGachaResults('streamer-1', vi.fn(), {
+      maxRetries: 1,
+      retryDelay: 10,
+      onError,
+    })
+
+    statusCallbacks[0]('CHANNEL_ERROR')
+    statusCallbacks[0]('CHANNEL_ERROR')
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(channels).toHaveLength(2)
+    expect(onError.mock.calls.filter(([error]) => (
+      error.message === 'Realtime connection issue: CHANNEL_ERROR'
+    ))).toHaveLength(1)
+    expect(onError.mock.calls.some(([error]) => (
+      error.message === 'Realtime reconnect limit reached; polling fallback is active.'
+    ))).toBe(false)
 
     cleanup()
   })


### PR DESCRIPTION
## Summary
- Treat finite Realtime retry exhaustion as an expected fallback handoff instead of a false error.
- Downgrade the max-retry log from warn to info and use a fallback-specific message.
- Ignore duplicate terminal Supabase statuses while a reconnect timer is pending so one failed channel consumes only one retry budget.

## Verification
- `./node_modules/.bin/vitest run tests/unit/realtime.test.ts tests/unit/components/overlay-page.test.tsx`
- `npm run lint`
- `npm run build`
- Subagent review: blockingなし