### PR TITLE
feat(gacha): カードパック機能を支援プラン/Twitchサブスク限定にする

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -62,6 +62,9 @@
       "collectionName": "Card Pack",
       "collectionNamePlaceholder": "e.g. Characters / Weapons (blank = unclassified)",
       "collectionNameHelp": "Only cards in the same pack are eligible for that channel point reward's gacha",
+      "collectionNameClear": "✕ Clear",
+      "collectionNamePremiumRequired": "Creating or changing card packs requires a supporter plan or Twitch subscription (you can still clear it)",
+      "collectionNamePremiumRequiredSaved": "The card was saved, but changing the pack assignment requires a supporter plan or Twitch subscription",
       "dropRate": "Drop Rate",
       "intraRarityWeight": "Drop Rate within Rarity",
       "intraRarityWeightHint": "Adjust drop balance among cards of the same rarity (default: 1.0)",
@@ -571,7 +574,9 @@
       "additionalLabel": "Additional reward card pack",
       "all": "All cards",
       "help": "Limit eligible cards by the pack names configured in card management.",
-      "missing": "{name} (no drawable cards)"
+      "missing": "{name} (no drawable cards)",
+      "premiumRequired": "Binding a new pack requires a supporter plan or Twitch subscription (you can still clear it)",
+      "premiumRequiredSaved": "Saved, but changing the pack binding requires a supporter plan or Twitch subscription"
     }
   },
   "gachaHistory": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -62,6 +62,9 @@
       "collectionName": "カードパック",
       "collectionNamePlaceholder": "例: キャラ / 武器 (空欄=未分類)",
       "collectionNameHelp": "同じパック名のカードだけがチャネポ報酬の抽選対象になります",
+      "collectionNameClear": "✕ 解除",
+      "collectionNamePremiumRequired": "カードパックの新規登録・変更には支援プランまたはTwitchサブスクが必要です(解除のみ可能)",
+      "collectionNamePremiumRequiredSaved": "カードは保存されましたが、パック設定の変更には支援プランまたはTwitchサブスクが必要です",
       "dropRate": "出現確率",
       "intraRarityWeight": "レアリティ内での排出確率",
       "intraRarityWeightHint": "同じレアリティ内での排出バランスを調整します（デフォルト: 1.0）",
@@ -571,7 +574,9 @@
       "additionalLabel": "追加報酬のカードパック",
       "all": "すべてのカード",
       "help": "カード管理で設定したパック名ごとに、排出対象を絞り込めます。",
-      "missing": "{name}(抽選可能カードなし)"
+      "missing": "{name}(抽選可能カードなし)",
+      "premiumRequired": "新しいパックの紐付けには支援プランまたはTwitchサブスクが必要です(解除のみ可能)",
+      "premiumRequiredSaved": "保存しましたが、パック設定の変更には支援プランまたはTwitchサブスクが必要です"
     }
   },
   "gachaHistory": {

--- a/src/app/api/cards/[id]/route.ts
+++ b/src/app/api/cards/[id]/route.ts
@@ -20,6 +20,7 @@ import { recalculateIfAutoMode } from "@/lib/recalculate-drop-rates";
 import { CARD_NUMBER_MESSAGES, isCardNumberConflictError, isMissingCardNumberColumnError } from "@/lib/card-number-errors";
 import { resolveCollectionNameField } from "@/lib/validation/collection-name";
 import { isMissingCollectionNameColumn } from "@/lib/collections/collection-existence";
+import { isCollectionChangeGated } from "@/lib/plan-gate";
 import type { ApiRateLimitResponse } from "@/types/api";
 
 function extractRarityWeights(streamers: unknown): Record<string, number> | null {
@@ -160,20 +161,50 @@ export async function PUT(
 
     // Verify ownership and get current image_url for cleanup
     // 所有権を確認し、クリーンアップ用に現在のimage_urlを取得
-    const { data: card } = await supabaseAdmin
+    let { data: card, error: cardSelectError } = await supabaseAdmin
       .from("cards")
       // streamers の埋め込みは FK 制約名で一意化する: migration 00051 の
       // card_owner_stats が cards↔streamers を m2m にも見せ、ヒントなしの
       // streamers(...) は PGRST201 で失敗するため。
-      .select("streamer_id, image_url, rarity, is_active, intra_rarity_weight, streamers!cards_streamer_id_fkey!inner(twitch_user_id, rarity_weights)")
+      .select("streamer_id, image_url, rarity, is_active, intra_rarity_weight, collection_name, streamers!cards_streamer_id_fkey!inner(twitch_user_id, rarity_weights)")
       .eq("id", id)
       .maybeSingle();
+
+    // Issue #269 (self-review fix): collection_name was added to this
+    // ownership-check SELECT to read the current pack value for the gate
+    // below. During the deploy window (migration 00061 not applied yet) that
+    // turns the SELECT itself into a 42703 "column does not exist" error,
+    // which would 403 EVERY card edit — not just pack-related ones — because
+    // this branch only checked `!card`, not `error`. Retry without the
+    // column so unrelated edits keep working; the gate then just sees no
+    // current pack value (treated as null), matching every other #393
+    // deploy-window fallback in this codebase.
+    if (cardSelectError && isMissingCollectionNameColumn(cardSelectError)) {
+      const retryResult = await supabaseAdmin
+        .from("cards")
+        .select("streamer_id, image_url, rarity, is_active, intra_rarity_weight, streamers!cards_streamer_id_fkey!inner(twitch_user_id, rarity_weights)")
+        .eq("id", id)
+        .maybeSingle();
+      card = retryResult.data
+        ? { ...retryResult.data, collection_name: null }
+        : null;
+      cardSelectError = retryResult.error;
+    }
 
     const twitchUserId = extractTwitchUserId(card?.streamers);
 
     if (!card || twitchUserId === null || twitchUserId !== session.twitchUserId) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
     }
+
+    // Issue #269: reassigning a card's pack to a NEW value requires a premium
+    // plan. Clearing it (null) or resubmitting the current value is always
+    // allowed, so a downgraded user keeps full read/edit access to the card.
+    const collectionNamePremiumRequired = await isCollectionChangeGated(
+      session.twitchUserId,
+      collectionNameResult.value,
+      card.collection_name
+    );
 
     const rarityWeights = extractRarityWeights(card.streamers);
     const rarityChanged = rarity !== undefined && rarity !== card.rarity;
@@ -195,7 +226,7 @@ export async function PUT(
     if (description !== undefined) updateData.description = description;
     if (imageUrl !== undefined) updateData.image_url = imageUrl;
     if (rarity !== undefined) updateData.rarity = typeof rarity === "string" ? rarity.trim() : rarity;
-    if (collectionNameResult.value !== undefined) updateData.collection_name = collectionNameResult.value;
+    if (collectionNameResult.value !== undefined && !collectionNamePremiumRequired) updateData.collection_name = collectionNameResult.value;
     if (cardNumber !== undefined) updateData.card_number = cardNumber;
     if (dropRate !== undefined) updateData.drop_rate = dropRate;
     if (intraRarityWeight !== undefined) updateData.intra_rarity_weight = intraRarityWeight;
@@ -298,6 +329,7 @@ export async function PUT(
     return NextResponse.json({
       ...updatedCard,
       recalculatedCards,
+      ...(collectionNamePremiumRequired ? { collectionNamePremiumRequired: true } : {}),
     });
   } catch (error) {
     return handleApiError(error, "Cards API: PUT");

--- a/src/app/api/cards/route.ts
+++ b/src/app/api/cards/route.ts
@@ -21,6 +21,7 @@ import { recalculateIfAutoMode } from "@/lib/recalculate-drop-rates";
 import { CARD_NUMBER_MESSAGES, isCardNumberConflictError, isMissingCardNumberColumnError } from "@/lib/card-number-errors";
 import { resolveCollectionNameField } from "@/lib/validation/collection-name";
 import { isMissingCollectionNameColumn } from "@/lib/collections/collection-existence";
+import { isCollectionChangeGated } from "@/lib/plan-gate";
 import type { ApiRateLimitResponse } from "@/types/api";
 
 // Cache TTL for cards list (30 seconds to balance freshness and CPU usage)
@@ -163,6 +164,17 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
     }
 
+    // Issue #269: assigning a pack to a new card requires a premium plan
+    // (support code or Twitch sub). New cards have no existing pack to
+    // compare against, so any non-null value is a new registration attempt.
+    // Gated requests still create the card — only the pack assignment is
+    // dropped — so basic-plan users keep full card management access.
+    const collectionNamePremiumRequired = await isCollectionChangeGated(
+      session.twitchUserId,
+      collectionNameResult.value,
+      null
+    );
+
     // NOTE: Drop rate validation removed because the system uses relative weights
     // The actual probability is calculated as: this_card_weight / total_weights
     // So there's no need to limit the sum to 100% - weights are relative, not absolute percentages
@@ -181,7 +193,8 @@ export async function POST(request: NextRequest) {
       drop_rate: dropRate,
     };
     // Issue #393: persist the pack name when provided (null clears it = all cards).
-    if (collectionNameResult.value !== undefined) {
+    // Issue #269: skip persisting it if the plan gate rejected this assignment.
+    if (collectionNameResult.value !== undefined && !collectionNamePremiumRequired) {
       insertData.collection_name = collectionNameResult.value;
     }
     if (intraRarityWeight !== undefined) {
@@ -251,6 +264,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({
       ...card,
       recalculatedCards,
+      ...(collectionNamePremiumRequired ? { collectionNamePremiumRequired: true } : {}),
     });
   } catch (error) {
     return handleApiError(error, "Cards API: POST");

--- a/src/app/api/streamer/additional-rewards/route.ts
+++ b/src/app/api/streamer/additional-rewards/route.ts
@@ -9,6 +9,7 @@ import { validateContentType } from "@/lib/request-validation";
 import { logger } from "@/lib/logger";
 import { resolveCollectionNameField } from "@/lib/validation/collection-name";
 import { checkCollectionHasActiveCards, isMissingCollectionNameColumn } from "@/lib/collections/collection-existence";
+import { isCollectionChangeGated } from "@/lib/plan-gate";
 
 function isRaidOptionsSchemaError(error: { message?: string; code?: string } | null | undefined) {
   const message = error?.message ?? "";
@@ -220,10 +221,22 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Issue #269: binding a pack to a new additional reward requires a
+    // premium plan. There is no update path for additional rewards (only
+    // create/delete), so any non-null value is a new registration attempt.
+    // Gated requests still create the reward — only the pack binding is
+    // dropped — so reward creation itself stays available on the basic plan.
+    const collectionNamePremiumRequired = await isCollectionChangeGated(
+      session.twitchUserId,
+      collectionNameResult.value,
+      null
+    );
+
     // Issue #393: when a pack is bound, ensure it actually has active cards so the
     // reward never resolves to an empty draw pool at redemption time. Skip the
-    // check during the deploy window (column not migrated yet).
-    if (typeof collectionNameResult.value === "string") {
+    // check during the deploy window (column not migrated yet) and when the
+    // assignment is gated (it will not be persisted, so existence is moot).
+    if (typeof collectionNameResult.value === "string" && !collectionNamePremiumRequired) {
       const existence = await checkCollectionHasActiveCards(
         supabaseAdmin,
         streamer.id,
@@ -245,7 +258,7 @@ export async function POST(request: NextRequest) {
       draw_count: normalizedDrawCount,
       is_raid_limited: isRaidLimited ?? false,
     };
-    if (typeof collectionNameResult.value === "string") {
+    if (typeof collectionNameResult.value === "string" && !collectionNamePremiumRequired) {
       insertPayload.collection_name = collectionNameResult.value;
     }
 
@@ -298,7 +311,11 @@ export async function POST(request: NextRequest) {
       `Additional reward registered: streamerId=${streamer.id}, rewardId=${rewardId}, rewardName=${rewardName}, drawCount=${normalizedDrawCount}, raidLimited=${isRaidLimited ?? false}`
     );
 
-    return NextResponse.json({ success: true, reward: newReward });
+    return NextResponse.json({
+      success: true,
+      reward: newReward,
+      ...(collectionNamePremiumRequired ? { collectionNamePremiumRequired: true } : {}),
+    });
   } catch (error) {
     return handleApiError(error, "Additional Rewards API: POST");
   }

--- a/src/app/api/streamer/settings/route.ts
+++ b/src/app/api/streamer/settings/route.ts
@@ -17,6 +17,7 @@ import { validateContentType } from "@/lib/request-validation";
 import { recalculateIfAutoMode } from "@/lib/recalculate-drop-rates";
 import { resolveCollectionNameField } from "@/lib/validation/collection-name";
 import { checkCollectionHasActiveCards, isMissingCollectionNameColumn } from "@/lib/collections/collection-existence";
+import { isCollectionChangeGated } from "@/lib/plan-gate";
 
 
 type RarityWeightsValidation =
@@ -250,20 +251,55 @@ export async function POST(request: NextRequest) {
     }
 
     // Verify ownership
-    const { data: streamer } = await supabaseAdmin
+    let { data: streamer, error: streamerSelectError } = await supabaseAdmin
       .from("streamers")
-      .select("id")
+      .select("id, channel_point_collection_name")
       .eq("id", streamerId)
       .eq("twitch_user_id", session.twitchUserId)
       .maybeSingle();
+
+    // Issue #269 (self-review fix): channel_point_collection_name was added
+    // to this ownership-check SELECT to read the current pack value for the
+    // gate below. During the deploy window (migration 00061 not applied yet)
+    // that turns the SELECT itself into a 42703 "column does not exist"
+    // error, which would 403 EVERY settings save — not just pack-related
+    // ones — because this branch only checked `!streamer`, not `error`.
+    // Retry without the column so unrelated settings keep saving; the gate
+    // then just sees no current pack value (treated as null), matching every
+    // other #393 deploy-window fallback in this codebase.
+    if (streamerSelectError && isMissingCollectionNameColumn(streamerSelectError)) {
+      const retryResult = await supabaseAdmin
+        .from("streamers")
+        .select("id")
+        .eq("id", streamerId)
+        .eq("twitch_user_id", session.twitchUserId)
+        .maybeSingle();
+      streamer = retryResult.data
+        ? { ...retryResult.data, channel_point_collection_name: null }
+        : null;
+      streamerSelectError = retryResult.error;
+    }
 
     if (!streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
     }
 
+    // Issue #269: binding the main reward to a NEW pack requires a premium
+    // plan. Clearing it or resubmitting the current value is always allowed,
+    // so a downgraded streamer keeps saving every other setting on this
+    // combined endpoint (rarity weights, sounds, chat announcements, etc.).
+    const collectionNamePremiumRequired = await isCollectionChangeGated(
+      session.twitchUserId,
+      channelPointCollectionResult.value,
+      streamer.channel_point_collection_name
+    );
+
     // Issue #393: reject binding the main reward to a pack with no active cards,
     // which would always resolve to an empty draw pool at redemption time.
-    if (typeof channelPointCollectionResult.value === "string") {
+    // Issue #269: skip when the assignment is gated — it will not be
+    // persisted, so validating its existence is wasted work and could wrongly
+    // block the rest of this save with COLLECTION_NOT_FOUND.
+    if (typeof channelPointCollectionResult.value === "string" && !collectionNamePremiumRequired) {
       const existence = await checkCollectionHasActiveCards(
         supabaseAdmin,
         streamer.id,
@@ -286,7 +322,8 @@ export async function POST(request: NextRequest) {
       updateData.channel_point_reward_name = channelPointRewardName;
     }
     // Issue #393: persist the main-reward pack binding (null clears it = all cards).
-    if (channelPointCollectionResult.value !== undefined) {
+    // Issue #269: skip persisting it if the plan gate rejected this assignment.
+    if (channelPointCollectionResult.value !== undefined && !collectionNamePremiumRequired) {
       updateData.channel_point_collection_name = channelPointCollectionResult.value;
     }
 
@@ -363,8 +400,13 @@ export async function POST(request: NextRequest) {
       botDisconnected = true;
     }
 
-    // 更新するフィールドがない場合はエラー
-    if (Object.keys(updateData).length === 0 && !botDisconnected) {
+    // 更新するフィールドがない場合はエラー。ただし、唯一意図された変更が
+    // プランゲートで除外された場合は「無効なリクエスト」ではなく、成功+
+    // collectionNamePremiumRequired フラグで理由を伝える(Issue #269)。
+    // No fields left to update is an error — UNLESS the only intended change
+    // was the pack binding and it was dropped by the plan gate, in which case
+    // we still report success with the flag instead of a generic 400.
+    if (Object.keys(updateData).length === 0 && !botDisconnected && !collectionNamePremiumRequired) {
       return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
     }
 
@@ -409,7 +451,11 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    return NextResponse.json({ success: true, recalculatedCards });
+    return NextResponse.json({
+      success: true,
+      recalculatedCards,
+      ...(collectionNamePremiumRequired ? { collectionNamePremiumRequired: true } : {}),
+    });
   } catch (error) {
     return handleApiError(error, "Streamer Settings API: General");
   }

--- a/src/app/dashboard/cards/page.tsx
+++ b/src/app/dashboard/cards/page.tsx
@@ -54,6 +54,8 @@ export default async function CardsPage() {
   const plan = await getUserPlan(session.twitchUserId);
   const maxImageWidth = PLAN_MAX_IMAGE_WIDTH[plan];
   const availableWidths = PLAN_AVAILABLE_WIDTHS[plan];
+  // Issue #269: card-pack (collection_name) assignment requires a premium plan.
+  const isPremium = plan !== "basic";
 
   return (
     <CardManager
@@ -65,6 +67,7 @@ export default async function CardsPage() {
       showViewToggle={true}
       maxImageWidth={maxImageWidth}
       availableWidths={availableWidths}
+      isPremium={isPremium}
     />
   );
 }

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -3,6 +3,7 @@ import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { getStreamerData } from "@/lib/dashboard-data";
 import { getCustomBotAccountDisplayForStreamer } from "@/lib/twitch/token-manager";
 import { shouldShowVoteCampaign } from "@/lib/storage-db";
+import { getUserPlan } from "@/lib/plan";
 import SettingsLayout from "@/components/SettingsLayout";
 
 // Note: Page is automatically dynamic due to cookies() usage in getSession()
@@ -25,11 +26,15 @@ export default async function SettingsPage() {
   const isStreamer = canUseStreamerFeatures(session);
   if (!isStreamer) redirect("/dashboard");
 
-  const [streamerData, showVoteCampaign] = await Promise.all([
+  const [streamerData, showVoteCampaign, plan] = await Promise.all([
     getStreamerData(session.twitchUserId),
     shouldShowVoteCampaign(session.twitchUserId),
+    getUserPlan(session.twitchUserId),
   ]);
   if (!streamerData) redirect("/dashboard");
+
+  // Issue #269: card-pack (collection_name) binding requires a premium plan.
+  const isPremium = plan !== "basic";
 
   const botAccount = await getCustomBotAccountDisplayForStreamer(streamerData.streamer.id);
 
@@ -51,6 +56,7 @@ export default async function SettingsPage() {
         rewardName: streamerData.streamer.channel_point_reward_name,
         collectionName: streamerData.streamer.channel_point_collection_name ?? null,
       }}
+      isPremium={isPremium}
       gachaSound={{
         soundUrl: streamerData.streamer.gacha_sound_url ?? null,
         soundEnabled: streamerData.streamer.gacha_sound_enabled ?? false,

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -77,6 +77,11 @@ interface CardManagerProps {
   // 配信者が定義したカスタムレアリティ名（rarity_weights とは独立）
   // Streamer-defined custom rarity names (decoupled from rarity_weights)
   initialCustomRarities?: string[];
+  // Issue #269: whether the streamer's plan allows assigning/changing card
+  // packs (collection_name). Defaults to false (fail-closed, matching
+  // plan.ts's "treat lookup failure as basic" stance) so omitting this prop
+  // never accidentally grants the premium-only capability.
+  isPremium?: boolean;
 }
 
 // Sorting field options
@@ -124,6 +129,7 @@ export default function CardManager({
   availableWidths = [800],
   initialRarityWeights = null,
   initialCustomRarities = [],
+  isPremium = false,
 }: CardManagerProps) {
   // i18n translations
   // i18n翻訳
@@ -300,6 +306,11 @@ export default function CardManager({
   const isDescriptionTooLong = descriptionCharacterCount > CARD_DESCRIPTION_MAX_CHARACTERS;
   const [saving, setSaving] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  // Issue #269: set when a save succeeded but the pack assignment was dropped
+  // because the user's plan doesn't allow new card-pack registrations. The
+  // card itself still saved, so this is a standalone notice, not tied to the
+  // (closing) form's visibility.
+  const [collectionPlanNotice, setCollectionPlanNotice] = useState(false);
   // Separate state for confirmed image URL (only update on blur)
   // プレビュー表示用の確定済み画像URL（フォーカスが外れた時のみ更新）
   const [confirmedImageUrl, setConfirmedImageUrl] = useState("");
@@ -1157,9 +1168,14 @@ export default function CardManager({
         const recalculatedCards = Array.isArray(responseData.recalculatedCards)
           ? (responseData.recalculatedCards as Card[])
           : null;
+        // Issue #269: read+strip the synthetic flag so it never leaks into
+        // the Card object stored in state (Card has no such field).
+        const collectionNamePremiumRequired = responseData.collectionNamePremiumRequired === true;
         const savedCardData = { ...(responseData as Record<string, unknown>) };
         delete savedCardData.recalculatedCards;
+        delete savedCardData.collectionNamePremiumRequired;
         const savedCard = savedCardData as unknown as Card;
+        setCollectionPlanNotice(collectionNamePremiumRequired);
 
         if (editingCard) {
           setCards((prevCards) => {
@@ -1345,6 +1361,18 @@ export default function CardManager({
         </div>
       )}
 
+      {/* Issue #269: card saved, but the pack assignment was dropped because
+          the plan doesn't allow new card-pack registrations. Standalone
+          banner (not tied to the form, which already closed on save). */}
+      {collectionPlanNotice && (
+        <div className="mb-4 rounded-lg bg-yellow-500/10 border border-yellow-500/30 p-4">
+          <p className="text-sm text-yellow-300">{t("form.collectionNamePremiumRequiredSaved")}</p>
+          <a href="/plans" className="mt-2 inline-block text-xs text-purple-400 hover:text-purple-300 underline">
+            支援特典について
+          </a>
+        </div>
+      )}
+
       {/* Storage usage info displayed at panel level */}
       {/* ストレージ使用量をパネルレベルで表示 */}
       {storageStatus && (
@@ -1486,30 +1514,44 @@ export default function CardManager({
                         </p>
                       </div>
                     </div>
-                    {/* Issue #393: カードパック名（任意）。datalist で既存パック名を提案しつつ自由入力も可。 */}
+                    {/* Issue #393: カードパック名（任意）。datalist で既存パック名を提案しつつ自由入力も可。
+                        Issue #269: 新規登録・変更には支援プラン/Twitchサブスクが必要。disabled
+                        にすると既存値の解除手段も失われるため、「✕ 解除」ボタンは常に有効にする。 */}
                     <div className="mt-3 min-w-0">
                       <label className="mb-1 block text-sm text-gray-300">
                         {t("form.collectionName")}
                       </label>
-                      <input
-                        type="text"
-                        name="collectionName"
-                        list="card-collection-options"
-                        maxLength={80}
-                        placeholder={t("form.collectionNamePlaceholder")}
-                        value={formData.collectionName}
-                        onChange={(e) =>
-                          setFormData({ ...formData, collectionName: e.target.value })
-                        }
-                        className="w-full min-w-0 rounded-lg bg-gray-600 px-4 py-2 text-white placeholder:text-gray-300"
-                      />
+                      <div className="flex gap-2">
+                        <input
+                          type="text"
+                          name="collectionName"
+                          list="card-collection-options"
+                          maxLength={80}
+                          disabled={!isPremium}
+                          placeholder={t("form.collectionNamePlaceholder")}
+                          value={formData.collectionName}
+                          onChange={(e) =>
+                            setFormData({ ...formData, collectionName: e.target.value })
+                          }
+                          className="w-full min-w-0 rounded-lg bg-gray-600 px-4 py-2 text-white placeholder:text-gray-300 disabled:cursor-not-allowed disabled:opacity-60"
+                        />
+                        {!isPremium && formData.collectionName !== "" && (
+                          <button
+                            type="button"
+                            onClick={() => setFormData({ ...formData, collectionName: "" })}
+                            className="shrink-0 rounded-lg border border-gray-500 px-3 text-sm text-gray-300 hover:bg-gray-700"
+                          >
+                            {t("form.collectionNameClear")}
+                          </button>
+                        )}
+                      </div>
                       <datalist id="card-collection-options">
                         {collectionNameOptions.map((name) => (
                           <option key={name} value={name} />
                         ))}
                       </datalist>
                       <p className="mt-1 text-xs text-gray-300">
-                        {t("form.collectionNameHelp")}
+                        {isPremium ? t("form.collectionNameHelp") : t("form.collectionNamePremiumRequired")}
                       </p>
                     </div>
                   </div>

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -51,6 +51,10 @@ interface ChannelPointSettingsProps {
   currentRewardName: string | null;
   // Issue #393: pack currently bound to the main reward (null = all cards)
   currentCollectionName?: string | null;
+  // Issue #269: whether the streamer's plan allows new/changed card-pack
+  // bindings. Defaults to false (fail-closed) so existing call sites that
+  // don't pass it never accidentally grant the premium-only capability.
+  isPremium?: boolean;
   /**
    * compact: シンプル表示モード用の縮約レンダリング。
    * EventSub 診断パネル / 追加報酬セクション / 詳細エラーリストを隠し、
@@ -71,6 +75,7 @@ export default function ChannelPointSettings({
   currentRewardId,
   currentRewardName,
   currentCollectionName = null,
+  isPremium = false,
   compact = false,
 }: ChannelPointSettingsProps) {
   const t = useTranslations("channelPointSettings");
@@ -92,6 +97,11 @@ export default function ChannelPointSettings({
   const [disconnecting, setDisconnecting] = useState(false);
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
+  // Issue #269: set when a save succeeded but a card-pack binding was dropped
+  // because the plan doesn't allow new registrations. Kept separate from
+  // `message` (which the EventSub flow overwrites several times after the
+  // settings save) so the notice survives until the next save attempt.
+  const [collectionPlanNotice, setCollectionPlanNotice] = useState(false);
   const [eventSubStatus, setEventSubStatus] = useState<EventSubStatus>("none");
   const [raidEventSubStatus, setRaidEventSubStatus] = useState<EventSubStatus>("none");
   const [raidEventSubWarning, setRaidEventSubWarning] = useState("");
@@ -386,6 +396,11 @@ export default function ChannelPointSettings({
         return;
       }
 
+      // Issue #269: the save succeeded, but the server may have dropped the
+      // pack binding if the plan doesn't allow new registrations.
+      const settingsData = await settingsResponse.json().catch(() => null);
+      setCollectionPlanNotice(settingsData?.collectionNamePremiumRequired === true);
+
       // Subscribe to EventSub
       const eventSubResponse = await fetch("/api/twitch/eventsub/subscribe", {
         method: "POST",
@@ -513,6 +528,9 @@ export default function ChannelPointSettings({
 
       // 3. Update state
       // 状態を更新
+      // Issue #269: the reward was created, but the server may have dropped
+      // the pack binding if the plan doesn't allow new registrations.
+      setCollectionPlanNotice(dbData?.collectionNamePremiumRequired === true);
       setMessage(raidSubscriptionWarning || t("additionalRewards.addSuccess"));
       setSelectedAdditionalRewardId("");
       setSelectedAdditionalCollectionName("");
@@ -799,6 +817,17 @@ export default function ChannelPointSettings({
         {getEventSubStatusBadge()}
       </div>
 
+      {/* Issue #269: saved successfully, but a card-pack binding was dropped
+          because the plan doesn't allow new registrations. */}
+      {collectionPlanNotice && (
+        <div className="mb-4 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3">
+          <p className="text-sm text-yellow-300">{t("collections.premiumRequiredSaved")}</p>
+          <a href="/plans" className="mt-1 inline-block text-xs text-purple-400 hover:text-purple-300 underline">
+            支援特典について
+          </a>
+        </div>
+      )}
+
        {needsReauth ? (
          // スコープ不足時のstep-up再認証導線。
          // 初回ログインではチャネルポイント系スコープを要求しないため、
@@ -879,7 +908,11 @@ export default function ChannelPointSettings({
                <p className="mt-1 text-xs text-gray-500">
                  {t("form.id")} {selectedRewardId}
                </p>
-               {/* Issue #393: メイン報酬に紐付けるカードパック。 */}
+               {/* Issue #393: メイン報酬に紐付けるカードパック。
+                   Issue #269: 新規登録・変更には支援プラン/Twitchサブスクが必要。
+                   <select> 自体はdisabledにせず、空("全カード")以外のoptionだけ
+                   disabledにすることで、選択中パックの表示維持と解除(空への変更)は
+                   常に可能なまま、新しいパックへの変更だけを防ぐ。 */}
                <label className="mt-3 block text-xs text-gray-300">
                  {t("collections.mainLabel")}
                  <select
@@ -889,7 +922,7 @@ export default function ChannelPointSettings({
                  >
                    <option value="">{t("collections.all")}</option>
                    {collections.map((name) => (
-                     <option key={name} value={name}>{name}</option>
+                     <option key={name} value={name} disabled={!isPremium}>{name}</option>
                    ))}
                    {/* 保存済みだが一覧に無い（抽選可能カードが消えた）パックも選択肢に残し、
                        黙ってスコープが全カードに変わる事故を防ぐ。取得完了後のみ
@@ -904,7 +937,7 @@ export default function ChannelPointSettings({
                  </select>
                </label>
                <p className="mt-1 text-xs text-gray-400">
-                 {t("collections.help")}
+                 {isPremium ? t("collections.help") : t("collections.premiumRequired")}
                </p>
              </div>
            )}
@@ -1189,7 +1222,9 @@ export default function ChannelPointSettings({
                        </option>
                      ))}
                  </select>
-                 {/* Issue #393: この追加報酬に紐付けるカードパック（任意）。 */}
+                 {/* Issue #393: この追加報酬に紐付けるカードパック（任意）。
+                     Issue #269: 新規追加報酬は常に作成可能。パックの新規紐付けのみ
+                     非空optionをdisabledにして支援プラン/Twitchサブスク限定にする。 */}
                  <select
                    value={selectedAdditionalCollectionName}
                    onChange={(e) => setSelectedAdditionalCollectionName(e.target.value)}
@@ -1198,7 +1233,7 @@ export default function ChannelPointSettings({
                  >
                    <option value="">{t("collections.all")}</option>
                    {collections.map((name) => (
-                     <option key={name} value={name}>{name}</option>
+                     <option key={name} value={name} disabled={!isPremium}>{name}</option>
                    ))}
                  </select>
                  {/*

--- a/src/components/SettingsLayout.tsx
+++ b/src/components/SettingsLayout.tsx
@@ -70,6 +70,10 @@ export interface SettingsLayoutData {
     // Issue #393: pack bound to the main reward (null = all cards)
     collectionName: string | null;
   };
+  // Issue #269: whether the streamer's plan allows new/changed card-pack
+  // bindings on the channel point reward(s). Defaults to false in
+  // ChannelPointSettings (fail-closed) if omitted.
+  isPremium?: boolean;
   gachaSound: {
     soundUrl: string | null;
     soundEnabled: boolean;
@@ -136,6 +140,7 @@ function SimpleLayout({ data }: { data: SettingsLayoutData }) {
           currentRewardId={data.channelPoint.rewardId}
           currentRewardName={data.channelPoint.rewardName}
           currentCollectionName={data.channelPoint.collectionName}
+          isPremium={data.isPremium}
           compact
         />
       </StepCard>
@@ -251,6 +256,7 @@ function AdvancedLayout({ data }: { data: SettingsLayoutData }) {
           currentRewardId={data.channelPoint.rewardId}
           currentRewardName={data.channelPoint.rewardName}
           currentCollectionName={data.channelPoint.collectionName}
+          isPremium={data.isPremium}
         />
       ),
     },

--- a/src/lib/plan-gate.ts
+++ b/src/lib/plan-gate.ts
@@ -1,0 +1,37 @@
+// Issue #269: gate NEW card-pack (collection_name) registrations behind a
+// premium plan (support / patron / twitch_sub), while leaving existing
+// pack-scoped gacha redemptions and unrelated settings saves unaffected even
+// after a user's support code or Twitch sub lapses.
+//
+// 課題 #269: カードパック(collection_name)の「新規登録・変更」のみを支援
+// プラン/Twitchサブスクで制限する。既存の引き換え・無関係な設定保存は、
+// 支援/サブスクが失効しても影響を受けない。
+
+import { getUserPlan } from "@/lib/plan";
+
+/**
+ * Determine whether a collection_name write must be dropped because the user
+ * is on the basic plan.
+ *
+ * Only a genuine new assignment is gated: `newValue` must be a non-null
+ * string AND differ from `currentValue`. Clearing to null, leaving the field
+ * unspecified (`undefined`), or resubmitting the current value are never
+ * gated — and `getUserPlan` (which calls out to the Twitch API) is skipped
+ * entirely in those cases.
+ *
+ * 「新しい登録」= 非null かつ現在値と異なる値への変更のみをゲートする。
+ * null化・未指定・現在値の再送信は常に許可し、getUserPlan(Twitch API呼び出し
+ * を含む)も呼ばない。
+ */
+export async function isCollectionChangeGated(
+  twitchUserId: string,
+  newValue: string | null | undefined,
+  currentValue: string | null
+): Promise<boolean> {
+  if (typeof newValue !== "string" || newValue === currentValue) {
+    return false;
+  }
+
+  const plan = await getUserPlan(twitchUserId);
+  return plan === "basic";
+}

--- a/tests/unit/additional-rewards-api.test.ts
+++ b/tests/unit/additional-rewards-api.test.ts
@@ -5,12 +5,17 @@ import { getSession, canUseStreamerFeatures } from '@/lib/session'
 import { checkRateLimit } from '@/lib/rate-limit'
 import { validateCSRFToken } from '@/lib/csrf'
 import { validateContentType } from '@/lib/request-validation'
+import { getUserPlan } from '@/lib/plan'
 import { createMockQueryBuilder } from '../utils/supabase-mock'
 
 vi.mock('@/lib/session')
 vi.mock('@/lib/rate-limit')
 vi.mock('@/lib/csrf')
 vi.mock('@/lib/request-validation')
+// Issue #269: pre-existing tests below predate plan gating and assume an
+// authorized (non-basic) streamer; default to premium so they keep
+// exercising collection-name persistence. Gate-specific tests override this.
+vi.mock('@/lib/plan')
 vi.mock('@/lib/supabase/admin', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/supabase/admin')>()
   return {
@@ -24,6 +29,7 @@ const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)
 const mockCheckRateLimit = vi.mocked(checkRateLimit)
 const mockValidateCSRFToken = vi.mocked(validateCSRFToken)
 const mockValidateContentType = vi.mocked(validateContentType)
+const mockGetUserPlan = vi.mocked(getUserPlan)
 
 function createThenableQuery(data: unknown, error: unknown = null) {
   const query = createMockQueryBuilder()
@@ -55,6 +61,7 @@ describe('/api/streamer/additional-rewards raid options', () => {
     })
     mockValidateCSRFToken.mockResolvedValue({ valid: true })
     mockValidateContentType.mockReturnValue(null)
+    mockGetUserPlan.mockResolvedValue('support')
   })
 
   it('persists drawCount and raid-limited options for an additional reward', async () => {
@@ -183,6 +190,84 @@ describe('/api/streamer/additional-rewards raid options', () => {
     }))
 
     expect(response.status).toBe(400)
+  })
+
+  // Issue #269: premium gate for additional-reward pack bindings.
+  describe('card-pack premium gate (Issue #269)', () => {
+    it('drops a pack binding on the basic plan but still creates the reward (200, flag set)', async () => {
+      mockGetUserPlan.mockResolvedValue('basic')
+      const streamerQuery = createMockQueryBuilder()
+      ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: { id: 'streamer-1', channel_point_reward_id: 'main-reward' },
+        error: null,
+      })
+      const insertQuery = createMockQueryBuilder()
+      ;(insertQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: { id: 'additional-1', reward_id: 'extra-reward', collection_name: null },
+        error: null,
+      })
+      const fromMock = vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        if (table === 'streamer_additional_gacha_rewards') return insertQuery
+        return createMockQueryBuilder()
+      })
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const response = await POST(new NextRequest('http://localhost/api/streamer/additional-rewards', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ rewardId: 'extra-reward', rewardName: 'Weapons', collectionName: 'weapons' }),
+      }))
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.success).toBe(true)
+      expect(data.collectionNamePremiumRequired).toBe(true)
+      // Gated: collection_name must never reach the insert payload, and the
+      // pack-existence check (which needs the 'cards' table) must be skipped.
+      expect(insertQuery.insert).toHaveBeenCalledWith(
+        expect.not.objectContaining({ collection_name: expect.anything() })
+      )
+    })
+
+    // Non-regression: collectionName-less reward creation is pre-#393
+    // functionality and must keep working on the basic plan.
+    it('still creates a reward with no pack on the basic plan (non-regression)', async () => {
+      mockGetUserPlan.mockResolvedValue('basic')
+      const streamerQuery = createMockQueryBuilder()
+      ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: { id: 'streamer-1', channel_point_reward_id: 'main-reward' },
+        error: null,
+      })
+      const insertQuery = createMockQueryBuilder()
+      ;(insertQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: { id: 'additional-1', reward_id: 'extra-reward' },
+        error: null,
+      })
+      const fromMock = vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        if (table === 'streamer_additional_gacha_rewards') return insertQuery
+        return createMockQueryBuilder()
+      })
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const response = await POST(new NextRequest('http://localhost/api/streamer/additional-rewards', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ rewardId: 'extra-reward', rewardName: 'No Pack' }),
+      }))
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.success).toBe(true)
+      expect(data.collectionNamePremiumRequired).toBeUndefined()
+      // getUserPlan must not even be consulted when no pack is being bound.
+      expect(mockGetUserPlan).not.toHaveBeenCalled()
+    })
   })
 
   it('rejects drawCount outside the supported range', async () => {

--- a/tests/unit/api/cards-collection-plan-gate.test.ts
+++ b/tests/unit/api/cards-collection-plan-gate.test.ts
@@ -1,0 +1,311 @@
+// Issue #269: premium gate for card-pack (collection_name) assignment on the
+// cards POST (create) and PUT (update) endpoints. Scoped to the gate's
+// behavior only — broader CRUD coverage for these routes is a pre-existing
+// gap outside this change.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/cards/route";
+import { PUT } from "@/app/api/cards/[id]/route";
+import { getSession, canUseStreamerFeatures } from "@/lib/session";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { validateCSRFToken } from "@/lib/csrf";
+import { getUserPlan } from "@/lib/plan";
+import { getStorageUsage } from "@/lib/storage-usage";
+import { createMockQueryBuilder } from "../../utils/supabase-mock";
+
+vi.mock("@/lib/session");
+vi.mock("@/lib/rate-limit");
+vi.mock("@/lib/csrf");
+vi.mock("@/lib/storage-usage");
+// Issue #269: getUserPlan defaults to premium below so only gate-specific
+// tests exercise the basic-plan path.
+vi.mock("@/lib/plan");
+vi.mock("@/lib/supabase/admin", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/supabase/admin")>();
+  return { ...actual, getSupabaseAdmin: vi.fn() };
+});
+
+const mockGetSession = vi.mocked(getSession);
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures);
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken);
+const mockGetUserPlan = vi.mocked(getUserPlan);
+const mockGetStorageUsage = vi.mocked(getStorageUsage);
+
+const SESSION = {
+  twitchUserId: "user1",
+  twitchUsername: "streamer",
+  twitchDisplayName: "Streamer",
+  twitchProfileImageUrl: null,
+  broadcasterType: "affiliate" as const,
+  expiresAt: Date.now() + 60_000,
+  version: 1,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetSession.mockResolvedValue(SESSION);
+  mockCanUseStreamerFeatures.mockReturnValue(true);
+  mockCheckRateLimit.mockResolvedValue({
+    success: true,
+    limit: 10,
+    remaining: 9,
+    reset: Date.now() + 60_000,
+  });
+  mockValidateCSRFToken.mockResolvedValue({ valid: true });
+  mockGetStorageUsage.mockResolvedValue({ planOverLimit: false } as Awaited<ReturnType<typeof getStorageUsage>>);
+  mockGetUserPlan.mockResolvedValue("support");
+});
+
+describe("POST /api/cards card-pack premium gate (Issue #269)", () => {
+  it("drops a NEW pack assignment on the basic plan but still creates the card (200, flag set)", async () => {
+    mockGetUserPlan.mockResolvedValue("basic");
+    const streamerQuery = createMockQueryBuilder();
+    (streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: "streamer1", rarity_weights: null },
+      error: null,
+    });
+    const cardsQuery = createMockQueryBuilder();
+    (cardsQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: "card1", streamer_id: "streamer1", collection_name: null },
+      error: null,
+    });
+    const fromMock = vi.fn((table: string) => (table === "streamers" ? streamerQuery : cardsQuery));
+
+    const { getSupabaseAdmin } = await import("@/lib/supabase/admin");
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const request = new NextRequest("http://localhost/api/cards", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        streamerId: "streamer1",
+        name: "Sword",
+        description: "",
+        imageUrl: "https://example.com/a.png",
+        rarity: "common",
+        dropRate: 0.5,
+        collectionName: "weapons",
+      }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.collectionNamePremiumRequired).toBe(true);
+    expect(cardsQuery.insert).toHaveBeenCalledWith(
+      expect.not.objectContaining({ collection_name: expect.anything() })
+    );
+  });
+
+  it("persists the pack assignment on a premium plan (no flag)", async () => {
+    mockGetUserPlan.mockResolvedValue("support");
+    const streamerQuery = createMockQueryBuilder();
+    (streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: "streamer1", rarity_weights: null },
+      error: null,
+    });
+    const cardsQuery = createMockQueryBuilder();
+    (cardsQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: "card1", streamer_id: "streamer1", collection_name: "weapons" },
+      error: null,
+    });
+    const fromMock = vi.fn((table: string) => (table === "streamers" ? streamerQuery : cardsQuery));
+
+    const { getSupabaseAdmin } = await import("@/lib/supabase/admin");
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const request = new NextRequest("http://localhost/api/cards", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        streamerId: "streamer1",
+        name: "Sword",
+        description: "",
+        imageUrl: "https://example.com/a.png",
+        rarity: "common",
+        dropRate: 0.5,
+        collectionName: "weapons",
+      }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.collectionNamePremiumRequired).toBeUndefined();
+    expect(cardsQuery.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ collection_name: "weapons" })
+    );
+  });
+});
+
+describe("PUT /api/cards/[id] card-pack premium gate (Issue #269)", () => {
+  function buildCardQuery(currentCollectionName: string | null) {
+    const cardQuery = createMockQueryBuilder();
+    (cardQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        streamer_id: "streamer1",
+        image_url: null,
+        rarity: "common",
+        is_active: true,
+        intra_rarity_weight: 1,
+        collection_name: currentCollectionName,
+        streamers: { twitch_user_id: "user1", rarity_weights: null },
+      },
+      error: null,
+    });
+    return cardQuery;
+  }
+
+  it("drops a change to a NEW pack value on the basic plan but still updates other fields (200, flag set)", async () => {
+    mockGetUserPlan.mockResolvedValue("basic");
+    const selectQuery = buildCardQuery("weapons");
+    const updateQuery = createMockQueryBuilder();
+    (updateQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: "card1", name: "Renamed", collection_name: "weapons" },
+      error: null,
+    });
+    let callCount = 0;
+    const fromMock = vi.fn(() => {
+      callCount += 1;
+      return callCount === 1 ? selectQuery : updateQuery;
+    });
+
+    const { getSupabaseAdmin } = await import("@/lib/supabase/admin");
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const request = new NextRequest("http://localhost/api/cards/card1", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Renamed", collectionName: "armor" }),
+    });
+
+    const response = await PUT(request, { params: Promise.resolve({ id: "card1" }) });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.collectionNamePremiumRequired).toBe(true);
+    expect(updateQuery.update).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Renamed" })
+    );
+    const updateCall = (updateQuery.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(updateCall).not.toHaveProperty("collection_name");
+  });
+
+  it("allows resubmitting the SAME pack value on the basic plan (no-op, no gate)", async () => {
+    mockGetUserPlan.mockResolvedValue("basic");
+    const selectQuery = buildCardQuery("weapons");
+    const updateQuery = createMockQueryBuilder();
+    (updateQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: "card1", collection_name: "weapons" },
+      error: null,
+    });
+    let callCount = 0;
+    const fromMock = vi.fn(() => {
+      callCount += 1;
+      return callCount === 1 ? selectQuery : updateQuery;
+    });
+
+    const { getSupabaseAdmin } = await import("@/lib/supabase/admin");
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const request = new NextRequest("http://localhost/api/cards/card1", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ collectionName: "weapons" }),
+    });
+
+    const response = await PUT(request, { params: Promise.resolve({ id: "card1" }) });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.collectionNamePremiumRequired).toBeUndefined();
+    expect(updateQuery.update).toHaveBeenCalledWith(
+      expect.objectContaining({ collection_name: "weapons" })
+    );
+    expect(mockGetUserPlan).not.toHaveBeenCalled();
+  });
+
+  it("allows clearing an existing pack to null on the basic plan", async () => {
+    mockGetUserPlan.mockResolvedValue("basic");
+    const selectQuery = buildCardQuery("weapons");
+    const updateQuery = createMockQueryBuilder();
+    (updateQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: "card1", collection_name: null },
+      error: null,
+    });
+    let callCount = 0;
+    const fromMock = vi.fn(() => {
+      callCount += 1;
+      return callCount === 1 ? selectQuery : updateQuery;
+    });
+
+    const { getSupabaseAdmin } = await import("@/lib/supabase/admin");
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const request = new NextRequest("http://localhost/api/cards/card1", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ collectionName: null }),
+    });
+
+    const response = await PUT(request, { params: Promise.resolve({ id: "card1" }) });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.collectionNamePremiumRequired).toBeUndefined();
+    expect(updateQuery.update).toHaveBeenCalledWith(
+      expect.objectContaining({ collection_name: null })
+    );
+    expect(mockGetUserPlan).not.toHaveBeenCalled();
+  });
+
+  // Self-review regression guard: the ownership-check SELECT now also reads
+  // collection_name for the gate's currentValue. If that column isn't
+  // migrated yet, the SELECT itself errors (42703) and must NOT 403 an
+  // otherwise-valid edit that has nothing to do with packs.
+  it("still updates the card when the collection_name column is not deployed yet (deploy window)", async () => {
+    const selectQuery = createMockQueryBuilder();
+    (selectQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: null,
+      error: { code: "42703", message: "column cards.collection_name does not exist" },
+    });
+    const retrySelectQuery = createMockQueryBuilder();
+    (retrySelectQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        streamer_id: "streamer1",
+        image_url: null,
+        rarity: "common",
+        is_active: true,
+        intra_rarity_weight: 1,
+        streamers: { twitch_user_id: "user1", rarity_weights: null },
+      },
+      error: null,
+    });
+    const updateQuery = createMockQueryBuilder();
+    (updateQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: "card1", name: "Renamed" },
+      error: null,
+    });
+    let selectCalls = 0;
+    const fromMock = vi.fn(() => {
+      selectCalls += 1;
+      if (selectCalls === 1) return selectQuery;
+      if (selectCalls === 2) return retrySelectQuery;
+      return updateQuery;
+    });
+
+    const { getSupabaseAdmin } = await import("@/lib/supabase/admin");
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const request = new NextRequest("http://localhost/api/cards/card1", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ name: "Renamed" }),
+    });
+
+    const response = await PUT(request, { params: Promise.resolve({ id: "card1" }) });
+    expect(response.status).toBe(200);
+    expect(updateQuery.update).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Renamed" })
+    );
+  });
+});

--- a/tests/unit/collections/plan-gate.test.ts
+++ b/tests/unit/collections/plan-gate.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { isCollectionChangeGated } from "@/lib/plan-gate";
+import { getUserPlan } from "@/lib/plan";
+
+vi.mock("@/lib/plan");
+
+const mockGetUserPlan = vi.mocked(getUserPlan);
+
+describe("isCollectionChangeGated (Issue #269)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("is not gated and never calls getUserPlan when newValue is undefined (field omitted)", async () => {
+    const result = await isCollectionChangeGated("user1", undefined, "weapons");
+    expect(result).toBe(false);
+    expect(mockGetUserPlan).not.toHaveBeenCalled();
+  });
+
+  it("is not gated and never calls getUserPlan when clearing to null", async () => {
+    const result = await isCollectionChangeGated("user1", null, "weapons");
+    expect(result).toBe(false);
+    expect(mockGetUserPlan).not.toHaveBeenCalled();
+  });
+
+  it("is not gated and never calls getUserPlan when resubmitting the current value", async () => {
+    const result = await isCollectionChangeGated("user1", "weapons", "weapons");
+    expect(result).toBe(false);
+    expect(mockGetUserPlan).not.toHaveBeenCalled();
+  });
+
+  it("is gated when assigning a NEW value on the basic plan", async () => {
+    mockGetUserPlan.mockResolvedValue("basic");
+    const result = await isCollectionChangeGated("user1", "weapons", null);
+    expect(result).toBe(true);
+    expect(mockGetUserPlan).toHaveBeenCalledWith("user1");
+  });
+
+  it("is gated when changing from one pack to a different pack on the basic plan", async () => {
+    mockGetUserPlan.mockResolvedValue("basic");
+    const result = await isCollectionChangeGated("user1", "armor", "weapons");
+    expect(result).toBe(true);
+  });
+
+  it.each(["support", "patron", "twitch_sub"] as const)(
+    "is NOT gated for a NEW value on the %s plan",
+    async (plan) => {
+      mockGetUserPlan.mockResolvedValue(plan);
+      const result = await isCollectionChangeGated("user1", "weapons", null);
+      expect(result).toBe(false);
+    }
+  );
+});

--- a/tests/unit/components/channel-point-settings-collections.test.tsx
+++ b/tests/unit/components/channel-point-settings-collections.test.tsx
@@ -43,7 +43,7 @@ function mockFetch(): FetchMock {
   return fetchMock;
 }
 
-function renderComponent() {
+function renderComponent(isPremium?: boolean) {
   return render(
     <NextIntlClientProvider locale="ja" messages={jaMessages}>
       <ChannelPointSettings
@@ -51,6 +51,7 @@ function renderComponent() {
         currentRewardId="main-reward"
         currentRewardName="Main"
         currentCollectionName={null}
+        isPremium={isPremium}
       />
     </NextIntlClientProvider>
   );
@@ -88,6 +89,30 @@ describe("ChannelPointSettings card pack dropdowns", () => {
       // so each name appears at least once.
       expect(screen.getAllByRole("option", { name: "weapons" }).length).toBeGreaterThan(0);
       expect(screen.getAllByRole("option", { name: "characters" }).length).toBeGreaterThan(0);
+    });
+  });
+
+  // Issue #269: non-premium (basic plan) users can see existing pack options
+  // but cannot select a new one — only the blank "all cards" option stays
+  // enabled, so clearing a binding remains possible while new registration
+  // does not.
+  it("disables non-blank pack options when isPremium is false (default)", async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      const options = screen.getAllByRole("option", { name: "weapons" }) as HTMLOptionElement[];
+      expect(options.length).toBeGreaterThan(0);
+      options.forEach((option) => expect(option.disabled).toBe(true));
+    });
+  });
+
+  it("enables pack options when isPremium is true", async () => {
+    renderComponent(true);
+
+    await waitFor(() => {
+      const options = screen.getAllByRole("option", { name: "weapons" }) as HTMLOptionElement[];
+      expect(options.length).toBeGreaterThan(0);
+      options.forEach((option) => expect(option.disabled).toBe(false));
     });
   });
 });

--- a/tests/unit/streamer-settings-api.test.ts
+++ b/tests/unit/streamer-settings-api.test.ts
@@ -5,12 +5,18 @@ import { getSession, canUseStreamerFeatures } from '@/lib/session'
 import { checkRateLimit } from '@/lib/rate-limit'
 import { validateCSRFToken } from '@/lib/csrf'
 import { validateContentType } from '@/lib/request-validation'
+import { getUserPlan } from '@/lib/plan'
 import { createSupabaseMock, createMockQueryBuilder } from '../utils/supabase-mock'
 
 vi.mock('@/lib/session')
 vi.mock('@/lib/rate-limit')
 vi.mock('@/lib/csrf')
 vi.mock('@/lib/request-validation')
+// Issue #269: most pre-existing tests below assume an authorized (non-basic)
+// streamer, since they predate plan gating. Default to a premium plan here so
+// they keep exercising collection-name persistence rather than the gate;
+// gate-specific tests override this per-case.
+vi.mock('@/lib/plan')
 // 本物の constants モジュールを保持する。RARITIES が空配列になると
 // route.ts の DEFAULT_RARITY_VALUES が空となり、デフォルトレアリティとの
 // 衝突検出ができなくなるため、ファクトリで実体をそのまま返す。
@@ -28,6 +34,7 @@ const mockCheckRateLimit = vi.mocked(checkRateLimit)
 const mockValidateCSRFToken = vi.mocked(validateCSRFToken)
 const mockValidateContentType = vi.mocked(validateContentType)
 const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)
+const mockGetUserPlan = vi.mocked(getUserPlan)
 
 describe('POST /api/streamer/settings', () => {
   beforeEach(() => {
@@ -53,6 +60,7 @@ describe('POST /api/streamer/settings', () => {
 
     mockValidateCSRFToken.mockResolvedValue({ valid: true })
     mockValidateContentType.mockReturnValue(null)
+    mockGetUserPlan.mockResolvedValue('support')
   })
 
   it('should update streamer settings with valid data', async () => {
@@ -623,5 +631,190 @@ describe('POST /api/streamer/settings', () => {
 
     const response = await POST(request)
     expect(response.status).toBe(400)
+  })
+
+  // Issue #269: premium gate for the main-reward pack binding.
+  describe('card-pack premium gate (Issue #269)', () => {
+    it('drops a NEW pack binding on the basic plan but still saves it (200, no DB write, flag set)', async () => {
+      mockGetUserPlan.mockResolvedValue('basic')
+      const streamerQuery = createMockQueryBuilder()
+      ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: { id: 'streamer123', twitch_user_id: 'streamer123', channel_point_collection_name: null },
+        error: null,
+      })
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue({
+        from: vi.fn(() => streamerQuery),
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          channelPointCollectionName: 'weapons',
+        }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.success).toBe(true)
+      expect(data.collectionNamePremiumRequired).toBe(true)
+      // Gated: the pack binding itself must never reach the DB write, and the
+      // pack-existence check must be skipped (it would otherwise wrongly 400
+      // on a since-deactivated pack even though nothing is being persisted).
+      expect(streamerQuery.update).not.toHaveBeenCalled()
+    })
+
+    it('saves rarityWeights alongside a gated pack-binding attempt on the basic plan (no collateral failure)', async () => {
+      mockGetUserPlan.mockResolvedValue('basic')
+      const streamerQuery = createMockQueryBuilder()
+      ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: { id: 'streamer123', twitch_user_id: 'streamer123', channel_point_collection_name: null },
+        error: null,
+      })
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue({
+        from: vi.fn(() => streamerQuery),
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          channelPointCollectionName: 'weapons',
+          rarityWeights: { common: 50, rare: 50 },
+        }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.collectionNamePremiumRequired).toBe(true)
+      // The unrelated field still saves — basic-plan users keep settings access.
+      expect(streamerQuery.update).toHaveBeenCalledWith(
+        expect.objectContaining({ rarity_weights: { common: 50, rare: 50 } })
+      )
+      const updateCall = (streamerQuery.update as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(updateCall).not.toHaveProperty('channel_point_collection_name')
+    })
+
+    it('allows resubmitting the SAME pack value on the basic plan (no-op change, no gate)', async () => {
+      mockGetUserPlan.mockResolvedValue('basic')
+      const streamerQuery = createMockQueryBuilder()
+      ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: { id: 'streamer123', twitch_user_id: 'streamer123', channel_point_collection_name: 'weapons' },
+        error: null,
+      })
+      const cardsQuery = createMockQueryBuilder()
+      ;(cardsQuery as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
+        resolve({ count: 3, error: null })
+        return cardsQuery
+      }
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue({
+        from: vi.fn((table: string) => (table === 'cards' ? cardsQuery : streamerQuery)),
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          channelPointCollectionName: 'weapons',
+        }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.collectionNamePremiumRequired).toBeUndefined()
+      expect(streamerQuery.update).toHaveBeenCalledWith(
+        expect.objectContaining({ channel_point_collection_name: 'weapons' })
+      )
+      // getUserPlan must not even be consulted for a no-op resubmission.
+      expect(mockGetUserPlan).not.toHaveBeenCalled()
+    })
+
+    it('allows clearing an existing pack binding to null on the basic plan', async () => {
+      mockGetUserPlan.mockResolvedValue('basic')
+      const streamerQuery = createMockQueryBuilder()
+      ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: { id: 'streamer123', twitch_user_id: 'streamer123', channel_point_collection_name: 'weapons' },
+        error: null,
+      })
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue({
+        from: vi.fn(() => streamerQuery),
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          channelPointCollectionName: null,
+        }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.collectionNamePremiumRequired).toBeUndefined()
+      expect(streamerQuery.update).toHaveBeenCalledWith(
+        expect.objectContaining({ channel_point_collection_name: null })
+      )
+      expect(mockGetUserPlan).not.toHaveBeenCalled()
+    })
+
+    // Self-review regression guard: the ownership-check SELECT now also
+    // reads channel_point_collection_name for the gate's currentValue. If
+    // that column isn't migrated yet, the SELECT itself errors (42703) and
+    // must NOT 403 an otherwise-valid settings save unrelated to packs.
+    it('still saves other settings when channel_point_collection_name is not deployed yet (deploy window)', async () => {
+      const selectQuery = createMockQueryBuilder()
+      ;(selectQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: null,
+        error: { code: '42703', message: 'column streamers.channel_point_collection_name does not exist' },
+      })
+      const retrySelectQuery = createMockQueryBuilder()
+      ;(retrySelectQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: { id: 'streamer123' },
+        error: null,
+      })
+      const updateQuery = createMockQueryBuilder()
+      let selectCalls = 0
+      const fromMock = vi.fn(() => {
+        selectCalls += 1
+        if (selectCalls === 1) return selectQuery
+        if (selectCalls === 2) return retrySelectQuery
+        return updateQuery
+      })
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          channelPointRewardId: 'reward-123',
+          channelPointRewardName: 'Test Reward',
+        }),
+      })
+
+      const response = await POST(request)
+      expect(response.status).toBe(200)
+      expect(updateQuery.update).toHaveBeenCalledWith(
+        expect.objectContaining({ channel_point_reward_id: 'reward-123' })
+      )
+    })
   })
 })


### PR DESCRIPTION
## Summary
- #393で実装したカードパック機能(チャネポ報酬ごとの抽選対象絞り込み)を、支援コード有効またはTwitchサブスク有効のユーザーのみ新規登録・変更できるよう制限する(#269)
- 支援/サブスクが失効しても、既存設定の閲覧・解除・ガチャ抽選(引き換え)・他の設定保存は常に成功させ、新しいパック登録のみを drop-and-flag 方式でブロックする(全体403にしない)
- 対象: カード作成/更新、配信者設定保存、追加報酬作成の4エンドポイント。UIは新規パック選択を防止(disabled入力/option)しつつ既存値の表示・解除は維持

Closes #269

## Review process
- codexによる実装プラン事前レビュー(3往復)
- 自己レビュー(subagent)で重大バグを発見・修正: 所有権確認SELECTへの`collection_name`系カラム追加が、デプロイ窓(migration未適用時)に無関係なカード編集・設定保存まで403にする回帰 → 列未デプロイ時のフォールバックリトライを追加、回帰テストも追加
- チームレビュー(本番リスク観点 + セキュリティ/正しさ観点、2エージェント並行)→ 重大な問題なし

## Test plan
- [x] `npx vitest run tests/unit` → 880 tests / 87 files pass
- [x] `npx tsc --noEmit` → 本変更によるエラーなし
- [x] `npx eslint`(変更ファイル) → クリーン
- [x] `npm run build` → 成功
- [ ] 実環境でのライブ動作確認(未実施)

🤖 Generated with [Claude Code](https://claude.com/claude-code)