### PR TITLE
fix(gacha): 発行上限のフォローアップ — limit_reached時の再抽選ほか（PR #450 レビュー）

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -61,7 +61,7 @@
       "cardNumberHelp": "Leave blank to auto-number",
       "maxIssuanceCount": "Issue Limit",
       "maxIssuanceCountPlaceholder": "e.g. 1 / 100",
-      "maxIssuanceCountHelp": "Blank is unlimited. 1 makes it unique-only.",
+      "maxIssuanceCountHelp": "Blank is unlimited. 1 makes it unique-only. (max 1,000,000)",
       "collectionName": "Card Pack",
       "collectionNameUnclassified": "{name} (all cards)",
       "collectionNameHelp": "Only cards in the same pack are eligible for that channel point reward's gacha. Register pack names in \"Pack Management\" first.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -61,7 +61,7 @@
       "cardNumberHelp": "空欄なら自動採番されます",
       "maxIssuanceCount": "発行可能枚数",
       "maxIssuanceCountPlaceholder": "例: 1 / 100",
-      "maxIssuanceCountHelp": "空欄なら無制限、1なら完全ユニークです",
+      "maxIssuanceCountHelp": "空欄なら無制限、1なら完全ユニークです（最大1,000,000まで）",
       "collectionName": "カードパック",
       "collectionNameUnclassified": "{name}（すべてのカード）",
       "collectionNameHelp": "同じパック名のカードだけがチャネポ報酬の抽選対象になります。パック名は「パック管理」で事前に登録してください。",

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -13,6 +13,7 @@ import { countCharacters } from "@/lib/text-utils";
 import { DEFAULT_PACK_SENTINEL } from "@/lib/validation/collection-name";
 import { cardMatchesPackKey } from "@/lib/collection-packs";
 import { isAllowedCardUploadFile, shouldPreserveOriginalCardUpload } from "@/lib/card-upload-mode";
+import { MAX_ISSUANCE_COUNT_CAP } from "@/lib/card-issuance";
 import ImageCropper, { type CropMode, getCropModes } from "./ImageCropper";
 import CardViewToggle, { type ViewMode } from "./CardViewToggle";
 import CardList from "./CardList";
