### PR TITLE
fix: resolve prefer-const lint error in sound-settings route

### DIFF
--- a/src/app/api/streamer/[streamerId]/sound-settings/route.ts
+++ b/src/app/api/streamer/[streamerId]/sound-settings/route.ts
@@ -34,7 +34,7 @@ export async function GET(
     // 配信者の効果音設定のみを取得
     // パブリックエンドポイントなので必要最小限の情報のみ返す
     // 502 一時障害に対するリトライ (Issue #325)
-    let { data: streamer, error, status } = await withRetry(
+    const soundSettingsResult = await withRetry(
       () => supabaseAdmin
         .from("streamers")
         .select("gacha_sound_url, gacha_sound_enabled, gacha_sound_rules")
@@ -42,6 +42,9 @@ export async function GET(
         .maybeSingle(),
       'getSoundSettings',
     );
+    let streamer = soundSettingsResult.data;
+    let error = soundSettingsResult.error;
+    const { status } = soundSettingsResult;
 
     if (error && (error.code === "PGRST204" || error.message.includes("gacha_sound_rules"))) {
       const fallbackResult = await withRetry(


### PR DESCRIPTION
## Summary
- PR #451 introduced a destructured `let { data: streamer, error, status } = ...` where `status` is never reassigned, tripping eslint's `prefer-const` rule.
- Split the `withRetry` result into separate bindings so only the fields that are actually reassigned (`streamer`, `error`) use `let`; `status` becomes a `const` destructure.
- No behavior change.

## Validation
- `npx eslint "src/app/api/streamer/[streamerId]/sound-settings/route.ts"` — clean
- `npx tsc --noEmit` — no errors in this file
- `npx vitest run tests/unit/sound-settings-api.test.ts` — 3/3 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01My3AXwVPaeSMhgd9xx1KHG)_