### PR TITLE
fix: suppress duplicate realtime channel errors

### DIFF
--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -309,6 +309,14 @@ export function subscribeToGachaResults(
             return
           }
 
+          const isRetryableTerminalStatus = status !== 'SUBSCRIBED' && !CONNECTING_STATUSES.includes(status)
+          if (isRetryableTerminalStatus && (retryTimeout || maxRetriesNotified)) {
+            // Supabase may repeat the same terminal status for one failed socket.
+            // Suppress duplicates before debug callbacks too, otherwise preview
+            // still shows duplicate CHANNEL_ERROR lines even though retry state is safe.
+            return
+          }
+
           onStatusChange?.(`SUBSCRIBE_STATUS: ${status}`)
 
           if (status === 'SUBSCRIBED') {
@@ -323,14 +331,6 @@ export function subscribeToGachaResults(
             onStatusChange?.(`CONNECTING: ${status}`)
           } else {
             const isExpected = EXPECTED_CLOSE_STATUSES.includes(status)
-
-            // Supabase can emit the same terminal status more than once for a
-            // single channel failure. Once a reconnect is already scheduled,
-            // ignore duplicate terminal callbacks so one failure consumes only
-            // one retry budget and cleanup can still cancel the pending timer.
-            if (retryTimeout) {
-              return
-            }
 
             const error: RealtimeError = {
               type: 'connection',

--- a/tests/unit/realtime.test.ts
+++ b/tests/unit/realtime.test.ts
@@ -139,10 +139,12 @@ describe('subscribeToGachaResults', () => {
 
   it('counts repeated terminal statuses with a pending retry as one failure', async () => {
     const onError = vi.fn()
+    const onStatusChange = vi.fn()
     const cleanup = subscribeToGachaResults('streamer-1', vi.fn(), {
       maxRetries: 1,
       retryDelay: 10,
       onError,
+      onStatusChange,
     })
 
     statusCallbacks[0]('CHANNEL_ERROR')
@@ -152,6 +154,9 @@ describe('subscribeToGachaResults', () => {
     expect(channels).toHaveLength(2)
     expect(onError.mock.calls.filter(([error]) => (
       error.message === 'Realtime connection issue: CHANNEL_ERROR'
+    ))).toHaveLength(1)
+    expect(onStatusChange.mock.calls.filter(([status]) => (
+      status === 'SUBSCRIBE_STATUS: CHANNEL_ERROR'
     ))).toHaveLength(1)
     expect(onError.mock.calls.some(([error]) => (
       error.message === 'Realtime reconnect limit reached; polling fallback is active.'


### PR DESCRIPTION
## Summary
- Suppress duplicate terminal Supabase Realtime statuses before debug status callbacks when a retry is already pending or fallback was already reported.
- Keep one failed socket to one retry budget consumption.
- Add a regression assertion that duplicate CHANNEL_ERROR emits only one status callback.

## Verification
- `./node_modules/.bin/vitest run tests/unit/realtime.test.ts tests/unit/components/overlay-page.test.tsx`
- `npm run lint`
- `npm run build`