@@ -1628,6 +1629,7 @@ export default function CardManager({
                           type="number"
                           name="maxIssuanceCount"
                           min="1"
+                          max={MAX_ISSUANCE_COUNT_CAP}
                           step="1"
                           inputMode="numeric"
                           placeholder={t("form.maxIssuanceCountPlaceholder")}

--- a/src/lib/card-issuance.ts
+++ b/src/lib/card-issuance.ts
@@ -1,11 +1,47 @@
 export const CARD_ISSUANCE_MESSAGES = {
   invalid: "発行可能枚数は1以上の整数、または空欄で入力してください",
   soldOut: "このカードは発行可能枚数に達しています",
+  // R2 (PR #450 レビュー follow-up): execute_gacha_transaction RPC が未デプロイ
+  // (42883)の間、executeGachaLegacy は発行枚数を FOR UPDATE で原子的に検証
+  // できないため limited カードの抽選を拒否する。以前はこの拒否が soldOut と
+  // 全く同じ文字列を使っていたため、eventsub route.ts の抑止フィルタ
+  // (genuine soldOut は Sentry/Issue化しない)が本来アラートすべき「RPC未デプロイ」
+  // という異常事態まで一緒に握りつぶしてしまっていた。ユーザー向け文言としては
+  // 区別せず「一時的に抽選できません」で十分だが、内部的な error 文字列としては
+  // soldOut と別の値にすることで、eventsub 側の抑止対象に含めず reportError を
+  // 発火させ、本番で確実にアラートされるようにする。
+  limitUnavailable: "上限付きカードは現在一時的に抽選できません",
 } as const;
+
+// R4 (PR #450 レビュー follow-up): max_issuance_count は DB 側で 4バイト
+// PostgreSQL INTEGER 列(cards.max_issuance_count, migration 00067)として
+// 保存されるため、その最大値 2147483647 を超える値を INSERT/UPDATE すると
+// PostgreSQL は "22003 numeric_value_out_of_range" を返し、これがどこにも
+// フレンドリーにハンドリングされないまま opaque な 500 エラーとして
+// ユーザーに見えてしまう。ここで先にアプリ層の「製品として現実的な上限」で
+// 弾き、CARD_ISSUANCE_MESSAGES.invalid の分かりやすいエラーメッセージへ
+// 誘導する。
+//
+// MAX_ISSUANCE_COUNT_CAP = 1,000,000 の根拠:
+// - どんな配信者の運用でも現実的にありえない発行枚数(1カードにつき100万枚
+//   発行するガチャ運用は存在しない)を十分に超えており、正当な入力を
+//   誤って弾くリスクはない。
+// - PostgreSQL INTEGER の最大値(2,147,483,647)よりも十分小さく、桁あふれの
+//   危険域から離れた安全マージンを持つ(将来 intra_rarity_weight 計算等で
+//   この値を使った乗算をしても INTEGER/DOUBLE PRECISION の範囲を超えない)。
+// UI(CardManager)からも同じ上限値を参照する(input[type=number] の max 属性)ため
+// export する。サーバー側バリデーションとクライアント側入力制限を単一の値で
+// 一致させ、値のドリフトを防ぐ。
+export const MAX_ISSUANCE_COUNT_CAP = 1_000_000;
 
 export function parseCardIssuanceLimit(value: unknown): number | null | "invalid" {
   if (value === undefined || value === null || value === "") return null;
-  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+  if (
+    typeof value !== "number" ||
+    !Number.isInteger(value) ||
+    value <= 0 ||
+    value > MAX_ISSUANCE_COUNT_CAP
+  ) {
     return "invalid";
   }
   return value;

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -257,101 +257,168 @@ export class GachaService {
           )
         : null
 
-      // drop_rate の正規化(DECIMAL文字列→number)は選択方式に関わらず必ず先に
-      // 通す。返却カードの再構築(下記)もこの正規化済み配列を参照することで、
-      // 生 rows の文字列 drop_rate が GachaResult/broadcast へ漏れないようにする
-      // (従来は selectWeightedCard の戻り値=正規化済みクローンをそのまま返して
-      // いたため保証されていた性質。再構築方式でも同じ保証を維持する)。
-      const normalizedCards = normalizeDropRate(availableCards)
+      // R1 (PR #450 レビュー follow-up): execute_gacha_transaction は、選択した
+      // カードが「同時実行中の別ドローに先に発行枠を取られた」または「選択後に
+      // 行自体が消えた」場合に limit_reached:true を返す(migration 00067
+      // L44-65: FOR UPDATE ロック取得後の NOT FOUND / 上限到達チェックは、どちらも
+      // gacha_history への INSERT (L67) より前に return するため、副作用ゼロで
+      // 中断される)。したがって同じ eventId で RPC を再実行しても二重付与や
+      // 二重履歴は発生しない — 安全に「選び直して再試行」できる。
+      //
+      // 修正前は limit_reached を「抽選全体の失敗」として即 soldOut を返して
+      // いたため、フェッチ済みプールの残り(多くの場合 90% 以上を占める無制限
+      // カード)がまだ選べるにもかかわらず、ユーザーはチャネルポイントを消費した
+      // 上でカードを受け取れなかった。max_issuance_count=1 の「ユニークカード」
+      // 争奪タイミング(バーストで同一カードに複数ドローが殺到する場面)で最も
+      // 深刻だった。
+      //
+      // 対策: limit_reached を受けたら、選ばれたカードだけをローカルの抽選
+      // プールから除外し、残りのプールに対して選択ロジック(実効重み/手動を
+      // 問わず selectCardFromPool に共通化)を再実行してから RPC を呼び直す。
+      // MAX_LIMIT_REACHED_RETRIES=5 で打ち切るのは、(a) 少数の上限カードへの
+      // バーストであれば数回の再選択で豊富な残りプールへ確実に落ちる一方、
+      // (b) 何らかの異常(例: プール全体が上限到達直前)で毎回 limit_reached が
+      // 続く場合に、1回のガチャで無制限に RPC を叩き続けてDB/RPCへ負荷を
+      // かけ続けることを防ぐため。プールが尽きた場合、または再試行上限に
+      // 達した場合のみ soldOut を返す。
+      const MAX_LIMIT_REACHED_RETRIES = 5
+      let pool = availableCards
 
-      // 選択プールは「id + 選択重み」だけの最小型に落とす(WeightedCard)。
-      // 両分岐の配列型が異なるユニオンのままだと selectWeightedCard の
-      // ジェネリック推論が単一の T を選べないため、明示的に共通型へ寄せる。
-      const selectionPool: Array<{ id: string; drop_rate: number }> = resolvedRarityWeights
-        ? computeEffectiveWeights(normalizedCards, resolvedRarityWeights).map(({ card, effectiveWeight }) => ({
-            id: card.id,
-            drop_rate: effectiveWeight,
-          }))
-        : normalizedCards
+      for (let attempt = 1; ; attempt += 1) {
+        const selectedCard = this.selectCardFromPool(pool, resolvedRarityWeights)
 
-      const picked = selectWeightedCard(selectionPool)
-
-      if (!picked) {
-        return err('Failed to select card')
-      }
-
-      // 選択には effectiveWeight (パック内実効重み) を drop_rate の代わりに
-      // 使うことがあるが、返す値・下流に渡す値は必ず元カード(正規化済み)から
-      // 再構築する。effectiveWeight は選択専用の一時的な重みであり実際の
-      // drop_rate とは異なる値になりうるため、gacha_history や配信オーバーレイ
-      // へのブロードキャストペイロードに漏れてはならない。intra_rarity_weight も
-      // GachaCard 型に存在しないフィールドなので同様に除外する。
-      const originalCard = normalizedCards.find((card) => card.id === picked.id)
-      if (!originalCard) {
-        return err('Failed to select card')
-      }
-      const selectedCard: GachaCard = {
-        id: originalCard.id,
-        name: originalCard.name,
-        description: originalCard.description,
-        image_url: originalCard.image_url,
-        rarity: originalCard.rarity,
-        drop_rate: originalCard.drop_rate,
-        // Issue #108: legacy フォールバック(executeGachaLegacy)が発行上限の
-        // 再チェックに参照するため、再構築後も必ず引き継ぐ。
-        max_issuance_count: originalCard.max_issuance_count ?? null,
-      }
-
-      // gacha_history, users, user_cards を1トランザクションでアトミックに実行
-      // 従来は3回の個別DB操作で中間状態（履歴あり・カード未付与）が発生しえた
-      const { data: rpcResult, error: rpcError } = await withRetry(
-        () => this.supabase.rpc('execute_gacha_transaction', {
-          p_event_id: eventId || null,
-          p_user_twitch_id: userTwitchId,
-          p_user_twitch_username: userTwitchUsername,
-          p_card_id: selectedCard.id,
-          p_streamer_id: streamerId,
-          p_reward_cost: rewardCost ?? null,
-        }),
-        'gacha:executeGacha:rpc',
-      )
-
-      if (rpcError) {
-        // RPC関数が未デプロイの場合（マイグレーション前）は旧ロジックにフォールバック
-        // 無停止デプロイ時にアプリコードが先にデプロイされても、
-        // ユーザーのチャネルポイントが消費されカード未付与になることを防ぐ
-        // TODO: マイグレーション適用確認後にフォールバックを削除
-        if (rpcError.code === '42883') {
-          logger.warn('execute_gacha_transaction not found, falling back to legacy operations', {
-            streamerId, userTwitchId, eventId,
-          })
-          return this.executeGachaLegacy(streamerId, userTwitchId, userTwitchUsername, selectedCard, eventId, rewardCost)
+        if (!selectedCard) {
+          return err('Failed to select card')
         }
 
-        await reportError(new Error(`Gacha RPC failed: ${rpcError.message}`), {
-          context: 'gacha:executeGacha:rpc',
-          streamerId,
-          userTwitchId,
-          eventId,
+        // gacha_history, users, user_cards を1トランザクションでアトミックに実行
+        // 従来は3回の個別DB操作で中間状態（履歴あり・カード未付与）が発生しえた
+        const { data: rpcResult, error: rpcError } = await withRetry(
+          () => this.supabase.rpc('execute_gacha_transaction', {
+            p_event_id: eventId || null,
+            p_user_twitch_id: userTwitchId,
+            p_user_twitch_username: userTwitchUsername,
+            p_card_id: selectedCard.id,
+            p_streamer_id: streamerId,
+            p_reward_cost: rewardCost ?? null,
+          }),
+          'gacha:executeGacha:rpc',
+        )
+
+        if (rpcError) {
+          // RPC関数が未デプロイの場合（マイグレーション前）は旧ロジックにフォールバック
+          // 無停止デプロイ時にアプリコードが先にデプロイされても、
+          // ユーザーのチャネルポイントが消費されカード未付与になることを防ぐ
+          // TODO: マイグレーション適用確認後にフォールバックを削除
+          if (rpcError.code === '42883') {
+            logger.warn('execute_gacha_transaction not found, falling back to legacy operations', {
+              streamerId, userTwitchId, eventId,
+            })
+            return this.executeGachaLegacy(streamerId, userTwitchId, userTwitchUsername, selectedCard, eventId, rewardCost)
+          }
+
+          await reportError(new Error(`Gacha RPC failed: ${rpcError.message}`), {
+            context: 'gacha:executeGacha:rpc',
+            streamerId,
+            userTwitchId,
+            eventId,
+          })
+          return err(`Failed to execute gacha transaction: ${rpcError.message}`)
+        }
+
+        // EventSub重複通知の場合（event_idが既に処理済み）
+        if (rpcResult?.is_duplicate) {
+          return err('Duplicate event')
+        }
+
+        if (rpcResult?.limit_reached) {
+          pool = pool.filter((card) => card.id !== selectedCard.id)
+          if (attempt >= MAX_LIMIT_REACHED_RETRIES || pool.length === 0) {
+            return err(CARD_ISSUANCE_MESSAGES.soldOut)
+          }
+          continue
+        }
+
+        return ok({
+          card: selectedCard,
+          userTwitchUsername,
         })
-        return err(`Failed to execute gacha transaction: ${rpcError.message}`)
       }
-
-      // EventSub重複通知の場合（event_idが既に処理済み）
-      if (rpcResult?.is_duplicate) {
-        return err('Duplicate event')
-      }
-
-      if (rpcResult?.limit_reached) {
-        return err(CARD_ISSUANCE_MESSAGES.soldOut)
-      }
-
-      return ok({
-        card: selectedCard,
-        userTwitchUsername,
-      })
     } catch (error) {
       return err(`Unexpected error: ${error}`)
+    }
+  }
+
+  /**
+   * 抽選プールから1枚選択し、返却/RPC送信用に再構築したカードを返す。
+   * executeGacha の初回選択と、limit_reached 時の再抽選(R1: PR #450
+   * follow-up)の両方から呼ばれる共通ロジック。呼び出しごとに(縮小した)
+   * プールを渡すことで、pack-scoped 自動配分の effectiveWeight もその都度
+   * プール全体で再計算され、正しく再正規化される(normalizeDropRate による
+   * 型保証含め、executeGacha 直書き時と同じ挙動を維持)。
+   *
+   * プールが空、または全カードの選択重みが0で選択不能な場合は null を返す。
+   */
+  private selectCardFromPool<
+    T extends {
+      id: string
+      name: string
+      description: string | null
+      image_url: string | null
+      rarity: GachaCard['rarity']
+      drop_rate: unknown
+      max_issuance_count?: number | null
+      intra_rarity_weight?: number | null
+    }
+  >(pool: T[], resolvedRarityWeights: Record<string, number> | null): GachaCard | null {
+    if (pool.length === 0) {
+      return null
+    }
+
+    // drop_rate の正規化(DECIMAL文字列→number)は選択方式に関わらず必ず先に
+    // 通す。返却カードの再構築(下記)もこの正規化済み配列を参照することで、
+    // 生 rows の文字列 drop_rate が GachaResult/broadcast へ漏れないようにする
+    // (従来は selectWeightedCard の戻り値=正規化済みクローンをそのまま返して
+    // いたため保証されていた性質。再構築方式でも同じ保証を維持する)。
+    const normalizedCards = normalizeDropRate(pool)
+
+    // 選択プールは「id + 選択重み」だけの最小型に落とす(WeightedCard)。
+    // 両分岐の配列型が異なるユニオンのままだと selectWeightedCard の
+    // ジェネリック推論が単一の T を選べないため、明示的に共通型へ寄せる。
+    const selectionPool: Array<{ id: string; drop_rate: number }> = resolvedRarityWeights
+      ? computeEffectiveWeights(normalizedCards, resolvedRarityWeights).map(({ card, effectiveWeight }) => ({
+          id: card.id,
+          drop_rate: effectiveWeight,
+        }))
+      : normalizedCards
+
+    const picked = selectWeightedCard(selectionPool)
+
+    if (!picked) {
+      return null
+    }
+
+    // 選択には effectiveWeight (パック内実効重み) を drop_rate の代わりに
+    // 使うことがあるが、返す値・下流に渡す値は必ず元カード(正規化済み)から
+    // 再構築する。effectiveWeight は選択専用の一時的な重みであり実際の
+    // drop_rate とは異なる値になりうるため、gacha_history や配信オーバーレイ
+    // へのブロードキャストペイロードに漏れてはならない。intra_rarity_weight も
+    // GachaCard 型に存在しないフィールドなので同様に除外する。
+    const originalCard = normalizedCards.find((card) => card.id === picked.id)
+    if (!originalCard) {
+      return null
+    }
+
+    return {
+      id: originalCard.id,
+      name: originalCard.name,
+      description: originalCard.description,
+      image_url: originalCard.image_url,
+      rarity: originalCard.rarity,
+      drop_rate: originalCard.drop_rate,
+      // Issue #108: legacy フォールバック(executeGachaLegacy)が発行上限の
+      // 再チェックに参照するため、再構築後も必ず引き継ぐ。
+      max_issuance_count: originalCard.max_issuance_count ?? null,
     }
   }
 
@@ -431,11 +498,20 @@ export class GachaService {
     // The legacy fallback runs only while execute_gacha_transaction is missing on the DB.
     // Without FOR UPDATE row locking we cannot enforce issuance limits atomically here,
     // so refuse to issue limited cards via this path to avoid over-issuing.
+    //
+    // R2 (PR #450 レビュー follow-up): この拒否は「本物の soldOut (発行枚数上限に
+    // 到達済み)」とは全く別の異常系(RPC関数が本番に存在しない = マイグレーション
+    // 未適用のはずが後続コードだけ先にデプロイされた不整合状態)である。以前は
+    // soldOut と同一の文字列を返していたため、eventsub route.ts のソフトフェイル
+    // 抑止フィルタ(発行枚数上限到達は運用上正常なので reportError しない)に巻き
+    // 込まれ、この深刻な不整合が本番で一切アラートされなかった。専用の
+    // limitUnavailable を返すことで、genuine soldOut の抑止は維持したまま、この
+    // ケースだけ確実に reportError が発火するようにする。
     if (selectedCard.max_issuance_count !== null && selectedCard.max_issuance_count !== undefined) {
       logger.warn('Legacy fallback: refused to issue limited card (RPC not deployed yet)', {
         streamerId, userTwitchId, eventId, cardId: selectedCard.id,
       })
-      return err(CARD_ISSUANCE_MESSAGES.soldOut)
+      return err(CARD_ISSUANCE_MESSAGES.limitUnavailable)
     }
 
     // gacha_history upsert（冪等性のためevent_idで重複チェック）

--- a/tests/unit/card-issuance.test.ts
+++ b/tests/unit/card-issuance.test.ts
@@ -19,6 +19,21 @@ describe('parseCardIssuanceLimit', () => {
     expect(parseCardIssuanceLimit(1.5)).toBe('invalid')
     expect(parseCardIssuanceLimit('100')).toBe('invalid')
   })
+
+  // R4 (PR #450 レビュー follow-up): cards.max_issuance_count はDB側で4バイト
+  // PostgreSQL INTEGER(最大2,147,483,647)。上限なしで受け付けると桁あふれで
+  // 22003エラー→opaqueな500になるため、製品として現実的な上限
+  // (1,000,000)でアプリ層が先に弾く。
+  it('rejects values above the product cap (1,000,000) to avoid PostgreSQL INTEGER overflow (22003)', () => {
+    expect(parseCardIssuanceLimit(1e12)).toBe('invalid')
+    expect(parseCardIssuanceLimit(1_000_001)).toBe('invalid')
+    // INTEGER自体の最大値を大きく超える入力も同様に拒否される
+    expect(parseCardIssuanceLimit(2_147_483_648)).toBe('invalid')
+  })
+
+  it('accepts the product cap itself (1,000,000)', () => {
+    expect(parseCardIssuanceLimit(1_000_000)).toBe(1_000_000)
+  })
 })
 
 describe('isMissingCardIssuanceColumnError', () => {

--- a/tests/unit/eventsub-redemption-limit.test.ts
+++ b/tests/unit/eventsub-redemption-limit.test.ts
@@ -156,6 +156,33 @@ describe('EventSub redemption: card issuance limit error handling', () => {
     expect(mockReport).not.toHaveBeenCalled()
   })
 
+  it('R2 (PR #450 follow-up): レガシーフォールバックの拒否(limitUnavailable)は genuine soldOut と区別され reportError を呼ぶ', async () => {
+    // execute_gacha_transaction RPC が未デプロイのまま limited カードが選ばれた
+    // 場合、GachaService.executeGachaLegacy は CARD_ISSUANCE_MESSAGES.soldOut
+    // ではなく専用の limitUnavailable を返す(src/lib/services/gacha.ts)。
+    // これは「発行枚数上限に達した」という運用上正常な状態ではなく、
+    // 「RPC関数が本番に存在しない」という本来あってはならない異常事態なので、
+    // eventsub route のソフトフェイル抑止リストに含めず reportError を発火させ、
+    // 確実にアラートされることを検証する。
+    const { CARD_ISSUANCE_MESSAGES } = await import('@/lib/card-issuance')
+    const { GachaService } = await import('@/lib/services/gacha')
+    const { reportError } = await import('@/lib/sentry/error-handler')
+    const mockReport = vi.mocked(reportError)
+    vi.mocked(GachaService).mockImplementation(() => ({
+      executeGachaForEventSub: vi.fn().mockResolvedValue({
+        success: false,
+        error: CARD_ISSUANCE_MESSAGES.limitUnavailable,
+      }),
+    }) as unknown as InstanceType<typeof GachaService>)
+
+    const { POST } = await import('@/app/api/twitch/eventsub/route')
+    const req = await buildRedemptionRequest('msg-limit-unavailable-1')
+    const res = await POST(req as unknown as import('next/server').NextRequest)
+
+    expect(res.status).toBe(200)
+    expect(mockReport).toHaveBeenCalledTimes(1)
+  })
+
   it('limit_reached 以外のエラーは引き続き reportError を呼ぶ (回帰防止)', async () => {
     const { GachaService } = await import('@/lib/services/gacha')
     const { reportError } = await import('@/lib/sentry/error-handler')

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -3,6 +3,7 @@ import { GachaService } from '@/lib/services/gacha'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { createMockQueryBuilder } from '../utils/supabase-mock'
 import { DEFAULT_PACK_SENTINEL } from '@/lib/validation/collection-name'
+import { CARD_ISSUANCE_MESSAGES } from '@/lib/card-issuance'
 
 vi.mock('@/lib/supabase/admin', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/supabase/admin')>()
@@ -417,14 +418,164 @@ describe('GachaService.executeGacha', () => {
     const result = await service.executeGacha('streamer-1', 'user-1', 'testuser', 'event-legacy-limited')
 
     // Legacy パスでは atomic な発行枚数チェックができないため、
-    // 上限超過リスクを避けて soldOut エラーを返す。
+    // 上限超過リスクを避けて拒否する。R2 (PR #450 follow-up): この拒否は
+    // 本物の soldOut とは別の異常系(RPC未デプロイ)なので、専用の
+    // limitUnavailable を返し、genuine soldOut の文字列とは区別される
+    // (eventsub route.ts のソフトフェイル抑止に巻き込まれずreportErrorが
+    // 発火することを別テストで検証する)。
     expect(result.success).toBe(false)
     if (!result.success) {
-      expect(result.error).toContain('発行可能枚数')
+      expect(result.error).toBe(CARD_ISSUANCE_MESSAGES.limitUnavailable)
+      expect(result.error).not.toBe(CARD_ISSUANCE_MESSAGES.soldOut)
     }
     // gacha_history / user_cards INSERT は実行されていないことを確認
     expect(fromMock).not.toHaveBeenCalledWith('gacha_history')
     expect(fromMock).not.toHaveBeenCalledWith('users')
+  })
+
+  // R1 (PR #450 レビュー follow-up): limit_reached はプール全体の抽選失敗ではなく、
+  // 選ばれたカードだけを除外して残りプールから再抽選すべき。migration 00067 が
+  // gacha_history INSERT より前に limit_reached を返すことを利用し、同じ eventId
+  // でRPCを再実行しても副作用が無いことに依拠する(gacha.ts のコメント参照)。
+  describe('limit_reached 時の再抽選 (R1)', () => {
+    it('limit_reachedを受けたカードをプールから除外し、別カードで同じeventIdでRPCを再実行して成功する', async () => {
+      const cardsQuery = createCardsQuery([
+        { id: 'card-a', name: 'A', description: null, image_url: null, rarity: 'common', drop_rate: 0.5, max_issuance_count: null },
+        { id: 'card-b', name: 'B', description: null, image_url: null, rarity: 'common', drop_rate: 0.5, max_issuance_count: null },
+      ] as unknown as typeof testCards)
+      const mockRpc = vi.fn()
+        .mockResolvedValueOnce({ data: { is_duplicate: false, limit_reached: true }, error: null })
+        .mockResolvedValueOnce({ data: { is_duplicate: false, limit_reached: false, history_id: 'h-retry' }, error: null })
+
+      mockGetSupabaseAdmin.mockReturnValue({
+        from: vi.fn((table: string) => (table === 'cards' ? cardsQuery : createMockQueryBuilder())),
+        rpc: mockRpc,
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const service = new GachaService()
+      const result = await service.executeGacha('streamer-1', 'user-1', 'testuser', 'event-retry')
+
+      expect(result.success).toBe(true)
+      expect(mockRpc).toHaveBeenCalledTimes(2)
+      const firstCardId = (mockRpc.mock.calls[0][1] as { p_card_id: string }).p_card_id
+      const secondCardId = (mockRpc.mock.calls[1][1] as { p_card_id: string }).p_card_id
+      // 2回目は1回目と別のカードが選ばれている(除外が効いている)
+      expect(secondCardId).not.toBe(firstCardId)
+      // 同じ eventId が両方の呼び出しに渡されている(副作用ゼロなので安全に同一eventIdで再試行できる)
+      expect((mockRpc.mock.calls[0][1] as { p_event_id: string }).p_event_id).toBe('event-retry')
+      expect((mockRpc.mock.calls[1][1] as { p_event_id: string }).p_event_id).toBe('event-retry')
+      if (result.success) {
+        expect(result.data.card.id).toBe(secondCardId)
+      }
+    })
+
+    it('パック内自動配分(effectiveWeight)でも limit_reached 後に残りプールから正しく再選択する', async () => {
+      // 発行上限付き(c1)+無制限(c2)の2枚パック。c1がまず選ばれてlimit_reachedに
+      // なっても、effectiveWeightの再計算を経てc2で成功することを確認する。
+      const packCards = [
+        { id: 'c1', name: 'Common1', description: null, image_url: null, rarity: 'common', collection_name: 'weapons', drop_rate: 1.0, intra_rarity_weight: 1.0, max_issuance_count: 1 },
+        { id: 'c2', name: 'Common2', description: null, image_url: null, rarity: 'common', collection_name: 'weapons', drop_rate: 1.0, intra_rarity_weight: 1.0, max_issuance_count: null },
+      ]
+      const cardsQuery = createCardsQuery(packCards as unknown as typeof testCards)
+      // c1はまだ未発行(0/1)なので発行上限フィルタ後も初期プールに残る
+      const userCardsQuery = createMockQueryBuilder()
+      ;(userCardsQuery as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
+        resolve({ data: [], error: null })
+        return userCardsQuery
+      }
+      const mockRpc = vi.fn()
+        .mockResolvedValueOnce({ data: { is_duplicate: false, limit_reached: true }, error: null })
+        .mockResolvedValueOnce({ data: { is_duplicate: false, limit_reached: false, history_id: 'h-effective-retry' }, error: null })
+
+      mockGetSupabaseAdmin.mockReturnValue({
+        from: vi.fn((table: string) => {
+          if (table === 'cards') return cardsQuery
+          if (table === 'user_cards') return userCardsQuery
+          return createMockQueryBuilder()
+        }),
+        rpc: mockRpc,
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const service = new GachaService()
+      const result = await service.executeGacha('streamer-1', 'user-1', 'testuser', 'event-effective-retry', 100, 'weapons', {
+        rarityWeightsScope: 'global',
+        rarityWeights: { common: 100 },
+        packRarityWeights: null,
+      })
+
+      expect(result.success).toBe(true)
+      expect(mockRpc).toHaveBeenCalledTimes(2)
+      const firstCardId = (mockRpc.mock.calls[0][1] as { p_card_id: string }).p_card_id
+      const secondCardId = (mockRpc.mock.calls[1][1] as { p_card_id: string }).p_card_id
+      expect(secondCardId).not.toBe(firstCardId)
+      if (result.success) {
+        expect(result.data.card.id).toBe(secondCardId)
+      }
+    })
+
+    it('全カードでlimit_reachedが続く場合はプールを使い果たしてsoldOutを返す', async () => {
+      const cardsQuery = createCardsQuery([
+        { id: 'card-a', name: 'A', description: null, image_url: null, rarity: 'common', drop_rate: 0.5, max_issuance_count: 1 },
+        { id: 'card-b', name: 'B', description: null, image_url: null, rarity: 'common', drop_rate: 0.5, max_issuance_count: 1 },
+      ] as unknown as typeof testCards)
+      // 両カードとも未発行として初期プールに残す
+      const userCardsQuery = createMockQueryBuilder()
+      ;(userCardsQuery as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
+        resolve({ data: [], error: null })
+        return userCardsQuery
+      }
+      const mockRpc = vi.fn().mockResolvedValue({ data: { is_duplicate: false, limit_reached: true }, error: null })
+
+      mockGetSupabaseAdmin.mockReturnValue({
+        from: vi.fn((table: string) => {
+          if (table === 'cards') return cardsQuery
+          if (table === 'user_cards') return userCardsQuery
+          return createMockQueryBuilder()
+        }),
+        rpc: mockRpc,
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const service = new GachaService()
+      const result = await service.executeGacha('streamer-1', 'user-1', 'testuser', 'event-exhausted')
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBe(CARD_ISSUANCE_MESSAGES.soldOut)
+      }
+      // 2枚のプールを2回で使い果たして打ち切られる
+      expect(mockRpc).toHaveBeenCalledTimes(2)
+    })
+
+    it('再試行回数の上限(5回)を超えたら、プールにまだカードが残っていてもsoldOutで打ち切る', async () => {
+      // 上限より多い6枚のプールを用意し、RPCが常にlimit_reachedを返す異常系でも
+      // 無制限にRPCを叩き続けないことを確認する。
+      const manyCards = Array.from({ length: 6 }, (_, index) => ({
+        id: `card-${index}`,
+        name: `Card ${index}`,
+        description: null,
+        image_url: null,
+        rarity: 'common',
+        drop_rate: 1,
+        max_issuance_count: null,
+      }))
+      const cardsQuery = createCardsQuery(manyCards as unknown as typeof testCards)
+      const mockRpc = vi.fn().mockResolvedValue({ data: { is_duplicate: false, limit_reached: true }, error: null })
+
+      mockGetSupabaseAdmin.mockReturnValue({
+        from: vi.fn((table: string) => (table === 'cards' ? cardsQuery : createMockQueryBuilder())),
+        rpc: mockRpc,
+      } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+      const service = new GachaService()
+      const result = await service.executeGacha('streamer-1', 'user-1', 'testuser', 'event-retry-cap')
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error).toBe(CARD_ISSUANCE_MESSAGES.soldOut)
+      }
+      // 6枚のプールが残っていても再試行は5回で打ち切られる(無制限ループ防止)
+      expect(mockRpc).toHaveBeenCalledTimes(5)
+    })
   })
 
   it('eventId未指定: p_event_idにnullが渡される', async () => {


### PR DESCRIPTION
## 概要

マージ済み PR #450（カード発行上限）の事後レビューで検出した3件の修正。

### R1（high）: limit_reached で抽選全体が失敗する問題
同時実行で選択カードの上限枠が先に取られると、プールの残り（多くは無制限カード）が選べるのに soldOut を返し、視聴者はチャネポ消費のうえカードを受け取れなかった。`execute_gacha_transaction` は limit_reached を **INSERT 前に副作用ゼロで返す**（migration 00067 実測確認）ため、同一 eventId での再実行は安全 — 選択カードをプールから除外して再選択→RPC 再実行するループ（上限5回、根拠コメント付き）に変更。実効重み/手動の両選択経路を `selectCardFromPool` に共通化し、縮小プールでの実効重み再計算・正規化・返却カード再構築の不変条件を維持。

### R2（medium）: レガシーフォールバックの拒否が本物の soldOut と同一文字列
RPC 未デプロイ（42883）時の上限付きカード拒否に専用メッセージ `limitUnavailable` を新設。EventSub の抑止フィルタに一致しないため、本番で RPC が本当に欠けた異常時は確実に reportError が発火する。

### R4（low）: max_issuance_count の上限なしで Postgres INTEGER あふれ→不透明な500
`parseCardIssuanceLimit` に上限 1,000,000 を追加（`MAX_ISSUANCE_COUNT_CAP`）、フォーム input に max 属性、ヘルプ文言更新（ja/en）。

繰り越し（別issue起票済み）: #592（発行カウントの「現在所有数」semantics とストーン交換の相互作用）

## テスト（実測）
新規7件（再抽選・同一eventId・プール枯渇・メッセージ分離・上限キャップ）含む **105 files / 1177 tests green** / eslint clean / tsc 24件（main と完全一致、新規ゼロ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn