### PR TITLE
fix(sound): 報酬別効果音ルールの対象をID手入力からプルダウン選択に (#586)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -427,7 +427,15 @@
       "targetType": "Playback condition",
       "rarity": "Rarity",
       "rewardId": "Reward ID",
-      "rewardPlaceholder": "Channel point reward ID"
+      "rewardPlaceholder": "Channel point reward ID",
+      "reward": "Target reward",
+      "rewardUnset": "-- Select Reward --",
+      "rewardMissing": "{name} (may have been deleted on Twitch; the current setting is kept)",
+      "rewardFetchFailedHint": "Couldn't load the reward list. Please enter the reward ID directly."
+    },
+    "options": {
+      "points": "points",
+      "disabled": "[Disabled]"
     },
     "targets": {
       "all": "All gacha draws",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -427,7 +427,15 @@
       "targetType": "再生条件",
       "rarity": "レアリティ",
       "rewardId": "報酬ID",
-      "rewardPlaceholder": "チャネルポイント報酬ID"
+      "rewardPlaceholder": "チャネルポイント報酬ID",
+      "reward": "対象の報酬",
+      "rewardUnset": "-- 報酬を選択 --",
+      "rewardMissing": "{name}（Twitchで削除された可能性があります。現在の設定は維持されています）",
+      "rewardFetchFailedHint": "報酬一覧を取得できませんでした。報酬IDを直接入力してください。"
+    },
+    "options": {
+      "points": "ポイント",
+      "disabled": "[無効]"
     },
     "targets": {
       "all": "すべてのガチャ",

--- a/src/components/GachaSoundSettings.tsx
+++ b/src/components/GachaSoundSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback, useMemo } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { logger } from "@/lib/logger";
 import { RARITIES, SOUND_UPLOAD_CONFIG } from "@/lib/constants";
@@ -13,6 +13,26 @@ import {
 } from "@/lib/gacha-sound-rules";
 import type { Json } from "@/types/database";
 import type { PlanType } from "@/lib/plan-constants";
