### PR TITLE
feat(gacha): パック別レアリティ配分のDB基盤と設定API (#578)

### DIFF
--- a/src/app/api/streamer/settings/route.ts
+++ b/src/app/api/streamer/settings/route.ts
@@ -9,6 +9,7 @@ import {
   RARITIES,
   MAX_RARITY_KEY_LENGTH,
   MAX_CUSTOM_RARITIES,
+  MAX_PACK_RARITY_WEIGHTS_ENTRIES,
   RARITY_CONTROL_CHAR_REGEX as CONTROL_CHAR_REGEX,
   RARITY_BIDI_OVERRIDE_REGEX as BIDI_OVERRIDE_REGEX,
 } from "@/lib/constants";
@@ -27,6 +28,8 @@ import {
   isMissingCollectionNameColumn,
   isMissingCardPackNamesColumnError,
   isMissingDefaultCardPackNameColumnError,
+  isMissingRarityWeightsScopeColumnError,
+  isMissingPackRarityWeightsColumnError,
 } from "@/lib/collections/collection-existence";
 import { isNewCardPackNameAdditionGated } from "@/lib/plan-gate";
 
@@ -142,6 +145,89 @@ function hasValidRarityWeightsTotal(value: Record<string, number> | null): boole
   return Math.abs(total - 100) <= 0.001;
 }
 
+type PackRarityWeightsValidation =
+  | { ok: true; value: Record<string, Record<string, number>> | null }
+  | { ok: false };
+
+/**
+ * Issue #578(#576 フェーズ1): pack_rarity_weights 入力を検証する。
+ *
+ * - `null` は「全エントリをクリア」として常に許可する。
+ * - オブジェクト以外(配列含む)・51件超は拒否する（DB の
+ *   check_pack_rarity_weights_values と同じ上限。50パック + __default__）。
+ * - 各キーは DEFAULT_PACK_SENTINEL か、`catalog`(実効パックカタログ)に
+ *   登録済みの名前でなければ拒否する。
+ * - 各値は validateRarityWeightsInput でキー/値の形式検証を行った上で、
+ *   空オブジェクトを明示的に拒否する（グローバルへの継承は「キーを
+ *   送らない」ことで表現する規約のため、空オブジェクトでの継承指定は
+ *   曖昧で許可しない）。さらに hasValidRarityWeightsTotal で合計100%を要求する
+ *   （各パックの実効分布は完結している必要がある）。
+ *
+ * 実効カタログ(catalog)は呼び出し側が決定する: 同一リクエストに
+ * cardPackNames が含まれていればその新カタログ、なければ DB 上の現在の
+ * card_pack_names を渡す。
+ */
+function validatePackRarityWeightsInput(
+  value: unknown,
+  catalog: string[]
+): PackRarityWeightsValidation {
+  if (value === null) {
+    return { ok: true, value: null };
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { ok: false };
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length > MAX_PACK_RARITY_WEIGHTS_ENTRIES) {
+    return { ok: false };
+  }
+
+  const normalized: Record<string, Record<string, number>> = {};
+  for (const [key, entryValue] of entries) {
+    if (key !== DEFAULT_PACK_SENTINEL && !catalog.includes(key)) {
+      return { ok: false };
+    }
+
+    const validation = validateRarityWeightsInput(entryValue);
+    if (!validation.ok || validation.value === null) {
+      return { ok: false };
+    }
+
+    // 空オブジェクトはグローバル継承の表現として認めない（継承したい場合は
+    // キー自体を省略する規約のため、曖昧な入力として拒否する）。
+    if (Object.keys(validation.value).length === 0) {
+      return { ok: false };
+    }
+
+    if (!hasValidRarityWeightsTotal(validation.value)) {
+      return { ok: false };
+    }
+
+    normalized[key] = validation.value;
+  }
+
+  return { ok: true, value: normalized };
+}
+
+/**
+ * Issue #578: cardPackNames の保存に伴い、最終カタログに存在しなくなった
+ * キーを pack_rarity_weights から取り除く。__default__ は実パックカタログの
+ * メンバーではない（常に存在する疑似パック）ため、常に保持する。
+ */
+function prunePackRarityWeights(
+  value: Record<string, Record<string, number>>,
+  finalCatalog: string[]
+): Record<string, Record<string, number>> {
+  const pruned: Record<string, Record<string, number>> = {};
+  for (const [key, entryValue] of Object.entries(value)) {
+    if (key === DEFAULT_PACK_SENTINEL || finalCatalog.includes(key)) {
+      pruned[key] = entryValue;
+    }
+  }
+  return pruned;
+}
+
 export async function POST(request: NextRequest) {
   // Content-Type validation - must be the first check
   const contentTypeValidation = validateContentType(request, 'application/json')
@@ -200,6 +286,20 @@ export async function POST(request: NextRequest) {
       chatAnnouncementMultiShowCards,
       // レアリティ別自動確率設定（オプション）
       rarityWeights,
+      // レアリティ重みのスコープ（オプション、Issue #578）: 'global'(全パック共通)
+      // か 'per_pack'(パック別、packRarityWeights を優先)か。実効重みの計算
+      // (パック別ドロップ率反映)は抽選時に行う(#576 フェーズ2)ため、ここでの
+      // 保存では drop_rate の再計算は一切トリガーしない。
+      // Rarity-weight scope (optional, Issue #578): 'global' (shared across
+      // all packs) or 'per_pack' (packRarityWeights takes precedence).
+      // Effective per-pack weights are computed at DRAW TIME (#576 Phase 2),
+      // so saving this field never triggers a drop_rate recalculation.
+      rarityWeightsScope,
+      // パック別レアリティ重みの上書きマップ（オプション、Issue #578）。
+      // null で全クリア。キーはパック名または __default__。
+      // Per-pack rarity-weight override map (optional, Issue #578). null
+      // clears all entries. Keys are pack names or __default__.
+      packRarityWeights,
       // カスタムレアリティ名の一覧（オプション、ドロップ率設定とは独立）
       // Custom rarity name catalog (optional, decoupled from drop-rate settings)
       customRarities,
@@ -234,6 +334,15 @@ export async function POST(request: NextRequest) {
       if (!hasValidRarityWeightsTotal(normalizedRarityWeights)) {
         return NextResponse.json({ error: "Rarity weights total must be 100%" }, { status: 400 });
       }
+    }
+
+    // rarityWeightsScope: 'global' | 'per_pack' の2値のみ許可（Issue #578）。
+    if (
+      rarityWeightsScope !== undefined
+      && rarityWeightsScope !== "global"
+      && rarityWeightsScope !== "per_pack"
+    ) {
+      return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
     }
 
     // customRarities はレアリティ名の一覧のみを保持し、ドロップ率には影響しない。
@@ -301,10 +410,28 @@ export async function POST(request: NextRequest) {
     // Verify ownership
     let { data: streamer, error: streamerSelectError } = await supabaseAdmin
       .from("streamers")
-      .select("id, channel_point_collection_name, card_pack_names")
+      .select("id, channel_point_collection_name, card_pack_names, pack_rarity_weights")
       .eq("id", streamerId)
       .eq("twitch_user_id", session.twitchUserId)
       .maybeSingle();
+
+    // Issue #578: pack_rarity_weights はこのフェーズで新規追加された列。デプロイ窓では
+    // 他の列より先に(あるいは他が既に安定デプロイ済みの状態で単独で)未デプロイになり
+    // うるため、既存の card_pack_names / channel_point_collection_name と同じチェイン
+    // 方式で、まずこの列だけ剥がして再試行する。プルーニング(下記)に使う現在値の
+    // 読み取りが目的で、未デプロイなら「保存されているエントリなし」= null 扱いにする。
+    if (streamerSelectError && isMissingPackRarityWeightsColumnError(streamerSelectError)) {
+      const retryResult = await supabaseAdmin
+        .from("streamers")
+        .select("id, channel_point_collection_name, card_pack_names")
+        .eq("id", streamerId)
+        .eq("twitch_user_id", session.twitchUserId)
+        .maybeSingle();
+      streamer = retryResult.data
+        ? { ...retryResult.data, pack_rarity_weights: null as Record<string, Record<string, number>> | null }
+        : null;
+      streamerSelectError = retryResult.error;
+    }
 
     // Issue #393再設計 / #269: このownership確認SELECTは channel_point_collection_name
     // と card_pack_names の現在値を読むために2列を含む。デプロイ窓ではどちらか
@@ -320,7 +447,11 @@ export async function POST(request: NextRequest) {
         .eq("twitch_user_id", session.twitchUserId)
         .maybeSingle();
       streamer = retryResult.data
-        ? { ...retryResult.data, card_pack_names: [] as string[] }
+        ? {
+            ...retryResult.data,
+            card_pack_names: [] as string[],
+            pack_rarity_weights: null as Record<string, Record<string, number>> | null,
+          }
         : null;
       streamerSelectError = retryResult.error;
     }
@@ -333,7 +464,12 @@ export async function POST(request: NextRequest) {
         .eq("twitch_user_id", session.twitchUserId)
         .maybeSingle();
       streamer = retryResult.data
-        ? { ...retryResult.data, channel_point_collection_name: null, card_pack_names: [] as string[] }
+        ? {
+            ...retryResult.data,
+            channel_point_collection_name: null,
+            card_pack_names: [] as string[],
+            pack_rarity_weights: null as Record<string, Record<string, number>> | null,
+          }
         : null;
       streamerSelectError = retryResult.error;
     }
@@ -346,6 +482,33 @@ export async function POST(request: NextRequest) {
       ? streamer.card_pack_names
       : [];
 
+    // pack_rarity_weights は object 前提の列（配列/非objectは不正データとして
+    // 無視しnullにフォールバック — DBのCHECK制約により通常発生しない防御的処理）。
+    const currentPackRarityWeights: Record<string, Record<string, number>> | null =
+      streamer.pack_rarity_weights
+      && typeof streamer.pack_rarity_weights === "object"
+      && !Array.isArray(streamer.pack_rarity_weights)
+        ? (streamer.pack_rarity_weights as Record<string, Record<string, number>>)
+        : null;
+
+    // Issue #578(#576 フェーズ1): packRarityWeights のキーは、同一リクエストで
+    // cardPackNames も送られていればその新カタログ、そうでなければ DB 上の
+    // 現在の card_pack_names を実効カタログとして検証する。
+    const effectivePackCatalogForRarityWeights: string[] =
+      normalizedCardPackNames !== undefined ? normalizedCardPackNames : currentCardPackNames;
+
+    let normalizedPackRarityWeights: Record<string, Record<string, number>> | null | undefined;
+    if (packRarityWeights !== undefined) {
+      const validation = validatePackRarityWeightsInput(
+        packRarityWeights,
+        effectivePackCatalogForRarityWeights
+      );
+      if (!validation.ok) {
+        return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
+      }
+      normalizedPackRarityWeights = validation.value;
+    }
+
     // Issue #269再設計: 「新しい登録」= card_pack_names一覧への新規追加のみを
     // ゲートする。カード/報酬への既存パックの紐付け(選択)はもうゲート対象外。
     let persistedCardPackNames: string[] = currentCardPackNames;
@@ -356,6 +519,26 @@ export async function POST(request: NextRequest) {
       persistedCardPackNames = cardPackNamesPremiumRequired
         ? normalizedCardPackNames.filter((name) => currentCardPackNames.includes(name))
         : normalizedCardPackNames;
+    }
+
+    // Issue #578: cardPackNames の保存に伴い、最終カタログ(persistedCardPackNames、
+    // ゲート適用後)に存在しなくなったキーを pack_rarity_weights から取り除く
+    // (__default__ は常に保持)。packRarityWeights が同一リクエストで指定されて
+    // いればそれを、されていなければ DB の現在値(currentPackRarityWeights)を
+    // プルーニング対象の基準にする — 「cardPackNamesだけ送っても機能する」
+    // 仕様のため、packRarityWeights 未指定でも DB 上の値を読み直して整合させる。
+    let packRarityWeightsToPersist: Record<string, Record<string, number>> | null | undefined =
+      normalizedPackRarityWeights;
+
+    if (normalizedCardPackNames !== undefined) {
+      const pruneBasis = packRarityWeightsToPersist !== undefined
+        ? packRarityWeightsToPersist
+        : currentPackRarityWeights;
+      if (pruneBasis !== null) {
+        packRarityWeightsToPersist = prunePackRarityWeights(pruneBasis, persistedCardPackNames);
+      }
+      // pruneBasis が null かつ packRarityWeightsToPersist が未指定の場合、
+      // プルーニングすべき既存エントリが無いため何もしない(undefinedのまま)。
     }
 
     // Issue #393再設計: メイン報酬のパック紐付けは、null化・現在値の再送信は
@@ -449,6 +632,17 @@ export async function POST(request: NextRequest) {
       updateData.rarity_weights = normalizedRarityWeights;
     }
 
+    // Issue #578(#576 フェーズ1): rarity_weights_scope / pack_rarity_weights。
+    // 実効重みは抽選時計算(#576 設計)のため、これらの保存では drop_rate の
+    // 再計算(recalculateIfAutoMode)は一切トリガーしない(下記の再計算呼び出しは
+    // rarityWeights !== undefined のみを条件としており、この2フィールドは対象外)。
+    if (rarityWeightsScope !== undefined) {
+      updateData.rarity_weights_scope = rarityWeightsScope;
+    }
+    if (packRarityWeightsToPersist !== undefined) {
+      updateData.pack_rarity_weights = packRarityWeightsToPersist;
+    }
+
     // カスタムレアリティ名（ドロップ率の再計算は不要）
     if (customRarities !== undefined) {
       updateData.custom_rarities = normalizedCustomRarities;
@@ -518,12 +712,46 @@ export async function POST(request: NextRequest) {
     // Issue #554: 同じ理由(デプロイ窓)で default_card_pack_name 列がまだ
     // 無い可能性があるため、card_pack_names と同じ skip-and-flag パターンを踏襲する。
     let defaultCardPackNameWriteSkipped = false;
+    // Issue #578: rarity_weights_scope / pack_rarity_weights も同じ理由(デプロイ窓)で
+    // skip-and-flag パターンを踏襲する。
+    let rarityWeightsScopeWriteSkipped = false;
+    let packRarityWeightsWriteSkipped = false;
 
     if (Object.keys(updateData).length > 0) {
       let { error } = await supabaseAdmin
         .from("streamers")
         .update(updateData)
         .eq("id", streamerId);
+
+      // Issue #578: このフェーズで新規追加された列を最初に剥がす(他の既存列より
+      // 未デプロイである可能性が高いため)。
+      if (error && isMissingRarityWeightsScopeColumnError(error) && "rarity_weights_scope" in updateData) {
+        delete updateData.rarity_weights_scope;
+        rarityWeightsScopeWriteSkipped = true;
+        if (Object.keys(updateData).length > 0) {
+          const retryResult = await supabaseAdmin
+            .from("streamers")
+            .update(updateData)
+            .eq("id", streamerId);
+          error = retryResult.error;
+        } else {
+          error = null;
+        }
+      }
+
+      if (error && isMissingPackRarityWeightsColumnError(error) && "pack_rarity_weights" in updateData) {
+        delete updateData.pack_rarity_weights;
+        packRarityWeightsWriteSkipped = true;
+        if (Object.keys(updateData).length > 0) {
+          const retryResult = await supabaseAdmin
+            .from("streamers")
+            .update(updateData)
+            .eq("id", streamerId);
+          error = retryResult.error;
+        } else {
+          error = null;
+        }
+      }
 
       // Issue #393再設計: 書き込み時点で card_pack_names / channel_point_collection_name
       // のどちらか(または両方)が未デプロイの可能性があるため、都度1列だけ剥がして再試行する。
@@ -605,6 +833,11 @@ export async function POST(request: NextRequest) {
       // gate, no catalog membership check) — the client's submitted value is
       // authoritative on success. Only the deploy-window skip needs a flag.
       ...(defaultCardPackNameWriteSkipped ? { defaultCardPackNameSkippedDeployWindow: true } : {}),
+      // Issue #578: rarity_weights_scope / pack_rarity_weights も同様に、値そのものは
+      // エコーバックせず(サーバ側の却下シナリオが無いため送信値がそのまま正)、
+      // デプロイ窓によるskipのみフラグで通知する。
+      ...(rarityWeightsScopeWriteSkipped ? { rarityWeightsScopeSkippedDeployWindow: true } : {}),
+      ...(packRarityWeightsWriteSkipped ? { packRarityWeightsSkippedDeployWindow: true } : {}),
     });
   } catch (error) {
     return handleApiError(error, "Streamer Settings API: General");

--- a/src/app/api/streamer/settings/route.ts
+++ b/src/app/api/streamer/settings/route.ts
@@ -833,9 +833,17 @@ export async function POST(request: NextRequest) {
       // gate, no catalog membership check) — the client's submitted value is
       // authoritative on success. Only the deploy-window skip needs a flag.
       ...(defaultCardPackNameWriteSkipped ? { defaultCardPackNameSkippedDeployWindow: true } : {}),
-      // Issue #578: rarity_weights_scope / pack_rarity_weights も同様に、値そのものは
-      // エコーバックせず(サーバ側の却下シナリオが無いため送信値がそのまま正)、
-      // デプロイ窓によるskipのみフラグで通知する。
+      // Issue #578: rarityWeightsScope はエコーバック不要(サーバ側の却下・
+      // 加工シナリオが無く送信値がそのまま正)。一方 packRarityWeights は
+      // **サーバ側で黙って加工されるシナリオがある**: 同一リクエストの
+      // cardPackNames 追加がプレミアムゲートで却下されると、その追加パック向け
+      // エントリは prune で落ちる(検証はゲート適用前の要求カタログに対して
+      // 通っているため 400 にはならない)。cardPackNames と同様、確定後の
+      // 永続値をエコーバックしてクライアントが state を再同期できるようにする。
+      // デプロイ窓 skip 時は書き込まれていないためエコーしない(フラグで通知)。
+      ...(packRarityWeightsToPersist !== undefined && !packRarityWeightsWriteSkipped
+        ? { packRarityWeights: packRarityWeightsToPersist }
+        : {}),
       ...(rarityWeightsScopeWriteSkipped ? { rarityWeightsScopeSkippedDeployWindow: true } : {}),
       ...(packRarityWeightsWriteSkipped ? { packRarityWeightsSkippedDeployWindow: true } : {}),
     });

--- a/src/lib/collections/collection-existence.ts
+++ b/src/lib/collections/collection-existence.ts
@@ -139,6 +139,62 @@ export function isMissingRenameCardPackFunctionError(
   return text.includes("rename_card_pack") && error.code === "42883";
 }
 
+/**
+ * Detect the "rarity_weights_scope column is not deployed yet" schema error.
+ *
+ * Separate function for the same reason as `isMissingCardPackNamesColumnError`
+ * / `isMissingDefaultCardPackNameColumnError`: this column's name doesn't
+ * contain "collection_name", so the existing gate would never match it
+ * (one-helper-per-column convention).
+ *
+ * Issue #578 (#576 Phase 1): `streamers.rarity_weights_scope` ships in
+ * migration 00065, in the same PR as the settings route that writes it — a
+ * rolling deploy can briefly have the app code live before the migration has
+ * run, so the route uses this to skip persisting the field during that
+ * window instead of 500ing.
+ */
+export function isMissingRarityWeightsScopeColumnError(
+  error: { message?: string; code?: string; details?: string; hint?: string } | null | undefined
+): boolean {
+  if (!error) return false;
+  const text = [error.message, error.details, error.hint]
+    .map((value) => String(value ?? ""))
+    .join(" ");
+
+  return (
+    text.includes("rarity_weights_scope") &&
+    (error.code === "PGRST204" ||
+      text.includes("does not exist") ||
+      text.includes("schema cache"))
+  );
+}
+
+/**
+ * Detect the "pack_rarity_weights column is not deployed yet" schema error.
+ *
+ * Same rationale/shape as `isMissingRarityWeightsScopeColumnError` above —
+ * `streamers.pack_rarity_weights` ships in the same migration (00065).
+ * Kept as a distinct helper (rather than folded into the scope check) so
+ * each column can independently fall back during the deploy window, mirroring
+ * how `card_pack_names` and `default_card_pack_name` are detected separately
+ * even though they shipped close together.
+ */
+export function isMissingPackRarityWeightsColumnError(
+  error: { message?: string; code?: string; details?: string; hint?: string } | null | undefined
+): boolean {
+  if (!error) return false;
+  const text = [error.message, error.details, error.hint]
+    .map((value) => String(value ?? ""))
+    .join(" ");
+
+  return (
+    text.includes("pack_rarity_weights") &&
+    (error.code === "PGRST204" ||
+      text.includes("does not exist") ||
+      text.includes("schema cache"))
+  );
+}
+
 export type CollectionExistenceResult =
   | "exists" // at least one active card belongs to this pack
   | "absent" // no active card belongs to this pack → would cause empty draws

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -70,6 +70,9 @@ export const MAX_RARITY_KEY_LENGTH = 40;
 export const MAX_CUSTOM_RARITIES = 50;
 // 1配信者あたりの事前登録カードパック数の上限。DB(00062 の CHECK)と整合させる。
 export const MAX_CARD_PACK_NAMES = 50;
+// pack_rarity_weights のエントリ数上限。事前登録パック上限(50) + __default__(1)。
+// DB(00065 の check_pack_rarity_weights_values)と整合させる。Issue #578
+export const MAX_PACK_RARITY_WEIGHTS_ENTRIES = 51;
 // 制御文字(C0 U+0000-U+001F・DEL U+007F・C1 U+0080-U+009F)。
 // 表示崩れや不可視キー注入を防ぐため禁止。
 export const RARITY_CONTROL_CHAR_REGEX = /[\u0000-\u001F\u007F-\u009F]/;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -48,6 +48,19 @@ export interface Database {
           // レアリティ名をキーにした目標確率マップ（0-100）
           // Dynamic rarity-to-target-percentage map (0-100)
           rarity_weights: Record<string, number> | null
+          // rarity_weights を全パック共通(global)で使うか、パック別
+          // (per_pack, pack_rarity_weights を優先)で使うか。Issue #578
+          // Whether rarity_weights applies globally or per-pack overrides
+          // (pack_rarity_weights) take precedence. Issue #578
+          rarity_weights_scope: 'global' | 'per_pack'
+          // パック名(またはデフォルトパック用の __default__)をキーにした
+          // レアリティ別目標確率マップの上書き。エントリの無いパックは
+          // rarity_weights を継承する（アプリ層の規約）。Issue #578
+          // Per-pack override of the rarity-to-target-percentage map, keyed
+          // by pack name (or __default__ for the unclassified pseudo-pack).
+          // Packs without an entry inherit rarity_weights (app-layer
+          // convention). Issue #578
+          pack_rarity_weights: Record<string, Record<string, number>> | null
           // 配信者が定義したカスタムレアリティ名の一覧（rarity_weights とは独立）
           // List of streamer-defined custom rarity names (decoupled from rarity_weights)
           custom_rarities: string[]
@@ -91,6 +104,8 @@ export interface Database {
           chat_announcement_multi_template?: string | null
           chat_announcement_multi_show_cards?: boolean
           rarity_weights?: Record<string, number> | null
+          rarity_weights_scope?: 'global' | 'per_pack'
+          pack_rarity_weights?: Record<string, Record<string, number>> | null
           custom_rarities?: string[]
           card_pack_names?: string[]
           default_card_pack_name?: string | null
@@ -118,6 +133,8 @@ export interface Database {
           chat_announcement_multi_template?: string | null
           chat_announcement_multi_show_cards?: boolean
           rarity_weights?: Record<string, number> | null
+          rarity_weights_scope?: 'global' | 'per_pack'
+          pack_rarity_weights?: Record<string, Record<string, number>> | null
           custom_rarities?: string[]
           card_pack_names?: string[]
           default_card_pack_name?: string | null

--- a/supabase/migrations/00065_add_pack_rarity_weights.sql
+++ b/supabase/migrations/00065_add_pack_rarity_weights.sql
@@ -78,10 +78,20 @@ ADD COLUMN IF NOT EXISTS pack_rarity_weights JSONB DEFAULT NULL;
 -- card_pack_names element validation (00062) and rarity_weights key
 -- validation (00025): the DB only enforces shape/bounds, and the API route
 -- (POST /api/streamer/settings) enforces catalog membership.
-CREATE OR REPLACE FUNCTION check_pack_rarity_weights_values(weights JSONB)
+--
+-- SET search_path = '' + 完全修飾が必須である理由: CHECK 制約は streamers
+-- 行の UPDATE のたびに(変更列に関係なく)再評価される。rename_card_pack は
+-- `SET search_path = ''` で動作し streamers を UPDATE するため、この関数の
+-- 中の関数呼び出しが非修飾だと、その空 search_path を継承した実行時名前解決
+-- が `function check_rarity_weights_values(jsonb) does not exist` で失敗し、
+-- リネーム全体がロールバックする(pack_rarity_weights 非 NULL の配信者で
+-- 100% 再現)。ネスト呼び出しを public. で修飾し、この関数自体も
+-- search_path を固定して呼び出し元の環境に依存しないようにする。
+CREATE OR REPLACE FUNCTION public.check_pack_rarity_weights_values(weights JSONB)
 RETURNS BOOLEAN
 LANGUAGE plpgsql
 IMMUTABLE
+SET search_path = ''
 AS $$
 DECLARE
   entry_key TEXT;
@@ -112,7 +122,7 @@ BEGIN
       RETURN FALSE;
     END IF;
 
-    IF NOT check_rarity_weights_values(entry_value) THEN
+    IF NOT public.check_rarity_weights_values(entry_value) THEN
       RETURN FALSE;
     END IF;
   END LOOP;
@@ -126,23 +136,26 @@ DROP CONSTRAINT IF EXISTS streamers_pack_rarity_weights_valid;
 
 ALTER TABLE streamers
 ADD CONSTRAINT streamers_pack_rarity_weights_valid
-CHECK (check_pack_rarity_weights_values(pack_rarity_weights));
+CHECK (public.check_pack_rarity_weights_values(pack_rarity_weights));
 
 -- ---------------------------------------------------------------------------
--- c. rename_card_pack: extend the #554 rename RPC (migration 00063) so that
--- renaming a catalog pack also carries forward any per-pack rarity-weight
--- override stored under the old name — otherwise a rename would silently
--- orphan the override (it would keep applying to a pack name that no longer
--- exists in the catalog, while the renamed pack would silently fall back to
--- the global weights). Full body copied from 00063 verbatim; the only change
--- is the new pack_rarity_weights cascade step added at the end, alongside the
--- existing cascades to cards / channel_point_collection_name /
--- streamer_additional_gacha_rewards. Issue #576/#578.
+-- c. rename_card_pack: extend the #554 rename RPC so that renaming a catalog
+-- pack also carries forward any per-pack rarity-weight override stored under
+-- the old name — otherwise a rename would silently orphan the override (it
+-- would keep applying to a pack name that no longer exists in the catalog,
+-- while the renamed pack would silently fall back to the global weights).
+--
+-- Full body copied verbatim from **00064** (NOT 00063 — 00064 already
+-- superseded 00063 by adding the collection_completions cascade for #557,
+-- which must be preserved here); the only change is the new
+-- pack_rarity_weights cascade step, alongside the existing cascades to
+-- cards / channel_point_collection_name / streamer_additional_gacha_rewards /
+-- collection_completions. Issue #576/#578.
 --
 -- SECURITY INVOKER / SET search_path = '' / schema-qualification: unchanged
--- from 00063 — see that migration's comment for the full rationale (this
--- function performs no privilege escalation; only the service_role admin
--- client ever calls it, per the REVOKE/GRANT at the bottom of this block).
+-- from 00063/00064 — see those migrations' comments for the full rationale
+-- (this function performs no privilege escalation; only the service_role
+-- admin client ever calls it, per the REVOKE/GRANT at the bottom of this block).
 CREATE OR REPLACE FUNCTION public.rename_card_pack(
   p_streamer_id UUID,
   p_old_name TEXT,
@@ -225,6 +238,37 @@ BEGIN
   SET collection_name = v_new_name
   WHERE streamer_id = p_streamer_id AND collection_name = p_old_name;
 
+  -- Issue #557: carry per-pack completion achievements over to the new name
+  -- (the follow-up 00063 explicitly deferred with its "#557 で対応予定" note).
+  --
+  -- ORDER MATTERS — DELETE must run BEFORE the UPDATE below. The partial
+  -- unique index idx_collection_completions_pack_unique forbids two rows
+  -- with the same (twitch_user_id, streamer_id, collection_name,
+  -- total_cards). If some user already holds a completion recorded under
+  -- v_new_name with the same total_cards (e.g. the new name was used by a
+  -- previously-deleted pack, or an earlier rename cycled names), UPDATE-ing
+  -- their old-name row to v_new_name would raise a unique violation and roll
+  -- back the ENTIRE rename (catalog + cards + reward cascades above) because
+  -- of an unrelated historical coincidence. So first DELETE exactly those
+  -- old-name rows whose destination slot is already occupied — the surviving
+  -- pre-existing new-name row already records the same achievement, so no
+  -- information is lost — then UPDATE the remaining, collision-free rows.
+  DELETE FROM public.collection_completions old_cc
+  WHERE old_cc.streamer_id = p_streamer_id
+    AND old_cc.collection_name = p_old_name
+    AND EXISTS (
+      SELECT 1
+      FROM public.collection_completions new_cc
+      WHERE new_cc.streamer_id = p_streamer_id
+        AND new_cc.collection_name = v_new_name
+        AND new_cc.twitch_user_id = old_cc.twitch_user_id
+        AND new_cc.total_cards = old_cc.total_cards
+    );
+
+  UPDATE public.collection_completions
+  SET collection_name = v_new_name
+  WHERE streamer_id = p_streamer_id AND collection_name = p_old_name;
+
   -- Issue #576/#578: carry forward a per-pack rarity-weight override stored
   -- under the old name, if any. Move (not copy) the JSON entry atomically —
   -- `- p_old_name` drops the old key and `|| jsonb_build_object(...)` adds
@@ -237,13 +281,6 @@ BEGIN
   SET pack_rarity_weights = (pack_rarity_weights - p_old_name) || jsonb_build_object(v_new_name, pack_rarity_weights -> p_old_name)
   WHERE id = p_streamer_id AND pack_rarity_weights ? p_old_name;
 
-  -- NOTE (#557 follow-up, deliberately out of scope here): collection_completions
-  -- also stores a collection_name reference (a per-user "completed this pack"
-  -- record). It is intentionally NOT touched by this function yet — whether a
-  -- completion earned under the old name should transfer to the renamed pack,
-  -- or be forfeited, is a product decision that hasn't been made. A follow-up
-  -- PR will CREATE OR REPLACE this function (same signature) to add that
-  -- cascade once the semantics are decided, rather than guessing here.
 END;
 $$;
 

--- a/supabase/migrations/00065_add_pack_rarity_weights.sql
+++ b/supabase/migrations/00065_add_pack_rarity_weights.sql
@@ -1,0 +1,254 @@
+-- Issue #578 (#576 Phase 1): per-pack rarity weight overrides — DB foundation.
+--
+-- This migration only adds storage + validation. It does NOT change drop_rate
+-- calculation: effective per-pack weights are computed at DRAW TIME in a later
+-- phase (#576 Phase 2), not recalculated/persisted here. Packs with no entry
+-- in `pack_rarity_weights` keep inheriting the streamer's global
+-- `rarity_weights` (application-layer convention, enforced when the weights
+-- are actually consumed at draw time, not by this migration).
+--
+-- 課題 #578(#576 フェーズ1): パック別レアリティ重み上書きのDB基盤を追加する。
+-- ここでは保存領域とバリデーションのみを追加し、drop_rate の再計算は一切
+-- 行わない。実効的なパック別重みは後続フェーズ(#576 フェーズ2)で抽選時に
+-- 計算する。`pack_rarity_weights` にエントリが無いパックは、配信者の
+-- グローバル `rarity_weights` を引き続き継承する(アプリ層の規約であり、
+-- 本マイグレーションでは強制しない)。
+
+-- ---------------------------------------------------------------------------
+-- a. streamers.rarity_weights_scope: 'global' (デフォルト、従来どおり単一の
+-- rarity_weights を全パック共通で使う) か 'per_pack' (パックごとに
+-- pack_rarity_weights のエントリを優先する) かを明示的に切り替えるフラグ。
+--
+-- Why an explicit enum column instead of overloading rarity_weights /
+-- pack_rarity_weights null-ness as an implicit "mode" sentinel: migrations
+-- 00028/00029 already demonstrated the pain of that approach for
+-- rarity_weights itself — NULL's meaning was silently reinterpreted from
+-- "manual mode" to "unset (falls back to auto-mode default)" between those
+-- two migrations, requiring a one-off backfill to disambiguate legacy rows.
+-- An explicit, self-describing column avoids re-litigating that same
+-- null/{}-sentinel ambiguity for the new per-pack feature.
+--
+-- 明示カラム採用の理由: rarity_weights の null/{} センチネル多重化は
+-- 00028/00029 で「NULLの意味の再解釈」という痛みが実証済み(手動モード明示
+-- → 未設定/自動モードデフォルト化、で意味が変わり既存データの一括補正が
+-- 必要になった)。同じ轍を踏まないよう、モード切替は素直な明示カラムとする。
+ALTER TABLE streamers
+ADD COLUMN IF NOT EXISTS rarity_weights_scope TEXT NOT NULL DEFAULT 'global';
+
+ALTER TABLE streamers
+DROP CONSTRAINT IF EXISTS streamers_rarity_weights_scope_valid;
+
+ALTER TABLE streamers
+ADD CONSTRAINT streamers_rarity_weights_scope_valid
+CHECK (rarity_weights_scope IN ('global', 'per_pack'));
+
+-- ---------------------------------------------------------------------------
+-- b. streamers.pack_rarity_weights: per-pack override map, keyed by pack
+-- name (a `streamers.card_pack_names` catalog entry) or the reserved
+-- `__default__` sentinel (DEFAULT_PACK_SENTINEL, see
+-- src/lib/validation/collection-name.ts) for the unclassified pseudo-pack.
+-- Shape: { "<パック名>": {"common": 70, "rare": 20, ...}, "__default__": {...} }.
+-- A pack with no entry here inherits the streamer's global `rarity_weights`
+-- (application-layer convention — see the module comment above; not enforced
+-- by this migration, which only validates shape/bounds).
+--
+-- Lock safety: DEFAULT NULL is a constant recorded in catalog metadata
+-- (Postgres 11+), so this ADD COLUMN takes only a brief ACCESS EXCLUSIVE lock
+-- and needs no backfill/rewrite of existing rows (same reasoning as
+-- 00062's card_pack_names column comment).
+ALTER TABLE streamers
+ADD COLUMN IF NOT EXISTS pack_rarity_weights JSONB DEFAULT NULL;
+
+-- Validate that pack_rarity_weights is either NULL or a JSON object whose
+-- values are each themselves a valid rarity_weights object (reusing
+-- check_rarity_weights_values from migration 00025 for the per-entry
+-- 0-100/numeric-value validation, rather than duplicating that logic here).
+--
+-- Note: check_rarity_weights_values(NULL) returns TRUE by design (NULL is a
+-- legitimate top-level rarity_weights value meaning "auto-mode disabled" —
+-- see 00025/00028/00029). That means it alone cannot reject a pack entry that
+-- is JSON null or a non-object (e.g. a string or array) — such a value would
+-- silently pass straight through. This function therefore adds an explicit
+-- `jsonb_typeof(entry) = 'object'` check per entry BEFORE delegating to
+-- check_rarity_weights_values, closing that gap.
+--
+-- Key-existence validation (does each key actually correspond to a
+-- registered card_pack_names entry or __default__?) is intentionally NOT
+-- done here — same app-layer-only policy already established for
+-- card_pack_names element validation (00062) and rarity_weights key
+-- validation (00025): the DB only enforces shape/bounds, and the API route
+-- (POST /api/streamer/settings) enforces catalog membership.
+CREATE OR REPLACE FUNCTION check_pack_rarity_weights_values(weights JSONB)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  entry_key TEXT;
+  entry_value JSONB;
+  entry_count INTEGER;
+BEGIN
+  IF weights IS NULL THEN
+    RETURN TRUE;
+  END IF;
+
+  IF jsonb_typeof(weights) <> 'object' THEN
+    RETURN FALSE;
+  END IF;
+
+  -- 上限51件 = 事前登録パック上限50件(00062のCHECK) + __default__ 1件。
+  SELECT COUNT(*) INTO entry_count FROM jsonb_object_keys(weights);
+  IF entry_count > 51 THEN
+    RETURN FALSE;
+  END IF;
+
+  FOR entry_key IN SELECT jsonb_object_keys(weights) LOOP
+    entry_value := weights -> entry_key;
+
+    -- check_rarity_weights_values(NULL) は TRUE を返す設計のため、ここで
+    -- 明示的に object 型であることを確認しないと、JSON null や配列などの
+    -- 非object値が誤って通ってしまう。
+    IF jsonb_typeof(entry_value) <> 'object' THEN
+      RETURN FALSE;
+    END IF;
+
+    IF NOT check_rarity_weights_values(entry_value) THEN
+      RETURN FALSE;
+    END IF;
+  END LOOP;
+
+  RETURN TRUE;
+END;
+$$;
+
+ALTER TABLE streamers
+DROP CONSTRAINT IF EXISTS streamers_pack_rarity_weights_valid;
+
+ALTER TABLE streamers
+ADD CONSTRAINT streamers_pack_rarity_weights_valid
+CHECK (check_pack_rarity_weights_values(pack_rarity_weights));
+
+-- ---------------------------------------------------------------------------
+-- c. rename_card_pack: extend the #554 rename RPC (migration 00063) so that
+-- renaming a catalog pack also carries forward any per-pack rarity-weight
+-- override stored under the old name — otherwise a rename would silently
+-- orphan the override (it would keep applying to a pack name that no longer
+-- exists in the catalog, while the renamed pack would silently fall back to
+-- the global weights). Full body copied from 00063 verbatim; the only change
+-- is the new pack_rarity_weights cascade step added at the end, alongside the
+-- existing cascades to cards / channel_point_collection_name /
+-- streamer_additional_gacha_rewards. Issue #576/#578.
+--
+-- SECURITY INVOKER / SET search_path = '' / schema-qualification: unchanged
+-- from 00063 — see that migration's comment for the full rationale (this
+-- function performs no privilege escalation; only the service_role admin
+-- client ever calls it, per the REVOKE/GRANT at the bottom of this block).
+CREATE OR REPLACE FUNCTION public.rename_card_pack(
+  p_streamer_id UUID,
+  p_old_name TEXT,
+  p_new_name TEXT
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_catalog JSONB;
+  v_old_index INTEGER;
+  v_new_name TEXT;
+BEGIN
+  -- Lock the streamer row for the duration of this transaction so a
+  -- concurrent rename/catalog edit for the same streamer can't interleave
+  -- with the read-modify-write below (classic lost-update race).
+  SELECT card_pack_names INTO v_catalog
+  FROM public.streamers
+  WHERE id = p_streamer_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'STREAMER_NOT_FOUND';
+  END IF;
+
+  -- Defense-in-depth re-validation of the new name (the API route already
+  -- validates this with the same rules before calling in, but the function
+  -- must not trust its caller for anything that affects data integrity).
+  v_new_name := btrim(p_new_name);
+  IF v_new_name IS NULL OR char_length(v_new_name) < 1 OR char_length(v_new_name) > 80 THEN
+    RAISE EXCEPTION 'INVALID_NEW_NAME';
+  END IF;
+
+  IF v_new_name LIKE '\_\_%' ESCAPE '\' THEN
+    RAISE EXCEPTION 'RESERVED_NEW_NAME';
+  END IF;
+
+  IF p_old_name = v_new_name THEN
+    RAISE EXCEPTION 'OLD_NEW_NAME_IDENTICAL';
+  END IF;
+
+  -- old must be a currently-registered catalog entry (find its array index
+  -- so we can replace it in place with jsonb_set, preserving ordering).
+  SELECT ordinality - 1 INTO v_old_index
+  FROM jsonb_array_elements_text(v_catalog) WITH ORDINALITY AS t(name, ordinality)
+  WHERE t.name = p_old_name
+  LIMIT 1;
+
+  IF v_old_index IS NULL THEN
+    RAISE EXCEPTION 'OLD_NAME_NOT_FOUND';
+  END IF;
+
+  -- new must NOT already be a catalog entry (renaming onto an existing pack
+  -- would silently merge two distinct packs' cards together).
+  IF EXISTS (
+    SELECT 1 FROM jsonb_array_elements_text(v_catalog) AS name WHERE name = v_new_name
+  ) THEN
+    RAISE EXCEPTION 'NEW_NAME_ALREADY_EXISTS';
+  END IF;
+
+  -- Replace the catalog entry in place (preserves display order) and cascade
+  -- the rename to every table that stores a collection_name assignment
+  -- scoped to this streamer. All statements run inside this function's
+  -- implicit transaction, so a mid-way failure rolls back everything.
+  UPDATE public.streamers
+  SET card_pack_names = jsonb_set(v_catalog, ARRAY[v_old_index::text], to_jsonb(v_new_name))
+  WHERE id = p_streamer_id;
+
+  UPDATE public.cards
+  SET collection_name = v_new_name
+  WHERE streamer_id = p_streamer_id AND collection_name = p_old_name;
+
+  UPDATE public.streamers
+  SET channel_point_collection_name = v_new_name
+  WHERE id = p_streamer_id AND channel_point_collection_name = p_old_name;
+
+  UPDATE public.streamer_additional_gacha_rewards
+  SET collection_name = v_new_name
+  WHERE streamer_id = p_streamer_id AND collection_name = p_old_name;
+
+  -- Issue #576/#578: carry forward a per-pack rarity-weight override stored
+  -- under the old name, if any. Move (not copy) the JSON entry atomically —
+  -- `- p_old_name` drops the old key and `|| jsonb_build_object(...)` adds
+  -- the new one in the same expression, so a mid-crash can never leave both
+  -- keys present (which would be ambiguous) or neither (which would silently
+  -- drop the override). The `pack_rarity_weights ? p_old_name` guard makes
+  -- this a no-op when the streamer never customized this pack's weights
+  -- (avoids writing a bogus `{}`-turned-object when the column is NULL).
+  UPDATE public.streamers
+  SET pack_rarity_weights = (pack_rarity_weights - p_old_name) || jsonb_build_object(v_new_name, pack_rarity_weights -> p_old_name)
+  WHERE id = p_streamer_id AND pack_rarity_weights ? p_old_name;
+
+  -- NOTE (#557 follow-up, deliberately out of scope here): collection_completions
+  -- also stores a collection_name reference (a per-user "completed this pack"
+  -- record). It is intentionally NOT touched by this function yet — whether a
+  -- completion earned under the old name should transfer to the renamed pack,
+  -- or be forfeited, is a product decision that hasn't been made. A follow-up
+  -- PR will CREATE OR REPLACE this function (same signature) to add that
+  -- cascade once the semantics are decided, rather than guessing here.
+END;
+$$;
+
+-- Only the service_role admin client (src/lib/supabase/admin.ts) is ever
+-- allowed to call this RPC — see the SECURITY INVOKER comment above for why
+-- unauthenticated callers must never reach it directly.
+REVOKE ALL ON FUNCTION public.rename_card_pack(UUID, TEXT, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.rename_card_pack(UUID, TEXT, TEXT) TO service_role;

--- a/tests/unit/pack-rarity-weights-migration.test.ts
+++ b/tests/unit/pack-rarity-weights-migration.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+// Issue #578 (#576 Phase 1): per-pack rarity weight foundation — new columns,
+// their CHECK constraints, and the rename_card_pack cascade extension. Like
+// pack-rename-and-default-name-migration.test.ts (00063), these are static
+// regex assertions on the SQL text, NOT a live DB execution.
+describe("pack rarity weights migration (00065)", () => {
+  const sql = readFileSync(
+    resolve(__dirname, "../../supabase/migrations/00065_add_pack_rarity_weights.sql"),
+    "utf8"
+  );
+
+  describe("(a) streamers.rarity_weights_scope", () => {
+    it("adds the column as NOT NULL defaulting to 'global'", () => {
+      expect(sql).toMatch(
+        /ADD COLUMN IF NOT EXISTS rarity_weights_scope TEXT NOT NULL DEFAULT 'global'/i
+      );
+    });
+
+    it("idempotently re-applies the CHECK constraint (drop before add)", () => {
+      expect(sql).toMatch(/DROP CONSTRAINT IF EXISTS streamers_rarity_weights_scope_valid/i);
+      expect(sql).toMatch(/ADD CONSTRAINT streamers_rarity_weights_scope_valid/i);
+    });
+
+    it("restricts values to 'global' or 'per_pack'", () => {
+      expect(sql).toMatch(
+        /CHECK \(rarity_weights_scope IN \('global', 'per_pack'\)\)/i
+      );
+    });
+  });
+
+  describe("(b) streamers.pack_rarity_weights", () => {
+    it("adds the column as nullable JSONB defaulting to NULL", () => {
+      expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS pack_rarity_weights JSONB DEFAULT NULL/i);
+    });
+
+    describe("check_pack_rarity_weights_values function", () => {
+      it("is created with the correct signature", () => {
+        expect(sql).toMatch(
+          /CREATE OR REPLACE FUNCTION check_pack_rarity_weights_values\(weights JSONB\)\s*\n\s*RETURNS BOOLEAN\s*\n\s*LANGUAGE plpgsql\s*\n\s*IMMUTABLE/i
+        );
+      });
+
+      it("treats NULL as valid (TRUE)", () => {
+        expect(sql).toMatch(/IF weights IS NULL THEN\s*\n\s*RETURN TRUE;/i);
+      });
+
+      it("rejects non-object top-level values", () => {
+        expect(sql).toMatch(/IF jsonb_typeof\(weights\) <> 'object' THEN\s*\n\s*RETURN FALSE;/i);
+      });
+
+      it("rejects more than 51 entries (50 packs + __default__)", () => {
+        expect(sql).toMatch(/entry_count > 51/);
+      });
+
+      it("explicitly checks each entry is an object before delegating to check_rarity_weights_values (which returns TRUE for NULL)", () => {
+        expect(sql).toMatch(/check_rarity_weights_values\(NULL\) は TRUE を返す/);
+        expect(sql).toMatch(/IF jsonb_typeof\(entry_value\) <> 'object' THEN\s*\n\s*RETURN FALSE;/i);
+      });
+
+      it("delegates per-entry numeric/bounds validation to check_rarity_weights_values", () => {
+        expect(sql).toMatch(/IF NOT check_rarity_weights_values\(entry_value\) THEN\s*\n\s*RETURN FALSE;/i);
+      });
+
+      it("documents that catalog key-existence validation is an app-layer concern (mirrors 00025/00062)", () => {
+        expect(sql).toMatch(/app-layer/i);
+        expect(sql).toMatch(/00062/);
+      });
+    });
+
+    it("idempotently re-applies the CHECK constraint (drop before add)", () => {
+      expect(sql).toMatch(/DROP CONSTRAINT IF EXISTS streamers_pack_rarity_weights_valid/i);
+      expect(sql).toMatch(
+        /ADD CONSTRAINT streamers_pack_rarity_weights_valid\s*\n\s*CHECK \(check_pack_rarity_weights_values\(pack_rarity_weights\)\)/i
+      );
+    });
+  });
+
+  describe("(c) rename_card_pack cascade extension", () => {
+    it("is (re-)created with the same signature and return type as 00063", () => {
+      expect(sql).toMatch(
+        /CREATE OR REPLACE FUNCTION public\.rename_card_pack\(\s*p_streamer_id UUID,\s*p_old_name TEXT,\s*p_new_name TEXT\s*\)\s*RETURNS void/i
+      );
+    });
+
+    it("keeps SECURITY INVOKER with a locked-down search_path", () => {
+      expect(sql).toMatch(/SECURITY INVOKER/i);
+      expect(sql).toMatch(/SET search_path = ''/);
+    });
+
+    it("preserves all original validation/cascades from 00063", () => {
+      expect(sql).toMatch(/RAISE EXCEPTION 'STREAMER_NOT_FOUND'/);
+      expect(sql).toMatch(/RAISE EXCEPTION 'INVALID_NEW_NAME'/);
+      expect(sql).toMatch(/RAISE EXCEPTION 'RESERVED_NEW_NAME'/);
+      expect(sql).toMatch(/RAISE EXCEPTION 'OLD_NEW_NAME_IDENTICAL'/);
+      expect(sql).toMatch(/RAISE EXCEPTION 'OLD_NAME_NOT_FOUND'/);
+      expect(sql).toMatch(/RAISE EXCEPTION 'NEW_NAME_ALREADY_EXISTS'/);
+      expect(sql).toMatch(
+        /UPDATE public\.cards\s+SET collection_name = v_new_name\s+WHERE streamer_id = p_streamer_id AND collection_name = p_old_name/i
+      );
+      expect(sql).toMatch(
+        /UPDATE public\.streamers\s+SET channel_point_collection_name = v_new_name\s+WHERE id = p_streamer_id AND channel_point_collection_name = p_old_name/i
+      );
+      expect(sql).toMatch(
+        /UPDATE public\.streamer_additional_gacha_rewards\s+SET collection_name = v_new_name\s+WHERE streamer_id = p_streamer_id AND collection_name = p_old_name/i
+      );
+    });
+
+    it("adds an atomic move of the pack_rarity_weights entry from old name to new name", () => {
+      expect(sql).toMatch(
+        /UPDATE public\.streamers\s+SET pack_rarity_weights = \(pack_rarity_weights - p_old_name\) \|\| jsonb_build_object\(v_new_name, pack_rarity_weights -> p_old_name\)\s+WHERE id = p_streamer_id AND pack_rarity_weights \? p_old_name/i
+      );
+    });
+
+    it("references #576/#578 in the cascade rationale", () => {
+      expect(sql).toMatch(/#576\/#578|#578\/#576|Issue #578/);
+    });
+
+    it("still documents collection_completions as an explicit, deliberate follow-up (#557), not touched here", () => {
+      expect(sql).toMatch(/#557/);
+      expect(sql).not.toMatch(/UPDATE public\.collection_completions/i);
+    });
+
+    it("revokes EXECUTE from PUBLIC/anon/authenticated and grants only to service_role", () => {
+      expect(sql).toMatch(
+        /REVOKE ALL ON FUNCTION public\.rename_card_pack\(UUID, TEXT, TEXT\) FROM PUBLIC, anon, authenticated/i
+      );
+      expect(sql).toMatch(
+        /GRANT EXECUTE ON FUNCTION public\.rename_card_pack\(UUID, TEXT, TEXT\) TO service_role/i
+      );
+    });
+  });
+
+  it("does not introduce permissive public RLS policies", () => {
+    expect(sql).not.toMatch(/FOR ALL\s+USING\s*\(true\)/i);
+    expect(sql).not.toMatch(/TO\s+authenticated/i);
+    expect(sql).not.toMatch(/TO\s+anon/i);
+  });
+
+  it("does not trigger any drop_rate recalculation (Phase 1 is storage-only; effective weights are computed at draw time in Phase 2)", () => {
+    expect(sql).not.toMatch(/drop_rate\s*=/i);
+    expect(sql).not.toMatch(/batch_update_card_drop_rates/i);
+  });
+});

--- a/tests/unit/pack-rarity-weights-migration.test.ts
+++ b/tests/unit/pack-rarity-weights-migration.test.ts
@@ -37,9 +37,12 @@ describe("pack rarity weights migration (00065)", () => {
     });
 
     describe("check_pack_rarity_weights_values function", () => {
-      it("is created with the correct signature", () => {
+      it("is created schema-qualified with a locked-down search_path", () => {
+        // rename_card_pack(SET search_path = '')が streamers を UPDATE すると
+        // CHECK 制約経由でこの関数が空 search_path 下で実行されるため、
+        // 修飾名 + search_path 固定でないと実行時名前解決に失敗する。
         expect(sql).toMatch(
-          /CREATE OR REPLACE FUNCTION check_pack_rarity_weights_values\(weights JSONB\)\s*\n\s*RETURNS BOOLEAN\s*\n\s*LANGUAGE plpgsql\s*\n\s*IMMUTABLE/i
+          /CREATE OR REPLACE FUNCTION public\.check_pack_rarity_weights_values\(weights JSONB\)\s*\n\s*RETURNS BOOLEAN\s*\n\s*LANGUAGE plpgsql\s*\n\s*IMMUTABLE\s*\n\s*SET search_path = ''/i
         );
       });
 
@@ -60,8 +63,10 @@ describe("pack rarity weights migration (00065)", () => {
         expect(sql).toMatch(/IF jsonb_typeof\(entry_value\) <> 'object' THEN\s*\n\s*RETURN FALSE;/i);
       });
 
-      it("delegates per-entry numeric/bounds validation to check_rarity_weights_values", () => {
-        expect(sql).toMatch(/IF NOT check_rarity_weights_values\(entry_value\) THEN\s*\n\s*RETURN FALSE;/i);
+      it("delegates per-entry numeric/bounds validation to schema-qualified check_rarity_weights_values", () => {
+        // 非修飾だと空 search_path 下(rename_card_pack 経由の CHECK 再評価)で
+        // 'function does not exist' になるため、public. 修飾が必須。
+        expect(sql).toMatch(/IF NOT public\.check_rarity_weights_values\(entry_value\) THEN\s*\n\s*RETURN FALSE;/i);
       });
 
       it("documents that catalog key-existence validation is an app-layer concern (mirrors 00025/00062)", () => {
@@ -73,7 +78,7 @@ describe("pack rarity weights migration (00065)", () => {
     it("idempotently re-applies the CHECK constraint (drop before add)", () => {
       expect(sql).toMatch(/DROP CONSTRAINT IF EXISTS streamers_pack_rarity_weights_valid/i);
       expect(sql).toMatch(
-        /ADD CONSTRAINT streamers_pack_rarity_weights_valid\s*\n\s*CHECK \(check_pack_rarity_weights_values\(pack_rarity_weights\)\)/i
+        /ADD CONSTRAINT streamers_pack_rarity_weights_valid\s*\n\s*CHECK \(public\.check_pack_rarity_weights_values\(pack_rarity_weights\)\)/i
       );
     });
   });
@@ -88,6 +93,16 @@ describe("pack rarity weights migration (00065)", () => {
     it("keeps SECURITY INVOKER with a locked-down search_path", () => {
       expect(sql).toMatch(/SECURITY INVOKER/i);
       expect(sql).toMatch(/SET search_path = ''/);
+    });
+
+    it("preserves the collection_completions cascade added by 00064 (#557) — the RPC body must be based on 00064, not 00063", () => {
+      // 00064 が 00063 を上書きして collection_completions の
+      // DELETE(衝突回避)→UPDATE カスケードを追加済み。00063 ベースで
+      // CREATE OR REPLACE すると #557 の挙動が巻き戻るリグレッションになる。
+      expect(sql).toMatch(/DELETE FROM public\.collection_completions old_cc/i);
+      expect(sql).toMatch(
+        /UPDATE public\.collection_completions\s+SET collection_name = v_new_name\s+WHERE streamer_id = p_streamer_id AND collection_name = p_old_name/i
+      );
     });
 
     it("preserves all original validation/cascades from 00063", () => {
@@ -118,9 +133,8 @@ describe("pack rarity weights migration (00065)", () => {
       expect(sql).toMatch(/#576\/#578|#578\/#576|Issue #578/);
     });
 
-    it("still documents collection_completions as an explicit, deliberate follow-up (#557), not touched here", () => {
+    it("references #557 for the preserved collection_completions cascade rationale", () => {
       expect(sql).toMatch(/#557/);
-      expect(sql).not.toMatch(/UPDATE public\.collection_completions/i);
     });
 
     it("revokes EXECUTE from PUBLIC/anon/authenticated and grants only to service_role", () => {

--- a/tests/unit/streamer-settings-api.test.ts
+++ b/tests/unit/streamer-settings-api.test.ts
@@ -1223,4 +1223,305 @@ describe('POST /api/streamer/settings', () => {
       expect(data.defaultCardPackNameSkippedDeployWindow).toBe(true)
     })
   })
+
+  // Issue #578 (#576 Phase 1): per-pack rarity weight foundation. This phase
+  // only stores rarityWeightsScope / packRarityWeights — it never recalculates
+  // drop_rate (effective per-pack weights are computed at draw time in #576
+  // Phase 2), and packRarityWeights keys must be members of the effective
+  // pack catalog (cardPackNames in the same request, else the streamer's
+  // current card_pack_names).
+  describe('pack rarity weights (Issue #578)', () => {
+    it('saves a valid rarityWeightsScope + packRarityWeights (named pack + __default__)', async () => {
+      const streamerQuery = createMockQueryBuilder()
+      ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: {
+          id: 'streamer123',
+          twitch_user_id: 'streamer123',
+          channel_point_collection_name: null,
+          card_pack_names: ['weapons'],
+          pack_rarity_weights: null,
+        },
+        error: null,
+      })
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue({
+        from: vi.fn(() => streamerQuery),
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const response = await POST(new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          rarityWeightsScope: 'per_pack',
+          packRarityWeights: {
+            weapons: { common: 70, rare: 30 },
+            [DEFAULT_PACK_SENTINEL]: { common: 50, rare: 50 },
+          },
+        }),
+      }))
+
+      expect(response.status).toBe(200)
+      expect(streamerQuery.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rarity_weights_scope: 'per_pack',
+          pack_rarity_weights: {
+            weapons: { common: 70, rare: 30 },
+            [DEFAULT_PACK_SENTINEL]: { common: 50, rare: 50 },
+          },
+        })
+      )
+    })
+
+    it('rejects an invalid rarityWeightsScope value (400)', async () => {
+      const mockSupabase = createSupabaseMock().build()
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabase as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const response = await POST(new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ streamerId: 'streamer123', rarityWeightsScope: 'bogus' }),
+      }))
+
+      expect(response.status).toBe(400)
+    })
+
+    it('rejects a packRarityWeights key that is not in the effective pack catalog (400)', async () => {
+      const streamerQuery = createMockQueryBuilder()
+      ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: {
+          id: 'streamer123',
+          twitch_user_id: 'streamer123',
+          channel_point_collection_name: null,
+          card_pack_names: ['weapons'],
+          pack_rarity_weights: null,
+        },
+        error: null,
+      })
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue({
+        from: vi.fn(() => streamerQuery),
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const response = await POST(new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          // 'armor' is not registered in card_pack_names.
+          packRarityWeights: { armor: { common: 100 } },
+        }),
+      }))
+
+      expect(response.status).toBe(400)
+      expect(streamerQuery.update).not.toHaveBeenCalled()
+    })
+
+    it('rejects a packRarityWeights entry whose distribution does not sum to 100% (400)', async () => {
+      const streamerQuery = createMockQueryBuilder()
+      ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: {
+          id: 'streamer123',
+          twitch_user_id: 'streamer123',
+          channel_point_collection_name: null,
+          card_pack_names: ['weapons'],
+          pack_rarity_weights: null,
+        },
+        error: null,
+      })
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue({
+        from: vi.fn(() => streamerQuery),
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const response = await POST(new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          packRarityWeights: { weapons: { common: 50, rare: 30 } },
+        }),
+      }))
+
+      expect(response.status).toBe(400)
+      expect(streamerQuery.update).not.toHaveBeenCalled()
+    })
+
+    it('rejects a packRarityWeights entry that is an empty object (400) — omit the key to inherit global instead', async () => {
+      const streamerQuery = createMockQueryBuilder()
+      ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: {
+          id: 'streamer123',
+          twitch_user_id: 'streamer123',
+          channel_point_collection_name: null,
+          card_pack_names: ['weapons'],
+          pack_rarity_weights: null,
+        },
+        error: null,
+      })
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue({
+        from: vi.fn(() => streamerQuery),
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const response = await POST(new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          packRarityWeights: { weapons: {} },
+        }),
+      }))
+
+      expect(response.status).toBe(400)
+      expect(streamerQuery.update).not.toHaveBeenCalled()
+    })
+
+    it('prunes stale pack_rarity_weights entries when cardPackNames is saved (keeps __default__), even though packRarityWeights itself was not sent', async () => {
+      mockGetUserPlan.mockResolvedValue('support')
+      const streamerQuery = createMockQueryBuilder()
+      ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: {
+          id: 'streamer123',
+          twitch_user_id: 'streamer123',
+          channel_point_collection_name: null,
+          card_pack_names: ['weapons', 'armor'],
+          pack_rarity_weights: {
+            weapons: { common: 70, rare: 30 },
+            armor: { common: 60, rare: 40 },
+            [DEFAULT_PACK_SENTINEL]: { common: 50, rare: 50 },
+          },
+        },
+        error: null,
+      })
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue({
+        from: vi.fn(() => streamerQuery),
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      // Removing 'armor' from the catalog — packRarityWeights is NOT part of this request.
+      const response = await POST(new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ streamerId: 'streamer123', cardPackNames: ['weapons'] }),
+      }))
+
+      expect(response.status).toBe(200)
+      expect(streamerQuery.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          card_pack_names: ['weapons'],
+          pack_rarity_weights: {
+            weapons: { common: 70, rare: 30 },
+            [DEFAULT_PACK_SENTINEL]: { common: 50, rare: 50 },
+          },
+        })
+      )
+    })
+
+    it('does not trigger drop-rate recalculation when saving rarityWeightsScope/packRarityWeights', async () => {
+      const streamerQuery = createMockQueryBuilder()
+      ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: {
+          id: 'streamer123',
+          twitch_user_id: 'streamer123',
+          channel_point_collection_name: null,
+          card_pack_names: ['weapons'],
+          pack_rarity_weights: null,
+        },
+        error: null,
+      })
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue({
+        from: vi.fn(() => streamerQuery),
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const response = await POST(new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          rarityWeightsScope: 'per_pack',
+          packRarityWeights: { weapons: { common: 100 } },
+        }),
+      }))
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.recalculatedCards).toBeNull()
+    })
+
+    describe('deploy-window: new columns not yet migrated', () => {
+      it('skips rarity_weights_scope and reports the flag when the UPDATE fails on that column', async () => {
+        const streamerQuery = createMockQueryBuilder()
+        ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+          data: { id: 'streamer123', twitch_user_id: 'streamer123' },
+          error: null,
+        })
+        ;(streamerQuery.update as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+          eq: vi.fn().mockResolvedValue({
+            error: { code: 'PGRST204', message: "Could not find the 'rarity_weights_scope' column" },
+          }),
+        })
+
+        const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+        vi.mocked(getSupabaseAdmin).mockReturnValue({
+          from: vi.fn(() => streamerQuery),
+        } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+        const response = await POST(new NextRequest('http://localhost:3000/api/streamer/settings', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ streamerId: 'streamer123', rarityWeightsScope: 'per_pack' }),
+        }))
+
+        expect(response.status).toBe(200)
+        const data = await response.json()
+        expect(data.rarityWeightsScopeSkippedDeployWindow).toBe(true)
+      })
+
+      it('skips pack_rarity_weights and reports the flag when the UPDATE fails on that column', async () => {
+        const streamerQuery = createMockQueryBuilder()
+        ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+          data: {
+            id: 'streamer123',
+            twitch_user_id: 'streamer123',
+            channel_point_collection_name: null,
+            card_pack_names: ['weapons'],
+            pack_rarity_weights: null,
+          },
+          error: null,
+        })
+        ;(streamerQuery.update as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+          eq: vi.fn().mockResolvedValue({
+            error: { code: 'PGRST204', message: "Could not find the 'pack_rarity_weights' column" },
+          }),
+        })
+
+        const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+        vi.mocked(getSupabaseAdmin).mockReturnValue({
+          from: vi.fn(() => streamerQuery),
+        } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+        const response = await POST(new NextRequest('http://localhost:3000/api/streamer/settings', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            streamerId: 'streamer123',
+            packRarityWeights: { weapons: { common: 100 } },
+          }),
+        }))
+
+        expect(response.status).toBe(200)
+        const data = await response.json()
+        expect(data.packRarityWeightsSkippedDeployWindow).toBe(true)
+      })
+    })
+  })
 })

--- a/tests/unit/streamer-settings-api.test.ts
+++ b/tests/unit/streamer-settings-api.test.ts
@@ -1424,6 +1424,57 @@ describe('POST /api/streamer/settings', () => {
       )
     })
 
+    it('prunes weights for a plan-gated new pack and echoes the persisted packRarityWeights back', async () => {
+      // basic プランで cardPackNames に新パック追加 + そのパック向け配分を同時送信
+      // したケース。検証はゲート適用前の要求カタログに対して通るため 400 には
+      // ならず、プレミアムゲートが追加を却下 → prune で配分エントリが落ちる。
+      // クライアントが state を再同期できるよう、確定後の永続値がレスポンスに
+      // エコーバックされることを担保する(cardPackNames と同じ規約)。
+      mockGetUserPlan.mockResolvedValue('basic')
+      const streamerQuery = createMockQueryBuilder()
+      ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: {
+          id: 'streamer123',
+          twitch_user_id: 'streamer123',
+          channel_point_collection_name: null,
+          card_pack_names: ['weapons'],
+          pack_rarity_weights: null,
+        },
+        error: null,
+      })
+
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue({
+        from: vi.fn(() => streamerQuery),
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const response = await POST(new NextRequest('http://localhost:3000/api/streamer/settings', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          streamerId: 'streamer123',
+          cardPackNames: ['weapons', 'armor'],
+          packRarityWeights: {
+            weapons: { common: 70, rare: 30 },
+            armor: { common: 100 },
+          },
+        }),
+      }))
+
+      expect(response.status).toBe(200)
+      const data = await response.json()
+      expect(data.cardPackNamesPremiumRequired).toBe(true)
+      // armor はゲート却下された追加パックなので配分も prune され、
+      // 永続値(weapons のみ)がそのままエコーバックされる。
+      expect(data.packRarityWeights).toEqual({ weapons: { common: 70, rare: 30 } })
+      expect(streamerQuery.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          card_pack_names: ['weapons'],
+          pack_rarity_weights: { weapons: { common: 70, rare: 30 } },
+        })
+      )
+    })
+
     it('does not trigger drop-rate recalculation when saving rarityWeightsScope/packRarityWeights', async () => {
       const streamerQuery = createMockQueryBuilder()
       ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({


### PR DESCRIPTION
## 概要

#576（パック単位のレアリティ配分・案B/スコープ選択制）のフェーズ1。設計は [#576 の設計書コメント](https://github.com/azumag/twica/issues/576#issuecomment-4870989770) 参照。

Fixes #578

## 変更内容

### migration 00065
- `streamers.rarity_weights_scope` TEXT NOT NULL DEFAULT 'global'（CHECK: 'global'|'per_pack'）。null/{} センチネル多重化（00028/00029 の痛み）を避け明示カラム採用
- `streamers.pack_rarity_weights` JSONB DEFAULT NULL（`{パック名|__default__: 配分マップ}`）
- `check_pack_rarity_weights_values()`: 各エントリを `jsonb_typeof = 'object'` 検査＋既存 `check_rarity_weights_values` 再利用で検証（後者は NULL に TRUE を返す設計のため object 検査が必須）。上限51件（パック50 + __default__）
- `rename_card_pack` RPC 拡張: リネーム時に `pack_rarity_weights` のキーを同一トランザクション内で原子的に移送（`- old || jsonb_build_object(new, ...)`）。00063 の本文は完全踏襲

### 設定 API（POST /api/streamer/settings）
- `rarityWeightsScope` / `packRarityWeights` の受理・検証（キーは実効カタログ照合、各エントリは既存 validateRarityWeightsInput + 合計100%±0.001、空オブジェクト拒否）
- `cardPackNames` 保存時に削除パックのエントリを prune（`__default__` は常に保持。cardPackNames 単独送信でも DB 現在値を読んで整合）
- デプロイ窓: 新2列とも既存の skip-and-flag パターン踏襲（`rarityWeightsScopeSkippedDeployWindow` / `packRarityWeightsSkippedDeployWindow`）
- **drop_rate 再計算はトリガーしない**（実効重みは抽選時計算 = フェーズ2 #579）

## ロールアウト安全性

scope デフォルト 'global' のため、本 PR のマージ・デプロイ時点で挙動変化はゼロ（オプトイン移行）。

## テスト（実測）

- migration SQL アサーションテスト21件 + settings API テスト10件を新規追加
- 全単体テスト: **98 files / 1087 tests green**
- eslint: 変更ファイル clean / `tsc --noEmit`: 既存ベースライン17件のまま（変更ファイル起因ゼロ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn