### PR TITLE
feat(gacha): 配分スコープ切替とパック別レアリティ配分エディタ (#580)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -85,7 +85,8 @@
       "selectResolution": "Select Resolution",
       "resolutionStandard": "Standard (800px)",
       "resolutionFullHd": "Full HD (1920px)",
-      "resolution4k": "4K (3840px)"
+      "resolution4k": "4K (3840px)",
+      "previewPoolLabel": "Probability within the \"{pack}\" pack"
     },
     "fileUpload": {
       "formats": "Supported: JPEG, PNG, GIF, WebP | ",
@@ -189,7 +190,9 @@
       "example2": "Card A: 50%, Card B: 25%",
       "example2Result": "→ Card A: 50÷75×100 = 66.7%, Card B: 33.3%",
       "note": "* Paused cards are not included in probability calculation.",
-      "close": "Close"
+      "close": "Close",
+      "packScopeTitle": "About pack-specific rewards",
+      "packScopeDescription": "When a channel point reward is scoped to a specific pack, probabilities are recalculated using only the cards in that pack. In auto mode, the \"By Rarity\" tab of Drop Rate Settings lets you choose whether the distribution is shared across all packs or set individually per pack."
     },
     "dropRateSettings": {
       "button": "Drop Rate Settings",
@@ -200,7 +203,18 @@
       "switchToAuto": "Switch to auto mode",
       "confirmSwitchToManual": "Auto-calculation by rarity will be disabled. Switch?",
       "confirmSwitchToAuto": "Rarity-based probability will be enabled and all card rates will be recalculated. Switch?",
-      "switchFailed": "Failed to switch mode"
+      "switchFailed": "Failed to switch mode",
+      "scopeLabel": "Distribution scope",
+      "scopeGlobal": "One shared distribution",
+      "scopePerPack": "Per-pack distribution",
+      "scopeGlobalHint": "All packs use the same rarity distribution.",
+      "scopePerPackHint": "Each pack can have its own rarity distribution. Packs without a setting inherit the global distribution.",
+      "packSelectLabel": "Pack to configure",
+      "inheritingGlobal": "Inheriting the global setting",
+      "makePackSpecific": "Set specifically for this pack",
+      "revertToInherit": "Revert to inherited",
+      "packTotalWarning": "One or more per-pack distributions do not total 100%",
+      "packScopeDeployWindow": "The distribution scope / per-pack settings feature is not ready yet, so your changes could not be saved. Please try again shortly."
     },
     "customRarity": {
       "button": "Custom Rarities",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -85,7 +85,8 @@
       "selectResolution": "解像度を選択",
       "resolutionStandard": "標準 (800px)",
       "resolutionFullHd": "Full HD (1920px)",
-      "resolution4k": "4K (3840px)"
+      "resolution4k": "4K (3840px)",
+      "previewPoolLabel": "「{pack}」パック内での確率"
     },
     "fileUpload": {
       "formats": "対応形式: JPEG, PNG, GIF, WebP | ",
@@ -189,7 +190,9 @@
       "example2": "カードA: 重み50%、カードB: 重み25%",
       "example2Result": "→ カードA: 50÷75×100 = 66.7%、カードB: 33.3%",
       "note": "※ 配布停止中のカードは確率計算に含まれません。",
-      "close": "閉じる"
+      "close": "閉じる",
+      "packScopeTitle": "パック指定の報酬について",
+      "packScopeDescription": "特定のパックに絞ったチャネルポイント報酬から引いた場合、そのパック内のカードだけを対象に確率が再計算されます。自動モードでは「カード排出確率設定」の「レアリティ別設定」タブから、配分をすべてのパックで共通にするか、パックごとに個別に設定するかを選べます。"
     },
     "dropRateSettings": {
       "button": "カード排出確率設定",
@@ -200,7 +203,18 @@
       "switchToAuto": "自動モードに切り替える",
       "confirmSwitchToManual": "レアリティ別の自動計算が無効になります。切り替えますか？",
       "confirmSwitchToAuto": "レアリティ別確率設定が有効になり、全カードの確率が再計算されます。切り替えますか？",
-      "switchFailed": "モードの切り替えに失敗しました"
+      "switchFailed": "モードの切り替えに失敗しました",
+      "scopeLabel": "配分スコープ",
+      "scopeGlobal": "全体で1つの配分",
+      "scopePerPack": "パック別の配分",
+      "scopeGlobalHint": "すべてのパックが同じレアリティ配分を使用します。",
+      "scopePerPackHint": "パックごとに個別のレアリティ配分を設定できます。設定の無いパックはグローバル配分を継承します。",
+      "packSelectLabel": "設定するパック",
+      "inheritingGlobal": "グローバル設定を継承中",
+      "makePackSpecific": "このパック専用に設定する",
+      "revertToInherit": "継承に戻す",
+      "packTotalWarning": "パック別配分のいずれかが合計100%になっていません",
+      "packScopeDeployWindow": "配分スコープ/パック別設定の機能が準備中のため、変更は保存できませんでした。しばらくしてから再度お試しください。"
     },
     "customRarity": {
       "button": "レアリティカスタム",

--- a/src/app/dashboard/cards/page.tsx
+++ b/src/app/dashboard/cards/page.tsx
@@ -70,6 +70,11 @@ export default async function CardsPage() {
       // (TS型は必須だがDB列が存在しない場合、Supabaseは単にキーを省く)、`?? null` で
       // 汎用ラベル表示にフォールバックする。
       initialDefaultPackName={streamerData.streamer.default_card_pack_name ?? null}
+      // Issue #580(#576 フェーズ3): 列未デプロイのデプロイ窓では実行時に
+      // undefined になり得るため、`?? 'global'`/`?? null` で安全側(グローバル
+      // 配分/上書きなし)にフォールバックする(card_pack_names等と同じ方針)。
+      initialRarityWeightsScope={streamerData.streamer.rarity_weights_scope ?? "global"}
+      initialPackRarityWeights={streamerData.streamer.pack_rarity_weights ?? null}
       viewMode="list"
       showViewToggle={true}
       maxImageWidth={maxImageWidth}

--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -14,6 +14,18 @@ interface CardListProps {
   // Total weight of all active cards (for calculating actual probability)
   // 全アクティブカードの重み合計（実際の出現確率計算用）
   totalActiveWeight?: number;
+  // Issue #580(#576 フェーズ3): カードID→実際の出現確率(%, 0-100)の事前計算済み
+  // マップ。指定されたカードは totalActiveWeight ベースの単純な比率計算より
+  // このマップの値を優先して表示する。呼び出し元(CardManager)がパック絞込+
+  // 自動モード時に computeEffectiveWeights(#579) で正しい実効確率を算出して
+  // 渡すためのフック。未指定/該当カードなしの場合は従来の
+  // totalActiveWeight 比率計算にフォールバックする(APIを最小限に保つ)。
+  // A pre-computed map of cardId -> actual display probability (%, 0-100).
+  // When present for a card, this value is shown instead of the simple
+  // totalActiveWeight ratio. Lets the caller (CardManager) supply
+  // computeEffectiveWeights-derived (Issue #579) probabilities for the
+  // pack-filtered auto-mode case, keeping this component's API minimal.
+  probabilityOverrides?: Map<string, number>;
   // Callback when edit button is clicked
   // 編集ボタンクリック時のコールバック
   onEdit?: (card: Card) => void;
@@ -46,6 +58,7 @@ const getRarityInfo = (rarity: Rarity) => getRarityDisplayInfo(rarity);
 export default function CardList({
   cards,
   totalActiveWeight = 0,
+  probabilityOverrides,
   onEdit,
   onDelete,
   onToggleActive,
@@ -59,11 +72,17 @@ export default function CardList({
    * Calculate actual probability for a card based on its weight and total active weight
    * カードの重みと全アクティブ重みから実際の出現確率を計算
    */
-  const calculateActualProbability = (dropRate: number, isActive: boolean): string => {
+  const calculateActualProbability = (card: Card): string => {
     // Inactive cards don't contribute to probability
     // 非アクティブカードは確率に寄与しない
-    if (!isActive || totalActiveWeight === 0) return "-";
-    const probability = (dropRate / totalActiveWeight) * 100;
+    if (!card.is_active) return "-";
+    // Issue #580: 事前計算済みの実効確率があれば優先する
+    const override = probabilityOverrides?.get(card.id);
+    if (override !== undefined) {
+      return `${override.toFixed(1)}%`;
+    }
+    if (totalActiveWeight === 0) return "-";
+    const probability = (card.drop_rate / totalActiveWeight) * 100;
     return `${probability.toFixed(1)}%`;
   };
   if (cards.length === 0) {
@@ -206,7 +225,7 @@ export default function CardList({
                 {/* Actual probability (calculated from weights) */}
                 {/* 出現確率（重みから計算された実際の確率） */}
                 <td className="px-4 py-3 text-sm text-green-400 font-medium">
-                  {calculateActualProbability(card.drop_rate, card.is_active)}
+                  {calculateActualProbability(card)}
                 </td>
 
                 {/* Status */}

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -12,6 +12,7 @@ import { validateUpload, getUploadErrorMessage } from "@/lib/upload-validation";
 import { countCharacters } from "@/lib/text-utils";
 import { DEFAULT_PACK_SENTINEL } from "@/lib/validation/collection-name";
 import { cardMatchesPackKey } from "@/lib/collection-packs";
+import { computeEffectiveWeights, resolveRarityWeightsForPool } from "@/lib/rarity-weight-calculator";
 import { isAllowedCardUploadFile, shouldPreserveOriginalCardUpload } from "@/lib/card-upload-mode";
 import { MAX_ISSUANCE_COUNT_CAP } from "@/lib/card-issuance";
 import ImageCropper, { type CropMode, getCropModes } from "./ImageCropper";
@@ -96,6 +97,20 @@ interface CardManagerProps {
   // Display-name override for the "default" (unclassified) pack (Issue #554).
   // null/undefined falls back to the generic label ("デフォルト").
   initialDefaultPackName?: string | null;
+  // Issue #580(#576 フェーズ3): rarity_weights を全パック共通(global)で使うか
+  // パック別(per_pack, initialPackRarityWeights を優先)で使うか。
+  // undefined/null(列未デプロイのデプロイ窓を含む)は 'global' として扱う。
+  // Issue #580 (#576 Phase 3): whether rarity_weights applies globally or
+  // per-pack. undefined/null (including deploy-window column absence) is
+  // treated as 'global'.
+  initialRarityWeightsScope?: "global" | "per_pack" | null;
+  // Issue #580: パック別レアリティ重みの上書きマップ。キーはパック名または
+  // DEFAULT_PACK_SENTINEL。エントリの無いパックはグローバル rarity_weights を
+  // 継承する(アプリ層規約、#578)。null/undefined はエントリなし。
+  // Issue #580: per-pack rarity-weight override map. Keys are pack names or
+  // DEFAULT_PACK_SENTINEL. Packs without an entry inherit the global
+  // rarity_weights (app-layer convention, #578). null/undefined = no entries.
+  initialPackRarityWeights?: Record<string, Record<string, number>> | null;
   // Issue #269再設計: 新規パック登録(パック管理モーダルでの追加)にのみ適用する
   // プラン判定。デフォルトfalse(フェイルクローズ)。
   isPremium?: boolean;
@@ -150,6 +165,8 @@ export default function CardManager({
   initialCustomRarities = [],
   initialCardPackNames = [],
   initialDefaultPackName = null,
+  initialRarityWeightsScope = "global",
+  initialPackRarityWeights = null,
   isPremium = false,
 }: CardManagerProps) {
   // i18n translations
@@ -178,6 +195,14 @@ export default function CardManager({
   const [cardPackNames, setCardPackNames] = useState<string[]>(initialCardPackNames);
   // 「デフォルト」(未分類)パックの表示名オーバーライド（Issue #554。専用モーダルで管理）
   const [defaultPackName, setDefaultPackName] = useState<string | null>(initialDefaultPackName);
+  // Issue #580: レアリティ重みのスコープ('global'|'per_pack')とパック別上書きマップ。
+  // ドロップ率設定モーダル(DropRateAutoModeContent)が保存・エコーバック同期を行う。
+  const [rarityWeightsScope, setRarityWeightsScope] = useState<"global" | "per_pack">(
+    initialRarityWeightsScope ?? "global"
+  );
+  const [packRarityWeights, setPackRarityWeights] = useState<Record<string, Record<string, number>> | null>(
+    initialPackRarityWeights ?? null
+  );
   const rarityOptions = useMemo(() => {
     const values = new Set<string>(RARITIES.map((rarity) => rarity.value));
     cards.forEach((card) => {
@@ -341,6 +366,52 @@ export default function CardManager({
         .reduce((sum, c) => sum + c.drop_rate, 0),
     [cards, packFilter]
   );
+
+  // Issue #580(#576 フェーズ3): 自動モード時、パックフィルタ選択中の確率列は
+  // totalActiveWeight の単純な drop_rate 比ではなく、実際の抽選ロジック
+  // (#579 GachaService.executeGacha / computeEffectiveWeights)と同じ計算で
+  // 表示する。drop_rate は「配信者の全アクティブカード」を母数に計算された
+  // 値であり、パック内の実際のレアリティ構成比とは一致しないことがあるため、
+  // drop_rate の単純な再正規化(旧#565実装)ではパック抽選時の実確率とズレる
+  // (PR #575 で指摘された不整合の原因)。ここでは resolveRarityWeightsForPool
+  // で解決した重み設定を使い、パック内プールに対して computeEffectiveWeights
+  // を再計算してから、選択時の暗黙の再正規化(selectWeightedCard は渡された
+  // 集合内の比率だけで選ぶ)を明示的に再現する。
+  // 手動モード(rarityWeights===null)またはフィルタ未選択時は null を返し、
+  // CardList 側は従来通り totalActiveWeight ベースの計算にフォールバックする。
+  const packScopedProbabilities = useMemo(() => {
+    if (!packFilter || !rarityWeights || Object.keys(rarityWeights).length === 0) {
+      return null;
+    }
+
+    const pool = cards.filter(
+      (c) => c.is_active && cardMatchesPackKey(c.collection_name, packFilter)
+    );
+    if (pool.length === 0) return null;
+
+    const resolvedWeights = resolveRarityWeightsForPool(
+      rarityWeightsScope,
+      rarityWeights,
+      packRarityWeights,
+      packFilter
+    );
+    // rarityWeights が非空であることは上で確認済みのため理論上 null にはならないが、
+    // 型上のnullable(手動モード用)を安全に扱うためガードする。
+    if (!resolvedWeights) return null;
+
+    const effective = computeEffectiveWeights(pool, resolvedWeights);
+    const totalEffectiveWeight = effective.reduce((sum, e) => sum + e.effectiveWeight, 0);
+
+    const probabilities = new Map<string, number>();
+    for (const { card, effectiveWeight } of effective) {
+      // selectWeightedCard はプール内の相対比率だけで選ぶため、合計<100%の
+      // 場合も実際の抽選確率はプール内合計に対する比率で再正規化される
+      // (rarity-weight-calculator.ts の resolveRarityWeightsForPool コメント参照)。
+      const probability = totalEffectiveWeight > 0 ? (effectiveWeight / totalEffectiveWeight) * 100 : 0;
+      probabilities.set(card.id, probability);
+    }
+    return probabilities;
+  }, [packFilter, rarityWeights, rarityWeightsScope, packRarityWeights, cards]);
 
   const [showForm, setShowForm] = useState(false);
   const [editingCard, setEditingCard] = useState<Card | null>(null);
@@ -859,6 +930,18 @@ export default function CardManager({
     [mergeRecalculatedCards]
   );
 
+  // Issue #580: DropRateAutoModeContent が保存成功後にサーバーの永続値
+  // (rarityWeightsScope はサーバーがそのまま受理するため送信値、
+  // packRarityWeights はサーバーのエコーバック値)で state を再同期するための
+  // コールバック。cardPackNames.length===0 のストリーマーでは呼ばれない。
+  const handlePackWeightsApply = useCallback(
+    (nextScope: "global" | "per_pack", nextPackRarityWeights: Record<string, Record<string, number>>) => {
+      setRarityWeightsScope(nextScope);
+      setPackRarityWeights(nextPackRarityWeights);
+    },
+    []
+  );
+
   // Calculate total weight and actual probability
   // 合計重みと実際の確率を計算
   const calculateActualProbability = (dropRate: number): number => {
@@ -874,15 +957,39 @@ export default function CardManager({
 
   // Calculate intra-rarity share and overall probability for auto mode preview
   // 自動モード時のレアリティ内シェアと全体確率を計算
+  //
+  // Issue #580(#576 フェーズ3): このプレビューは「編集中カードが実際に属する
+  // パック」のプールに対して計算する(scope-aware)。パック別配分(per_pack
+  // スコープ)が設定されている場合、そのパック専用の重み(または継承した
+  // グローバル重み)を resolveRarityWeightsForPool で解決してから使う。
+  // 全体確率(overallPercent)は同レアリティ内シェアだけでなく、パック内の
+  // 他レアリティとの合計(<100%になりうる、resolveRarityWeightsForPool の
+  // コメント参照)に対しても再正規化する必要があるため、computeEffectiveWeights
+  // (#579)にプレビュー中のカードを仮想的に含めて計算し、実際の抽選ロジックと
+  // 同じ式を再利用する(手計算で式を重複させて乖離するのを防ぐ)。
   const calculateIntraRarityStats = useCallback((intraWeight: number, rarity: string) => {
     if (!rarityWeights) return null;
-    const targetPercent = rarityWeights[rarity];
+
+    const packKey = formData.collectionName.trim() || DEFAULT_PACK_SENTINEL;
+    const resolvedWeights = resolveRarityWeightsForPool(
+      rarityWeightsScope,
+      rarityWeights,
+      packRarityWeights,
+      packKey
+    );
+    // rarityWeights が非nullであることは上で確認済みのため理論上nullにはならない
+    if (!resolvedWeights) return null;
+
+    const targetPercent = resolvedWeights[rarity];
     if (targetPercent === undefined || targetPercent <= 0) return null;
 
-    // Sum intra weights for all active cards in the same rarity (excluding the editing card)
-    // 同レアリティの全アクティブカードのintra weightを合算（編集中カードは除外）
+    // このカード自身のパック内、同レアリティのアクティブカード(編集中カードは除外)
     const sameRarityCards = cards.filter(
-      c => c.is_active && c.rarity === rarity && (!editingCard || c.id !== editingCard.id)
+      c =>
+        c.is_active &&
+        c.rarity === rarity &&
+        cardMatchesPackKey(c.collection_name, packKey) &&
+        (!editingCard || c.id !== editingCard.id)
     );
     const othersIntraSum = sameRarityCards.reduce(
       (sum, c) => sum + (c.intra_rarity_weight ?? 1.0), 0
@@ -892,13 +999,24 @@ export default function CardManager({
     const intraPercent = totalIntraWeight > 0
       ? (intraWeight / totalIntraWeight) * 100
       : 0;
-    // Overall drop probability (e.g., 4% of all drops)
-    const overallPercent = totalIntraWeight > 0
-      ? (targetPercent / 100) * (intraWeight / totalIntraWeight) * 100
+
+    // 全体確率: パック内プール全体(全レアリティ)に対する実効重みの比率。
+    // プレビュー中のカードを仮想エントリとしてパック内プールに加え、
+    // computeEffectiveWeights で実際の抽選計算式を再利用する。
+    const poolWithoutEditing = cards.filter(
+      c => c.is_active && cardMatchesPackKey(c.collection_name, packKey) && (!editingCard || c.id !== editingCard.id)
+    );
+    const previewCard = { id: "__preview__", rarity, intra_rarity_weight: intraWeight };
+    const effective = computeEffectiveWeights([...poolWithoutEditing, previewCard], resolvedWeights);
+    const totalEffectiveWeight = effective.reduce((sum, e) => sum + e.effectiveWeight, 0);
+    const previewEffectiveWeight = effective.find(e => e.card.id === "__preview__")?.effectiveWeight ?? 0;
+    const overallPercent = totalEffectiveWeight > 0
+      ? (previewEffectiveWeight / totalEffectiveWeight) * 100
       : 0;
+
     const cardCount = sameRarityCards.length + 1; // +1 for current card
-    return { intraPercent, overallPercent, cardCount, targetPercent };
-  }, [cards, editingCard, rarityWeights]);
+    return { intraPercent, overallPercent, cardCount, targetPercent, packKey };
+  }, [cards, editingCard, rarityWeights, rarityWeightsScope, packRarityWeights, formData.collectionName]);
 
   // Handle image removal and let the update API clean up the previous image if needed
   // 画像削除処理。必要なら既存画像のクリーンアップは更新API側で行う
@@ -1879,7 +1997,33 @@ export default function CardManager({
             </div>
             ) : (
               <div className="md:col-span-2">
-                <label className="mb-1 block text-sm text-gray-300">{t("form.intraRarityWeight")}</label>
+                <div className="mb-1 flex items-center gap-2">
+                  <label className="text-sm text-gray-300">{t("form.intraRarityWeight")}</label>
+                  {/* Issue #580: パックが登録されている配信者向けに、この数値が
+                      どのパックのプールを基準にしているかを説明するヘルプへの導線。
+                      「出現確率について」モーダル(dropRateInfo)を手動モードと共用する。 */}
+                  {cardPackNames.length > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => setShowDropRateInfo(true)}
+                      className="text-gray-400 hover:text-white"
+                      title={t("dropRateInfo.title")}
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                      </svg>
+                    </button>
+                  )}
+                </div>
+                {/* Issue #580: プレビュー数値がどのパック(の重み配分)を基準に
+                    計算されているかを明示するラベル。 */}
+                {cardPackNames.length > 0 && (
+                  <p className="mb-2 text-xs text-gray-500">
+                    {t("form.previewPoolLabel", {
+                      pack: formData.collectionName.trim() || (defaultPackName ?? t("cardPackModal.defaultName")),
+                    })}
+                  </p>
+                )}
                 <div className="flex items-center gap-3">
                   <input
                     type="range"
@@ -2197,6 +2341,7 @@ export default function CardManager({
               <CardList
                 cards={displayCards}
                 totalActiveWeight={totalActiveWeight}
+                probabilityOverrides={packScopedProbabilities ?? undefined}
                 onEdit={handleEdit}
                 onDelete={handleDelete}
                 onToggleActive={handleToggleActive}
@@ -2379,6 +2524,19 @@ export default function CardManager({
               <p className="text-sm text-gray-400">
                 {t("dropRateInfo.note")}
               </p>
+              {/* Issue #580(#576 フェーズ3): パックが登録されている配信者にのみ、
+                  パック指定報酬の確率計算とスコープ設定について説明する。
+                  パックが無い配信者にはスコープ概念自体が無意味なため出さない。 */}
+              {cardPackNames.length > 0 && (
+                <div className="rounded-lg bg-gray-700/60 p-4">
+                  <p className="mb-2 text-sm font-medium text-gray-200">
+                    {t("dropRateInfo.packScopeTitle")}
+                  </p>
+                  <p className="text-sm text-gray-400">
+                    {t("dropRateInfo.packScopeDescription")}
+                  </p>
+                </div>
+              )}
             </div>
             <button
               onClick={() => setShowDropRateInfo(false)}
@@ -2519,6 +2677,11 @@ export default function CardManager({
         onRarityWeightsApply={handleRarityWeightsApply}
         rarityWeights={rarityWeights}
         customRarities={customRarities}
+        cardPackNames={cardPackNames}
+        defaultPackName={defaultPackName}
+        rarityWeightsScope={rarityWeightsScope}
+        packRarityWeights={packRarityWeights}
+        onPackWeightsApply={handlePackWeightsApply}
       />
 
       {/* Custom Rarity Modal */}

--- a/src/components/DropRateAutoModeContent.tsx
+++ b/src/components/DropRateAutoModeContent.tsx
@@ -8,6 +8,8 @@ import { RARITIES } from "@/lib/constants";
 import { formatRarityLabel, getRarityDisplayInfo } from "@/lib/rarity";
 import { logger } from "@/lib/logger";
 import { getOptimizedImageUrl } from "@/lib/image-utils";
+import { DEFAULT_PACK_SENTINEL } from "@/lib/validation/collection-name";
+import { cardMatchesPackKey } from "@/lib/collection-packs";
 
 interface DropRateAutoModeContentProps {
   cards: Card[];
@@ -15,6 +17,20 @@ interface DropRateAutoModeContentProps {
   rarityWeights: Record<string, number>;
   // カスタムレアリティ名（カード未使用でも重み設定欄に表示するため）
   customRarities: string[];
+  // Issue #580(#576 フェーズ3): パック別レアリティ配分UI用のプロップ群。
+  // 事前登録カードパック名（空配列ならスコープ切替UI自体を出さない）。
+  cardPackNames: string[];
+  // 「デフォルト」(未分類)パックの表示名オーバーライド
+  defaultPackName: string | null;
+  // レアリティ重みのスコープ('global'|'per_pack')
+  rarityWeightsScope: "global" | "per_pack";
+  // パック別レアリティ重みの上書きマップ（null = エントリなし）
+  packRarityWeights: Record<string, Record<string, number>> | null;
+  // 保存成功後、サーバーの永続値でスコープ/パック別重みを再同期するコールバック
+  onPackWeightsApply: (
+    scope: "global" | "per_pack",
+    packRarityWeights: Record<string, Record<string, number>>
+  ) => void;
   onCardsSave: (updatedCards: Card[]) => void;
   onRarityWeightsApply: (
     w: Record<string, number> | null,
@@ -32,6 +48,124 @@ function clampPercent(value: number): number {
 }
 
 /**
+ * Issue #580: 2つのパック別重みマップ(ネストしたRecord<string,Record<string,number>>)
+ * が実質的に等しいかどうかを判定する。保存ボタンの活性化判定(scopeOrPackHasChanges)
+ * に使う。数値比較は他の重み比較と同じ許容誤差(0.001)を用いる。
+ */
+function packWeightsEqual(
+  a: Record<string, Record<string, number>>,
+  b: Record<string, Record<string, number>>
+): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+
+  for (const key of aKeys) {
+    const aEntry = a[key];
+    const bEntry = b[key];
+    if (!bEntry) return false;
+
+    const aEntryKeys = Object.keys(aEntry);
+    const bEntryKeys = Object.keys(bEntry);
+    if (aEntryKeys.length !== bEntryKeys.length) return false;
+
+    for (const rarityKey of aEntryKeys) {
+      if (!Object.prototype.hasOwnProperty.call(bEntry, rarityKey)) return false;
+      if (Math.abs(aEntry[rarityKey] - bEntry[rarityKey]) > 0.001) return false;
+    }
+  }
+
+  return true;
+}
+
+interface RarityWeightFieldsProps {
+  rarityKeys: string[];
+  values: Record<string, number>;
+  activeCounts: Map<string, number>;
+  getRarityLabel: (rarity: string) => string;
+  activeCardsSuffix: string;
+  noCardsLabel: string;
+  // true の場合、値を編集不可の静的表示にする(パックがグローバル設定を
+  // 継承中のときのベースライン表示に使用)。
+  readOnly?: boolean;
+  onChange?: (rarity: string, value: number) => void;
+}
+
+/**
+ * Issue #580(#576 フェーズ3): レアリティ別%スライダー行の一覧UI。
+ * グローバル配分編集・パック別配分編集(専用設定/継承中の読み取り専用表示)の
+ * 3箇所で同一マークアップが必要になったため、共通コンポーネントとして抽出した
+ * (以前は「レアリティ別設定」タブ内に1箇所だけ直書きしていた)。
+ */
+function RarityWeightFields({
+  rarityKeys,
+  values,
+  activeCounts,
+  getRarityLabel,
+  activeCardsSuffix,
+  noCardsLabel,
+  readOnly = false,
+  onChange,
+}: RarityWeightFieldsProps) {
+  return (
+    <div className="space-y-3">
+      {rarityKeys.map((rarity) => {
+        const count = activeCounts.get(rarity) || 0;
+        const value = values[rarity] ?? 0;
+
+        return (
+          <div key={rarity} className="rounded-lg bg-gray-700 p-3">
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-sm font-medium text-white">
+                {getRarityLabel(rarity)}
+              </span>
+              <span className="text-xs text-gray-400">
+                {count > 0 ? `${count}${activeCardsSuffix}` : noCardsLabel}
+              </span>
+            </div>
+            {readOnly ? (
+              <div className="flex items-center gap-2">
+                <div className="h-2 flex-1 overflow-hidden rounded-full bg-gray-600">
+                  <div
+                    className="h-2 rounded-full bg-gray-500"
+                    style={{ width: `${Math.min(value, 100)}%` }}
+                  />
+                </div>
+                <span className="w-16 text-right text-sm text-gray-300">
+                  {value.toFixed(1)}%
+                </span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-3">
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  step={0.1}
+                  value={value}
+                  onChange={(event) => onChange?.(rarity, Number(event.target.value))}
+                  className="h-2 flex-1 cursor-pointer appearance-none rounded-full bg-gray-600 accent-purple-500"
+                />
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={0.1}
+                  value={value}
+                  onChange={(event) => onChange?.(rarity, Number(event.target.value))}
+                  className="w-20 rounded bg-gray-600 px-2 py-1 text-right text-sm text-white"
+                />
+                <span className="w-6 text-sm text-gray-400">%</span>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
  * DropRateAutoModeContent - 自動モード用の排出確率設定コンテンツ
  *
  * タブ1（レアリティ別設定）: レアリティごとの%スライダー+数値入力
@@ -42,6 +176,11 @@ export default function DropRateAutoModeContent({
   streamerId,
   rarityWeights,
   customRarities,
+  cardPackNames,
+  defaultPackName,
+  rarityWeightsScope,
+  packRarityWeights,
+  onPackWeightsApply,
   onCardsSave,
   onRarityWeightsApply,
   onSwitchToManualMode,
@@ -51,6 +190,10 @@ export default function DropRateAutoModeContent({
   const tRarity = useTranslations("rarity");
   const tCommon = useTranslations("common");
   const tRarityProb = useTranslations("rarityProbability");
+
+  // Issue #580: パックが1件も登録されていない配信者にはスコープ切替UI自体を
+  // 出さない(デフォルトパック=グローバルなので、切替が意味を持たない)。
+  const hasPacks = cardPackNames.length > 0;
 
   const [activeTab, setActiveTab] = useState<"rarity" | "perCard">("rarity");
   const [showHelp, setShowHelp] = useState(false);
@@ -68,6 +211,18 @@ export default function DropRateAutoModeContent({
   const [raritySaving, setRaritySaving] = useState(false);
   const [rarityMessage, setRarityMessage] = useState<string | null>(null);
   const [rarityError, setRarityError] = useState<string | null>(null);
+
+  // === タブ1: パック別配分（Issue #580, #576 フェーズ3）state ===
+  // 配分スコープのドラフト。保存ボタンを押すまでDBへは反映しない
+  // (既存のレアリティ%編集と同じ「明示的な保存」フローに揃える)。
+  const [draftScope, setDraftScope] = useState<"global" | "per_pack">(rarityWeightsScope);
+  // パック別上書きマップのドラフト。キーの無いパックはグローバルを継承する
+  // (#578 のアプリ層規約)。null(エントリなし)は空オブジェクトとして扱う。
+  const [packWeightsDraft, setPackWeightsDraft] = useState<Record<string, Record<string, number>>>(
+    () => packRarityWeights ?? {}
+  );
+  // パック別配分タブで現在選択中のパック。デフォルト(未分類疑似パック)から開始する。
+  const [selectedPackKey, setSelectedPackKey] = useState<string>(DEFAULT_PACK_SENTINEL);
 
   // === タブ2: カードごとの調整 state ===
   const [localIntraWeights, setLocalIntraWeights] = useState<
@@ -144,6 +299,73 @@ export default function DropRateAutoModeContent({
   }, [draftWeights]);
   const isRarityTotalValid = Math.abs(rarityTotal - 100) <= 0.001;
 
+  // === パック別配分（Issue #580） ===
+  // 選択中パック内のアクティブカード数（レアリティ別）。継承中の読み取り専用
+  // ベースライン表示でも「このパックに何枚あるか」を見せるため、専用/継承の
+  // どちらの表示でも同じマップを使う。
+  const packActiveCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const card of cards) {
+      if (!card.is_active) continue;
+      if (!cardMatchesPackKey(card.collection_name, selectedPackKey)) continue;
+      counts.set(card.rarity, (counts.get(card.rarity) || 0) + 1);
+    }
+    return counts;
+  }, [cards, selectedPackKey]);
+
+  const selectedPackHasEntry = Object.prototype.hasOwnProperty.call(
+    packWeightsDraft,
+    selectedPackKey
+  );
+  const selectedPackWeights = useMemo(
+    () => packWeightsDraft[selectedPackKey] ?? {},
+    [packWeightsDraft, selectedPackKey]
+  );
+  const selectedPackTotal = useMemo(
+    () => Object.values(selectedPackWeights).reduce((sum, value) => sum + value, 0),
+    [selectedPackWeights]
+  );
+  const isSelectedPackTotalValid = Math.abs(selectedPackTotal - 100) <= 0.001;
+
+  // 送信対象になる全パックエントリが合計100%かどうか（保存ボタンの活性判定用。
+  // 選択中でないパックに不正な入力が残っていても送信してしまうため、
+  // 全エントリを検証する）。
+  const arePackWeightsValid = useMemo(
+    () =>
+      Object.values(packWeightsDraft).every(
+        (entry) => Math.abs(Object.values(entry).reduce((sum, value) => sum + value, 0) - 100) <= 0.001
+      ),
+    [packWeightsDraft]
+  );
+
+  const scopeHasChanges = draftScope !== rarityWeightsScope;
+  const packWeightsHasChanges = useMemo(
+    () => !packWeightsEqual(packWeightsDraft, packRarityWeights ?? {}),
+    [packWeightsDraft, packRarityWeights]
+  );
+  // hasPacks でない配信者はスコープUI自体が無いため、変更判定にも含めない。
+  const scopeOrPackHasChanges = hasPacks && (scopeHasChanges || packWeightsHasChanges);
+
+  const handleMakePackSpecific = () => {
+    setPackWeightsDraft((prev) => ({ ...prev, [selectedPackKey]: { ...draftWeights } }));
+  };
+
+  const handleRevertToInherit = () => {
+    setPackWeightsDraft((prev) => {
+      const next = { ...prev };
+      delete next[selectedPackKey];
+      return next;
+    });
+  };
+
+  const updateSelectedPackWeight = (rarity: string, value: number) => {
+    const nextValue = clampPercent(value);
+    setPackWeightsDraft((prev) => ({
+      ...prev,
+      [selectedPackKey]: { ...prev[selectedPackKey], [rarity]: nextValue },
+    }));
+  };
+
   // カードごと: intra weight初期化
   useEffect(() => {
     const initial = new Map<string, number>();
@@ -207,15 +429,27 @@ export default function DropRateAutoModeContent({
   }, [draftWeights, rarityWeights, rarityKeys]);
 
   // 両タブの変更を常にチェック（タブ切替後のクローズでも確認ダイアログが出るように）
-  const hasAnyChanges = rarityHasChanges || perCardHasChanges;
+  // Issue #580: スコープ切替/パック別配分の未保存変更も含める。
+  const hasAnyChanges = rarityHasChanges || perCardHasChanges || scopeOrPackHasChanges;
 
   const getRarityLabel = (rarity: string): string => formatRarityLabel(rarity, tRarity);
 
   const getRarityInfo = (rarity: Rarity) => getRarityDisplayInfo(rarity);
 
+  // レアリティ別%の入力欄で使う「n枚」「0枚」ラベル（RarityWeightFieldsへ渡す）
+  const activeCardsSuffix = tRarityProb("activeCards");
+  const noCardsLabel = tRarityProb("noCards");
+
   // === レアリティ別: 保存 ===
   // レアリティ保存後、サーバーがカードのdrop_rateを再計算するため
   // カードごとタブの未保存weight変更は意味を失う → 確認してからリセット
+  //
+  // Issue #580(#576 フェーズ3): hasPacks の配信者は、グローバル配分
+  // (draftWeights)に加えて配分スコープ(draftScope)とパック別上書きマップ
+  // (packWeightsDraft)も同じ保存ボタンで一括送信する(モーダルの既存「明示的
+  // 保存」フローに揃える方針)。packRarityWeights は full-map-replace APIのため、
+  // 変更が無くても常に現在のドラフト全体を送る(既存 packRarityWeights との
+  // 差分計算はしない)。
   const saveRarityWeights = async () => {
     if (perCardHasChanges && !confirm(t("batchDropRate.confirmClose"))) return;
     if (!isRarityTotalValid) {
@@ -223,21 +457,37 @@ export default function DropRateAutoModeContent({
       setRarityError(tRarityProb("totalWarning"));
       return;
     }
+    if (hasPacks && !arePackWeightsValid) {
+      setRarityMessage(null);
+      setRarityError(t("dropRateSettings.packTotalWarning"));
+      return;
+    }
     setRaritySaving(true);
     setRarityMessage(null);
     setRarityError(null);
 
     try {
+      const body: {
+        streamerId: string;
+        rarityWeights: Record<string, number>;
+        rarityWeightsScope?: "global" | "per_pack";
+        packRarityWeights?: Record<string, Record<string, number>>;
+      } = {
+        streamerId,
+        rarityWeights: draftWeights,
+      };
+      if (hasPacks) {
+        body.rarityWeightsScope = draftScope;
+        body.packRarityWeights = packWeightsDraft;
+      }
+
       const response = await fetch("/api/streamer/settings", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
         credentials: "include",
-        body: JSON.stringify({
-          streamerId,
-          rarityWeights: draftWeights,
-        }),
+        body: JSON.stringify(body),
       });
 
       const data = await response.json();
@@ -250,6 +500,35 @@ export default function DropRateAutoModeContent({
         ? (data.recalculatedCards as Card[])
         : null;
       onRarityWeightsApply(draftWeights, recalculatedCards);
+
+      if (hasPacks) {
+        if (data.rarityWeightsScopeSkippedDeployWindow || data.packRarityWeightsSkippedDeployWindow) {
+          // デプロイ窓で列自体への書き込みが見送られたケース。rarityWeights
+          // (グローバル配分)は保存できているが、スコープ/パック別配分は
+          // 反映されていないため、GachaSoundSettings.saveRules と同じ
+          // パターンで案内する（成功扱いにはしない）。
+          //
+          // ここで return し、下の tRarityProb("saved") 成功メッセージを
+          // 出さない: 両方のメッセージが同時に表示されると「保存できた」と
+          // 「保存できなかった」が矛盾して見え、ユーザーがスコープ/パック別
+          // 設定は実際には反映されていないことを見落としかねないため
+          // (自己レビューで発見: GachaSoundSettings.saveRules は同種のケースで
+          // 常に return false し、成功メッセージを一切出さない)。
+          setRarityError(t("dropRateSettings.packScopeDeployWindow"));
+          return;
+        }
+
+        // packRarityWeights は常にエコーバックされる(サーバー側でプレミアム
+        // ゲート等により加工されうるため)。応答に無ければ防御的に送信値へ
+        // フォールバックする。rarityWeightsScope はサーバー側の加工シナリオが
+        // 無いためエコー不要（送信値がそのまま正）。
+        const persistedPackWeights = (
+          data.packRarityWeights ?? packWeightsDraft
+        ) as Record<string, Record<string, number>>;
+        setPackWeightsDraft(persistedPackWeights);
+        onPackWeightsApply(draftScope, persistedPackWeights);
+      }
+
       setRarityMessage(tRarityProb("saved"));
     } catch (saveError) {
       logger.error("Failed to save rarity weights:", saveError);
@@ -271,11 +550,15 @@ export default function DropRateAutoModeContent({
   };
 
   // === カードごと: 保存 ===
-  // カードごと保存時にレアリティタブの未保存変更があれば確認
-  // （保存完了後にモーダルが閉じるため、ドラフトが消失する）
+  // カードごと保存時にレアリティタブ(グローバル配分/スコープ切替/パック別配分)の
+  // 未保存変更があれば確認（保存完了後にモーダルが閉じるため、ドラフトが消失する）。
+  // Issue #580自己レビューで発見: scopeOrPackHasChanges を見落とすと、
+  // パック別配分だけを編集した状態でこちらのタブから保存した場合に
+  // 確認なしでドラフトが破棄されてしまう(hasAnyChangesは正しく含めているのに
+  // ここだけ旧来のrarityHasChangesのみだった)。
   const handlePerCardSave = async () => {
     if (!perCardHasChanges) return;
-    if (rarityHasChanges && !confirm(t("batchDropRate.confirmClose"))) return;
+    if ((rarityHasChanges || scopeOrPackHasChanges) && !confirm(t("batchDropRate.confirmClose"))) return;
     setPerCardSaving(true);
     try {
       const updates: Array<{
@@ -463,78 +746,173 @@ export default function DropRateAutoModeContent({
           {activeTab === "rarity" ? (
             /* === タブ1: レアリティ別設定 === */
             <div className="space-y-4">
-              <div className="flex flex-wrap items-center gap-3">
-                <span className="text-sm text-gray-300">
-                  {tRarityProb("total")}:{" "}
-                  <span className="font-medium text-white">
-                    {rarityTotal.toFixed(1)}%
-                  </span>
-                </span>
-                {!isRarityTotalValid && (
-                  <span className="rounded bg-yellow-500/20 px-2 py-1 text-xs text-yellow-300">
-                    {tRarityProb("totalWarning")}
-                  </span>
-                )}
-              </div>
+              {/* Issue #580(#576 フェーズ3): 配分スコープ切替。パックが
+                  1件も無い配信者には出さない(デフォルトパック=グローバルで
+                  意味を持たないため)。 */}
+              {hasPacks && (
+                <div className="rounded-lg bg-gray-700/60 p-3">
+                  <p className="mb-2 text-sm font-medium text-gray-200">
+                    {t("dropRateSettings.scopeLabel")}
+                  </p>
+                  <div
+                    role="radiogroup"
+                    aria-label={t("dropRateSettings.scopeLabel")}
+                    className="inline-flex overflow-hidden rounded-lg border border-gray-600"
+                  >
+                    <button
+                      type="button"
+                      role="radio"
+                      aria-checked={draftScope === "global"}
+                      onClick={() => setDraftScope("global")}
+                      className={`px-3 py-1.5 text-sm transition ${
+                        draftScope === "global"
+                          ? "bg-purple-600 text-white"
+                          : "bg-gray-800 text-gray-300 hover:bg-gray-700"
+                      }`}
+                    >
+                      {t("dropRateSettings.scopeGlobal")}
+                    </button>
+                    <button
+                      type="button"
+                      role="radio"
+                      aria-checked={draftScope === "per_pack"}
+                      onClick={() => setDraftScope("per_pack")}
+                      className={`px-3 py-1.5 text-sm transition ${
+                        draftScope === "per_pack"
+                          ? "bg-purple-600 text-white"
+                          : "bg-gray-800 text-gray-300 hover:bg-gray-700"
+                      }`}
+                    >
+                      {t("dropRateSettings.scopePerPack")}
+                    </button>
+                  </div>
+                  <p className="mt-2 text-xs text-gray-400">
+                    {draftScope === "global"
+                      ? t("dropRateSettings.scopeGlobalHint")
+                      : t("dropRateSettings.scopePerPackHint")}
+                  </p>
+                </div>
+              )}
 
-              <div className="space-y-3">
-                {rarityKeys.map((rarity) => {
-                  const count = activeCounts.get(rarity) || 0;
-                  const value = draftWeights[rarity] ?? 0;
+              {hasPacks && draftScope === "per_pack" ? (
+                <>
+                  {/* パック選択 */}
+                  <div>
+                    <label
+                      htmlFor="drop-rate-pack-select"
+                      className="mb-1 block text-sm text-gray-300"
+                    >
+                      {t("dropRateSettings.packSelectLabel")}
+                    </label>
+                    <select
+                      id="drop-rate-pack-select"
+                      value={selectedPackKey}
+                      onChange={(event) => setSelectedPackKey(event.target.value)}
+                      className="w-full rounded-lg bg-gray-700 px-3 py-2 text-sm text-white border border-gray-600"
+                    >
+                      <option value={DEFAULT_PACK_SENTINEL}>
+                        {defaultPackName ?? t("cardPackModal.defaultName")}
+                      </option>
+                      {cardPackNames.map((name) => (
+                        <option key={name} value={name}>
+                          {name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
 
-                  return (
-                    <div key={rarity} className="rounded-lg bg-gray-700 p-3">
-                      <div className="mb-2 flex items-center justify-between">
-                        <span className="text-sm font-medium text-white">
-                          {getRarityLabel(rarity)}
-                        </span>
-                        <span className="text-xs text-gray-400">
-                          {count > 0
-                            ? `${count}${tRarityProb("activeCards")}`
-                            : tRarityProb("noCards")}
-                        </span>
+                  {selectedPackHasEntry ? (
+                    <>
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div className="flex flex-wrap items-center gap-3">
+                          <span className="text-sm text-gray-300">
+                            {tRarityProb("total")}:{" "}
+                            <span className="font-medium text-white">
+                              {selectedPackTotal.toFixed(1)}%
+                            </span>
+                          </span>
+                          {!isSelectedPackTotalValid && (
+                            <span className="rounded bg-yellow-500/20 px-2 py-1 text-xs text-yellow-300">
+                              {tRarityProb("totalWarning")}
+                            </span>
+                          )}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={handleRevertToInherit}
+                          className="text-xs text-gray-400 underline hover:text-white"
+                        >
+                          {t("dropRateSettings.revertToInherit")}
+                        </button>
                       </div>
-                      <div className="flex items-center gap-3">
-                        <input
-                          type="range"
-                          min={0}
-                          max={100}
-                          step={0.1}
-                          value={value}
-                          onChange={(event) => {
-                            const nextValue = clampPercent(
-                              Number(event.target.value)
-                            );
-                            setDraftWeights((prev) => ({
-                              ...prev,
-                              [rarity]: nextValue,
-                            }));
-                          }}
-                          className="h-2 flex-1 cursor-pointer appearance-none rounded-full bg-gray-600 accent-purple-500"
-                        />
-                        <input
-                          type="number"
-                          min={0}
-                          max={100}
-                          step={0.1}
-                          value={value}
-                          onChange={(event) => {
-                            const nextValue = clampPercent(
-                              Number(event.target.value)
-                            );
-                            setDraftWeights((prev) => ({
-                              ...prev,
-                              [rarity]: nextValue,
-                            }));
-                          }}
-                          className="w-20 rounded bg-gray-600 px-2 py-1 text-right text-sm text-white"
-                        />
-                        <span className="w-6 text-sm text-gray-400">%</span>
+                      <RarityWeightFields
+                        rarityKeys={rarityKeys}
+                        values={selectedPackWeights}
+                        activeCounts={packActiveCounts}
+                        getRarityLabel={getRarityLabel}
+                        activeCardsSuffix={activeCardsSuffix}
+                        noCardsLabel={noCardsLabel}
+                        onChange={updateSelectedPackWeight}
+                      />
+                    </>
+                  ) : (
+                    <>
+                      <div className="flex items-center justify-between gap-3 rounded-lg bg-gray-700/40 px-3 py-2">
+                        <span className="text-sm text-gray-300">
+                          {t("dropRateSettings.inheritingGlobal")}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={handleMakePackSpecific}
+                          className="rounded-lg border border-purple-500 px-3 py-1 text-xs text-purple-300 transition hover:bg-purple-500 hover:text-white"
+                        >
+                          {t("dropRateSettings.makePackSpecific")}
+                        </button>
                       </div>
-                    </div>
-                  );
-                })}
-              </div>
+                      <RarityWeightFields
+                        rarityKeys={rarityKeys}
+                        values={draftWeights}
+                        activeCounts={packActiveCounts}
+                        getRarityLabel={getRarityLabel}
+                        activeCardsSuffix={activeCardsSuffix}
+                        noCardsLabel={noCardsLabel}
+                        readOnly
+                      />
+                    </>
+                  )}
+                </>
+              ) : (
+                <>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <span className="text-sm text-gray-300">
+                      {tRarityProb("total")}:{" "}
+                      <span className="font-medium text-white">
+                        {rarityTotal.toFixed(1)}%
+                      </span>
+                    </span>
+                    {!isRarityTotalValid && (
+                      <span className="rounded bg-yellow-500/20 px-2 py-1 text-xs text-yellow-300">
+                        {tRarityProb("totalWarning")}
+                      </span>
+                    )}
+                  </div>
+                  <RarityWeightFields
+                    rarityKeys={rarityKeys}
+                    values={draftWeights}
+                    activeCounts={activeCounts}
+                    getRarityLabel={getRarityLabel}
+                    activeCardsSuffix={activeCardsSuffix}
+                    noCardsLabel={noCardsLabel}
+                    onChange={(rarity, value) => {
+                      const nextValue = clampPercent(value);
+                      setDraftWeights((prev) => ({
+                        ...prev,
+                        [rarity]: nextValue,
+                      }));
+                    }}
+                  />
+                </>
+              )}
 
               {rarityMessage && (
                 <p className="text-sm text-green-400">{rarityMessage}</p>
@@ -679,7 +1057,12 @@ export default function DropRateAutoModeContent({
               {activeTab === "rarity" ? (
                 <button
                   onClick={saveRarityWeights}
-                  disabled={!rarityHasChanges || raritySaving || !isRarityTotalValid}
+                  disabled={
+                    !(rarityHasChanges || scopeOrPackHasChanges) ||
+                    raritySaving ||
+                    !isRarityTotalValid ||
+                    (hasPacks && !arePackWeightsValid)
+                  }
                   className="rounded-lg bg-purple-600 px-4 py-2 text-white hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {raritySaving

--- a/src/components/DropRateSettingsModal.tsx
+++ b/src/components/DropRateSettingsModal.tsx
@@ -21,6 +21,20 @@ interface DropRateSettingsModalProps {
   rarityWeights: Record<string, number> | null;
   // カスタムレアリティ名（自動モードで重みを割り当てられるよう一覧へ含める）
   customRarities: string[];
+  // Issue #580(#576 フェーズ3): パック別レアリティ配分UI用のプロップ群。
+  // 事前登録カードパック名(空配列ならスコープ切替UI自体を出さない)。
+  cardPackNames: string[];
+  // 「デフォルト」(未分類)パックの表示名オーバーライド
+  defaultPackName: string | null;
+  // レアリティ重みのスコープ('global'|'per_pack')
+  rarityWeightsScope: "global" | "per_pack";
+  // パック別レアリティ重みの上書きマップ（null = エントリなし）
+  packRarityWeights: Record<string, Record<string, number>> | null;
+  // 保存成功後、サーバーの永続値でスコープ/パック別重みを再同期するコールバック
+  onPackWeightsApply: (
+    scope: "global" | "per_pack",
+    packRarityWeights: Record<string, Record<string, number>>
+  ) => void;
 }
 
 /**
@@ -39,6 +53,11 @@ export default function DropRateSettingsModal({
   onRarityWeightsApply,
   rarityWeights,
   customRarities,
+  cardPackNames,
+  defaultPackName,
+  rarityWeightsScope,
+  packRarityWeights,
+  onPackWeightsApply,
 }: DropRateSettingsModalProps) {
   const t = useTranslations("cardManager");
   const [switching, setSwitching] = useState(false);
@@ -114,6 +133,11 @@ export default function DropRateSettingsModal({
         streamerId={streamerId}
         rarityWeights={rarityWeights}
         customRarities={customRarities}
+        cardPackNames={cardPackNames}
+        defaultPackName={defaultPackName}
+        rarityWeightsScope={rarityWeightsScope}
+        packRarityWeights={packRarityWeights}
+        onPackWeightsApply={onPackWeightsApply}
         onCardsSave={onCardsSave}
         onRarityWeightsApply={onRarityWeightsApply}
         onSwitchToManualMode={() => switchMode(false)}

--- a/tests/unit/components/card-manager-pack-scoped-probability.test.tsx
+++ b/tests/unit/components/card-manager-pack-scoped-probability.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { screen, fireEvent, within } from "@testing-library/react";
+import { baseCard, renderCardManager } from "../../utils/card-manager-test-helpers";
+
+vi.mock("@/lib/logger");
+
+// Issue #580(#576 フェーズ3): 確率表示の統一(PR #575 の指摘の解消)。
+//
+// #565 まではパックフィルタ選択中の確率列を「フィルタ後の drop_rate 比」で
+// 計算していたが、drop_rate は「配信者の全アクティブカード」を母数に自動
+// 計算された値であり、パック内の実際のレアリティ構成比とズレることがある。
+// このテストでは、パック外に同じレアリティのカードが存在することで
+// 単純比率(旧実装)と computeEffectiveWeights ベース(新実装)の結果が
+// 意図的に食い違う fixture を使い、新実装の値が表示されることを検証する。
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {})));
+});
+
+const rowFor = (name: string) => screen.getByText(name).closest("tr") as HTMLElement;
+
+const selectPackFilter = (value: string) => {
+  fireEvent.change(screen.getByRole("combobox", { name: "カードパックで絞り込む" }), {
+    target: { value },
+  });
+};
+
+describe("CardManager pack-scoped probability in auto mode (Issue #580)", () => {
+  // common: A(intra=1, in pack) + A2(intra=1, outside pack) => drop_rate は
+  // ストリーマー全体のコモン内で 1:1 分配された値(50% * 1/2 = 25%→0.25相当)。
+  // rare: B のみ(パック内)。パック内だけで見ると common/rare は 1枚ずつなので
+  // 実際のパック抽選は 50%/50% になるが、旧実装(drop_rate単純比)は
+  // 0.3:0.6=33.3%/66.7% になってしまう。
+  const cards = [
+    baseCard({ id: "a", name: "CardA", rarity: "common", collection_name: "weapons", intra_rarity_weight: 1, drop_rate: 0.3 }),
+    baseCard({ id: "a2", name: "CardA2", rarity: "common", collection_name: null, intra_rarity_weight: 1, drop_rate: 0.3 }),
+    baseCard({ id: "b", name: "CardB", rarity: "rare", collection_name: "weapons", intra_rarity_weight: 1, drop_rate: 0.6 }),
+  ];
+
+  it("shows computeEffectiveWeights-based probabilities (not the naive drop_rate ratio) when a pack filter is active", () => {
+    renderCardManager(cards, {
+      initialCardPackNames: ["weapons"],
+      initialRarityWeights: { common: 50, rare: 50 },
+      viewMode: "list",
+    });
+
+    selectPackFilter("weapons");
+
+    // 正しい実効確率: コモン/レア、それぞれパック内1枚ずつ → 50%/50%
+    expect(within(rowFor("CardA")).getByText("50.0%")).toBeInTheDocument();
+    expect(within(rowFor("CardB")).getByText("50.0%")).toBeInTheDocument();
+    // 旧実装(drop_rate単純比: 0.3:0.6)の値は出ない
+    expect(screen.queryByText("33.3%")).not.toBeInTheDocument();
+    expect(screen.queryByText("66.7%")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the totalActiveWeight ratio when no pack filter is selected", () => {
+    renderCardManager(cards, {
+      initialCardPackNames: ["weapons"],
+      initialRarityWeights: { common: 50, rare: 50 },
+      viewMode: "list",
+    });
+
+    // フィルタ未選択時は従来通り: 0.3 : 0.3 : 0.6 の合計1.2に対する比率
+    expect(within(rowFor("CardA")).getByText("25.0%")).toBeInTheDocument();
+    expect(within(rowFor("CardA2")).getByText("25.0%")).toBeInTheDocument();
+    expect(within(rowFor("CardB")).getByText("50.0%")).toBeInTheDocument();
+  });
+
+  it("keeps the simple drop_rate ratio unchanged for manual mode + pack filter", () => {
+    renderCardManager(cards, {
+      initialCardPackNames: ["weapons"],
+      initialRarityWeights: {}, // 手動モード明示
+      viewMode: "list",
+    });
+
+    selectPackFilter("weapons");
+
+    // 手動モードは drop_rate がそのまま抽選重みなので、パック内の単純比率
+    // (0.3 : 0.6 → 33.3% / 66.7%)のままで正しい(#579 の対象外)。
+    expect(within(rowFor("CardA")).getByText("33.3%")).toBeInTheDocument();
+    expect(within(rowFor("CardB")).getByText("66.7%")).toBeInTheDocument();
+  });
+});
+
+describe("CardManager card-form preview: scope-aware pool label + probability (Issue #580)", () => {
+  it("shows the pack pool label and a probability resolved from the pack's own weights (not the global ones)", () => {
+    // X, Y はパック内(weapons)。Z はパック外(未分類) → プレビュー計算から
+    // 除外されるべき。パック別重み(common:80%/rare:20%)はグローバル
+    // (common:50%/rare:50%)と異なる値にして、正しくパック専用の重みが
+    // 使われていることも同時に検証する。
+    const cards = [
+      baseCard({ id: "x", name: "X", rarity: "common", collection_name: "weapons", intra_rarity_weight: 1 }),
+      baseCard({ id: "y", name: "Y", rarity: "rare", collection_name: "weapons", intra_rarity_weight: 1 }),
+      baseCard({ id: "z", name: "Z", rarity: "common", collection_name: null, intra_rarity_weight: 1 }),
+    ];
+
+    renderCardManager(cards, {
+      initialCardPackNames: ["weapons"],
+      initialRarityWeights: { common: 50, rare: 50 },
+      initialRarityWeightsScope: "per_pack",
+      initialPackRarityWeights: { weapons: { common: 80, rare: 20 } },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "新規カード追加" }));
+
+    const packSelect = document.querySelector('select[name="collectionName"]') as HTMLSelectElement;
+    fireEvent.change(packSelect, { target: { value: "weapons" } });
+
+    // ラベル: このカードは "weapons" パック内の確率を基準にしている
+    expect(screen.getByText("「weapons」パック内での確率")).toBeInTheDocument();
+
+    // rarity は初期値 "common"、intraRarityWeight は初期値 1.0。
+    // パック内プール = {X(common,1), Y(rare,1), 編集中カード(common,1)}
+    // (Zは別パックなので除外)。パック専用重み{common:80,rare:20}を使うと:
+    //   common合計intra = X(1) + 編集中(1) = 2 → 編集中のシェアは1/2=50%
+    //   effectiveWeight(編集中) = 0.8 * (1/2) = 0.4
+    //   effectiveWeight(X) = 0.8 * (1/2) = 0.4
+    //   effectiveWeight(Y) = 0.2 * (1/1) = 0.2
+    //   合計 = 1.0 → 編集中カードの全体排出率 = 0.4/1.0 = 40.0%
+    // (グローバル重み50/50を使った場合は25.0%になり、値が異なるため
+    //  パック専用重みが正しく使われていることの検証にもなる)
+    expect(screen.getByText("コモン内:")).toBeInTheDocument();
+    expect(screen.getByText("50%")).toBeInTheDocument();
+    expect(screen.getByText("40.0%")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/drop-rate-auto-mode-pack-weights.test.tsx
+++ b/tests/unit/components/drop-rate-auto-mode-pack-weights.test.tsx
@@ -1,0 +1,280 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import DropRateAutoModeContent from "@/components/DropRateAutoModeContent";
+import jaMessages from "../../../messages/ja.json";
+import { baseCard } from "../../utils/card-manager-test-helpers";
+
+vi.mock("@/lib/logger");
+
+// Issue #580(#576 フェーズ3): 配分スコープ切替(全体/パック別)とパック別
+// レアリティ配分エディタのテスト。DropRateSettingsModal を経由せず、
+// DropRateAutoModeContent を直接レンダリングする(GachaSoundSettings のテストと
+// 同じ方針。isOpen ゲートは親のDropRateSettingsModal側の責務のため不要)。
+
+type Props = React.ComponentProps<typeof DropRateAutoModeContent>;
+
+function renderContent(overrides: Partial<Props> = {}) {
+  const defaultProps: Props = {
+    cards: [],
+    streamerId: "streamer-1",
+    rarityWeights: { common: 70, rare: 20, epic: 8, legendary: 2 },
+    customRarities: [],
+    cardPackNames: [],
+    defaultPackName: null,
+    rarityWeightsScope: "global",
+    packRarityWeights: null,
+    onPackWeightsApply: vi.fn(),
+    onCardsSave: vi.fn(),
+    onRarityWeightsApply: vi.fn(),
+    onSwitchToManualMode: vi.fn(),
+    onClose: vi.fn(),
+  };
+  return render(
+    <NextIntlClientProvider locale="ja" messages={jaMessages}>
+      <DropRateAutoModeContent {...defaultProps} {...overrides} />
+    </NextIntlClientProvider>
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("DropRateAutoModeContent scope toggle visibility", () => {
+  it("does not render the scope toggle when the streamer has no registered packs", () => {
+    renderContent({ cardPackNames: [] });
+    expect(screen.queryByText("配分スコープ")).not.toBeInTheDocument();
+  });
+
+  it("renders the scope toggle (defaulting to the current scope prop) when packs exist", () => {
+    renderContent({ cardPackNames: ["武器パック"], rarityWeightsScope: "global" });
+    expect(screen.getByText("配分スコープ")).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "全体で1つの配分" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    expect(screen.getByRole("radio", { name: "パック別の配分" })).toHaveAttribute(
+      "aria-checked",
+      "false"
+    );
+  });
+});
+
+describe("DropRateAutoModeContent per-pack editor: inherit -> 専用設定 -> 継承に戻す", () => {
+  it("shows the pack selector and a read-only inherited baseline for a pack with no override", () => {
+    renderContent({ cardPackNames: ["武器パック"] });
+
+    fireEvent.click(screen.getByRole("radio", { name: "パック別の配分" }));
+
+    const select = document.querySelector("#drop-rate-pack-select") as HTMLSelectElement;
+    expect(select).not.toBeNull();
+    expect(within(select).getByRole("option", { name: "デフォルト" })).toBeInTheDocument();
+    expect(within(select).getByRole("option", { name: "武器パック" })).toBeInTheDocument();
+
+    expect(screen.getByText("グローバル設定を継承中")).toBeInTheDocument();
+    expect(screen.getByText("このパック専用に設定する")).toBeInTheDocument();
+    // 継承中は読み取り専用表示のため編集用の入力は存在しない
+    expect(document.querySelectorAll('input[type="range"]').length).toBe(0);
+    expect(document.querySelectorAll('input[type="number"]').length).toBe(0);
+  });
+
+  it("copies the global values into an editable per-pack entry, then reverts back to inheriting", () => {
+    renderContent({ cardPackNames: ["武器パック"] });
+
+    fireEvent.click(screen.getByRole("radio", { name: "パック別の配分" }));
+    fireEvent.click(screen.getByText("このパック専用に設定する"));
+
+    // グローバル値(70+20+8+2=100)がそのままコピーされ、編集可能になる
+    expect(screen.getByText("継承に戻す")).toBeInTheDocument();
+    expect(document.querySelectorAll('input[type="number"]').length).toBe(4);
+    expect(screen.getByText("100.0%")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("継承に戻す"));
+
+    expect(screen.getByText("グローバル設定を継承中")).toBeInTheDocument();
+    expect(screen.getByText("このパック専用に設定する")).toBeInTheDocument();
+    expect(document.querySelectorAll('input[type="number"]').length).toBe(0);
+  });
+
+  it("preserves edits to a pack that is not currently selected when switching packs", () => {
+    renderContent({ cardPackNames: ["武器パック", "防具パック"] });
+
+    fireEvent.click(screen.getByRole("radio", { name: "パック別の配分" }));
+
+    // デフォルト(初期選択)から武器パックへ切り替えてから専用設定にする
+    const select = document.querySelector("#drop-rate-pack-select") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "武器パック" } });
+    fireEvent.click(screen.getByText("このパック専用に設定する"));
+
+    // 武器パックのコモンを変更
+    const numberInputs = document.querySelectorAll('input[type="number"]');
+    fireEvent.change(numberInputs[0], { target: { value: "60" } });
+
+    // 別パックへ切り替え → まだ継承中のはず
+    fireEvent.change(select, { target: { value: "防具パック" } });
+    expect(screen.getByText("グローバル設定を継承中")).toBeInTheDocument();
+
+    // 武器パックへ戻すと編集内容が維持されている
+    fireEvent.change(select, { target: { value: "武器パック" } });
+    const restoredInputs = document.querySelectorAll('input[type="number"]');
+    expect((restoredInputs[0] as HTMLInputElement).value).toBe("60");
+  });
+});
+
+describe("DropRateAutoModeContent per-pack sum-100 validation", () => {
+  it("shows a warning and disables save when a per-pack entry does not total 100%", () => {
+    renderContent({ cardPackNames: ["武器パック"] });
+
+    fireEvent.click(screen.getByRole("radio", { name: "パック別の配分" }));
+    fireEvent.click(screen.getByText("このパック専用に設定する"));
+
+    const numberInputs = document.querySelectorAll('input[type="number"]');
+    // common を 70 -> 50 に変更(合計が80%になり不正)
+    fireEvent.change(numberInputs[0], { target: { value: "50" } });
+
+    expect(screen.getByText("合計が100%ではありません")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "保存して適用" })).toBeDisabled();
+  });
+});
+
+describe("DropRateAutoModeContent save payload + deploy-window handling (Issue #580)", () => {
+  it("sends rarityWeights + rarityWeightsScope + the full packRarityWeights map together, and resyncs from the echo", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      new Response(
+        JSON.stringify({
+          success: true,
+          recalculatedCards: [],
+          packRarityWeights: { 武器パック: { common: 70, rare: 20, epic: 8, legendary: 2 } },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onPackWeightsApply = vi.fn();
+    renderContent({ cardPackNames: ["武器パック"], onPackWeightsApply });
+
+    fireEvent.click(screen.getByRole("radio", { name: "パック別の配分" }));
+    const select = document.querySelector("#drop-rate-pack-select") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "武器パック" } });
+    fireEvent.click(screen.getByText("このパック専用に設定する"));
+    fireEvent.click(screen.getByRole("button", { name: "保存して適用" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/streamer/settings");
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body).toEqual({
+      streamerId: "streamer-1",
+      rarityWeights: { common: 70, rare: 20, epic: 8, legendary: 2 },
+      rarityWeightsScope: "per_pack",
+      packRarityWeights: { 武器パック: { common: 70, rare: 20, epic: 8, legendary: 2 } },
+    });
+
+    await waitFor(() => {
+      expect(onPackWeightsApply).toHaveBeenCalledWith("per_pack", {
+        武器パック: { common: 70, rare: 20, epic: 8, legendary: 2 },
+      });
+    });
+  });
+
+  it("does not send scope/pack fields for streamers with zero registered packs", async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      new Response(JSON.stringify({ success: true, recalculatedCards: [] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderContent({ cardPackNames: [] });
+
+    // レアリティ別設定を変更して保存可能にする
+    const numberInputs = document.querySelectorAll('input[type="number"]');
+    fireEvent.change(numberInputs[0], { target: { value: "60" } });
+    fireEvent.change(numberInputs[1], { target: { value: "30" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "保存して適用" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const [, options] = fetchMock.mock.calls[0];
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body).toEqual({
+      streamerId: "streamer-1",
+      rarityWeights: { common: 60, rare: 30, epic: 8, legendary: 2 },
+    });
+  });
+
+  it("surfaces a deploy-window message and does not resync when the scope/pack columns are not deployed yet", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            success: true,
+            recalculatedCards: [],
+            rarityWeightsScopeSkippedDeployWindow: true,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const onPackWeightsApply = vi.fn();
+    renderContent({ cardPackNames: ["武器パック"], onPackWeightsApply });
+
+    fireEvent.click(screen.getByRole("radio", { name: "パック別の配分" }));
+    fireEvent.click(screen.getByRole("button", { name: "保存して適用" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "配分スコープ/パック別設定の機能が準備中のため、変更は保存できませんでした。しばらくしてから再度お試しください。"
+        )
+      ).toBeInTheDocument();
+    });
+    expect(onPackWeightsApply).not.toHaveBeenCalled();
+    // 自己レビューで発見(F1相当): デプロイ窓エラーと同時に「保存しました」の
+    // 成功メッセージが出ると、rarityWeightsは保存済みでもスコープ/パック別
+    // 設定は反映されていないという事実が矛盾するメッセージに埋もれてしまう。
+    // GachaSoundSettings.saveRules と同様、この失敗ケースでは成功メッセージを
+    // 一切出さないことを保証する。
+    expect(screen.queryByText("確率を再計算しました")).not.toBeInTheDocument();
+  });
+});
+
+describe("DropRateAutoModeContent per-card save guards unsaved pack-weight drafts (Issue #580)", () => {
+  it("confirms before discarding an unsaved per-pack draft when saving from the per-card tab", async () => {
+    // 自己レビューで発見: 「カードごとの調整」タブの保存(handlePerCardSave)は
+    // 保存完了後にモーダルを閉じるため、レアリティタブの未保存変更(グローバル
+    // 配分に加えてスコープ切替/パック別配分も含む)を破棄してしまう。
+    // rarityHasChanges だけを見ていると、パック別配分だけを編集した状態では
+    // 確認なしに破棄されてしまう(hasAnyChangesは正しくscopeOrPackHasChangesを
+    // 含めているのに、handlePerCardSaveだけ旧来のチェックのままだった)。
+    const confirmSpy = vi.fn(() => false);
+    vi.stubGlobal("confirm", confirmSpy);
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const card = baseCard({ id: "c1", name: "Card1", rarity: "common", intra_rarity_weight: 1 });
+    renderContent({ cards: [card], cardPackNames: ["武器パック"] });
+
+    // パック別配分に切り替えて専用設定にする(rarityHasChangesはfalseのまま、
+    // scopeOrPackHasChangesだけがtrueになる状態を作る)。
+    fireEvent.click(screen.getByRole("radio", { name: "パック別の配分" }));
+    fireEvent.click(screen.getByText("このパック専用に設定する"));
+
+    // カードごとの調整タブへ移動し、intra weightを変更する
+    fireEvent.click(screen.getByRole("button", { name: "カードごとの調整" }));
+    const intraSlider = document.querySelector('input[type="range"]') as HTMLInputElement;
+    fireEvent.change(intraSlider, { target: { value: "2" } });
+
+    fireEvent.click(screen.getByRole("button", { name: "一括保存" }));
+
+    // 確認ダイアログが出て、キャンセル(false)を返したので保存処理も
+    // モーダルを閉じる処理も走らない。
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要

#576 フェーズ3。設計は [#576 設計書コメント](https://github.com/azumag/twica/issues/576#issuecomment-4870989770) 参照。

Fixes #580

## 変更内容

### スコープ切替＋パック別エディタ（ドロップ率設定モーダル・自動モード）
- パック登録済み配信者のみ「全体で1つの配分 / パック別の配分」トグルを表示
- パック別: パックセレクタ（デフォルト＋登録パック）。エントリ無し=「グローバル設定を継承中」（読み取り専用＋専用設定化ボタン）、有り=編集可能スライダー＋「継承に戻す」
- 既存の「保存して適用」に統合し `rarityWeights`/`rarityWeightsScope`/`packRarityWeights` を1POSTで送信。サーバー echo から再同期、デプロイ窓スキップは警告表示
- レアリティ%スライダーを `RarityWeightFields` に抽出し3箇所で共用

### 確率表示の統一（PR #575 レビュー繰り越し2件を解消）
- 確率列: パックフィルタ×自動モード時は `computeEffectiveWeights`＋明示的再正規化で**実抽選（#579）と同値**を表示（旧 #565 の drop_rate 単純比率はパック内構成比とズレるバグがあった）
- フォーム内「実際の確率」プレビューをスコープ・所属パック対応（対象プールのラベル付き）
- 「出現確率について」モーダルにパック指定報酬の説明を追記

### 実装エージェントの自己レビューで検出・修正済みのバグ2件（回帰テスト付き）
- デプロイ窓スキップ時にエラーと成功メッセージが同時表示される return 漏れ
- パック別配分のみ編集時に未保存確認ガードが効かない問題

## テスト（実測）

- 新規テスト2ファイル14件を含む **108 files / 1223 tests green**
- eslint clean / tsc **origin/main と完全一致**（別 worktree で実測比較・新規ゼロ）
- **`npm run workers:build` 成功**（#596 の教訓によりビルドゲートを必須化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn