### PR TITLE
ci: マイグレーション番号のout-of-orderチェックを追加 (#541)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,41 @@ jobs:
       - name: Lint
         run: npm run lint
 
+  migration-order-check:
+    # マイグレーション番号の out-of-order チェック (#541)。
+    # PR ごとに、ベースブランチとの merge-base 以降で新規追加された
+    # supabase/migrations/*.sql の番号がベースブランチの既存最大番号より
+    # 大きいことを検証する（マージ順序と採番順序のズレが原因だった #525-527 の再発防止）。
+    # push イベント（マージ後）にはこの比較対象がないため PR コンテキストのみで実行する。
+    name: Migration order check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # ベースブランチとの merge-base を計算するために全履歴を取得する
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Fetch base branch
+        # PR の base ブランチの「現時点の」最新状態を明示的に取得する。
+        # actions/checkout はチェックアウト対象 ref の履歴のみを取得するため、
+        # 自分がブランチを作成した後に base ブランチへ別 PR がマージされていた場合
+        # その最新コミットは fetch-depth: 0 だけでは取得されない。
+        run: git fetch origin ${{ github.base_ref }}
+
+      - name: Check migration order
+        run: npm run check:migration-order -- --base=origin/${{ github.base_ref }}
+
   build:
     runs-on: ubuntu-latest
     needs: [test, lint]

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "db:status": "npx supabase migration list --linked",
     "db:push": "npx supabase db push",
     "db:push:dry": "npx supabase db push --dry-run",
+    "check:migration-order": "node scripts/check-migration-order.js",
     "migrate:vercel-to-r2": "node scripts/migrate-vercel-blob-to-r2.js",
     "migrate:vercel-to-r2:dry": "node scripts/migrate-vercel-blob-to-r2.js --dry-run",
     "error-reporter:deploy": "cd workers/error-reporter && npx wrangler deploy",

--- a/scripts/check-migration-order.js
+++ b/scripts/check-migration-order.js
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+
+/**
+ * Migration order checker / マイグレーション番号の順序チェッカー (#541)
+ *
+ * 背景:
+ * supabase/migrations 配下のファイルは `NNNNN_name.sql` という連番プレフィックスを持つ。
+ * 過去のインシデント (#525-527) では、複数の PR が並行してマイグレーションを追加した際に
+ * マージ順序と番号の採番順序がズレ、番号の小さいファイルが後からマージされてしまった。
+ * その結果 `supabase db push` が「番号が既に適用済みの最大番号より小さい」として拒否する
+ * ("out of order") か、最悪の場合コードのデプロイがスキーマ変更より先行してしまう事故が起きた。
+ * (根本原因である採番プロセス自体の見直しは #536 で別途トラッキングされており、
+ *  本スクリプトはあくまで機械的な順序チェックのみを担う)
+ *
+ * このスクリプトは2つの不変条件を検証する:
+ *
+ *   ルール1 (常に実行): supabase/migrations/*.sql をファイル名の昇順でソートしたとき、
+ *     抽出した番号が「重複なく厳密に増加」していること。
+ *     欠番 (ファイル削除・リナンバーで飛ぶ) は許容する。
+ *
+ *   ルール2 (git のベースブランチ参照が可能な場合のみ実行): このブランチ/PR で新規に
+ *     追加されたマイグレーションファイルの番号が、ベースブランチ (デフォルト origin/main) に
+ *     現時点で存在する全マイグレーションの番号より大きいこと。
+ *     → 採番は早いが実装に時間がかかっている PR が、その間に別の PR が確保した
+ *       (=マージされ、場合によっては本番に適用済みの) より大きい番号を、
+ *       後から追い抜いて低い番号でマージしてしまう #525-527 と同型の事故を防ぐ。
+ *
+ * 使い方:
+ *   node scripts/check-migration-order.js [--base=<git-ref>]
+ *   npm run check:migration-order
+ *   npm run check:migration-order -- --base=origin/preview
+ *
+ * --base を省略した場合は origin/main を使う。指定したベースブランチの参照が
+ * ローカルに存在しない (git fetch していない等) 場合、ルール2 のチェックは
+ * 警告を出してスキップされる (ルール1 は常に実行され、失敗すれば非ゼロ終了する)。
+ */
+
+'use strict'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const fs = require('fs')
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require('path')
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { execFileSync } = require('child_process')
+
+const REPO_ROOT = path.join(__dirname, '..')
+const MIGRATIONS_DIR = path.join(REPO_ROOT, 'supabase', 'migrations')
+const MIGRATIONS_GIT_PATH = 'supabase/migrations'
+const MIGRATION_FILENAME_RE = /^(\d+)_.+\.sql$/
+
+/**
+ * ファイル名から先頭の数値プレフィックスを抽出する純粋関数。
+ * @param {string} filename
+ * @returns {{ raw: string, value: number } | null} マッチしない場合は null
+ */
+function extractMigrationNumber(filename) {
+  const match = filename.match(MIGRATION_FILENAME_RE)
+  if (!match) return null
+  return { raw: match[1], value: parseInt(match[1], 10) }
+}
+
+/**
+ * ファイル名の昇順ソート順に、抽出した番号が「重複なく厳密に増加」しているかを検証する。
+ * git やファイルシステムに依存しない純粋関数 (unit test 対象)。
+ *
+ * @param {string[]} filenames 検証対象のファイル名一覧 (順不同で渡してよい。内部でソートする)
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateMigrationOrder(filenames) {
+  const errors = []
+  const sorted = [...filenames].sort()
+  const parsed = []
+
+  for (const filename of sorted) {
+    const info = extractMigrationNumber(filename)
+    if (!info) {
+      errors.push(`不正なファイル名 (数値プレフィックスがありません): ${filename}`)
+      continue
+    }
+    parsed.push({ filename, ...info })
+  }
+
+  const firstSeenBy = new Map()
+  for (const p of parsed) {
+    const existing = firstSeenBy.get(p.value)
+    if (existing) {
+      errors.push(`番号が重複しています (${p.raw}): ${existing} と ${p.filename}`)
+    } else {
+      firstSeenBy.set(p.value, p.filename)
+    }
+  }
+
+  for (let i = 1; i < parsed.length; i++) {
+    const prev = parsed[i - 1]
+    const curr = parsed[i]
+    if (curr.value < prev.value) {
+      errors.push(
+        `番号が逆順です: ${curr.filename} (${curr.raw}) はファイル名の並び順で ` +
+          `${prev.filename} (${prev.raw}) の後に来ますが、番号がそれより小さいです`
+      )
+    }
+  }
+
+  return { valid: errors.length === 0, errors }
+}
+
+/**
+ * `git diff --name-status` の出力 ("A\tpath" / "D\tpath" 形式、1行1エントリ) を
+ * 追加/削除された .sql ファイルのベース名一覧にパースする純粋関数 (unit test 対象)。
+ *
+ * @param {string} nameStatusOutput
+ * @returns {{ added: string[], deleted: string[] }}
+ */
+function parseNameStatus(nameStatusOutput) {
+  const added = []
+  const deleted = []
+  if (!nameStatusOutput) return { added, deleted }
+
+  for (const line of nameStatusOutput.split('\n')) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+
+    const [status, ...pathParts] = trimmed.split('\t')
+    const filePath = pathParts.join('\t')
+    if (!filePath.endsWith('.sql')) continue
+
+    const basename = path.basename(filePath)
+    if (status.startsWith('A')) {
+      added.push(basename)
+    } else if (status.startsWith('D')) {
+      deleted.push(basename)
+    }
+  }
+
+  return { added, deleted }
+}
+
+/**
+ * 追加ファイルのうち、「同じ番号のファイルが同じ diff 内で削除されている」ものを除外する
+ * 純粋関数 (unit test 対象)。
+ *
+ * 番号を変えずにファイル名の説明部分だけ直す (誤字修正など) その場リネームは、
+ * `--no-renames` 指定下では削除+追加として現れる。この場合は新しい番号を
+ * 要求しているわけではないため、ルール2 (新規番号は既存最大より大きい) の対象から除外する。
+ * 番号自体を変える「リナンバー」(例: 00050 → 00070) は削除側と追加側で番号が異なるため、
+ * このフィルタでは除外されず、引き続きルール2 の検証対象になる。
+ *
+ * @param {string[]} addedFilenames
+ * @param {string[]} deletedFilenames
+ * @returns {string[]}
+ */
+function excludeSameNumberRenames(addedFilenames, deletedFilenames) {
+  const deletedNumbers = new Set(
+    deletedFilenames
+      .map(extractMigrationNumber)
+      .filter(Boolean)
+      .map((info) => info.value)
+  )
+
+  return addedFilenames.filter((filename) => {
+    const info = extractMigrationNumber(filename)
+    if (!info) return true // 不正なファイル名は除外せず後続のチェックで検出させる
+    return !deletedNumbers.has(info.value)
+  })
+}
+
+/**
+ * 新規追加されたマイグレーションの番号が、既存の全マイグレーション番号より大きいかを検証する
+ * 純粋関数 (unit test 対象)。
+ *
+ * @param {string[]} existingFilenames ベースブランチに既に存在するファイル名一覧
+ * @param {string[]} newFilenames このブランチ/PRで新規追加されたファイル名一覧
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateNewMigrationsAreHighest(existingFilenames, newFilenames) {
+  const errors = []
+
+  const existingNumbers = existingFilenames
+    .map(extractMigrationNumber)
+    .filter(Boolean)
+    .map((info) => info.value)
+  const maxExisting = existingNumbers.length > 0 ? Math.max(...existingNumbers) : -1
+
+  for (const filename of newFilenames) {
+    const info = extractMigrationNumber(filename)
+    if (!info) {
+      errors.push(`不正なファイル名 (数値プレフィックスがありません): ${filename}`)
+      continue
+    }
+    if (info.value <= maxExisting) {
+      errors.push(
+        `新規マイグレーション ${filename} (${info.raw}) の番号が、ベースブランチの最大番号 ` +
+          `(${maxExisting}) 以下です。他の PR が先にマージされ、その番号を既に確保している可能性が` +
+          'あります。番号を採番し直してください。'
+      )
+    }
+  }
+
+  return { valid: errors.length === 0, errors }
+}
+
+/** 現在のファイルシステム上の supabase/migrations/*.sql 一覧を返す。 */
+function listMigrationFiles() {
+  return fs.readdirSync(MIGRATIONS_DIR).filter((f) => f.endsWith('.sql'))
+}
+
+function runGit(args) {
+  return execFileSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8' }).trim()
+}
+
+/** git コマンドの出力 (改行区切りのパス) を .sql ファイルのベース名一覧に変換する。 */
+function toSqlBasenames(gitOutput) {
+  if (!gitOutput) return []
+  return gitOutput
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.endsWith('.sql'))
+    .map((line) => path.basename(line))
+}
+
+function getBaseArg(argv) {
+  const arg = argv.find((a) => a.startsWith('--base='))
+  return arg ? arg.slice('--base='.length) : 'origin/main'
+}
+
+function main() {
+  const baseRef = getBaseArg(process.argv.slice(2))
+  const allErrors = []
+
+  // ルール1: ファイル名順に番号が重複なく厳密に増加しているか (常に実行)
+  const filenames = listMigrationFiles()
+  const orderResult = validateMigrationOrder(filenames)
+  allErrors.push(...orderResult.errors)
+
+  // ルール2: 新規追加分の番号がベースブランチの既存最大番号より大きいか (git が使える場合のみ)
+  //
+  // まずベースブランチの参照可否だけを確認する。ここで失敗するのはローカルで
+  // git fetch していない等の「想定内」のケースなので、警告を出してルール2 全体を
+  // スキップするだけに留める。一方、ベースブランチが解決できたにもかかわらず
+  // 後続の ls-tree / diff が失敗する場合は想定外のエラーなので、握りつぶさずに
+  // 例外として伝播させ、CI を確実に失敗させる (silent green を防ぐ)。
+  let rule2Skipped = false
+  try {
+    runGit(['rev-parse', '--verify', baseRef])
+  } catch (err) {
+    rule2Skipped = true
+    const message = err && err.message ? err.message.split('\n')[0] : String(err)
+    console.warn(
+      `[check-migration-order] 警告: ベースブランチ "${baseRef}" を参照できないため、` +
+        `新規マイグレーション番号の比較チェック (ルール2) をスキップしました (${message})`
+    )
+  }
+
+  if (!rule2Skipped) {
+    const existingOutput = runGit(['ls-tree', '-r', '--name-only', baseRef, '--', MIGRATIONS_GIT_PATH])
+    const existingFilenames = toSqlBasenames(existingOutput)
+
+    const diffOutput = runGit([
+      'diff',
+      '--no-renames',
+      '--diff-filter=AD',
+      '--name-status',
+      `${baseRef}...HEAD`,
+      '--',
+      MIGRATIONS_GIT_PATH,
+    ])
+    const { added, deleted } = parseNameStatus(diffOutput)
+    // 番号を変えずにファイル名だけ変えた「その場リネーム」は新規の番号取得とみなさない
+    const newFilenames = excludeSameNumberRenames(added, deleted)
+
+    const newHighestResult = validateNewMigrationsAreHighest(existingFilenames, newFilenames)
+    allErrors.push(...newHighestResult.errors)
+  }
+
+  if (allErrors.length > 0) {
+    console.error('マイグレーション番号のチェックに失敗しました:\n')
+    for (const error of allErrors) {
+      console.error(`  - ${error}`)
+    }
+    console.error(
+      '\nsupabase/migrations/*.sql は NNNNN_name.sql の連番で、重複なく厳密に増加している必要があります。' +
+        '新規ファイルの番号は、マージ先ブランチに既にある全マイグレーションより大きい番号を採番してください。'
+    )
+    process.exit(1)
+  }
+
+  console.log(
+    `[check-migration-order] OK: ${filenames.length} 件のマイグレーションを検証しました` +
+      (rule2Skipped ? ' (ルール2 はスキップ)' : '')
+  )
+}
+
+if (require.main === module) {
+  main()
+}
+
+module.exports = {
+  extractMigrationNumber,
+  validateMigrationOrder,
+  validateNewMigrationsAreHighest,
+  parseNameStatus,
+  excludeSameNumberRenames,
+}

