### PR TITLE
feat: tune multi-draw overlay duration

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -604,6 +604,8 @@
       "smallModeDescription": "Smaller display for images under 400x400 (auto-applied)",
       "displayDuration": "Card Display Duration",
       "displayDurationDescription": "Set how long the card appears on screen",
+      "multiDrawDisplayDuration": "Multi-draw Card Display Duration",
+      "multiDrawDisplayDurationDescription": "Set how long each card appears during multi-draw gacha",
       "seconds": "s",
       "portraitInfoSection": "Portrait Image Info (Below Image)",
       "portraitShowName": "Show Name",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -604,6 +604,8 @@
       "smallModeDescription": "400x400未満の画像用に縮小表示（自動適用）",
       "displayDuration": "カードの表示時間",
       "displayDurationDescription": "カードが画面に表示される時間を設定します",
+      "multiDrawDisplayDuration": "N連時のカード表示時間",
+      "multiDrawDisplayDurationDescription": "N連ガチャ時の1枚あたりの表示時間を設定します",
       "seconds": "秒",
       "portraitInfoSection": "縦長画像の付帯情報（画像の下に表示）",
       "portraitShowName": "カード名を表示",

--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -97,6 +97,7 @@ interface OverlayOptions {
   effects: boolean;
   smallMode: boolean;
   displayDuration: number;  // カードの表示時間（秒）、デフォルト6秒
+  multiDrawDisplayDuration: number;  // N連ガチャ時のカード表示時間（秒）、デフォルト3秒
   debug: boolean;
   // 縦長画像の付帯情報表示オプション（画像に被らず表示）
   portraitShowName: boolean;
@@ -131,6 +132,7 @@ export default function OverlayPage() {
     effects: true,
     smallMode: true,     // デフォルトで小さい画像モードを有効化
     displayDuration: 6,  // カードの表示時間（秒）、デフォルト6秒
+    multiDrawDisplayDuration: 3,  // N連ガチャ時のカード表示時間（秒）、デフォルト3秒
     debug: false,        // デバッグモード（接続状態の詳細表示）
     // 縦長画像の付帯情報オプション（デフォルトでレアリティのみ表示）
     portraitShowName: false,
@@ -157,7 +159,7 @@ export default function OverlayPage() {
   const connectionStatusRef = useRef(connectionStatus);
   // ガチャ結果キュー: アニメーション中に到着した結果をバッファし順番に表示する
   // 連続引き換え時に前のカードが消えて最後の1件しか表示されない問題を解消
-  const queueRef = useRef<GachaResult[]>([]);
+  const queueRef = useRef<(GachaResult & { isMultiDraw?: boolean })[]>([]);
   const isDisplayingRef = useRef(false);
   const playedSoundGroupIdsRef = useRef<Set<string>>(new Set());
   // processQueueの再帰呼び出し用ref（useCallback内で自身を参照するため）
@@ -272,6 +274,10 @@ export default function OverlayPage() {
     const displayDuration = durationParam
       ? Math.min(15, Math.max(2, parseInt(durationParam, 10) || 6))
       : 6;
+    const multiDrawDurationParam = urlParams.get("mDuration");
+    const multiDrawDisplayDuration = multiDrawDurationParam
+      ? Math.min(10, Math.max(1, parseInt(multiDrawDurationParam, 10) || 3))
+      : 3;
     // queueMicrotaskで非同期に実行してカスケードレンダーを回避
     queueMicrotask(() => {
       setOptions({
@@ -280,6 +286,7 @@ export default function OverlayPage() {
         effects: urlParams.get("effects") !== "false",             // デフォルトはtrue
         smallMode: urlParams.get("smallMode") !== "false",         // デフォルトはtrue
         displayDuration,  // カードの表示時間（秒）
+        multiDrawDisplayDuration,  // N連ガチャ時のカード表示時間（秒）
         debug: isDebug,
         // 縦長画像の付帯情報オプション
         // pName, pRarity, pDesc, pUser（短縮パラメータ名）
@@ -376,6 +383,7 @@ export default function OverlayPage() {
     setSparklePositions(generateSparklePositions());
     setResult(next);
     setShowCard(false);
+    const displaySeconds = next.isMultiDraw ? options.multiDrawDisplayDuration : options.displayDuration;
 
     // Show card after brief delay
     animationTimeoutRef.current = setTimeout(() => {
@@ -399,9 +407,9 @@ export default function OverlayPage() {
           // ref経由で最新のprocessQueueを呼び出し（再帰）
           processQueueRef.current();
         }, 500);
-      }, options.displayDuration * 1000);
+      }, displaySeconds * 1000);
     }, 100);
-  }, [checkImageAspectRatio, playGachaSound, options.displayDuration]);
+  }, [checkImageAspectRatio, playGachaSound, options.displayDuration, options.multiDrawDisplayDuration]);
 
   // processQueueRefを最新のcallbackで更新
   useEffect(() => {
@@ -414,11 +422,13 @@ export default function OverlayPage() {
    */
   const enqueueResult = useCallback((data: GachaResult) => {
     const cards = data.cards?.length ? data.cards : [data.card];
+    const isMultiDraw = cards.length > 1;
     queueRef.current.push(
       ...cards.map((card, index) => ({
         ...data,
         card,
         cards: undefined,
+        isMultiDraw,
         shouldPlaySound: data.shouldPlaySound !== false && index === 0,
       }))
     );

--- a/src/components/OverlayPreview.tsx
+++ b/src/components/OverlayPreview.tsx
@@ -15,6 +15,7 @@ interface OverlayOptions {
   effects: boolean;         // レジェンダリーのキラキラエフェクト表示
   smallMode: boolean;       // 小さい画像用の縮小表示モード
   displayDuration: number;  // カードの表示時間（秒）、デフォルト6秒
+  multiDrawDisplayDuration: number;  // N連ガチャ時のカード表示時間（秒）、デフォルト3秒
   // 縦長画像の付帯情報表示オプション（画像に被らず下に表示）
   // Portrait image info options (displayed below image, not overlapping)
   portraitShowName: boolean;        // 縦長画像でカード名を表示
@@ -29,6 +30,7 @@ const DEFAULT_OVERLAY_OPTIONS: OverlayOptions = {
   effects: true,
   smallMode: true,
   displayDuration: 6,
+  multiDrawDisplayDuration: 3,
   portraitShowName: false,
   portraitShowRarity: true,
   portraitShowDescription: false,
@@ -49,6 +51,14 @@ function clampDisplayDuration(value: unknown) {
   return Math.min(15, Math.max(2, parsed));
 }
 
+function clampMultiDrawDisplayDuration(value: unknown) {
+  const parsed = typeof value === "number" ? value : Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_OVERLAY_OPTIONS.multiDrawDisplayDuration;
+  }
+  return Math.min(10, Math.max(1, parsed));
+}
+
 function parseStoredOptions(value: unknown): OverlayOptions {
   if (!value || typeof value !== "object") {
     return { ...DEFAULT_OVERLAY_OPTIONS };
@@ -62,6 +72,7 @@ function parseStoredOptions(value: unknown): OverlayOptions {
     effects: readStoredBoolean(stored.effects, DEFAULT_OVERLAY_OPTIONS.effects),
     smallMode: readStoredBoolean(stored.smallMode, DEFAULT_OVERLAY_OPTIONS.smallMode),
     displayDuration: clampDisplayDuration(stored.displayDuration),
+    multiDrawDisplayDuration: clampMultiDrawDisplayDuration(stored.multiDrawDisplayDuration),
     portraitShowName: readStoredBoolean(stored.portraitShowName, DEFAULT_OVERLAY_OPTIONS.portraitShowName),
     portraitShowRarity: readStoredBoolean(stored.portraitShowRarity, DEFAULT_OVERLAY_OPTIONS.portraitShowRarity),
     portraitShowDescription: readStoredBoolean(stored.portraitShowDescription, DEFAULT_OVERLAY_OPTIONS.portraitShowDescription),
@@ -76,6 +87,7 @@ function areOverlayOptionsEqual(a: OverlayOptions, b: OverlayOptions) {
     a.effects === b.effects &&
     a.smallMode === b.smallMode &&
     a.displayDuration === b.displayDuration &&
+    a.multiDrawDisplayDuration === b.multiDrawDisplayDuration &&
     a.portraitShowName === b.portraitShowName &&
     a.portraitShowRarity === b.portraitShowRarity &&
     a.portraitShowDescription === b.portraitShowDescription &&
@@ -219,6 +231,9 @@ export default function OverlayPreview({
     // カードの表示時間（デフォルト6秒、それ以外の場合のみ出力）
     // Display duration in seconds (default 6, only output if different)
     if (options.displayDuration !== 6) params.set("duration", String(options.displayDuration));
+    // N連ガチャ時のカード表示時間（デフォルト3秒、それ以外の場合のみ出力）
+    // Multi-draw card display duration in seconds (default 3, only output if different)
+    if (options.multiDrawDisplayDuration !== 3) params.set("mDuration", String(options.multiDrawDisplayDuration));
     // 縦長画像の付帯情報オプション
     // Portrait info options
     if (options.portraitShowName) params.set("pName", "true");               // デフォルトfalse、trueの場合のみ出力
@@ -493,6 +508,27 @@ export default function OverlayPreview({
               <span>15{t("options.seconds")}</span>
             </div>
             <p className="text-xs text-gray-400 mt-1">{t("options.displayDurationDescription")}</p>
+          </div>
+
+          <div className="pt-3">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-white">{t("options.multiDrawDisplayDuration")}</span>
+              <span className="text-sm text-purple-400 font-medium">{options.multiDrawDisplayDuration}{t("options.seconds")}</span>
+            </div>
+            <input
+              type="range"
+              min="1"
+              max="10"
+              step="1"
+              value={options.multiDrawDisplayDuration}
+              onChange={(e) => setOptions(prev => ({ ...prev, multiDrawDisplayDuration: Number(e.target.value) }))}
+              className="w-full h-2 bg-gray-700 rounded-lg appearance-none cursor-pointer accent-purple-600"
+            />
+            <div className="flex justify-between text-xs text-gray-500 mt-1">
+              <span>1{t("options.seconds")}</span>
+              <span>10{t("options.seconds")}</span>
+            </div>
+            <p className="text-xs text-gray-400 mt-1">{t("options.multiDrawDisplayDurationDescription")}</p>
           </div>
         </div>
 

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -131,13 +131,13 @@ describe('OverlayPage', () => {
     expect(playMock).toHaveBeenCalledTimes(1)
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(6600)
+      await vi.advanceTimersByTimeAsync(3600)
     })
     expect(screen.getByText('Beta')).toBeInTheDocument()
     expect(playMock).toHaveBeenCalledTimes(1)
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(6600)
+      await vi.advanceTimersByTimeAsync(3600)
     })
     expect(screen.getByText('Gamma')).toBeInTheDocument()
     expect(playMock).toHaveBeenCalledTimes(1)

--- a/tests/unit/components/overlay-preview.test.tsx
+++ b/tests/unit/components/overlay-preview.test.tsx
@@ -38,6 +38,8 @@ const messages = {
       smallModeDescription: '説明',
       displayDuration: 'カードの表示時間',
       displayDurationDescription: '説明',
+      multiDrawDisplayDuration: 'N連時のカード表示時間',
+      multiDrawDisplayDurationDescription: '説明',
       seconds: '秒',
       portraitInfoSection: '縦長画像の付帯情報（画像の下に表示）',
       portraitShowName: 'カード名を表示',
@@ -72,6 +74,7 @@ describe('OverlayPreview', () => {
       effects: false,
       smallMode: false,
       displayDuration: 10,
+      multiDrawDisplayDuration: 4,
       portraitShowName: true,
       portraitShowRarity: false,
       portraitShowDescription: true,
@@ -89,7 +92,7 @@ describe('OverlayPreview', () => {
     await waitFor(() => {
       expect(
         screen.getByDisplayValue(
-          'https://example.com/overlay/streamer-1?imageOnly=true&autoPortrait=false&effects=false&smallMode=false&duration=10&pName=true&pRarity=false&pDesc=true&pUser=true'
+          'https://example.com/overlay/streamer-1?imageOnly=true&autoPortrait=false&effects=false&smallMode=false&duration=10&mDuration=4&pName=true&pRarity=false&pDesc=true&pUser=true'
         )
       ).toBeInTheDocument()
     })
@@ -119,10 +122,37 @@ describe('OverlayPreview', () => {
         effects: true,
         smallMode: true,
         displayDuration: 6,
+        multiDrawDisplayDuration: 3,
         portraitShowName: false,
         portraitShowRarity: true,
         portraitShowDescription: false,
         portraitShowUsername: false,
+      })
+    })
+  })
+
+  it('N連表示時間を URL と localStorage に反映する', async () => {
+    renderWithIntl(
+      <OverlayPreview
+        streamerId="streamer-1"
+        baseUrl="https://example.com"
+        showPreview={false}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'オーバーレイカスタマイズ' }))
+    const sliders = screen.getAllByRole('slider')
+    fireEvent.change(sliders[1], { target: { value: '5' } })
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('https://example.com/overlay/streamer-1?mDuration=5')).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      const savedOptions = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')
+      expect(savedOptions).toMatchObject({
+        displayDuration: 6,
+        multiDrawDisplayDuration: 5,
       })
     })
   })


### PR DESCRIPTION
## Summary
- Reopen the closed #513 work on top of the restored `preview` branch.
- Add a separate `multiDrawDisplayDuration` overlay option for N-draw gacha cards.
- Emit the new OBS URL parameter as `mDuration`, with a 3-second default and 1-10 second clamp.
- Preserve single-card timing through `duration` while tagging multi-draw queue items so only N-draw playback uses the shorter duration.

Closes #496

## Validation
- `npm_config_cache=/tmp/twica-npm-cache npx vitest run tests/unit/components/overlay-preview.test.tsx tests/unit/components/overlay-page.test.tsx`
- `git diff --check origin/preview...HEAD`
- `npm_config_cache=/tmp/twica-npm-cache npm run lint` (existing warnings only)
- `npm_config_cache=/tmp/twica-npm-cache npm run build`
- `npm_config_cache=/tmp/twica-npm-cache npm run workers:build`

## Notes
- The earlier PR #513 was closed unmerged after `preview` disappeared. This PR reapplies the same reviewed implementation on the current restored `preview` branch.
