### PR TITLE
[codex] Clarify GIF upload limits in release notes

### DIFF
--- a/src/app/plans/page.tsx
+++ b/src/app/plans/page.tsx
@@ -195,6 +195,10 @@ export default async function PlansPage() {
                 </div>
               </div>
             </div>
+
+            <p className="mt-4 text-sm text-gray-500">
+              ※ アニメーションGIFはトリミング・再圧縮せず原本を保持するため、1ファイルあたりの上限（素地1MB / 助力5MB / ご贔屓・Twitchサブスク10MB）がそのまま適用されます。
+            </p>
           </section>
 
           {/* コードの取得方法 */}

--- a/src/app/releases/page.tsx
+++ b/src/app/releases/page.tsx
@@ -150,7 +150,8 @@ export default async function ReleasesPage() {
                   </h3>
                   <p className="text-gray-400">
                     支援特典ページを今回の内容に合わせて更新しました。
-                    カードパックの追加登録やガチャ効果音の詳細設定など、
+                    カードパックの追加登録、ガチャ効果音の詳細設定、
+                    アニメーションGIFを含む1ファイルあたりのアップロード上限など、
                     利用できる特典内容を確認しやすくしています。
                   </p>
                 </div>
@@ -202,6 +203,7 @@ export default async function ReleasesPage() {
                   </p>
                   <p className="mt-3 text-gray-400">
                     使い方は、通常のカード画像と同じようにGIFファイルをアップロードします。
+                    GIFはトリミング・再圧縮せず原本を保持するため、1ファイルあたりの上限は素地1MB、助力5MB、ご贔屓・Twitchサブスク10MBです。
                   </p>
                 </div>
 


### PR DESCRIPTION
## Summary
- リリースノートの支援特典ページ説明に、アニメーションGIFを含む1ファイルあたりのアップロード上限を追記
- アニメーションGIF対応の使い方に、GIFは原本保持のためプラン別上限（素地1MB / 助力5MB / ご贔屓・Twitchサブスク10MB）が効くことを明記

## Verification
- `npm run lint -- src/app/releases/page.tsx`
- `git diff --check -- src/app/releases/page.tsx`