--- a/tests/unit/check-migration-order.test.ts
+++ b/tests/unit/check-migration-order.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractMigrationNumber,
+  validateMigrationOrder,
+  validateNewMigrationsAreHighest,
+  parseNameStatus,
+  excludeSameNumberRenames,
+} from '../../scripts/check-migration-order.js'
+
+describe('extractMigrationNumber', () => {
+  it('抽出した番号と生の桁文字列を返す', () => {
+    expect(extractMigrationNumber('00042_add_foo.sql')).toEqual({ raw: '00042', value: 42 })
+  })
+
+  it('数値プレフィックスのないファイル名は null を返す', () => {
+    expect(extractMigrationNumber('add_foo.sql')).toBeNull()
+    expect(extractMigrationNumber('README.md')).toBeNull()
+    expect(extractMigrationNumber('seed.sql')).toBeNull()
+  })
+})
+
+describe('validateMigrationOrder', () => {
+  it('ファイル名順に番号が重複なく増加していれば valid', () => {
+    const result = validateMigrationOrder(['00001_init.sql', '00002_add_users.sql', '00010_add_cards.sql'])
+
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it('欠番 (削除・リナンバーによるギャップ) は許容する', () => {
+    const result = validateMigrationOrder(['00001_init.sql', '00005_add_users.sql', '00099_add_cards.sql'])
+
+    expect(result.valid).toBe(true)
+  })
+
+  it('入力の順序に関わらずファイル名でソートしてから検証する', () => {
+    // わざと逆順で渡しても、ファイル名昇順に並べ直した上で判定される
+    const result = validateMigrationOrder(['00010_add_cards.sql', '00001_init.sql', '00002_add_users.sql'])
+
+    expect(result.valid).toBe(true)
+  })
+
+  it('桁数の異なるプレフィックスが混在すると文字列順と数値順がズレて検出される', () => {
+    // '00010_y.sql' は文字列比較で '9_x.sql' より前に来るが、数値としては 10 > 9 なので
+    // ファイル名順に並べると番号が逆順 (10 の次に 9) になる、実際に起こりうる採番ミスの再現
+    const result = validateMigrationOrder(['9_x.sql', '00010_y.sql'])
+
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes('逆順'))).toBe(true)
+  })
+
+  it('同じ番号を持つファイルが複数あると重複として検出される', () => {
+    const result = validateMigrationOrder(['00005_a.sql', '00005_b.sql', '00006_c.sql'])
+
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes('重複'))).toBe(true)
+  })
+
+  it('番号が減少するリグレッション (#525-527 相当) を検出する', () => {
+    // ファイル名昇順で 00059 の次に 00060 が来るのは正常だが、
+    // ここでは 00060 の次に 00059 が並ぶ壊れたケースを直接構築して検証する
+    const result = validateMigrationOrder(['00060_fast_pr.sql', '00061_late_pr_wrong.sql'])
+    expect(result.valid).toBe(true) // これは正常系 (増加している)
+
+    const broken = validateMigrationOrder(['0059_late_pr.sql', '00060_fast_pr.sql'])
+    // '0059...' (4桁) は文字列比較で '00060...' (5桁) より後ろに来るため、
+    // 抽出番号は [60, 59] となり逆順として検出される
+    expect(broken.valid).toBe(false)
+  })
+
+  it('数値プレフィックスのないファイルはエラーとして報告する', () => {
+    const result = validateMigrationOrder(['00001_init.sql', 'not_numbered.sql'])
+
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes('not_numbered.sql'))).toBe(true)
+  })
+})
+
+describe('validateNewMigrationsAreHighest', () => {
+  it('新規ファイルの番号が既存の最大番号より大きければ valid', () => {
+    const result = validateNewMigrationsAreHighest(
+      ['00058_a.sql', '00059_b.sql', '00060_c.sql'],
+      ['00061_new.sql', '00062_new2.sql']
+    )
+
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+
+  it('#525-527 の再現: 先にマージされた PR が確保した番号より小さい番号で新規追加すると invalid', () => {
+    // ベースブランチには既に 00060 まで存在する (別の速い PR が先にマージ・適用済み)
+    // このブランチは着手が早かったため 00059 を採番していたが、マージが遅れた
+    const result = validateNewMigrationsAreHighest(['00058_a.sql', '00059_b.sql', '00060_faster_pr.sql'], [
+      '00059_this_pr.sql',
+    ])
+
+    expect(result.valid).toBe(false)
+    expect(result.errors[0]).toContain('00059_this_pr.sql')
+  })
+
+  it('新規ファイルの番号が既存の最大番号と同じ (重複)場合も invalid', () => {
+    const result = validateNewMigrationsAreHighest(['00060_a.sql'], ['00060_b.sql'])
+
+    expect(result.valid).toBe(false)
+  })
+
+  it('既存ファイルが空でも新規ファイルが妥当な番号なら valid', () => {
+    const result = validateNewMigrationsAreHighest([], ['00001_init.sql'])
+
+    expect(result.valid).toBe(true)
+  })
+
+  it('新規ファイルが空なら常に valid', () => {
+    const result = validateNewMigrationsAreHighest(['00060_a.sql'], [])
+
+    expect(result.valid).toBe(true)
+    expect(result.errors).toEqual([])
+  })
+})
+
+describe('parseNameStatus', () => {
+  it('A/D ステータス行を added/deleted に振り分ける', () => {
+    const output = ['A\tsupabase/migrations/00061_new.sql', 'D\tsupabase/migrations/00050_old.sql'].join('\n')
+
+    expect(parseNameStatus(output)).toEqual({
+      added: ['00061_new.sql'],
+      deleted: ['00050_old.sql'],
+    })
+  })
+
+  it('.sql 以外のファイルは無視する', () => {
+    const output = ['A\tREADME.md', 'A\tsupabase/migrations/00061_new.sql'].join('\n')
+
+    expect(parseNameStatus(output)).toEqual({
+      added: ['00061_new.sql'],
+      deleted: [],
+    })
+  })
+
+  it('空文字列や空行のみの入力では空配列を返す', () => {
+    expect(parseNameStatus('')).toEqual({ added: [], deleted: [] })
+    expect(parseNameStatus('\n\n')).toEqual({ added: [], deleted: [] })
+  })
+
+  it('M (変更) など A/D 以外のステータスは無視する', () => {
+    const output = 'M\tsupabase/migrations/00061_new.sql'
+
+    expect(parseNameStatus(output)).toEqual({ added: [], deleted: [] })
+  })
+})
+
+describe('excludeSameNumberRenames', () => {
+  it('同じ番号が削除側にもある「その場リネーム」は新規追加から除外する', () => {
+    // 00002_add_users.sql の誤字を直しただけで番号は変えていないケース
+    const result = excludeSameNumberRenames(['00002_add_users_fixed_typo.sql'], ['00002_add_users.sql'])
+
+    expect(result).toEqual([])
+  })
+
+  it('番号自体が変わるリナンバーは除外されず引き続き検証対象になる', () => {
+    // 00050 を 00070 にリナンバーした場合、追加側と削除側で番号が異なるため除外しない
+    const result = excludeSameNumberRenames(['00070_renumbered.sql'], ['00050_renumbered.sql'])
+
+    expect(result).toEqual(['00070_renumbered.sql'])
+  })
+
+  it('削除ファイルがなければ全ての追加ファイルをそのまま返す', () => {
+    const result = excludeSameNumberRenames(['00061_new.sql', '00062_new2.sql'], [])
+
+    expect(result).toEqual(['00061_new.sql', '00062_new2.sql'])
+  })
+
+  it('不正なファイル名の追加ファイルは除外せず後続チェックに回す', () => {
+    const result = excludeSameNumberRenames(['not_numbered.sql'], ['00002_old.sql'])
+
+    expect(result).toEqual(['not_numbered.sql'])
+  })
+})
+
+describe('統合シナリオ: リネームを検出してからルール2を適用する', () => {
+  it('その場リネームのみの PR は常に valid になる', () => {
+    const diffOutput = [
+      'A\tsupabase/migrations/00002_add_users_fixed_typo.sql',
+      'D\tsupabase/migrations/00002_add_users.sql',
+    ].join('\n')
+    const { added, deleted } = parseNameStatus(diffOutput)
+    const newFilenames = excludeSameNumberRenames(added, deleted)
+
+    const result = validateNewMigrationsAreHighest(
+      ['00001_init.sql', '00002_add_users.sql', '00068_latest.sql'],
+      newFilenames
+    )
+
+    expect(result.valid).toBe(true)
+  })
+})


### PR DESCRIPTION
## 概要

過去のインシデント（#525-527、原因機能は差し戻し済みでクローズ済み）の再発防止。マイグレーション番号のマージ順序ズレを機械的に検出する。

Fixes #541

## 変更内容

- `scripts/check-migration-order.js`: 純粋関数で実装（unit test 対象）
  - ルール1（常時）: ファイル名昇順で番号が重複なく厳密増加していること
  - ルール2（PR時のみ）: 新規追加ファイルの番号がベースブランチの既存最大番号より大きいこと
- `.github/workflows/ci.yml`: `migration-order-check` ジョブを新設（`pull_request` イベントのみ）
- `npm run check:migration-order`

恒久的な採番プロセス自体の見直しは #536 で別途扱う。

## テスト（実測）

- 新規23件のユニットテスト green
- `npm run check:migration-order`: 現行60件のmigrationを検証しOK
- 全体テスト・eslint・`npm run workers:build` すべてclean worktreeで実測確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn