### PR TITLE
fix(build): overlay page の不正 named export で next build が失敗する問題を修正

### DIFF
--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -18,10 +18,9 @@ import { getRarityGlowClass, getRarityGradientClass, getRarityDisplayInfo } from
 import {
   normalizeGachaSoundRules,
   pickGachaSoundRule,
+  pickSoundBearingCardIndex,
   type GachaSoundRule,
-  type GachaSoundTargetType,
 } from "@/lib/gacha-sound-rules";
-import { RARITY_ORDER } from "@/lib/constants";
 
 // OBSブラウザソース（古いCEF）向けのqueueMicrotaskポリフィル
 // 一部のOBSバージョンではqueueMicrotaskがサポートされていないため
@@ -57,78 +56,6 @@ interface OverlayPollingEvent {
   userTwitchUsername: string;
   card: Pick<Card, "id" | "name" | "description" | "image_url" | "rarity">;
   rewardId?: string | null;
-}
-
-// pickGachaSoundRule と同じ優先順位(reward > rarity > all)。ここでの
-// 「どのカードを音の代表にするか」の比較にも同じ優先度を使い、一致させる。
-const SOUND_RULE_SPECIFICITY: Record<GachaSoundTargetType, number> = {
-  reward: 3,
-  rarity: 2,
-  all: 1,
-};
-
-/**
- * N連ガチャの複数カードの中から、効果音を鳴らす1枚を選ぶ（PR #451 レビュー
- * 指摘 F2）。
- *
- * 従来は常に「1枚目のカード」のレアリティだけで効果音ルールを決めていたため、
- * 例えば10連の4枚目にレジェンダリーが出ても、1枚目がコモンならレジェンダリー
- * 音は鳴らなかった。ここではバッチ内の各カードを pickGachaSoundRule で個別に
- * 評価し、一致したルールの具体性(reward > rarity > all)が最も高いカードを選ぶ。
- * 同じ具体性で複数枚が一致する場合(例: レア/レジェンダリー両方のレアリティ
- * ルールが設定されていて両方引いた)は、より希少なレアリティのカードを優先する
- * (RARITY_ORDER: legendary が最も希少 = 配列の先頭)。
- *
- * - soundRules が空(レガシー単一URL設定、ルール非対応)の場合は、従来どおり
- *   1枚目を代表とする(レガシー動作は変えない)。
- * - soundRules が1件以上あるのにどのカードもルールに一致しない場合は -1 を
- *   返す(F1bのオーバーレイ側no-matchフォールバック撤廃と一貫して「何も鳴らさない」)。
- *
- * テストで直接検証できるよう named export にしている(デフォルトエクスポートは
- * Next.js のページコンポーネントのみが対象で、追加の named export は
- * ルーティングに影響しない)。
- */
-export function pickSoundBearingCardIndex(
-  cards: Pick<Card, "rarity">[],
-  rewardId: string | null | undefined,
-  soundRules: GachaSoundRule[],
-): number {
-  if (soundRules.length === 0) {
-    return cards.length > 0 ? 0 : -1;
-  }
-
-  let bestIndex = -1;
-  let bestSpecificity = 0;
-  let bestRarityRank = Number.POSITIVE_INFINITY;
-
-  cards.forEach((card, index) => {
-    const rule = pickGachaSoundRule(soundRules, { rarity: card.rarity, rewardId });
-    if (!rule) return;
-
-    const specificity = SOUND_RULE_SPECIFICITY[rule.targetType];
-    const rawRarityRank = RARITY_ORDER.indexOf(card.rarity);
-    const rarityRank = rawRarityRank === -1 ? Number.POSITIVE_INFINITY : rawRarityRank;
-
-    const isMoreSpecific = specificity > bestSpecificity;
-    // 「同率なら希少なカードを優先」は rarity ルール同士が並んだ場合に限る
-    // (仕様上のtie-break対象)。reward/all は、rewardId が全カード共通の
-    // バッチ単位の情報である(=一致すれば全カードが等しく一致する)ため、
-    // ここで希少度によるタイブレークを適用すると「常に一番レアなカード」に
-    // 音が偏ってしまい非直感的。reward/all の同率タイは、先に一致した
-    // (=表示順で先頭の)カードを採用する。
-    const isRarityTierTieBreak =
-      specificity === bestSpecificity
-      && rule.targetType === "rarity"
-      && rarityRank < bestRarityRank;
-
-    if (isMoreSpecific || isRarityTierTieBreak) {
-      bestIndex = index;
-      bestSpecificity = specificity;
-      bestRarityRank = rarityRank;
-    }
-  });
-
-  return bestIndex;
 }
 
 function fetchJsonWithXhrFallback<T>(url: string): Promise<T> {

--- a/src/lib/gacha-sound-rules.ts
+++ b/src/lib/gacha-sound-rules.ts
@@ -1,4 +1,5 @@
 import type { Rarity } from "@/types/database";
+import { RARITY_ORDER } from "@/lib/constants";
 
 export type GachaSoundTargetType = "all" | "rarity" | "reward";
 
@@ -192,4 +193,78 @@ export function legacySoundToRules(soundUrl: string | null, soundEnabled: boolea
     rewardId: null,
     rewardName: null,
   }];
+}
+
+// pickGachaSoundRule と同じ優先順位(reward > rarity > all)。
+// 「どのカードを音の代表にするか」の比較にも同じ優先度を使い、一致させる。
+const SOUND_RULE_SPECIFICITY: Record<GachaSoundTargetType, number> = {
+  reward: 3,
+  rarity: 2,
+  all: 1,
+};
+
+/**
+ * N連ガチャの複数カードの中から、効果音を鳴らす1枚を選ぶ（PR #451 レビュー
+ * 指摘 F2）。
+ *
+ * 従来は常に「1枚目のカード」のレアリティだけで効果音ルールを決めていたため、
+ * 例えば10連の4枚目にレジェンダリーが出ても、1枚目がコモンならレジェンダリー
+ * 音は鳴らなかった。ここではバッチ内の各カードを pickGachaSoundRule で個別に
+ * 評価し、一致したルールの具体性(reward > rarity > all)が最も高いカードを選ぶ。
+ * 同じ具体性で複数枚が一致する場合(例: レア/レジェンダリー両方のレアリティ
+ * ルールが設定されていて両方引いた)は、より希少なレアリティのカードを優先する
+ * (RARITY_ORDER: legendary が最も希少 = 配列の先頭)。
+ *
+ * - soundRules が空(レガシー単一URL設定、ルール非対応)の場合は、従来どおり
+ *   1枚目を代表とする(レガシー動作は変えない)。
+ * - soundRules が1件以上あるのにどのカードもルールに一致しない場合は -1 を
+ *   返す(オーバーレイ側no-matchフォールバック撤廃と一貫して「何も鳴らさない」)。
+ *
+ * このモジュールに置く理由: 当初 overlay page (page.tsx) の named export と
+ * して実装されていたが、Next.js の Page ファイルは規定フィールド以外の
+ * export を持てず `next build` の Page 型検証で失敗する(vitest/tsc では
+ * 検出されない build 固有の検査)。ロジックの帰属先としても、同じ優先度定義を
+ * 持つ pickGachaSoundRule の隣が正しい。
+ */
+export function pickSoundBearingCardIndex(
+  cards: Array<{ rarity: string }>,
+  rewardId: string | null | undefined,
+  soundRules: GachaSoundRule[],
+): number {
+  if (soundRules.length === 0) {
+    return cards.length > 0 ? 0 : -1;
+  }
+
+  let bestIndex = -1;
+  let bestSpecificity = 0;
+  let bestRarityRank = Number.POSITIVE_INFINITY;
+
+  cards.forEach((card, index) => {
+    const rule = pickGachaSoundRule(soundRules, { rarity: card.rarity, rewardId });
+    if (!rule) return;
+
+    const specificity = SOUND_RULE_SPECIFICITY[rule.targetType];
+    const rawRarityRank = RARITY_ORDER.indexOf(card.rarity);
+    const rarityRank = rawRarityRank === -1 ? Number.POSITIVE_INFINITY : rawRarityRank;
+
+    const isMoreSpecific = specificity > bestSpecificity;
+    // 「同率なら希少なカードを優先」は rarity ルール同士が並んだ場合に限る
+    // (仕様上のtie-break対象)。reward/all は、rewardId が全カード共通の
+    // バッチ単位の情報である(=一致すれば全カードが等しく一致する)ため、
+    // ここで希少度によるタイブレークを適用すると「常に一番レアなカード」に
+    // 音が偏ってしまい非直感的。reward/all の同率タイは、先に一致した
+    // (=表示順で先頭の)カードを採用する。
+    const isRarityTierTieBreak =
+      specificity === bestSpecificity
+      && rule.targetType === "rarity"
+      && rarityRank < bestRarityRank;
+
+    if (isMoreSpecific || isRarityTierTieBreak) {
+      bestIndex = index;
+      bestSpecificity = specificity;
+      bestRarityRank = rarityRank;
+    }
+  });
+
+  return bestIndex;
 }

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import type { GachaBroadcastPayload, RealtimeError, SubscribeOptions } from '@/lib/realtime'
 import type { GachaSoundRule } from '@/lib/gacha-sound-rules'
-import OverlayPage, { pickSoundBearingCardIndex } from '@/app/overlay/[streamerId]/page'
+import OverlayPage from '@/app/overlay/[streamerId]/page'
+import { pickSoundBearingCardIndex } from '@/lib/gacha-sound-rules'
 
 const { subscribeMock } = vi.hoisted(() => ({
   subscribeMock: vi.fn(),


### PR DESCRIPTION
## 概要

**main が現在ビルド不能**（#595 で `page.tsx` に追加された `pickSoundBearingCardIndex` の named export が Next.js の Page 型検証で失敗。#595 の twica-preview ビルド fail と同原因）。関数を `gacha-sound-rules.ts` へ移動して修正。ロジック無変更。

- vitest / `tsc --noEmit` では検出されない `next build` 固有の検査のため CI を素通りした（CI に build ジョブが無い問題は #588 に追記予定）

## テスト（実測）
- `npm run workers:build` **成功**（EXIT=0、修正前は失敗を再現）
- 106 files / 1209 tests green / eslint clean / tsc 24件（ベースライン一致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn