### PR TITLE
fix(overlay): 紙吹雪・ハートをスタイル専用アニメーションに分離 (#587)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,73 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-sans-stack);
   --font-mono: var(--font-mono-stack);
+
+  /*
+   * Issue #587: overlayのガチャ演出（sparkle/confetti/hearts）のうち、
+   * confetti と hearts が sparkle と同じ上下バウンスを流用しており、紙吹雪もハートも
+   * 「粒がぴょこぴょこ動くだけ」の見た目になっていた。スタイルごとに専用の
+   * アニメーションを定義する（sparkle は既存の Tailwind 組み込み animate-ping を
+   * そのまま使い続けるため変更しない）。
+   * per-particle の animation-delay / animation-duration は
+   * src/app/overlay/[streamerId]/page.tsx 側で inline style により個別に上書きし、
+   * 20個のパーティクルが機械的に同期しないようにしている。
+   */
+  --animate-overlay-effect-confetti: overlay-confetti-fall 2.8s linear infinite;
+  --animate-overlay-effect-hearts: overlay-hearts-float 3.2s ease-in infinite;
+}
+
+@keyframes overlay-confetti-fall {
+  /* 紙吹雪: カード上部付近から出現し、左右に揺れながら回転して落下する */
+  0% {
+    transform: translate(0, 0) rotate(0deg) rotateX(0deg);
+    opacity: 0;
+  }
+  8% {
+    opacity: 1;
+  }
+  25% {
+    transform: translate(16px, 70px) rotate(160deg) rotateX(200deg);
+  }
+  50% {
+    transform: translate(-18px, 150px) rotate(320deg) rotateX(20deg);
+  }
+  75% {
+    transform: translate(14px, 230px) rotate(460deg) rotateX(200deg);
+  }
+  92% {
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-10px, 300px) rotate(620deg) rotateX(20deg);
+    opacity: 0;
+  }
+}
+
+@keyframes overlay-hearts-float {
+  /* ハート: カード下部/側面付近から出現し、左右に揺れながら拡大したのち
+     縮小・フェードアウトしつつ上に浮かび上がる */
+  0% {
+    transform: translate(0, 0) scale(0.6);
+    opacity: 0;
+  }
+  12% {
+    opacity: 1;
+    transform: translate(6px, -36px) scale(1);
+  }
+  38% {
+    transform: translate(-12px, -96px) scale(1.08);
+  }
+  64% {
+    transform: translate(10px, -160px) scale(1.08);
+  }
+  85% {
+    opacity: 0.85;
+    transform: translate(-6px, -210px) scale(0.95);
+  }
+  100% {
+    transform: translate(0, -250px) scale(0.75);
+    opacity: 0;
+  }
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -6,7 +6,14 @@ import Image from "next/image";
 import type { Card, Rarity } from "@/types/database";
 import { logger } from "@/lib/logger";
 import { subscribeToGachaResults } from "@/lib/realtime";
-import { type OverlayEffectStyle, normalizeOverlayEffectStyle } from "@/lib/overlay-effect";
+import {
+  type OverlayEffectStyle,
+  type OverlayEffectParticle,
+  normalizeOverlayEffectStyle,
+  generateOverlayEffectParticles,
+  OVERLAY_EFFECT_PARTICLE_COUNT,
+  OVERLAY_EFFECT_PARTICLE_CONFIG,
+} from "@/lib/overlay-effect";
 import { getRarityGlowClass, getRarityGradientClass, getRarityDisplayInfo } from "@/lib/rarity";
 import { normalizeGachaSoundRules, pickGachaSoundRule, type GachaSoundRule } from "@/lib/gacha-sound-rules";
 
@@ -75,13 +82,6 @@ function fetchJsonWithXhrFallback<T>(url: string): Promise<T> {
     });
 }
 
-interface SparklePosition {
-  left: string;
-  top: string;
-  animationDelay: string;
-  animationDuration: string;
-}
-
 // 共有定義に集約: src/lib/overlay-effect.ts を Single Source of Truth とする
 function parseOverlayEffectStyle(value: string | null): OverlayEffectStyle {
   return normalizeOverlayEffectStyle(value);
@@ -116,22 +116,14 @@ interface OverlayOptions {
   portraitShowUsername: boolean;
 }
 
-// Generate sparkle positions outside of render
-function generateSparklePositions(): SparklePosition[] {
-  return [...Array(20)].map(() => ({
-    left: `${Math.random() * 100}%`,
-    top: `${Math.random() * 100}%`,
-    animationDelay: `${Math.random() * 2}s`,
-    animationDuration: `${1 + Math.random()}s`,
-  }));
-}
-
 export default function OverlayPage() {
   const params = useParams();
   const streamerId = params.streamerId as string;
   const [result, setResult] = useState<GachaResult | null>(null);
   const [showCard, setShowCard] = useState(false);
-  const [sparklePositions, setSparklePositions] = useState<SparklePosition[]>([]);
+  // エフェクトパーティクル（スタイルごとの出現位置・タイミング）。
+  // options.effectStyle に応じて generateOverlayEffectParticles で生成する。
+  const [effectParticles, setEffectParticles] = useState<OverlayEffectParticle[]>([]);
   const [connectionStatus, setConnectionStatus] = useState<'connecting' | 'connected' | 'disconnected' | 'error'>('connecting');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   // オーバーレイ表示オプション（URLパラメータで設定）
@@ -432,7 +424,7 @@ export default function OverlayPage() {
     // 画像のアスペクト比をチェック（autoPortraitモード用）
     await checkImageAspectRatio(next.card.image_url);
 
-    setSparklePositions(generateSparklePositions());
+    setEffectParticles(generateOverlayEffectParticles(options.effectStyle, OVERLAY_EFFECT_PARTICLE_COUNT));
     setResult(next);
     setShowCard(false);
 
@@ -460,7 +452,7 @@ export default function OverlayPage() {
         }, 500);
       }, options.displayDuration * 1000);
     }, 100);
-  }, [checkImageAspectRatio, playGachaSound, options.displayDuration]);
+  }, [checkImageAspectRatio, playGachaSound, options.displayDuration, options.effectStyle]);
 
   // processQueueRefを最新のcallbackで更新
   useEffect(() => {
@@ -745,22 +737,33 @@ export default function OverlayPage() {
       return null;
     }
 
-    // i * 23deg: 23 は 360 と互いに素な素数のため、N=20 個並べても回転角が均等に
-    // 散らばり (周期 360°) 偏りが目立たない。色も 4 色を i%4 で循環させ、視覚的な
-    // ランダム感を低コストで演出する（CSS 1行で済ませる狙い）。
-    const CONFETTI_ROTATION_STEP_DEG = 23;
+    // スタイルごとのアニメーションクラス・出現位置は src/lib/overlay-effect.ts の
+    // OVERLAY_EFFECT_PARTICLE_CONFIG を Single Source of Truth として参照する
+    // （Issue #587: 以前は全スタイルが同じ animate-bounce を共有し、紙吹雪もハートも
+    // 「ぴょこぴょこ上下に動く虫」のような見た目になっていた）。
+    const animationClassName = OVERLAY_EFFECT_PARTICLE_CONFIG[options.effectStyle].animationClassName;
+
     return (
       <div
         className="pointer-events-none absolute inset-0 overflow-hidden"
         // スクリーンリーダーには無意味な装飾なので非読み上げに
         aria-hidden="true"
       >
-        {sparklePositions.map((pos, i) => {
+        {effectParticles.map((particle, i) => {
+          const style = {
+            left: particle.left,
+            top: particle.top,
+            animationDelay: particle.animationDelay,
+            animationDuration: particle.animationDuration,
+          };
+
           if (options.effectStyle === "confetti") {
+            // 紙吹雪: 小さな色付き矩形が上端付近から左右に揺れながら回転しつつ落下する
+            // （overlay-confetti-fall keyframes @ globals.css）
             return (
               <div
                 key={i}
-                className={`absolute h-2.5 w-1.5 animate-bounce rounded-sm ${
+                className={`absolute h-2.5 w-1.5 rounded-sm ${animationClassName} ${
                   i % 4 === 0
                     ? "bg-yellow-300"
                     : i % 4 === 1
@@ -769,20 +772,25 @@ export default function OverlayPage() {
                         ? "bg-cyan-300"
                         : "bg-purple-400"
                 }`}
-                style={{ ...pos, transform: `rotate(${i * CONFETTI_ROTATION_STEP_DEG}deg)` }}
+                style={style}
               />
             );
           }
 
+          if (options.effectStyle === "hearts") {
+            // ハート: カード下部/側面付近から左右に揺れながら拡大→フェードアウトしつつ
+            // 上に浮かび上がる（overlay-hearts-float keyframes @ globals.css）
+            return (
+              <div key={i} className={`absolute text-pink-300 ${animationClassName}`} style={style}>
+                ♥
+              </div>
+            );
+          }
+
+          // sparkle（デフォルト）: 既存の見た目・動きを完全維持（回帰防止）
           return (
-            <div
-              key={i}
-              className={`absolute ${
-                options.effectStyle === "hearts" ? "animate-bounce text-pink-300" : "animate-ping"
-              }`}
-              style={pos}
-            >
-              {options.effectStyle === "hearts" ? "♥" : "✨"}
+            <div key={i} className={`absolute ${animationClassName}`} style={style}>
+              ✨
             </div>
           );
         })}

--- a/src/lib/overlay-effect.ts
+++ b/src/lib/overlay-effect.ts
@@ -22,3 +22,91 @@ function isOverlayEffectStyle(value: unknown): value is OverlayEffectStyle {
 export function normalizeOverlayEffectStyle(value: unknown): OverlayEffectStyle {
   return isOverlayEffectStyle(value) ? value : DEFAULT_OVERLAY_EFFECT_STYLE;
 }
+
+/**
+ * Issue #587: sparkle/confetti/hearts が全て同じ「上下バウンス」アニメーションを
+ * 共有していたため、紙吹雪もハートも見た目だけ差し替えた虫のような動きになっていた。
+ * スタイルごとに「どこから出現し、どう動くか」を明確に区別するための設定を
+ * ここに集約する（overlay page が唯一の描画元。OverlayPreview は overlay page を
+ * iframe で埋め込んでプレビューしているため、この設定を直接参照しなくても
+ * 自動的に本番と同じ見た目になる）。
+ *
+ * - sparkle: 画面全体にランダム出現し、Tailwind 組み込みの animate-ping
+ *   （拡大しながらフェードアウト）を使う既存の見た目を完全維持する（回帰防止）。
+ * - confetti: カード上部付近から出現し、左右に揺れながら回転して落下する
+ *   「紙吹雪」らしい動き（globals.css の overlay-confetti-fall keyframes）。
+ * - hearts: カード下部/側面付近から出現し、左右に揺れながら拡大→縮小しつつ
+ *   上に浮かび上がる「ハートが舞い上がる」動き（globals.css の
+ *   overlay-hearts-float keyframes）。
+ */
+export interface OverlayEffectParticleConfig {
+  /** globals.css で定義されたアニメーションを適用する CSS クラス名 */
+  animationClassName: string;
+  /** パーティクル出現位置の left(%) 範囲 [min, max]（100 を超える/0未満の値も許容し、はみ出した状態から出現させられる） */
+  spawnLeftPercentRange: readonly [number, number];
+  /** パーティクル出現位置の top(%) 範囲 [min, max] */
+  spawnTopPercentRange: readonly [number, number];
+  /** 1周期のアニメーション所要秒数の範囲 [min, max] */
+  durationSecRange: readonly [number, number];
+  /** アニメーション開始遅延秒数の範囲 [min, max] */
+  delaySecRange: readonly [number, number];
+}
+
+/** overlay page が1回のエフェクト表示で生成するパーティクル数（既存挙動を維持し変更しない） */
+export const OVERLAY_EFFECT_PARTICLE_COUNT = 20;
+
+export const OVERLAY_EFFECT_PARTICLE_CONFIG: Readonly<Record<OverlayEffectStyle, OverlayEffectParticleConfig>> = {
+  sparkle: {
+    animationClassName: "animate-ping",
+    spawnLeftPercentRange: [0, 100],
+    spawnTopPercentRange: [0, 100],
+    durationSecRange: [1, 2],
+    delaySecRange: [0, 2],
+  },
+  confetti: {
+    animationClassName: "animate-overlay-effect-confetti",
+    // 紙吹雪はカード上端付近（画面上端よりわずかに上も含む）から降り始める
+    spawnLeftPercentRange: [0, 100],
+    spawnTopPercentRange: [-8, 8],
+    durationSecRange: [2.2, 3.6],
+    delaySecRange: [0, 2.4],
+  },
+  hearts: {
+    animationClassName: "animate-overlay-effect-hearts",
+    // ハートはカード下部〜側面付近から浮かび上がる
+    spawnLeftPercentRange: [0, 100],
+    spawnTopPercentRange: [50, 100],
+    durationSecRange: [2.6, 4.2],
+    delaySecRange: [0, 2.4],
+  },
+} as const;
+
+export interface OverlayEffectParticle {
+  left: string;
+  top: string;
+  animationDelay: string;
+  animationDuration: string;
+}
+
+function randomInRange([min, max]: readonly [number, number]): number {
+  return min + Math.random() * (max - min);
+}
+
+/**
+ * 指定スタイルのパーティクル出現位置・タイミングを生成する。
+ * left/top はスタイルごとの出現エリア（OVERLAY_EFFECT_PARTICLE_CONFIG）からランダムに、
+ * animationDelay/animationDuration もスタイルごとの範囲からランダムに決め、
+ * 20個が完全に同期して動く「機械的」な見た目にならないようにする。
+ */
+export function generateOverlayEffectParticles(
+  style: OverlayEffectStyle,
+  count: number,
+): OverlayEffectParticle[] {
+  const config = OVERLAY_EFFECT_PARTICLE_CONFIG[style];
+  return Array.from({ length: count }, () => ({
+    left: `${randomInRange(config.spawnLeftPercentRange).toFixed(2)}%`,
+    top: `${randomInRange(config.spawnTopPercentRange).toFixed(2)}%`,
+    animationDelay: `${randomInRange(config.delaySecRange).toFixed(2)}s`,
+    animationDuration: `${randomInRange(config.durationSecRange).toFixed(2)}s`,
+  }));
+}

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -140,6 +140,111 @@ describe('OverlayPage', () => {
     expect(playMock).toHaveBeenCalledTimes(1)
   })
 
+  it('Issue #587: confetti は紙吹雪専用アニメーションクラスを使い、旧バグのanimate-bounceを共有しない', async () => {
+    vi.useFakeTimers()
+    window.history.replaceState({}, '', '/overlay/streamer-1?effect=confetti')
+
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
+      options.onSuccess?.()
+      return vi.fn()
+    })
+
+    const { container } = render(<OverlayPage />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        card: { id: 'card-legendary', name: 'Legend', description: null, image_url: null, rarity: 'legendary' },
+        userTwitchUsername: 'Viewer',
+      })
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+
+    // パーティクル数(20個)は変更しない。全て紙吹雪専用クラスを持ち、
+    // 旧実装で共有されていたanimate-bounceは一切使わない。
+    expect(container.querySelectorAll('.animate-overlay-effect-confetti')).toHaveLength(20)
+    expect(container.querySelectorAll('.animate-bounce')).toHaveLength(0)
+  })
+
+  it('Issue #587: hearts はハート専用アニメーションクラスを使い、旧バグのanimate-bounceを共有しない', async () => {
+    vi.useFakeTimers()
+    window.history.replaceState({}, '', '/overlay/streamer-1?effect=hearts')
+
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
+      options.onSuccess?.()
+      return vi.fn()
+    })
+
+    const { container } = render(<OverlayPage />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        card: { id: 'card-legendary', name: 'Legend', description: null, image_url: null, rarity: 'legendary' },
+        userTwitchUsername: 'Viewer',
+      })
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+
+    expect(container.querySelectorAll('.animate-overlay-effect-hearts')).toHaveLength(20)
+    expect(container.querySelectorAll('.animate-bounce')).toHaveLength(0)
+    expect(screen.getAllByText('♥')).toHaveLength(20)
+  })
+
+  it('sparkle（デフォルト）は既存のanimate-pingを維持する（回帰防止）', async () => {
+    vi.useFakeTimers()
+    window.history.replaceState({}, '', '/overlay/streamer-1')
+
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
+      options.onSuccess?.()
+      return vi.fn()
+    })
+
+    const { container } = render(<OverlayPage />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        card: { id: 'card-legendary', name: 'Legend', description: null, image_url: null, rarity: 'legendary' },
+        userTwitchUsername: 'Viewer',
+      })
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+
+    expect(container.querySelectorAll('.animate-ping')).toHaveLength(20)
+    expect(screen.getAllByText('✨')).toHaveLength(20)
+  })
+
   it('複数の効果音ルールをルールごとにプリロードする', async () => {
     const createdUrls: string[] = []
     class MockAudio {

--- a/tests/unit/overlay-effect.test.ts
+++ b/tests/unit/overlay-effect.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest'
 import {
   DEFAULT_OVERLAY_EFFECT_STYLE,
   OVERLAY_EFFECT_STYLES,
+  OVERLAY_EFFECT_PARTICLE_COUNT,
+  OVERLAY_EFFECT_PARTICLE_CONFIG,
   normalizeOverlayEffectStyle,
+  generateOverlayEffectParticles,
 } from '@/lib/overlay-effect'
 
 describe('overlay-effect: normalizeOverlayEffectStyle', () => {
@@ -27,5 +30,93 @@ describe('overlay-effect: normalizeOverlayEffectStyle', () => {
 
   it('全ての登録スタイルがデフォルトを含む', () => {
     expect(OVERLAY_EFFECT_STYLES).toContain(DEFAULT_OVERLAY_EFFECT_STYLE)
+  })
+})
+
+describe('overlay-effect: OVERLAY_EFFECT_PARTICLE_CONFIG', () => {
+  it('全スタイル分の設定が存在する', () => {
+    for (const style of OVERLAY_EFFECT_STYLES) {
+      expect(OVERLAY_EFFECT_PARTICLE_CONFIG[style]).toBeDefined()
+    }
+  })
+
+  it('sparkle は既存のアニメーション（animate-ping）を維持する（回帰防止）', () => {
+    expect(OVERLAY_EFFECT_PARTICLE_CONFIG.sparkle.animationClassName).toBe('animate-ping')
+  })
+
+  it('Issue #587: confetti / hearts は sparkle や互いと異なる専用アニメーションを持つ', () => {
+    const { sparkle, confetti, hearts } = OVERLAY_EFFECT_PARTICLE_CONFIG
+    const classNames = [sparkle.animationClassName, confetti.animationClassName, hearts.animationClassName]
+    expect(new Set(classNames).size).toBe(3)
+    // 旧実装のバグ（confetti/heartsが同じanimate-bounceを共有）の再発防止
+    expect(confetti.animationClassName).not.toBe('animate-bounce')
+    expect(hearts.animationClassName).not.toBe('animate-bounce')
+  })
+
+  it('confetti はカード上端付近（top<=8%）から出現する', () => {
+    const [minTop, maxTop] = OVERLAY_EFFECT_PARTICLE_CONFIG.confetti.spawnTopPercentRange
+    expect(minTop).toBeLessThanOrEqual(0)
+    expect(maxTop).toBeLessThanOrEqual(10)
+  })
+
+  it('hearts はカード下部付近（top>=50%）から出現する', () => {
+    const [minTop] = OVERLAY_EFFECT_PARTICLE_CONFIG.hearts.spawnTopPercentRange
+    expect(minTop).toBeGreaterThanOrEqual(50)
+  })
+
+  it('各スタイルの range 設定は min <= max である', () => {
+    for (const style of OVERLAY_EFFECT_STYLES) {
+      const config = OVERLAY_EFFECT_PARTICLE_CONFIG[style]
+      expect(config.spawnLeftPercentRange[0]).toBeLessThanOrEqual(config.spawnLeftPercentRange[1])
+      expect(config.spawnTopPercentRange[0]).toBeLessThanOrEqual(config.spawnTopPercentRange[1])
+      expect(config.durationSecRange[0]).toBeLessThanOrEqual(config.durationSecRange[1])
+      expect(config.delaySecRange[0]).toBeLessThanOrEqual(config.delaySecRange[1])
+    }
+  })
+})
+
+describe('overlay-effect: generateOverlayEffectParticles', () => {
+  it('要求した個数ちょうどのパーティクルを返す（パーティクル数は変更しない）', () => {
+    expect(OVERLAY_EFFECT_PARTICLE_COUNT).toBe(20)
+    for (const style of OVERLAY_EFFECT_STYLES) {
+      const particles = generateOverlayEffectParticles(style, OVERLAY_EFFECT_PARTICLE_COUNT)
+      expect(particles).toHaveLength(20)
+    }
+  })
+
+  it('各パーティクルのleft/top/animationDelay/animationDurationがスタイルの設定範囲内に収まる', () => {
+    for (const style of OVERLAY_EFFECT_STYLES) {
+      const config = OVERLAY_EFFECT_PARTICLE_CONFIG[style]
+      const particles = generateOverlayEffectParticles(style, 50)
+
+      for (const particle of particles) {
+        const left = Number.parseFloat(particle.left)
+        const top = Number.parseFloat(particle.top)
+        const delay = Number.parseFloat(particle.animationDelay)
+        const duration = Number.parseFloat(particle.animationDuration)
+
+        expect(particle.left.endsWith('%')).toBe(true)
+        expect(particle.top.endsWith('%')).toBe(true)
+        expect(particle.animationDelay.endsWith('s')).toBe(true)
+        expect(particle.animationDuration.endsWith('s')).toBe(true)
+
+        expect(left).toBeGreaterThanOrEqual(config.spawnLeftPercentRange[0])
+        expect(left).toBeLessThanOrEqual(config.spawnLeftPercentRange[1])
+        expect(top).toBeGreaterThanOrEqual(config.spawnTopPercentRange[0])
+        expect(top).toBeLessThanOrEqual(config.spawnTopPercentRange[1])
+        expect(delay).toBeGreaterThanOrEqual(config.delaySecRange[0])
+        expect(delay).toBeLessThanOrEqual(config.delaySecRange[1])
+        expect(duration).toBeGreaterThanOrEqual(config.durationSecRange[0])
+        expect(duration).toBeLessThanOrEqual(config.durationSecRange[1])
+      }
+    }
+  })
+
+  it('各パーティクルの位置・タイミングはランダム化され、20個すべてが同一にはならない（機械的な動き防止）', () => {
+    const particles = generateOverlayEffectParticles('hearts', OVERLAY_EFFECT_PARTICLE_COUNT)
+    const uniqueLefts = new Set(particles.map((p) => p.left))
+    const uniqueDurations = new Set(particles.map((p) => p.animationDuration))
+    expect(uniqueLefts.size).toBeGreaterThan(1)
+    expect(uniqueDurations.size).toBeGreaterThan(1)
   })
 })


### PR DESCRIPTION
## 概要

Fixes #587（PR #452 のフォローアップ）

sparkle/confetti/hearts が全て同じ上下バウンス（`animate-bounce`）を共有し「虫がぴょこぴょこ動く」見た目だったのを、スタイル専用アニメーションに分離。

- **紙吹雪**: カード上端付近から出現し、左右に揺れ＋`rotate`/`rotateX` の紙フラッターで回転しながら落下（`overlay-confetti-fall`）
- **ハート**: カード下部/側面から出現し、揺れながら拡大→縮小・フェードで浮上（`overlay-hearts-float`、Twitch風）
- **キラキラ**: 既存の `animate-ping` を完全維持（回帰ゼロ）
- スタイル別の出現位置・duration/delay レンジ・クラス名は `overlay-effect.ts` の `OVERLAY_EFFECT_PARTICLE_CONFIG` に集約（OverlayPreview は overlay ページの iframe 埋め込みのため自動的に同一表示）
- パーティクル数(20)・表示トリガー（legendary時）・表示時間は不変

## テスト（実測）

- overlay-effect のスタイル別設定/生成テスト + **overlay-page のスタイル別クラス/要素数の回帰テスト**（#452 レビューで指摘された page レベルのテストギャップにも対応）
- 全単体テスト 104 files / 1175 tests green / eslint clean / tsc ベースライン24件のまま / `next build` 成功（Tailwind v4 keyframes のコンパイル確認）

## 残検証

ブラウザ上での視覚モーションは未確認 → **マージ・本番反映後にライブ目視確認を実施予定**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn