### PR TITLE
perf(gacha): issuedCounts集計をGROUP BYクエリへ最適化 (#548)

### DIFF
--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -65,6 +65,29 @@ function isRaidOptionsSchemaError(error: { message?: string; code?: string } | n
 
 const ADDITIONAL_REWARD_OPTIONS_UNAVAILABLE = 'Additional reward options unavailable'
 
+/**
+ * get_issued_card_counts RPC (migration 00069) の JSONB 戻り値
+ * ({ "<card_id>": <count>, ... }) を Map<card_id, count> にパースする。
+ * Issue #548: 旧実装の issuedCounts と完全に同じ形状を維持する。
+ *
+ * RPC が未デプロイ/エラー時のフォールバック(select+in→JS集計)と混線しないよう、
+ * 想定外の形(null/配列/非オブジェクト)は空Mapとして扱い、呼び出し側で例外を
+ * 起こさない防御的パースにする。
+ */
+function parseIssuedCardCountsRpc(rpcResult: unknown): Map<string, number> {
+  const counts = new Map<string, number>()
+  if (!rpcResult || typeof rpcResult !== 'object' || Array.isArray(rpcResult)) {
+    return counts
+  }
+  for (const [cardId, rawCount] of Object.entries(rpcResult as Record<string, unknown>)) {
+    const count = Number(rawCount)
+    if (Number.isFinite(count)) {
+      counts.set(cardId, count)
+    }
+  }
+  return counts
+}
+
 function isStreamerSettingsSchemaError(error: { message?: string; code?: string } | null | undefined) {
   const message = error?.message ?? ''
   return error?.code === 'PGRST204'
@@ -208,21 +231,11 @@ export class GachaService {
       const limitedCards = cards.filter((card) => card.max_issuance_count !== null && card.max_issuance_count !== undefined)
       let availableCards = cards
       if (limitedCards.length > 0) {
-        const { data: issuedRows, error: issuedError } = await this.supabase
-          .from('user_cards')
-          .select('card_id')
-          .in('card_id', limitedCards.map((card) => card.id))
-
-        if (issuedError) {
-          return err(`Database error: ${issuedError.message}`)
+        const issuedCountsResult = await this.getIssuedCounts(limitedCards.map((card) => card.id))
+        if (!issuedCountsResult.success) {
+          return err(issuedCountsResult.error)
         }
-
-        const issuedCounts = new Map<string, number>()
-        for (const row of issuedRows || []) {
-          const cardId = (row as { card_id?: string }).card_id
-          if (!cardId) continue
-          issuedCounts.set(cardId, (issuedCounts.get(cardId) || 0) + 1)
-        }
+        const issuedCounts = issuedCountsResult.data
 
         availableCards = cards.filter((card) => {
           if (card.max_issuance_count === null || card.max_issuance_count === undefined) return true
@@ -347,6 +360,60 @@ export class GachaService {
     } catch (error) {
       return err(`Unexpected error: ${error}`)
     }
+  }
+
+  /**
+   * 発行上限付きカード(max_issuance_count が設定されたカード)について、
+   * card_id ごとの発行済み枚数を取得する。
+   *
+   * Issue #548: 旧実装は user_cards から該当card_idの行を .in() で全件フェッチし、
+   * アプリ側(JS)で card_id ごとに1行ずつ数えていた。発行数が多い人気の限定
+   * カードほど、件数を知りたいだけなのに数千行をDBからアプリへ転送することになり、
+   * 転送量・メモリ・レイテンシが発行済み枚数に比例して線形に悪化していた。
+   * get_issued_card_counts RPC (migration 00069) はDB側で GROUP BY / COUNT(*) を
+   * 実行し、{ "<card_id>": <count> } 形式のJSONBオブジェクト1個だけを返す。
+   * これにより転送量は「発行上限付きカードの種類数」(通常一桁〜十数件)にしか
+   * 依存しなくなる。
+   *
+   * 無停止デプロイの過渡期でRPCが未デプロイ(42883)の場合は、旧来の
+   * select+in によるフェッチ→JS集計にフォールバックする。Map<card_id, count>
+   * の中身は両経路で完全に同一になるため、呼び出し側(executeGacha)の
+   * フィルタリングロジックへの影響はない。
+   */
+  private async getIssuedCounts(cardIds: string[]): Promise<Result<Map<string, number>>> {
+    const { data: rpcData, error: rpcError } = await withRetry(
+      () => this.supabase.rpc('get_issued_card_counts', { p_card_ids: cardIds }),
+      'gacha:executeGacha:issuedCounts',
+    )
+
+    if (!rpcError) {
+      return ok(parseIssuedCardCountsRpc(rpcData))
+    }
+
+    if (rpcError.code !== '42883') {
+      return err(`Database error: ${rpcError.message}`)
+    }
+
+    logger.warn('get_issued_card_counts not deployed, falling back to per-row aggregation', {
+      cardCount: cardIds.length,
+    })
+
+    const { data: issuedRows, error: issuedError } = await this.supabase
+      .from('user_cards')
+      .select('card_id')
+      .in('card_id', cardIds)
+
+    if (issuedError) {
+      return err(`Database error: ${issuedError.message}`)
+    }
+
+    const issuedCounts = new Map<string, number>()
+    for (const row of issuedRows || []) {
+      const cardId = (row as { card_id?: string }).card_id
+      if (!cardId) continue
+      issuedCounts.set(cardId, (issuedCounts.get(cardId) || 0) + 1)
+    }
+    return ok(issuedCounts)
   }
 
   /**

--- a/supabase/migrations/00069_add_issued_card_counts_rpc.sql
+++ b/supabase/migrations/00069_add_issued_card_counts_rpc.sql
@@ -1,0 +1,57 @@
+-- Issue #548: 発行上限付きカードの「発行済み枚数」集計をDB側のGROUP BY COUNTへ移す。
+--
+-- 旧実装(GachaService.executeGacha)は、発行上限(max_issuance_count)が設定された
+-- カードIDの集合に対して user_cards を
+--   SELECT card_id FROM user_cards WHERE card_id IN (...)
+-- で「該当行を全件」フェッチし、アプリ側(JS)で card_id ごとに件数を数えていた。
+-- 人気の限定カード(発行数が数千枚に達するもの)ほど、件数を知るためだけに
+-- 数千行をDBからアプリへ転送することになり、発行数が増えるほど線形にI/O・
+-- メモリ・レイテンシが悪化する。
+--
+-- get_issued_card_counts は同じ集計をDB側で GROUP BY / COUNT(*) して、
+-- { "<card_id>": <count>, ... } 形式のJSONBオブジェクト1個だけを返す。
+-- 返却サイズは「発行上限付きカードの種類数」(通常は配信者あたり一桁〜十数件)
+-- に比例し、発行済み枚数そのものには一切依存しなくなる。
+--
+-- user_cards(card_id) には 00001_initial_schema.sql の idx_user_cards_card_id が
+-- 既に存在する(00067/00068 で重複索引が整理済み)ため、新規インデックスは不要。
+-- このインデックスにより WHERE card_id = ANY($1) は索引スキャンで解決できる。
+--
+-- Rewriting the issued-count aggregation from "fetch every matching row and
+-- count client-side" to a single server-side GROUP BY COUNT query. Response
+-- size now scales with the number of distinct limited cards (typically a
+-- handful per streamer), not with how many copies have been issued.
+--
+-- 呼び出し側 (GachaService.getIssuedCounts) は、この関数が無停止デプロイの
+-- 過渡期でまだ存在しない場合 (42883) に、旧来の select+in によるフェッチ→
+-- JS集計へ自動フォールバックする。挙動(Map<card_id, count>の中身)は
+-- 完全に同一のまま維持される。
+
+DROP FUNCTION IF EXISTS get_issued_card_counts(UUID[]);
+
+CREATE OR REPLACE FUNCTION get_issued_card_counts(
+  p_card_ids UUID[]
+)
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT COALESCE(
+    jsonb_object_agg(counts.card_id, counts.issued_count),
+    '{}'::JSONB
+  )
+  FROM (
+    SELECT card_id, COUNT(*)::BIGINT AS issued_count
+    FROM user_cards
+    WHERE card_id = ANY(p_card_ids)
+    GROUP BY card_id
+  ) counts;
+$$;
+
+COMMENT ON FUNCTION get_issued_card_counts(UUID[]) IS
+  '指定した card_id 集合について、user_cards の発行済み枚数を { "<card_id>": <count> } のJSONBオブジェクトとしてDB側でGROUP BY集計して返す(Issue #548)。';
+
+REVOKE ALL ON FUNCTION get_issued_card_counts(UUID[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_issued_card_counts(UUID[]) TO service_role;

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -32,6 +32,39 @@ function createCardsQuery<T extends Record<string, unknown>>(cards: T[]) {
   return q
 }
 
+/**
+ * rpc() の共通モック。Issue #548 以降、発行上限付きカードがあると
+ * executeGacha は execute_gacha_transaction とは別に get_issued_card_counts も
+ * 呼ぶため、単純な単一 mockResolvedValue では両者を区別できない。
+ * 呼ばれた関数名(第1引数)で振り分け、get_issued_card_counts には
+ * issuedCounts (card_id -> 発行済み枚数のプレーンオブジェクト、
+ * get_issued_card_counts RPC の実際の戻り値と同じ形)を返す。
+ * execute_gacha_transaction は呼ばれるたびに transactionResponses を
+ * 1つずつ消費し、最後の要素は使い切った後も繰り返し返す
+ * (`mockResolvedValue` と同じ「以降は同じ値」の挙動)。
+ */
+function createRpcMock(options: {
+  issuedCounts?: Record<string, number>
+  transactionResponses: Array<{ data: unknown; error: { message: string; code?: string } | null }>
+}) {
+  const { issuedCounts = {}, transactionResponses } = options
+  let callIndex = 0
+  // 第2引数(params)を明示的にシグネチャへ含める: これが無いと vi.fn() の型が
+  // 1要素タプル([fnName: string])に推論され、呼び出し側で
+  // `mock.calls[n][1]` (params) にアクセスするコードが型エラーになる。
+  // params 自体はこのモックの分岐に使わないため、`void` で参照だけして
+  // no-unused-vars を満たす(呼び出し側の型安全性のためだけに存在する引数)。
+  return vi.fn((fnName: string, params?: Record<string, unknown>) => {
+    void params
+    if (fnName === 'get_issued_card_counts') {
+      return Promise.resolve({ data: issuedCounts, error: null })
+    }
+    const response = transactionResponses[Math.min(callIndex, transactionResponses.length - 1)]
+    callIndex += 1
+    return Promise.resolve(response)
+  })
+}
+
 describe('GachaService.executeGacha', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -275,22 +308,13 @@ describe('GachaService.executeGacha', () => {
       { id: 'sold-out-card', name: 'Sold Out', description: null, image_url: null, rarity: 'legendary', drop_rate: 100, max_issuance_count: 1 },
       { id: 'available-card', name: 'Available', description: null, image_url: null, rarity: 'common', drop_rate: 1, max_issuance_count: null },
     ] as typeof testCards)
-    const userCardsQuery = createMockQueryBuilder()
-    ;(userCardsQuery as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
-      resolve({ data: [{ card_id: 'sold-out-card' }], error: null })
-      return userCardsQuery
-    }
-    const mockRpc = vi.fn().mockResolvedValue({
-      data: { is_duplicate: false, limit_reached: false, history_id: 'h-1' },
-      error: null,
+    const mockRpc = createRpcMock({
+      issuedCounts: { 'sold-out-card': 1 },
+      transactionResponses: [{ data: { is_duplicate: false, limit_reached: false, history_id: 'h-1' }, error: null }],
     })
 
     mockGetSupabaseAdmin.mockReturnValue({
-      from: vi.fn((table: string) => {
-        if (table === 'cards') return cardsQuery
-        if (table === 'user_cards') return userCardsQuery
-        return createMockQueryBuilder()
-      }),
+      from: vi.fn((table: string) => (table === 'cards' ? cardsQuery : createMockQueryBuilder())),
       rpc: mockRpc,
     } as unknown as ReturnType<typeof getSupabaseAdmin>)
 
@@ -303,53 +327,37 @@ describe('GachaService.executeGacha', () => {
     }))
   })
 
-  it('発行枚数チェッククエリは limitedCards のIDのみに絞り込む（無制限カードIDを含まない）', async () => {
+  it('発行枚数チェックRPCは limitedCards のIDのみに絞り込む（無制限カードIDを含まない）', async () => {
     const cardsQuery = createCardsQuery([
       { id: 'unlimited-card', name: 'Unlimited', description: null, image_url: null, rarity: 'common', drop_rate: 1, max_issuance_count: null },
       { id: 'limited-card', name: 'Limited', description: null, image_url: null, rarity: 'rare', drop_rate: 1, max_issuance_count: 5 },
     ] as typeof testCards)
-    const userCardsQuery = createMockQueryBuilder()
-    const inSpy = vi.spyOn(userCardsQuery, 'in')
-    ;(userCardsQuery as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
-      resolve({ data: [], error: null })
-      return userCardsQuery
-    }
+    const mockRpc = createRpcMock({
+      transactionResponses: [{ data: { is_duplicate: false, history_id: 'h-1' }, error: null }],
+    })
 
     mockGetSupabaseAdmin.mockReturnValue({
-      from: vi.fn((table: string) => {
-        if (table === 'cards') return cardsQuery
-        if (table === 'user_cards') return userCardsQuery
-        return createMockQueryBuilder()
-      }),
-      rpc: vi.fn().mockResolvedValue({ data: { is_duplicate: false, history_id: 'h-1' }, error: null }),
+      from: vi.fn((table: string) => (table === 'cards' ? cardsQuery : createMockQueryBuilder())),
+      rpc: mockRpc,
     } as unknown as ReturnType<typeof getSupabaseAdmin>)
 
     await new GachaService().executeGacha('streamer-1', 'user-1', 'testuser', 'event-query-scope')
 
-    // user_cards の .in() は limitedCards の ID のみで呼ばれる
-    expect(inSpy).toHaveBeenCalledWith('card_id', ['limited-card'])
-    // 無制限カードの ID は含まれない
-    const calledIds = inSpy.mock.calls[0]?.[1] as string[]
-    expect(calledIds).not.toContain('unlimited-card')
+    // get_issued_card_counts RPC は limitedCards の ID のみで呼ばれる(無制限カードIDを含まない)
+    expect(mockRpc).toHaveBeenCalledWith('get_issued_card_counts', { p_card_ids: ['limited-card'] })
   })
 
   it('全カードが発行上限に達している場合はエラーを返す', async () => {
     const cardsQuery = createCardsQuery([
       { id: 'sold-out-card', name: 'Sold Out', description: null, image_url: null, rarity: 'legendary', drop_rate: 100, max_issuance_count: 1 },
     ] as typeof testCards)
-    const userCardsQuery = createMockQueryBuilder()
-    ;(userCardsQuery as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
-      resolve({ data: [{ card_id: 'sold-out-card' }], error: null })
-      return userCardsQuery
-    }
-    const mockRpc = vi.fn()
+    const mockRpc = createRpcMock({
+      issuedCounts: { 'sold-out-card': 1 },
+      transactionResponses: [],
+    })
 
     mockGetSupabaseAdmin.mockReturnValue({
-      from: vi.fn((table: string) => {
-        if (table === 'cards') return cardsQuery
-        if (table === 'user_cards') return userCardsQuery
-        return createMockQueryBuilder()
-      }),
+      from: vi.fn((table: string) => (table === 'cards' ? cardsQuery : createMockQueryBuilder())),
       rpc: mockRpc,
     } as unknown as ReturnType<typeof getSupabaseAdmin>)
 
@@ -360,7 +368,9 @@ describe('GachaService.executeGacha', () => {
     if (!result.success) {
       expect(result.error).toContain('発行可能枚数')
     }
-    expect(mockRpc).not.toHaveBeenCalled()
+    // 発行枚数チェックRPC (get_issued_card_counts) は呼ばれるが、全カード売り切れのため
+    // 抽選トランザクションRPC (execute_gacha_transaction) は呼ばれない
+    expect(mockRpc).not.toHaveBeenCalledWith('execute_gacha_transaction', expect.anything())
   })
 
   it('RPCが発行上限到達を返した場合はカード付与成功にしない', async () => {
@@ -478,21 +488,16 @@ describe('GachaService.executeGacha', () => {
       ]
       const cardsQuery = createCardsQuery(packCards as unknown as typeof testCards)
       // c1はまだ未発行(0/1)なので発行上限フィルタ後も初期プールに残る
-      const userCardsQuery = createMockQueryBuilder()
-      ;(userCardsQuery as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
-        resolve({ data: [], error: null })
-        return userCardsQuery
-      }
-      const mockRpc = vi.fn()
-        .mockResolvedValueOnce({ data: { is_duplicate: false, limit_reached: true }, error: null })
-        .mockResolvedValueOnce({ data: { is_duplicate: false, limit_reached: false, history_id: 'h-effective-retry' }, error: null })
+      const mockRpc = createRpcMock({
+        issuedCounts: {},
+        transactionResponses: [
+          { data: { is_duplicate: false, limit_reached: true }, error: null },
+          { data: { is_duplicate: false, limit_reached: false, history_id: 'h-effective-retry' }, error: null },
+        ],
+      })
 
       mockGetSupabaseAdmin.mockReturnValue({
-        from: vi.fn((table: string) => {
-          if (table === 'cards') return cardsQuery
-          if (table === 'user_cards') return userCardsQuery
-          return createMockQueryBuilder()
-        }),
+        from: vi.fn((table: string) => (table === 'cards' ? cardsQuery : createMockQueryBuilder())),
         rpc: mockRpc,
       } as unknown as ReturnType<typeof getSupabaseAdmin>)
 
@@ -504,9 +509,11 @@ describe('GachaService.executeGacha', () => {
       })
 
       expect(result.success).toBe(true)
-      expect(mockRpc).toHaveBeenCalledTimes(2)
-      const firstCardId = (mockRpc.mock.calls[0][1] as { p_card_id: string }).p_card_id
-      const secondCardId = (mockRpc.mock.calls[1][1] as { p_card_id: string }).p_card_id
+      // 発行枚数チェックRPCの1回 + 抽選トランザクションRPCの2回(1回目はlimit_reached)
+      const transactionCalls = mockRpc.mock.calls.filter(([fnName]) => fnName === 'execute_gacha_transaction')
+      expect(transactionCalls).toHaveLength(2)
+      const firstCardId = (transactionCalls[0][1] as { p_card_id: string }).p_card_id
+      const secondCardId = (transactionCalls[1][1] as { p_card_id: string }).p_card_id
       expect(secondCardId).not.toBe(firstCardId)
       if (result.success) {
         expect(result.data.card.id).toBe(secondCardId)
@@ -519,19 +526,13 @@ describe('GachaService.executeGacha', () => {
         { id: 'card-b', name: 'B', description: null, image_url: null, rarity: 'common', drop_rate: 0.5, max_issuance_count: 1 },
       ] as unknown as typeof testCards)
       // 両カードとも未発行として初期プールに残す
-      const userCardsQuery = createMockQueryBuilder()
-      ;(userCardsQuery as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
-        resolve({ data: [], error: null })
-        return userCardsQuery
-      }
-      const mockRpc = vi.fn().mockResolvedValue({ data: { is_duplicate: false, limit_reached: true }, error: null })
+      const mockRpc = createRpcMock({
+        issuedCounts: {},
+        transactionResponses: [{ data: { is_duplicate: false, limit_reached: true }, error: null }],
+      })
 
       mockGetSupabaseAdmin.mockReturnValue({
-        from: vi.fn((table: string) => {
-          if (table === 'cards') return cardsQuery
-          if (table === 'user_cards') return userCardsQuery
-          return createMockQueryBuilder()
-        }),
+        from: vi.fn((table: string) => (table === 'cards' ? cardsQuery : createMockQueryBuilder())),
         rpc: mockRpc,
       } as unknown as ReturnType<typeof getSupabaseAdmin>)
 
@@ -542,8 +543,9 @@ describe('GachaService.executeGacha', () => {
       if (!result.success) {
         expect(result.error).toBe(CARD_ISSUANCE_MESSAGES.soldOut)
       }
-      // 2枚のプールを2回で使い果たして打ち切られる
-      expect(mockRpc).toHaveBeenCalledTimes(2)
+      // 2枚のプールを2回で使い果たして打ち切られる(発行枚数チェックRPCは別カウント)
+      const transactionCalls = mockRpc.mock.calls.filter(([fnName]) => fnName === 'execute_gacha_transaction')
+      expect(transactionCalls).toHaveLength(2)
     })
 
     it('再試行回数の上限(5回)を超えたら、プールにまだカードが残っていてもsoldOutで打ち切る', async () => {


### PR DESCRIPTION
## 概要

Fixes #548

発行上限カウントの旧実装は該当card_idの`user_cards`行を全件フェッチしJS側で集計しており、人気の限定カードほど転送量が線形に悪化していた。

## 変更内容

- migration 00069: `get_issued_card_counts(UUID[])` RPCがDB側でGROUP BY/COUNT(*)を実行し `{card_id: count}` のJSONBを1個返す
- `GachaService.getIssuedCounts`: RPC未デプロイ(42883)時は旧来のselect+in集計へ自動フォールバック。`Map<card_id, count>`の中身は両経路で完全同一

## テスト（実測）

- 108 files green / eslint clean / `npm run workers:build` 成功（clean worktreeで実測確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn