### PR TITLE
feat: add multi-draw guaranteed rarity slots

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -549,6 +549,14 @@
       "raidOnly": "Raid only",
       "multiDraw": "{count} draws",
       "raidLimited": "Raid limited",
+      "guaranteedRarity": "Guaranteed slot",
+      "guaranteedRarityNone": "None",
+      "guaranteedRarityBadge": "Last slot {rarity}+",
+      "guaranteedRarityOptions": {
+        "rare": "Rare",
+        "epic": "Epic",
+        "legendary": "Legendary"
+      },
       "raidGiftTitle": "Raid gacha",
       "raidGiftDescription": "When a raid arrives, gift gacha draws to the raider. Set how many draws to gift. 0 disables it.",
       "raidGiftEnabled": "When a raid arrives, gift gacha draws to the raider. Set how many draws to gift. 0 disables it.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -549,6 +549,14 @@
       "raidOnly": "レイド限定",
       "multiDraw": "{count}連",
       "raidLimited": "レイド限定",
+      "guaranteedRarity": "確定枠",
+      "guaranteedRarityNone": "なし",
+      "guaranteedRarityBadge": "最終{rarity}+確定",
+      "guaranteedRarityOptions": {
+        "rare": "レア",
+        "epic": "エピック",
+        "legendary": "レジェンダリー"
+      },
       "raidGiftTitle": "レイドガチャ",
       "raidGiftDescription": "レイドがきたら、そのレイド元の人にガチャをプレゼントできる設定。プレゼント枚数を指定できます。0なら無効",
       "raidGiftEnabled": "レイドがきたら、そのレイド元の人にガチャをプレゼントできる設定。プレゼント枚数を指定できます。0なら無効",

--- a/src/app/api/streamer/additional-rewards/route.ts
+++ b/src/app/api/streamer/additional-rewards/route.ts
@@ -7,10 +7,14 @@ import { ERROR_MESSAGES } from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
 import { logger } from "@/lib/logger";
+import { isGuaranteedRarity, normalizeGuaranteedRarity } from "@/lib/rarity";
 
 function isRaidOptionsSchemaError(error: { message?: string; code?: string } | null | undefined) {
   const message = error?.message ?? "";
-  return error?.code === "PGRST204" || message.includes("draw_count") || message.includes("is_raid_limited");
+  return error?.code === "PGRST204"
+    || message.includes("draw_count")
+    || message.includes("is_raid_limited")
+    || message.includes("guaranteed_rarity");
 }
 
 const RAID_OPTIONS_SCHEMA_PENDING_MESSAGE =
@@ -63,7 +67,7 @@ export async function GET(request: NextRequest) {
     // このストリーマーの全ての追加報酬を取得
     let { data: rewards, error } = await supabaseAdmin
       .from("streamer_additional_gacha_rewards")
-      .select("id, reward_id, reward_name, draw_count, is_raid_limited, created_at")
+      .select("id, reward_id, reward_name, draw_count, is_raid_limited, guaranteed_rarity, created_at")
       .eq("streamer_id", streamer.id)
       .order("created_at", { ascending: true });
 
@@ -77,6 +81,7 @@ export async function GET(request: NextRequest) {
         ...reward,
         draw_count: 1,
         is_raid_limited: false,
+        guaranteed_rarity: null,
       }));
       error = fallbackResult.error;
     }
@@ -142,7 +147,7 @@ export async function POST(request: NextRequest) {
   try {
     const supabaseAdmin = getSupabaseAdmin();
     const body = await request.json();
-    const { rewardId, rewardName, drawCount, isRaidLimited } = body;
+    const { rewardId, rewardName, drawCount, isRaidLimited, guaranteedRarity: guaranteedRarityInput } = body;
 
     if (!rewardId) {
       return NextResponse.json({ error: ERROR_MESSAGES.MISSING_REWARD_ID }, { status: 400 });
@@ -162,6 +167,19 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+
+    if (
+      guaranteedRarityInput !== undefined
+      && guaranteedRarityInput !== null
+      && guaranteedRarityInput !== ""
+      && !isGuaranteedRarity(guaranteedRarityInput)
+    ) {
+      return NextResponse.json(
+        { error: "guaranteedRarity must be one of rare, epic, legendary, or null" },
+        { status: 400 }
+      );
+    }
+    const guaranteedRarity = normalizeGuaranteedRarity(guaranteedRarityInput);
 
     // Get streamer info to verify ownership
     // ストリーマー情報を取得して所有権を確認
@@ -203,6 +221,7 @@ export async function POST(request: NextRequest) {
         reward_name: rewardName || null,
         draw_count: normalizedDrawCount,
         is_raid_limited: isRaidLimited ?? false,
+        guaranteed_rarity: normalizedDrawCount >= 2 ? guaranteedRarity : null,
       })
       .select()
       .maybeSingle();
@@ -233,7 +252,7 @@ export async function POST(request: NextRequest) {
     }
 
     logger.info(
-      `Additional reward registered: streamerId=${streamer.id}, rewardId=${rewardId}, rewardName=${rewardName}, drawCount=${normalizedDrawCount}, raidLimited=${isRaidLimited ?? false}`
+      `Additional reward registered: streamerId=${streamer.id}, rewardId=${rewardId}, rewardName=${rewardName}, drawCount=${normalizedDrawCount}, raidLimited=${isRaidLimited ?? false}, guaranteedRarity=${normalizedDrawCount >= 2 ? guaranteedRarity ?? "none" : "none"}`
     );
 
     return NextResponse.json({ success: true, reward: newReward });

--- a/src/app/api/streamer/raid-gacha/route.ts
+++ b/src/app/api/streamer/raid-gacha/route.ts
@@ -7,12 +7,14 @@ import { ERROR_MESSAGES } from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
 import { logger } from "@/lib/logger";
+import { isGuaranteedRarity, normalizeGuaranteedRarity } from "@/lib/rarity";
 
 function isRaidStateSchemaError(error: { message?: string; code?: string } | null | undefined) {
   const message = error?.message ?? "";
   return error?.code === "PGRST204"
     || message.includes("raid_gacha_active_until")
-    || message.includes("raid_gacha_draw_count");
+    || message.includes("raid_gacha_draw_count")
+    || message.includes("raid_gacha_guaranteed_rarity");
 }
 
 function isActiveUntil(value: string | null | undefined): boolean {
@@ -25,7 +27,7 @@ async function getOwnedStreamer(twitchUserId: string) {
   const supabaseAdmin = getSupabaseAdmin();
   let { data: streamer, error } = await supabaseAdmin
     .from("streamers")
-    .select("id, raid_gacha_active_until, raid_gacha_draw_count")
+    .select("id, raid_gacha_active_until, raid_gacha_draw_count, raid_gacha_guaranteed_rarity")
     .eq("twitch_user_id", twitchUserId)
     .maybeSingle();
 
@@ -36,7 +38,7 @@ async function getOwnedStreamer(twitchUserId: string) {
       .eq("twitch_user_id", twitchUserId)
       .maybeSingle();
     streamer = fallbackResult.data
-      ? { ...fallbackResult.data, raid_gacha_active_until: null, raid_gacha_draw_count: 0 }
+      ? { ...fallbackResult.data, raid_gacha_active_until: null, raid_gacha_draw_count: 0, raid_gacha_guaranteed_rarity: null }
       : fallbackResult.data;
     error = fallbackResult.error;
   }
@@ -76,6 +78,7 @@ export async function GET(request: NextRequest) {
       active: isActiveUntil(streamer.raid_gacha_active_until),
       activeUntil: streamer.raid_gacha_active_until,
       drawCount: streamer.raid_gacha_draw_count ?? 0,
+      guaranteedRarity: streamer.raid_gacha_guaranteed_rarity ?? null,
     }, {
       headers: { "Cache-Control": "no-store, no-cache, must-revalidate" },
     });
@@ -118,6 +121,7 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const requestedDrawCount = body.drawCount === undefined ? 0 : Number(body.drawCount);
+    const guaranteedRarityInput = body.guaranteedRarity;
 
     if (!Number.isInteger(requestedDrawCount) || requestedDrawCount < 0 || requestedDrawCount > 10) {
       return NextResponse.json(
@@ -126,6 +130,19 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    if (
+      guaranteedRarityInput !== undefined
+      && guaranteedRarityInput !== null
+      && guaranteedRarityInput !== ""
+      && !isGuaranteedRarity(guaranteedRarityInput)
+    ) {
+      return NextResponse.json(
+        { error: "guaranteedRarity must be one of rare, epic, legendary, or null" },
+        { status: 400 },
+      );
+    }
+    const guaranteedRarity = normalizeGuaranteedRarity(guaranteedRarityInput);
+
     const { streamer, error: streamerError } = await getOwnedStreamer(session.twitchUserId);
     if (streamerError) return handleDatabaseError(streamerError, "Raid Gacha API: POST lookup");
     if (!streamer) return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
@@ -133,9 +150,12 @@ export async function POST(request: NextRequest) {
     const supabaseAdmin = getSupabaseAdmin();
     const { data: updatedStreamer, error } = await supabaseAdmin
       .from("streamers")
-      .update({ raid_gacha_draw_count: requestedDrawCount })
+      .update({
+        raid_gacha_draw_count: requestedDrawCount,
+        raid_gacha_guaranteed_rarity: requestedDrawCount >= 2 ? guaranteedRarity : null,
+      })
       .eq("id", streamer.id)
-      .select("raid_gacha_active_until, raid_gacha_draw_count")
+      .select("raid_gacha_active_until, raid_gacha_draw_count, raid_gacha_guaranteed_rarity")
       .maybeSingle();
 
     if (error) return handleDatabaseError(error, "Raid Gacha API: POST update");
@@ -143,6 +163,7 @@ export async function POST(request: NextRequest) {
     logger.info("Raid gacha state updated", {
       streamerId: streamer.id,
       drawCount: requestedDrawCount,
+      guaranteedRarity: requestedDrawCount >= 2 ? guaranteedRarity : null,
     });
 
     return NextResponse.json({
@@ -150,6 +171,7 @@ export async function POST(request: NextRequest) {
       active: isActiveUntil(updatedStreamer?.raid_gacha_active_until),
       activeUntil: updatedStreamer?.raid_gacha_active_until ?? null,
       drawCount: updatedStreamer?.raid_gacha_draw_count ?? requestedDrawCount,
+      guaranteedRarity: updatedStreamer?.raid_gacha_guaranteed_rarity ?? null,
     });
   } catch (error) {
     return handleApiError(error, "Raid Gacha API: POST");

--- a/src/app/api/twitch/channel-point-bootstrap/route.ts
+++ b/src/app/api/twitch/channel-point-bootstrap/route.ts
@@ -23,14 +23,18 @@ interface TwitchReward {
 
 function isRaidOptionsSchemaError(error: { message?: string; code?: string } | null | undefined) {
   const message = error?.message ?? "";
-  return error?.code === "PGRST204" || message.includes("draw_count") || message.includes("is_raid_limited");
+  return error?.code === "PGRST204"
+    || message.includes("draw_count")
+    || message.includes("is_raid_limited")
+    || message.includes("guaranteed_rarity");
 }
 
 function isRaidStateSchemaError(error: { message?: string; code?: string } | null | undefined) {
   const message = error?.message ?? "";
   return error?.code === "PGRST204"
     || message.includes("raid_gacha_active_until")
-    || message.includes("raid_gacha_draw_count");
+    || message.includes("raid_gacha_draw_count")
+    || message.includes("raid_gacha_guaranteed_rarity");
 }
 
 async function getTwitchRewards(twitchUserId: string): Promise<{ rewards: TwitchReward[]; requiresReauth?: boolean; error?: string }> {
@@ -120,7 +124,7 @@ async function getAdditionalRewards(streamerId: string) {
   const supabaseAdmin = getSupabaseAdmin();
   let { data: rewards, error } = await supabaseAdmin
     .from("streamer_additional_gacha_rewards")
-    .select("id, reward_id, reward_name, draw_count, is_raid_limited, created_at")
+    .select("id, reward_id, reward_name, draw_count, is_raid_limited, guaranteed_rarity, created_at")
     .eq("streamer_id", streamerId)
     .order("created_at", { ascending: true });
 
@@ -134,6 +138,7 @@ async function getAdditionalRewards(streamerId: string) {
       ...reward,
       draw_count: 1,
       is_raid_limited: false,
+      guaranteed_rarity: null,
     }));
     error = fallbackResult.error;
   }
@@ -149,7 +154,7 @@ async function getOwnedStreamer(twitchUserId: string) {
   const supabaseAdmin = getSupabaseAdmin();
   let { data: streamer, error } = await supabaseAdmin
     .from("streamers")
-    .select("id, channel_point_reward_id, raid_gacha_draw_count")
+    .select("id, channel_point_reward_id, raid_gacha_draw_count, raid_gacha_guaranteed_rarity")
     .eq("twitch_user_id", twitchUserId)
     .maybeSingle();
 
@@ -160,7 +165,7 @@ async function getOwnedStreamer(twitchUserId: string) {
       .eq("twitch_user_id", twitchUserId)
       .maybeSingle();
     streamer = fallbackResult.data
-      ? { ...fallbackResult.data, raid_gacha_draw_count: 0 }
+      ? { ...fallbackResult.data, raid_gacha_draw_count: 0, raid_gacha_guaranteed_rarity: null }
       : fallbackResult.data;
     error = fallbackResult.error;
   }
@@ -234,6 +239,7 @@ export async function GET(request: NextRequest) {
       responsePayload.raidEventSubStatus = status.raidStatus;
       responsePayload.additionalRewards = await getAdditionalRewards(streamer.id);
       responsePayload.raidGiftDrawCount = streamer.raid_gacha_draw_count ?? 0;
+      responsePayload.raidGiftGuaranteedRarity = streamer.raid_gacha_guaranteed_rarity ?? null;
     }
 
     return NextResponse.json(responsePayload);

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -28,8 +28,11 @@ interface AdditionalReward {
   reward_name: string | null;
   draw_count: number;
   is_raid_limited: boolean;
+  guaranteed_rarity: string | null;
   created_at: string;
 }
+
+const GUARANTEED_RARITY_OPTIONS = ["rare", "epic", "legendary"] as const;
 
 const getRaidSubscriptionWarning = (data: unknown): string => {
   const raidSubscription = (data as { raidSubscription?: { warning?: unknown } })?.raidSubscription;
@@ -94,7 +97,9 @@ export default function ChannelPointSettings({
   const [addingAdditional, setAddingAdditional] = useState(false);
   const [selectedAdditionalRewardId, setSelectedAdditionalRewardId] = useState("");
   const [additionalDrawCount, setAdditionalDrawCount] = useState(1);
+  const [additionalGuaranteedRarity, setAdditionalGuaranteedRarity] = useState("");
   const [raidGiftDrawCount, setRaidGiftDrawCount] = useState(0);
+  const [raidGiftGuaranteedRarity, setRaidGiftGuaranteedRarity] = useState("");
   const [updatingRaidGift, setUpdatingRaidGift] = useState(false);
   // Track if registration failed (webhook unreachable)
   // 登録失敗を追跡（Webhookに到達できなかった場合）
@@ -143,6 +148,7 @@ export default function ChannelPointSettings({
         if (typeof data.raidGiftDrawCount !== "undefined") {
           setRaidGiftDrawCount(Math.min(10, Math.max(0, Number(data.raidGiftDrawCount ?? 0))));
         }
+        setRaidGiftGuaranteedRarity(typeof data.raidGiftGuaranteedRarity === "string" ? data.raidGiftGuaranteedRarity : "");
       }
     } catch (err) {
       logger.error("Failed to bootstrap channel point settings:", err);
@@ -193,6 +199,7 @@ export default function ChannelPointSettings({
       if (response.ok) {
         const data = await response.json();
         setRaidGiftDrawCount(Math.min(10, Math.max(0, Number(data.drawCount ?? 0))));
+        setRaidGiftGuaranteedRarity(typeof data.guaranteedRarity === "string" ? data.guaranteedRarity : "");
       }
     } catch {
       logger.error("Failed to fetch raid gacha status");
@@ -208,7 +215,10 @@ export default function ChannelPointSettings({
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ drawCount: raidGiftDrawCount }),
+        body: JSON.stringify({
+          drawCount: raidGiftDrawCount,
+          guaranteedRarity: raidGiftDrawCount >= 2 ? raidGiftGuaranteedRarity || null : null,
+        }),
       });
       const data = await response.json();
 
@@ -218,6 +228,7 @@ export default function ChannelPointSettings({
       }
 
       setRaidGiftDrawCount(Math.min(10, Math.max(0, Number(data.drawCount ?? 0))));
+      setRaidGiftGuaranteedRarity(typeof data.guaranteedRarity === "string" ? data.guaranteedRarity : "");
       setMessage(t("additionalRewards.raidGiftSaved"));
     } catch {
       setMessage(t("additionalRewards.raidStatusFailed"));
@@ -455,6 +466,7 @@ export default function ChannelPointSettings({
           rewardName: rewardName,
           drawCount: additionalDrawCount,
           isRaidLimited: false,
+          guaranteedRarity: additionalDrawCount >= 2 ? additionalGuaranteedRarity || null : null,
         }),
       });
 
@@ -471,6 +483,7 @@ export default function ChannelPointSettings({
       setMessage(raidSubscriptionWarning || t("additionalRewards.addSuccess"));
       setSelectedAdditionalRewardId("");
       setAdditionalDrawCount(1);
+      setAdditionalGuaranteedRarity("");
       await fetchAdditionalRewards();
       await fetchEventSubStatus(selectedRewardId);
       setRaidEventSubWarning(raidSubscriptionWarning);
@@ -1029,6 +1042,13 @@ export default function ChannelPointSettings({
                                {t("additionalRewards.raidLimited")}
                              </span>
                            )}
+                           {reward.draw_count > 1 && reward.guaranteed_rarity && (
+                             <span className="rounded bg-amber-500/20 px-2 py-0.5 text-amber-100">
+                               {t("additionalRewards.guaranteedRarityBadge", {
+                                 rarity: t(`additionalRewards.guaranteedRarityOptions.${reward.guaranteed_rarity}`),
+                               })}
+                             </span>
+                           )}
                          </div>
                        </div>
                        <button
@@ -1051,7 +1071,7 @@ export default function ChannelPointSettings({
                      {t("additionalRewards.raidGiftDescription")}
                    </div>
                  </div>
-                 <div className="flex items-center gap-2">
+                 <div className="flex flex-wrap items-center gap-2">
                    <input
                      type="number"
                      min={0}
@@ -1060,6 +1080,24 @@ export default function ChannelPointSettings({
                      onChange={(e) => setRaidGiftDrawCount(Math.min(10, Math.max(0, Number(e.target.value) || 0)))}
                      className="h-9 w-16 rounded-md border border-gray-600 bg-gray-700 px-2 text-sm text-gray-100 transition-colors hover:border-gray-500 focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500/40"
                    />
+                   <label className="flex h-9 items-center gap-2 rounded-md border border-gray-600 bg-gray-700 pl-3 pr-2 text-sm text-gray-200 transition-colors hover:border-gray-500 focus-within:border-cyan-500 focus-within:ring-1 focus-within:ring-cyan-500/40">
+                     <span className="whitespace-nowrap text-xs text-gray-300">
+                       {t("additionalRewards.guaranteedRarity")}
+                     </span>
+                     <select
+                       value={raidGiftDrawCount >= 2 ? raidGiftGuaranteedRarity : ""}
+                       onChange={(e) => setRaidGiftGuaranteedRarity(e.target.value)}
+                       disabled={raidGiftDrawCount < 2}
+                       className="h-7 rounded bg-gray-800 px-2 text-xs text-gray-100 focus:outline-none disabled:text-gray-500"
+                     >
+                       <option value="">{t("additionalRewards.guaranteedRarityNone")}</option>
+                       {GUARANTEED_RARITY_OPTIONS.map((rarity) => (
+                         <option key={rarity} value={rarity}>
+                           {t(`additionalRewards.guaranteedRarityOptions.${rarity}`)}
+                         </option>
+                       ))}
+                     </select>
+                   </label>
                    <button
                      type="button"
                      onClick={updateRaidGiftSettings}
@@ -1073,7 +1111,7 @@ export default function ChannelPointSettings({
 
                {/* Add new additional reward */}
                {/* 新しい追加報酬を追加 */}
-               <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_180px_auto] sm:items-center">
+               <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_180px_180px_auto] sm:items-center">
                  {/*
                    ネイティブの矢印アイコンを残しつつ右側に余白を確保。
                    bg-gray-700 で他のフォーム要素と階調を揃え、フォーカスリングで状態を明示する。
@@ -1114,6 +1152,24 @@ export default function ChannelPointSettings({
                      onChange={(e) => setAdditionalDrawCount(Math.min(10, Math.max(1, Number(e.target.value) || 1)))}
                      className="h-7 w-12 rounded bg-gray-800 px-2 text-sm text-gray-100 focus:outline-none"
                    />
+                 </label>
+                 <label className="group flex h-10 items-center gap-2 rounded-md border border-gray-600 bg-gray-700 pl-3 pr-2 text-sm text-gray-200 transition-colors hover:border-gray-500 focus-within:border-purple-500 focus-within:ring-1 focus-within:ring-purple-500/40">
+                   <span className="whitespace-nowrap text-xs text-gray-300">
+                     {t("additionalRewards.guaranteedRarity")}
+                   </span>
+                   <select
+                     value={additionalDrawCount >= 2 ? additionalGuaranteedRarity : ""}
+                     onChange={(e) => setAdditionalGuaranteedRarity(e.target.value)}
+                     disabled={additionalDrawCount < 2}
+                     className="h-7 min-w-0 flex-1 rounded bg-gray-800 px-2 text-xs text-gray-100 focus:outline-none disabled:text-gray-500"
+                   >
+                     <option value="">{t("additionalRewards.guaranteedRarityNone")}</option>
+                     {GUARANTEED_RARITY_OPTIONS.map((rarity) => (
+                       <option key={rarity} value={rarity}>
+                         {t(`additionalRewards.guaranteedRarityOptions.${rarity}`)}
+                       </option>
+                     ))}
+                   </select>
                  </label>
                  <button
                    onClick={handleAddAdditionalReward}

--- a/src/lib/rarity.ts
+++ b/src/lib/rarity.ts
@@ -75,3 +75,30 @@ export function getRarityGradientClass(rarity: string): string {
 export function getRarityGlowClass(rarity: string): string {
   return RARITY_GLOW[rarity] ?? DEFAULT_RARITY_GLOW_CLASS;
 }
+
+export const GUARANTEED_RARITY_VALUES = ["rare", "epic", "legendary"] as const;
+
+export type GuaranteedRarity = (typeof GUARANTEED_RARITY_VALUES)[number];
+
+const RARITY_RANK: Record<string, number> = {
+  common: 0,
+  rare: 1,
+  epic: 2,
+  legendary: 3,
+};
+
+export function isGuaranteedRarity(value: unknown): value is GuaranteedRarity {
+  return typeof value === "string" && GUARANTEED_RARITY_VALUES.includes(value as GuaranteedRarity);
+}
+
+export function normalizeGuaranteedRarity(value: unknown): GuaranteedRarity | null {
+  if (value === undefined || value === null || value === "") return null;
+  return isGuaranteedRarity(value) ? value : null;
+}
+
+export function meetsRarityFloor(cardRarity: string, floor: GuaranteedRarity): boolean {
+  const cardRank = RARITY_RANK[cardRarity];
+  const floorRank = RARITY_RANK[floor];
+  if (cardRank === undefined || floorRank === undefined) return false;
+  return cardRank >= floorRank;
+}

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -5,13 +5,14 @@ import { Result, ok, err } from '@/types/result'
 import { logger } from '@/lib/logger'
 import { reportError } from '@/lib/sentry/error-handler'
 import { withRetry } from '@/lib/supabase/retry'
+import { meetsRarityFloor, normalizeGuaranteedRarity, type GuaranteedRarity } from '@/lib/rarity'
 
 export interface GachaCard {
   id: string
   name: string
   description: string | null
   image_url: string | null
-  rarity: 'common' | 'rare' | 'epic' | 'legendary'
+  rarity: string
   drop_rate: number
 }
 
@@ -41,7 +42,10 @@ export interface GachaResult {
 
 function isRaidOptionsSchemaError(error: { message?: string; code?: string } | null | undefined) {
   const message = error?.message ?? ''
-  return error?.code === 'PGRST204' || message.includes('draw_count') || message.includes('is_raid_limited')
+  return error?.code === 'PGRST204'
+    || message.includes('draw_count')
+    || message.includes('is_raid_limited')
+    || message.includes('guaranteed_rarity')
 }
 
 const ADDITIONAL_REWARD_OPTIONS_UNAVAILABLE = 'Additional reward options unavailable'
@@ -51,6 +55,7 @@ function isStreamerSettingsSchemaError(error: { message?: string; code?: string 
   return error?.code === 'PGRST204'
     || message.includes('raid_gacha_active_until')
     || message.includes('raid_gacha_draw_count')
+    || message.includes('raid_gacha_guaranteed_rarity')
     || message.includes('chat_announcement_multi_template')
     || message.includes('chat_announcement_multi_show_cards')
 }
@@ -64,7 +69,14 @@ function isRaidGachaActive(activeUntil: string | null | undefined, now = new Dat
 export class GachaService {
   private supabase = getSupabaseAdmin()
 
-  async executeGacha(streamerId: string, userTwitchId: string, userTwitchUsername: string, eventId?: string, rewardCost?: number): Promise<Result<GachaResult>> {
+  async executeGacha(
+    streamerId: string,
+    userTwitchId: string,
+    userTwitchUsername: string,
+    eventId?: string,
+    rewardCost?: number,
+    guaranteedRarity?: GuaranteedRarity | null
+  ): Promise<Result<GachaResult>> {
     try {
       // Get active cards for this streamer
       // このストリーマーの有効なカードを取得
@@ -85,9 +97,19 @@ export class GachaService {
         return err('No cards available for this streamer')
       }
 
-      // Select a card based on drop rates
-      // ドロップ率に基づいてカードを選択
-      const selectedCard = selectWeightedCard(normalizeDropRate(cards))
+      const guaranteedCandidates = guaranteedRarity
+        ? cards.filter((card) => meetsRarityFloor(card.rarity, guaranteedRarity))
+        : cards
+      const candidateCards = guaranteedCandidates.length > 0 ? guaranteedCandidates : cards
+
+      if (guaranteedRarity && guaranteedCandidates.length === 0) {
+        logger.warn('No cards match guaranteed rarity floor; falling back to normal gacha candidates', {
+          streamerId,
+          guaranteedRarity,
+        })
+      }
+
+      const selectedCard = selectWeightedCard(normalizeDropRate(candidateCards))
 
       if (!selectedCard) {
         return err('Failed to select card')
@@ -149,7 +171,8 @@ export class GachaService {
     userTwitchUsername: string,
     drawCount: number,
     eventId?: string,
-    rewardCost?: number
+    rewardCost?: number,
+    guaranteedRarity?: GuaranteedRarity | null
   ): Promise<Result<GachaResult>> {
     const cards: GachaCard[] = []
     const historyIds: string[] = []
@@ -158,12 +181,16 @@ export class GachaService {
     for (let index = 0; index < drawCount; index += 1) {
       const drawEventId = eventId && index > 0 ? `${eventId}:${index + 1}` : eventId
       const drawRewardCost = index === 0 ? rewardCost : undefined
+      const drawGuaranteedRarity = drawCount >= 2 && index === drawCount - 1
+        ? guaranteedRarity
+        : null
       const result = await this.executeGacha(
         streamerId,
         userTwitchId,
         userTwitchUsername,
         drawEventId,
-        drawRewardCost
+        drawRewardCost,
+        drawGuaranteedRarity
       )
 
       if (!result.success) {
@@ -342,7 +369,7 @@ export class GachaService {
       const { data: additionalReward, error: additionalError } = await withRetry(
         () => this.supabase
           .from('streamer_additional_gacha_rewards')
-          .select('id, draw_count, is_raid_limited')
+          .select('id, draw_count, is_raid_limited, guaranteed_rarity')
           .eq('streamer_id', streamer.id)
           .eq('reward_id', event.reward.id)
           .maybeSingle(),
@@ -377,8 +404,28 @@ export class GachaService {
         // Additional reward matched, execute gacha
         // 追加報酬が一致したのでガチャを実行
         const drawCount = Math.min(Math.max(Number(additionalReward.draw_count ?? 1), 1), 10)
-        logger.info(`Gacha triggered by additional reward: rewardId=${event.reward.id}, streamerId=${streamer.id}, drawCount=${drawCount}, raidLimited=${Boolean(additionalReward.is_raid_limited)}`)
-        return await executeAndAttachStreamer(drawCount)
+        const guaranteedRarity = normalizeGuaranteedRarity(additionalReward.guaranteed_rarity)
+        logger.info(`Gacha triggered by additional reward: rewardId=${event.reward.id}, streamerId=${streamer.id}, drawCount=${drawCount}, raidLimited=${Boolean(additionalReward.is_raid_limited)}, guaranteedRarity=${guaranteedRarity ?? 'none'}`)
+        const result = await this.executeGachaDraws(
+          streamer.id,
+          event.user_id,
+          event.user_name,
+          drawCount,
+          eventId,
+          event.reward.cost,
+          guaranteedRarity
+        )
+        if (!result.success) return result
+        return ok({
+          ...result.data,
+          streamer: {
+            id: streamer.id,
+            chat_announcement_enabled: streamer.chat_announcement_enabled,
+            chat_announcement_template: streamer.chat_announcement_template,
+            chat_announcement_multi_template: streamer.chat_announcement_multi_template,
+            chat_announcement_multi_show_cards: streamer.chat_announcement_multi_show_cards ?? true,
+          },
+        })
       }
 
       return err('Reward ID mismatch')
@@ -399,7 +446,7 @@ export class GachaService {
     try {
       let { data: streamer, error: streamerError } = await this.supabase
         .from('streamers')
-        .select('id, chat_announcement_enabled, chat_announcement_template, chat_announcement_multi_template, chat_announcement_multi_show_cards, raid_gacha_draw_count')
+        .select('id, chat_announcement_enabled, chat_announcement_template, chat_announcement_multi_template, chat_announcement_multi_show_cards, raid_gacha_draw_count, raid_gacha_guaranteed_rarity')
         .eq('twitch_user_id', event.to_broadcaster_user_id)
         .maybeSingle()
 
@@ -415,6 +462,7 @@ export class GachaService {
               chat_announcement_multi_template: null,
               chat_announcement_multi_show_cards: true,
               raid_gacha_draw_count: 0,
+              raid_gacha_guaranteed_rarity: null,
             }
           : fallbackResult.data
         streamerError = fallbackResult.error
@@ -436,7 +484,8 @@ export class GachaService {
         userName,
         drawCount,
         eventId,
-        undefined
+        undefined,
+        normalizeGuaranteedRarity(streamer.raid_gacha_guaranteed_rarity)
       )
 
       if (!result.success) return result

--- a/supabase/migrations/00053_add_multi_draw_guaranteed_rarity.sql
+++ b/supabase/migrations/00053_add_multi_draw_guaranteed_rarity.sql
@@ -1,0 +1,26 @@
+-- Add minimum-rarity guarantees for the final slot of multi-draw gacha rewards.
+ALTER TABLE streamer_additional_gacha_rewards
+  ADD COLUMN IF NOT EXISTS guaranteed_rarity TEXT NULL;
+
+ALTER TABLE streamer_additional_gacha_rewards
+  DROP CONSTRAINT IF EXISTS streamer_additional_gacha_rewards_guaranteed_rarity_check;
+
+ALTER TABLE streamer_additional_gacha_rewards
+  ADD CONSTRAINT streamer_additional_gacha_rewards_guaranteed_rarity_check
+  CHECK (guaranteed_rarity IS NULL OR guaranteed_rarity IN ('rare', 'epic', 'legendary'));
+
+COMMENT ON COLUMN streamer_additional_gacha_rewards.guaranteed_rarity IS
+  'Minimum rarity guaranteed on the last draw of a multi-draw channel point reward. NULL disables the guarantee.';
+
+ALTER TABLE streamers
+  ADD COLUMN IF NOT EXISTS raid_gacha_guaranteed_rarity TEXT NULL;
+
+ALTER TABLE streamers
+  DROP CONSTRAINT IF EXISTS streamers_raid_gacha_guaranteed_rarity_check;
+
+ALTER TABLE streamers
+  ADD CONSTRAINT streamers_raid_gacha_guaranteed_rarity_check
+  CHECK (raid_gacha_guaranteed_rarity IS NULL OR raid_gacha_guaranteed_rarity IN ('rare', 'epic', 'legendary'));
+
+COMMENT ON COLUMN streamers.raid_gacha_guaranteed_rarity IS
+  'Minimum rarity guaranteed on the last draw of a raid-triggered multi-draw gacha. NULL disables the guarantee.';

--- a/tests/unit/additional-rewards-api.test.ts
+++ b/tests/unit/additional-rewards-api.test.ts
@@ -71,6 +71,7 @@ describe('/api/streamer/additional-rewards raid options', () => {
         reward_name: 'Raid 10',
         draw_count: 10,
         is_raid_limited: true,
+        guaranteed_rarity: 'rare',
       },
       error: null,
     })
@@ -91,6 +92,7 @@ describe('/api/streamer/additional-rewards raid options', () => {
         rewardName: 'Raid 10',
         drawCount: 10,
         isRaidLimited: true,
+        guaranteedRarity: 'rare',
       }),
     }))
 
@@ -98,7 +100,29 @@ describe('/api/streamer/additional-rewards raid options', () => {
     expect(insertQuery.insert).toHaveBeenCalledWith(expect.objectContaining({
       draw_count: 10,
       is_raid_limited: true,
+      guaranteed_rarity: 'rare',
     }))
+  })
+
+  it('rejects unsupported guaranteedRarity values', async () => {
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from: vi.fn() } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const response = await POST(new NextRequest('http://localhost/api/streamer/additional-rewards', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        rewardId: 'raid-reward',
+        rewardName: 'Raid 10',
+        drawCount: 10,
+        guaranteedRarity: 'common',
+      }),
+    }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'guaranteedRarity must be one of rare, epic, legendary, or null',
+    })
   })
 
   it('rejects drawCount outside the supported range', async () => {
@@ -201,6 +225,7 @@ describe('/api/streamer/additional-rewards raid options', () => {
         reward_id: 'legacy-reward',
         draw_count: 1,
         is_raid_limited: false,
+        guaranteed_rarity: null,
       }),
     ])
   })

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -21,7 +21,7 @@ const testCards = [
 ]
 
 /** cardsクエリの共通モック生成。thenableにしてawait対応 */
-function createCardsQuery(cards: typeof testCards | []) {
+function createCardsQuery(cards: Array<(typeof testCards)[number]> | []) {
   const q = createMockQueryBuilder()
   ;(q as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
     resolve({ data: cards, error: null })
@@ -404,6 +404,115 @@ describe('GachaService.executeGachaForEventSub', () => {
     expect(mockRpc).toHaveBeenNthCalledWith(3, 'execute_gacha_transaction', expect.objectContaining({
       p_event_id: 'event-raid:3',
       p_reward_cost: null,
+    }))
+  })
+
+  it('追加報酬のN連最終枠に確定レアリティを適用する', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        id: 'streamer-1',
+        channel_point_reward_id: 'main-reward',
+        chat_announcement_enabled: false,
+        chat_announcement_template: null,
+        raid_gacha_active_until: '2099-01-01T00:00:00.000Z',
+      },
+      error: null,
+    })
+    const additionalRewardQuery = createMockQueryBuilder()
+    ;(additionalRewardQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: 'additional-1', draw_count: 2, is_raid_limited: false, guaranteed_rarity: 'rare' },
+      error: null,
+    })
+    const cardsQuery = createCardsQuery([
+      { id: 'common-card', name: 'Common', description: null, image_url: null, rarity: 'common', drop_rate: 1 },
+      { id: 'rare-card', name: 'Rare', description: null, image_url: null, rarity: 'rare', drop_rate: 1 },
+    ])
+    const mockRpc = vi.fn().mockResolvedValue({
+      data: { is_duplicate: false },
+      error: null,
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        if (table === 'streamer_additional_gacha_rewards') return additionalRewardQuery
+        if (table === 'cards') return cardsQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'rare-reward', cost: 500 },
+    }, 'event-rare')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.cards?.[1].id).toBe('rare-card')
+    }
+    expect(mockRpc).toHaveBeenNthCalledWith(2, 'execute_gacha_transaction', expect.objectContaining({
+      p_card_id: 'rare-card',
+      p_event_id: 'event-rare:2',
+    }))
+  })
+
+  it('確定レアリティ対象カードがない場合は通常候補にフォールバックする', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        id: 'streamer-1',
+        channel_point_reward_id: 'main-reward',
+        chat_announcement_enabled: false,
+        chat_announcement_template: null,
+        raid_gacha_active_until: '2099-01-01T00:00:00.000Z',
+      },
+      error: null,
+    })
+    const additionalRewardQuery = createMockQueryBuilder()
+    ;(additionalRewardQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: 'additional-1', draw_count: 2, is_raid_limited: false, guaranteed_rarity: 'legendary' },
+      error: null,
+    })
+    const cardsQuery = createCardsQuery([
+      { id: 'common-card', name: 'Common', description: null, image_url: null, rarity: 'common', drop_rate: 1 },
+    ])
+    const mockRpc = vi.fn().mockResolvedValue({
+      data: { is_duplicate: false },
+      error: null,
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        if (table === 'streamer_additional_gacha_rewards') return additionalRewardQuery
+        if (table === 'cards') return cardsQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'legendary-reward', cost: 500 },
+    }, 'event-fallback')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.cards).toHaveLength(2)
+    }
+    expect(mockRpc).toHaveBeenNthCalledWith(2, 'execute_gacha_transaction', expect.objectContaining({
+      p_card_id: 'common-card',
+      p_event_id: 'event-fallback:2',
     }))
   })
 

--- a/tests/unit/rarity.test.ts
+++ b/tests/unit/rarity.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  aggregateCustomRarities,
   formatRarityLabel,
   getRarityColorClass,
+  getRarityDisplayInfo,
   getRarityGlowClass,
   getRarityGradientClass,
-  getRarityDisplayInfo,
-  aggregateCustomRarities,
+  isGuaranteedRarity,
+  meetsRarityFloor,
+  normalizeGuaranteedRarity,
 } from "@/lib/rarity";
 
 describe("rarity helpers", () => {
@@ -59,6 +62,31 @@ describe("rarity helpers", () => {
       expect(
         aggregateCustomRarities([{ rarity: "common" }, { rarity: "rare" }]),
       ).toEqual([]);
+    });
+  });
+
+  describe("guaranteed rarity helpers", () => {
+    it("recognizes supported guaranteed rarity values", () => {
+      expect(isGuaranteedRarity("rare")).toBe(true);
+      expect(isGuaranteedRarity("epic")).toBe(true);
+      expect(isGuaranteedRarity("legendary")).toBe(true);
+      expect(isGuaranteedRarity("common")).toBe(false);
+      expect(isGuaranteedRarity("custom")).toBe(false);
+    });
+
+    it("normalizes empty guaranteed rarity values to null", () => {
+      expect(normalizeGuaranteedRarity(undefined)).toBeNull();
+      expect(normalizeGuaranteedRarity(null)).toBeNull();
+      expect(normalizeGuaranteedRarity("")).toBeNull();
+      expect(normalizeGuaranteedRarity("rare")).toBe("rare");
+      expect(normalizeGuaranteedRarity("common")).toBeNull();
+    });
+
+    it("checks built-in rarity floors while excluding custom rarity values", () => {
+      expect(meetsRarityFloor("rare", "rare")).toBe(true);
+      expect(meetsRarityFloor("epic", "rare")).toBe(true);
+      expect(meetsRarityFloor("common", "rare")).toBe(false);
+      expect(meetsRarityFloor("custom-ultra", "rare")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Reopen the closed #514 work on top of the restored `preview` branch.
- Add guaranteed rarity settings for additional channel point rewards and raid gacha multi-draws.
- Apply the guarantee only to the final slot of N-draw gacha, with normal weighted fallback when no eligible cards exist.
- Add DB migration, settings UI/i18n, bootstrap/API support, and focused coverage for rarity helpers, API validation, and gacha execution.

Closes #486

## Validation
- `npm_config_cache=/tmp/twica-npm-cache npx vitest run tests/unit/rarity.test.ts tests/unit/gacha-service.test.ts tests/unit/additional-rewards-api.test.ts`
- `git diff --check origin/preview...HEAD`
- `npm_config_cache=/tmp/twica-npm-cache npm run lint` (existing warnings only)
- `npm_config_cache=/tmp/twica-npm-cache npm run build`
- `npm_config_cache=/tmp/twica-npm-cache npm run workers:build`

## Notes
- The earlier PR #514 was closed unmerged after `preview` disappeared. This PR reapplies the same reviewed implementation on the current restored `preview` branch.