+
+// Issue #586: 報酬別ルールの対象選択に使うTwitchチャネルポイント報酬の最小形状。
+// 同じ形状の interface が src/components/ChannelPointSettings.tsx と
+// src/app/api/twitch/channel-point-bootstrap/route.ts にも独立して存在する
+// (既存の踏襲パターン — 3箇所目の重複は、共有モジュール化するほどの複雑さが
+// ないため許容する)。
+interface TwitchReward {
+  id: string;
+  title: string;
+  cost: number;
+  is_enabled: boolean;
+}
+
+// 報酬一覧の取得状態。「reward」ターゲット選択UIをセレクトボックスにするか、
+// 生ID入力にフォールバックするかを決める。
+// - idle: 未取得（isPremiumでない、またはマウント直後）
+// - loading: 取得中
+// - loaded: 取得成功（0件でもセレクトを表示する — 空はエラーではない）
+// - error: 取得失敗（Twitch APIエラー・未アフィリエイト等）。生ID入力にフォールバック
+type RewardsFetchStatus = "idle" | "loading" | "loaded" | "error";
 
 interface GachaSoundSettingsProps {
   streamerId: string;
@@ -49,10 +69,49 @@ export default function GachaSoundSettings({
   const [message, setMessage] = useState("");
   const [isError, setIsError] = useState(false);
 
+  // Issue #586: 「チャネルポイント報酬別」ルールの対象をIDの手入力ではなく
+  // 一覧から選べるようにする。ChannelPointSettings と同じ
+  // GET /api/twitch/rewards を叩く（あちらは診断情報込みの
+  // /api/twitch/channel-point-bootstrap を使うが、ここでは報酬一覧だけで
+  // 十分なため、より軽量な専用エンドポイントを使う）。
+  const [rewards, setRewards] = useState<TwitchReward[]>([]);
+  const [rewardsStatus, setRewardsStatus] = useState<RewardsFetchStatus>("idle");
+
   const audioRefs = useRef<Record<string, HTMLAudioElement | null>>({});
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const enabledRule = rules.find((rule) => rule.enabled);
+
+  // basicプランでは効果音ルールUI全体が inert（操作不可）になるため、
+  // 取得しても無駄になるTwitch APIコールを避ける。プランがアップグレード
+  // されて isPremium が true になった時点で改めて取得する。
+  useEffect(() => {
+    if (!isPremium) return;
+
+    let cancelled = false;
+    setRewardsStatus("loading");
+
+    (async () => {
+      try {
+        const response = await fetch("/api/twitch/rewards", { credentials: "include" });
+        if (!response.ok) {
+          if (!cancelled) setRewardsStatus("error");
+          return;
+        }
+        const data = await response.json();
+        if (cancelled) return;
+        setRewards(Array.isArray(data) ? data : []);
+        setRewardsStatus("loaded");
+      } catch (error) {
+        logger.error("Failed to fetch channel point rewards for sound rules:", error);
+        if (!cancelled) setRewardsStatus("error");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isPremium]);
 
   const saveRules = useCallback(async (nextRules: GachaSoundRule[]) => {
     setSaving(true);
@@ -328,18 +387,73 @@ export default function GachaSoundSettings({
                 </select>
               )}
 
+              {/* Issue #586: 報酬IDの生入力は「変更しようがない」不具合だったため、
+                  ChannelPointSettings と同じ /api/twitch/rewards から取得した
+                  一覧をセレクトボックスとして表示する。取得に失敗した場合
+                  （Twitch APIエラー・未アフィリエイト等）のみ、従来どおりの
+                  生ID入力にフォールバックし、機能が使用不能にならないようにする。 */}
               {rule.targetType === "reward" && (
-                <input
-                  value={rule.rewardId ?? ""}
-                  onChange={(event) => setRules(current => current.map(item => item.id === rule.id ? { ...item, rewardId: event.target.value } : item))}
-                  onBlur={(event) => updateRule(rule.id, {
-                    rewardId: event.target.value.trim(),
-                    rewardName: event.target.value.trim() === currentRewardId ? currentRewardName ?? null : rule.rewardName,
-                  })}
-                  placeholder={currentRewardId ? `${currentRewardName || "Reward"} (${currentRewardId})` : t("form.rewardPlaceholder")}
-                  className="min-w-0 rounded-lg bg-gray-800 px-3 py-2 text-sm text-white"
-                  aria-label={t("form.rewardId")}
-                />
+                rewardsStatus === "loaded" ? (
+                  <select
+                    value={rule.rewardId ?? ""}
+                    onChange={(event) => {
+                      const nextRewardId = event.target.value;
+                      const matchedReward = rewards.find((reward) => reward.id === nextRewardId);
+                      updateRule(rule.id, {
+                        // 空選択("--報酬を選択--") = 未設定。normalizeGachaSoundRules側で
+                        // reward対象なのにrewardIdが空のルールは「デッドルール」として
+                        // 除外される既存仕様をそのまま踏襲する。
+                        rewardId: nextRewardId || null,
+                        rewardName: matchedReward
+                          ? matchedReward.title
+                          // 選択値が変わっていない(孤立IDを選び直しただけ)場合は
+                          // キャッシュ済みの表示名を保持する。
+                          : nextRewardId === rule.rewardId
+                            ? rule.rewardName
+                            : null,
+                      });
+                    }}
+                    className="min-w-0 rounded-lg bg-gray-800 px-3 py-2 text-sm text-white"
+                    aria-label={t("form.reward")}
+                  >
+                    <option value="">{t("form.rewardUnset")}</option>
+                    {rewards.map((reward) => (
+                      <option key={reward.id} value={reward.id}>
+                        {reward.title} ({reward.cost} {t("options.points")})
+                        {!reward.is_enabled && t("options.disabled")}
+                      </option>
+                    ))}
+                    {/* Issue #586: 取得した一覧に無い(Twitch側で削除済みの)報酬IDが
+                        既に設定されている場合、選択肢から消してしまうと配信者が
+                        気づかないうちにルールが無効化される。孤立IDのまま選択肢
+                        として残し、既存の紐付けを維持する
+                        （CardManager/ChannelPointSettingsの孤立パック表示と同じ方針）。 */}
+                    {rule.rewardId && !rewards.some((reward) => reward.id === rule.rewardId) && (
+                      <option value={rule.rewardId}>
+                        {t("form.rewardMissing", { name: rule.rewardName || rule.rewardId })}
+                      </option>
+                    )}
+                  </select>
+                ) : (
+                  <div>
+                    <input
+                      value={rule.rewardId ?? ""}
+                      onChange={(event) => setRules(current => current.map(item => item.id === rule.id ? { ...item, rewardId: event.target.value } : item))}
+                      onBlur={(event) => updateRule(rule.id, {
+                        rewardId: event.target.value.trim(),
+                        rewardName: event.target.value.trim() === currentRewardId ? currentRewardName ?? null : rule.rewardName,
+                      })}
+                      placeholder={currentRewardId ? `${currentRewardName || "Reward"} (${currentRewardId})` : t("form.rewardPlaceholder")}
+                      className="min-w-0 rounded-lg bg-gray-800 px-3 py-2 text-sm text-white"
+                      aria-label={t("form.rewardId")}
+                    />
+                    {/* 取得失敗時のみヒントを出す。ロード中/未取得(basicプラン)では
+                        単に既存の生ID入力を静かに見せる。 */}
+                    {rewardsStatus === "error" && (
+                      <p className="mt-1 text-xs text-yellow-500">{t("form.rewardFetchFailedHint")}</p>
+                    )}
+                  </div>
+                )
               )}
             </div>
 

--- a/tests/unit/components/gacha-sound-settings-reward-select.test.tsx
+++ b/tests/unit/components/gacha-sound-settings-reward-select.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import GachaSoundSettings from "@/components/GachaSoundSettings";
+import jaMessages from "../../../messages/ja.json";
+import type { GachaSoundRule } from "@/lib/gacha-sound-rules";
+import type { Json } from "@/types/database";
+
+vi.mock("@/lib/logger");
+
+// Issue #586: 「チャネルポイントIDだけ表示されても変更しようがない」— 報酬別
+// 効果音ルールの対象選択を、生ID入力からChannelPointSettingsと同じ
+// /api/twitch/rewards 取得プルダウンに置き換えた変更のリグレッションガード。
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+const REWARD_A = { id: "reward-a", title: "カードガチャ", cost: 100, is_enabled: true };
+const REWARD_B = { id: "reward-b", title: "レア確定ガチャ", cost: 500, is_enabled: false };
+
+function mockFetch(
+  options: { rewardsOk?: boolean; rewards?: Array<typeof REWARD_A> } = {}
+): FetchMock {
+  const { rewardsOk = true, rewards = [REWARD_A, REWARD_B] } = options;
+
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+
+    if (url.includes("/api/twitch/rewards")) {
+      if (!rewardsOk) {
+        return new Response(JSON.stringify({ error: "fetch failed" }), {
+          status: 500,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(JSON.stringify(rewards), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    if (url.includes("/api/streamer/settings")) {
+      return new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    // Any other endpoint: respond with a benign empty payload.
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+}
+
+function rewardRuleFixture(overrides: Partial<GachaSoundRule> = {}): GachaSoundRule {
+  return {
+    id: "rule-1",
+    url: "https://example.com/sound.mp3",
+    enabled: true,
+    label: "効果音",
+    targetType: "reward",
+    rarity: null,
+    rewardId: "reward-a",
+    rewardName: "カードガチャ",
+    ...overrides,
+  };
+}
+
+function renderComponent(props: Partial<React.ComponentProps<typeof GachaSoundSettings>> = {}) {
+  return render(
+    <NextIntlClientProvider locale="ja" messages={jaMessages}>
+      <GachaSoundSettings
+        streamerId="streamer-1"
+        plan="support"
+        currentSoundUrl={null}
+        currentSoundEnabled={false}
+        currentSoundRules={[rewardRuleFixture()] as unknown as Json}
+        currentRewardId="reward-a"
+        currentRewardName="カードガチャ"
+        {...props}
+      />
+    </NextIntlClientProvider>
+  );
+}
+
+describe("GachaSoundSettings reward select (Issue #586)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the reward select (not a raw ID input) populated with fetched reward titles + cost", async () => {
+    vi.stubGlobal("fetch", mockFetch());
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("対象の報酬")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("option", { name: "カードガチャ (100 ポイント)" })).toBeInTheDocument();
+    // Disabled rewards are still selectable but visibly marked.
+    expect(screen.getByRole("option", { name: "レア確定ガチャ (500 ポイント)[無効]" })).toBeInTheDocument();
+    // The old raw-ID input must be gone once the select is available.
+    expect(screen.queryByLabelText("報酬ID")).not.toBeInTheDocument();
+  });
+
+  it("includes an unset option so a rule can be left without a reward target", async () => {
+    vi.stubGlobal("fetch", mockFetch());
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "-- 報酬を選択 --" })).toBeInTheDocument();
+    });
+  });
+
+  it("keeps a rule's current rewardId selectable even if it is missing from the fetched list (orphan/deleted reward)", async () => {
+    vi.stubGlobal("fetch", mockFetch({ rewards: [REWARD_A] }));
+    renderComponent({
+      currentSoundRules: [
+        rewardRuleFixture({ rewardId: "reward-deleted", rewardName: "廃止済み報酬" }),
+      ] as unknown as Json,
+    });
+
+    const select = (await screen.findByLabelText("対象の報酬")) as HTMLSelectElement;
+    expect(select.value).toBe("reward-deleted");
+    expect(
+      screen.getByRole("option", {
+        name: "廃止済み報酬（Twitchで削除された可能性があります。現在の設定は維持されています）",
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the raw reward-ID text input when the reward list fetch fails", async () => {
+    vi.stubGlobal("fetch", mockFetch({ rewardsOk: false }));
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("報酬ID")).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText("対象の報酬")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("報酬一覧を取得できませんでした。報酬IDを直接入力してください。")
+    ).toBeInTheDocument();
+  });
+
+  it("does not call the rewards endpoint for basic-plan (non-premium) users, and still shows the text-input fallback", async () => {
+    const fetchMock = mockFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    renderComponent({ plan: "basic" });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("報酬ID")).toBeInTheDocument();
+    });
+    const calledRewardsEndpoint = fetchMock.mock.calls.some(([input]) =>
+      String(input).includes("/api/twitch/rewards")
+    );
+    expect(calledRewardsEndpoint).toBe(false);
+  });
+
+  it("saves the same rule payload shape as before when a reward is picked from the dropdown", async () => {
+    const fetchMock = mockFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    renderComponent();
+
+    const select = (await screen.findByLabelText("対象の報酬")) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "reward-b" } });
+
+    await waitFor(() => {
+      const settingsCall = fetchMock.mock.calls.find(([input]) =>
+        String(input).includes("/api/streamer/settings")
+      );
+      expect(settingsCall).toBeDefined();
+    });
+
+    const settingsCall = fetchMock.mock.calls.find(([input]) =>
+      String(input).includes("/api/streamer/settings")
+    )!;
+    const init = settingsCall[1] as RequestInit;
+    const body = JSON.parse(init.body as string);
+
+    // Payload shape (streamerId + gachaSoundRules array of rule objects) must be
+    // unchanged from before this fix — only rewardId/rewardName values differ.
+    expect(body).toEqual({
+      streamerId: "streamer-1",
+      gachaSoundRules: [
+        {
+          id: "rule-1",
+          url: "https://example.com/sound.mp3",
+          enabled: true,
+          label: "効果音",
+          targetType: "reward",
+          rarity: null,
+          rewardId: "reward-b",
+          rewardName: "レア確定ガチャ",
+        },
+      ],
+    });
+  });
+
+  it("clears rewardId/rewardName to null when the unset option is chosen (preserves existing null-means-inactive semantics)", async () => {
+    const fetchMock = mockFetch();
+    vi.stubGlobal("fetch", fetchMock);
+    renderComponent();
+
+    const select = (await screen.findByLabelText("対象の報酬")) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "" } });
+
+    await waitFor(() => {
+      const settingsCall = fetchMock.mock.calls.find(([input]) =>
+        String(input).includes("/api/streamer/settings")
+      );
+      expect(settingsCall).toBeDefined();
+    });
+
+    const settingsCall = fetchMock.mock.calls.find(([input]) =>
+      String(input).includes("/api/streamer/settings")
+    )!;
+    const init = settingsCall[1] as RequestInit;
+    const body = JSON.parse(init.body as string);
+    expect(body.gachaSoundRules[0].rewardId).toBeNull();
+    expect(body.gachaSoundRules[0].rewardName).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

Fixes #586（PR #451 のフォローアップ）

報酬別効果音ルールの対象選択が報酬の生ID手入力前提で「IDだけ表示されても変更しようがない」状態だったのを、`GET /api/twitch/rewards`（ChannelPointSettings と同じソース）から取得した報酬一覧のプルダウンに置き換え。

- 選択肢は「報酬名（消費ポイント pt）」、無効化された報酬には `[無効]` 表示
- 削除済み等で一覧に無い設定済み rewardId は孤立オプションとして保持（黙って設定が外れない — 孤立パック表示と同じ方針）
- 取得失敗時（未アフィリエイト等）のみ従来の生ID入力へフォールバック
- basic プラン（inert 表示）では API コールを発火しない
- `rewardId: null` = ルール無効の既存仕様・保存ペイロード形状は不変（回帰テストで担保）

## テスト（実測）

- 新規コンポーネントテスト7件 / 全単体テスト **105 files / 1170 tests green** / eslint clean / tsc 既存ベースライン24件のまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn