### PR TITLE
docs(plans): 支援特典ページを実装済み機能に合わせて更新

### DIFF
--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -116,6 +116,14 @@ export default async function PlansPage() {
                     <span className="text-blue-400 mt-0.5">✓</span>
                     <span>支援者向け問い合わせフォーム</span>
                   </li>
+                  <li className="flex items-start gap-2">
+                    <span className="text-blue-400 mt-0.5">✓</span>
+                    <span>カードパックの追加登録（既存パックの利用・削除は無料のまま）</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="text-blue-400 mt-0.5">✓</span>
+                    <span>効果音の詳細設定（レアリティ・報酬別に複数ルールを登録）</span>
+                  </li>
                 </ul>
               </div>
 
@@ -143,6 +151,14 @@ export default async function PlansPage() {
                   <li className="flex items-start gap-2">
                     <span className="text-yellow-400 mt-0.5">✓</span>
                     <span>支援者向け問い合わせフォーム</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="text-yellow-400 mt-0.5">✓</span>
+                    <span>カードパックの追加登録（既存パックの利用・削除は無料のまま）</span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="text-yellow-400 mt-0.5">✓</span>
+                    <span>効果音の詳細設定（レアリティ・報酬別に複数ルールを登録）</span>
                   </li>
                 </ul>
               </div>
@@ -286,10 +302,8 @@ export default async function PlansPage() {
             </h2>
             <div className="rounded-xl bg-gray-800 p-6">
               <ul className="ml-4 list-disc space-y-2 text-gray-400">
-                <li>効果音の細かい設定（レアリティ別の効果音など）</li>
+                <li>パック別レアリティ排出率設定（パックごとにレアリティ配分を変更）</li>
                 <li>動画カード対応</li>
-                <li>複数コレクション</li>
-                <li>N連ガチャ</li>
                 <li>全期間統計</li>
               </ul>
             </div>


### PR DESCRIPTION
## 概要

支援特典ページが実装に追いついていなかったため更新。

### 特典一覧に追加（助力・ご贔屓の両カード）
- カードパックの追加登録（既存パックの利用・削除は無料のまま — `isNewCardPackNameAdditionGated` の実仕様どおり）
- 効果音の詳細設定（レアリティ・報酬別の複数ルール — settings route の basic 403 ゲートどおり）

### 「今後予定している特典」の整理
- 削除: 効果音の細かい設定（実装済み）/ 複数コレクション（パック機能として実装済み）/ N連ガチャ（実装済み・プランゲート無しの無料機能のため特典外）
- 追加: パック別レアリティ排出率設定（#576 実装中）
- 維持: 動画カード対応・全期間統計（未実装を確認済み）

数値系（ストレージ/画像幅/ファイル上限）は plan-constants.ts と一致確認済みで変更なし。

## テスト（実測）
- eslint clean / tsc 対象エラーなし / 全単体テスト green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn