### PR TITLE
docs: middleware.ts→proxy.ts 移行不可の根拠を明文化 (#417 調査)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,10 +5,28 @@ import { setSecurityHeaders } from '@/lib/security-headers'
 import { ERROR_MESSAGES } from '@/lib/constants'
 import { defaultLocale, locales, LOCALE_COOKIE_NAME, type Locale } from '@/i18n/config'
 
-// Next.js 16 recommends proxy.ts, but Proxy always builds as Node.js runtime.
-// OpenNext Cloudflare 1.16.1 cannot deploy Node.js middleware, so this file
-// intentionally stays on the deprecated middleware.ts convention until the
-// Cloudflare adapter supports Proxy or an equivalent deploy path.
+// Next.js 16 recommends proxy.ts, but Proxy always builds as Node.js runtime
+// with no opt-out: setting `export const config = { runtime: 'edge' }` in a
+// proxy.ts file throws "Proxy always runs on Node.js runtime" at build time.
+// (https://nextjs.org/docs/messages/middleware-to-proxy)
+// @opennextjs/cloudflare (currently ^1.16.1) hard-fails `workers:build` with
+// "Node.js middleware is not currently supported. Consider switching to Edge
+// Middleware." whenever it detects Node.js-runtime middleware/proxy output
+// (see useNodeMiddleware() in its build.js). This is still true as of
+// @opennextjs/cloudflare 1.20.1, the latest published version as of this
+// writing (2026-07-03) — confirmed by inspecting that version's published
+// build.js, which contains the identical check.
+// Upstream tracking: opennextjs/opennextjs-cloudflare maintainers say real
+// proxy.ts support is planned only via Next.js's "Adapters API"
+// (opennextjs/opennextjs-cloudflare#972). The concrete bug is tracked at
+// opennextjs/opennextjs-cloudflare#1277 (open), with a community fix at PR
+// #1280 (open, changes requested by a maintainer, stalled since 2026-06-21 —
+// not merged/released). A maintainer's current guidance on #1277 is to keep
+// using middleware.ts if it doesn't need Node.js-only APIs, which is exactly
+// what this file does.
+// This file intentionally stays on the deprecated middleware.ts convention
+// (with edge-compatible code only) until proxy.ts support ships in a
+// released @opennextjs/cloudflare version.
 
 /**
  * Detect locale from request (cookie or Accept-Language header)


### PR DESCRIPTION
## 概要

#417 の調査。**現時点では移行不可** — コード変更なし、コメント更新のみ。

## 実測で確認した事実
- `proxy.ts` は Node.js runtime 固定で edge へのオプトアウトが無い（`runtime: 'edge'` 指定はビルドエラー）
- `@opennextjs/cloudflare` は Node.js middleware/proxy 検出時に `workers:build` を強制失敗させる（`process.exit(1)`）。最新版 1.20.1（現行は ^1.16.1）でも同一ガードを npm registry から取得し確認
- 上流 [opennextjs-cloudflare#972](https://github.com/opennextjs/opennextjs-cloudflare/issues/972)（proxy対応はNext.js Adapters API経由でのみ計画）/ [#1277](https://github.com/opennextjs/opennextjs-cloudflare/issues/1277)（本件と同一バグ、open）/ [#1280](https://github.com/opennextjs/opennextjs-cloudflare/pull/1280)（修正PR、2026-06-21から停滞、未マージ）
- メンテナ本人が「Node.js専用APIが不要ならmiddleware.tsを使い続けてよい」と明言 — 現状の回避策は公式に妥当

## 対応
`src/middleware.ts` 冒頭コメントを上記根拠込みで更新。ロジック変更なし。

## 検証
- `npx vitest run tests/unit/session-middleware.test.ts`: 12件 pass
- `npm run workers:build`: 成功（警告は引き続き出るが想定どおり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn