### PR TITLE
fix(collection): 達成日時表示のhydration mismatchを解消

### DIFF
--- a/src/components/CollectionProgress.tsx
+++ b/src/components/CollectionProgress.tsx
@@ -105,7 +105,14 @@ export default function CollectionProgress({
             {t("complete")}
           </p>
           {currentCompleteRecord && (
-            <p className="text-xs text-emerald-200/90">
+            // formatDateTime は Intl.DateTimeFormat に timeZone を指定していないため、
+            // SSR (Cloudflare Workers = UTC) とクライアント（ユーザーのローカルTZ）で
+            // 整形結果が異なりうる。これは「ユーザーのローカルタイムゾーンで達成日時を
+            // 表示する」という意図した挙動であり、hydration mismatch ではない。
+            // timeZone を固定すると全ユーザーにその TZ を強制してしまうため不採用とし、
+            // React 公式にタイムスタンプ用途で認められている suppressHydrationWarning で
+            // 警告を抑制する。
+            <p className="text-xs text-emerald-200/90" suppressHydrationWarning>
               {t("currentCompleteAt", {
                 dateTime: formatDateTime(currentCompleteRecord.completed_at),
               })}
@@ -118,7 +125,13 @@ export default function CollectionProgress({
       {pastCompletionHistory.length > 0 && (
         <div className="mt-3 space-y-1">
           {pastCompletionHistory.map((record) => (
-            <p key={`${record.total_cards}-${record.completed_at}`} className="text-xs text-gray-300">
+            // 上と同様、達成日時はユーザーのローカルTZで表示する意図した挙動のため
+            // suppressHydrationWarning でSSR/クライアント間の差分警告を抑制する。
+            <p
+              key={`${record.total_cards}-${record.completed_at}`}
+              className="text-xs text-gray-300"
+              suppressHydrationWarning
+            >
               {t("pastCompleteWithDateTime", {
                 totalCards: record.total_cards,
                 dateTime: formatDateTime(record.completed_at),

--- a/tests/unit/components/collection-progress.test.tsx
+++ b/tests/unit/components/collection-progress.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { act } from 'react'
+import { renderToString } from 'react-dom/server'
+import { hydrateRoot } from 'react-dom/client'
+import { NextIntlClientProvider } from 'next-intl'
+import CollectionProgress from '@/components/CollectionProgress'
+import jaMessages from '../../../messages/ja.json'
+
+// Issue #557 の回帰: CollectionProgress が Server→Client Component 化された結果、
+// 達成日時表示が hydration の対象になった。formatDateTime は Intl.DateTimeFormat に
+// timeZone を指定していないため、SSR (Cloudflare Workers = UTC 想定) とクライアント
+// (ユーザーのローカルTZ、例: JST) で整形結果が異なり、React error #418
+// (hydration text mismatch) がコンソールに出ていた。
+//
+// 修正は timeZone を固定するのではなく（全ユーザーにJSTを強制してしまうため）、
+// 達成日時を含む要素に suppressHydrationWarning を付与して警告を抑制する方針。
+// ここでは実際に renderToString → hydrateRoot を行い、サーバー/クライアントで
+// フォーマット結果が異なる状況でも console.error が呼ばれないことを確認する。
+describe('CollectionProgress hydration mismatch (Issue #557 regression)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  const baseProps = {
+    owned: 3,
+    total: 3,
+    completionHistory: [
+      { total_cards: 3, completed_at: '2026-01-01T00:00:00Z' },
+      { total_cards: 2, completed_at: '2025-06-01T00:00:00Z' },
+    ],
+  }
+
+  it('does not log a hydration warning even when the formatted date differs between server and client render', async () => {
+    // Intl.DateTimeFormat をモックし、1回目の呼び出し（SSR相当）と2回目以降の呼び出し
+    // （クライアント相当）で異なる文字列を返すことで、UTC/JSTのようなTZ差を再現する。
+    let callCount = 0
+    vi.spyOn(Intl, 'DateTimeFormat').mockImplementation(() => {
+      callCount += 1
+      const isServerRender = callCount <= baseProps.completionHistory.length
+      return {
+        format: () =>
+          isServerRender ? '2026/01/01 00:00:00 (server)' : '2026/01/01 09:00:00 (client)',
+      } as unknown as Intl.DateTimeFormat
+    })
+
+    const tree = (
+      <NextIntlClientProvider locale="ja" messages={jaMessages}>
+        <CollectionProgress {...baseProps} />
+      </NextIntlClientProvider>
+    )
+
+    const html = renderToString(tree)
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // React はハイドレーション時のミスマッチ警告をスケジューラのタスクとして
+    // 非同期に出力するため、act(async () => {...}) でハイドレーション作業と
+    // それに伴う警告出力の完了まで待ってから console.error の呼び出しを検証する。
+    await act(async () => {
+      hydrateRoot(container, tree)
+    })
+
+    // React はハイドレーションミスマッチを console.error(Error) の形で報告する
+    // （第一引数が文字列とは限らず Error インスタンスのこともある）ため、
+    // message も含めて文字列化してから判定する。
+    const hydrationMismatchLogged = consoleErrorSpy.mock.calls.some((args) =>
+      args.some((arg) => {
+        const text = arg instanceof Error ? arg.message : String(arg)
+        return text.includes("didn't match") || text.includes('Hydration failed')
+      })
+    )
+    expect(hydrationMismatchLogged).toBe(false)
+  })
+
+  it('renders suppressHydrationWarning on the timestamp elements (source-level guard against regressions)', async () => {
+    // suppressHydrationWarning は DOM 属性として出力されないため描画結果からは検証できない。
+    // 上のhydrateRootテストが実挙動の検証を担う一方、ここでは実装がsuppressHydrationWarningの
+    // 付与という修正方針から外れて削除されていないかをソースレベルで軽く検知する。
+    const fs = await import('node:fs/promises')
+    const path = await import('node:path')
+    const source = await fs.readFile(
+      path.resolve(__dirname, '../../../src/components/CollectionProgress.tsx'),
+      'utf-8'
+    )
+    const occurrences = source.match(/suppressHydrationWarning/g) ?? []
+    // 現在コンプリート中の達成日時 + 過去履歴の各行、の2箇所
+    expect(occurrences.length).toBeGreaterThanOrEqual(2)
+  })
+})


### PR DESCRIPTION
## 概要
preview E2E テストで発見した回帰の修正。コレクションページを開くたびに React error #418 (hydration text mismatch) がコンソールに発生していた。

## 原因
`CollectionProgress.tsx` の `formatDateTime` が `Intl.DateTimeFormat` に timeZone を指定していないため、SSR (Cloudflare Workers = UTC) とクライアント (ユーザーのローカルTZ) で整形文字列が異なる。#557 (PR #561) で本コンポーネントを Client Component 化したことで hydration 対象となり顕在化。

## 修正
達成日時テキストの2箇所に `suppressHydrationWarning` を付与 (React 公式がタイムスタンプ用途で認める方式)。「ユーザーのローカルTZで表示する」現行の望ましい挙動は維持 (timeZone 固定は全ユーザーへのTZ強制になるため不採用)。理由はコード内コメントに明記。

## テスト
- 新規: `renderToString` → `hydrateRoot` でSSR/クライアントの日時差分を実際に再現し console.error が出ないことを検証するテスト (**修正を外すと実際に失敗することを確認済み** = vacuous でない)
- `npm run test:unit`: **1050 passed / 0 failed**
- tsc / eslint / build: 新規エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn