### PR TITLE
fix(overlay): プレビューへのオプション変更反映をUX改善 (#532)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -704,7 +704,7 @@
       "effects": "Show Effects",
       "effectsDescription": "Show sparkle effects for legendary cards",
       "effectStyle": "Effect Style",
-      "effectStyleDescription": "Choose the animation used for legendary card reveals",
+      "effectStyleDescription": "Choose the animation used for legendary card reveals (only shown for legendary cards)",
       "effectStyles": {
         "sparkle": "Sparkles",
         "confetti": "Confetti",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -704,7 +704,7 @@
       "effects": "エフェクト表示",
       "effectsDescription": "レジェンダリーカードのキラキラエフェクトを表示",
       "effectStyle": "エフェクト種類",
-      "effectStyleDescription": "レジェンダリーカード表示時の演出を選択します",
+      "effectStyleDescription": "レジェンダリーカード表示時の演出を選択します（レジェンダリーカードにのみ表示されます）",
       "effectStyles": {
         "sparkle": "キラキラ",
         "confetti": "紙吹雪",

--- a/src/components/OverlayPreview.tsx
+++ b/src/components/OverlayPreview.tsx
@@ -44,6 +44,19 @@ const DEFAULT_OVERLAY_OPTIONS: OverlayOptions = {
 
 const OVERLAY_OPTIONS_STORAGE_KEY_PREFIX = "twica:overlay-options:";
 
+/**
+ * Issue #532: オプション変更はiframeのURLに正しく反映されていたが、オーバーレイは
+ * カード非表示中は透明な背景のみのため、変更してもユーザーが見た目の変化に
+ * 気づけないUX問題があった。デモ実行直後の一定時間内にオプションを変更した場合は
+ * 自動でプレビューDEMOを再実行し、変更が視覚的にすぐ確認できるようにする。
+ *
+ * この時間を超えた変更では自動発火しない（無関係なタイミングでカードが
+ * 勝手に出るのを防ぐ）。
+ */
+const RECENT_DEMO_WINDOW_MS = 30_000;
+/** スライダー操作等の連続的なオプション変更を1回の再デモにまとめるデバウンス時間 */
+const AUTO_REDEMO_DEBOUNCE_MS = 800;
+
 function readStoredBoolean(value: unknown, fallback: boolean) {
   return typeof value === "boolean" ? value : fallback;
 }
@@ -148,6 +161,15 @@ export default function OverlayPreview({
   // iframeの参照（DEMOボタン用）
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
+  // Issue #532: 直近にプレビューDEMOを実行した時刻（自動再デモの判定に使用）
+  // null の場合はまだ一度もデモを実行していないことを表す。
+  // 初回表示やOBS URLをコピーしただけの利用では勝手にカードを出さないためのガードとして使う。
+  const lastDemoAtRef = useRef<number | null>(null);
+  // 自動再デモのデバウンス用タイマーID
+  const autoRedemoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // オプション変更の初回検知フラグ（URL更新メッセージ用のisFirstRenderとは別管理）
+  const isFirstOptionsChange = useRef(true);
+
   // デバッグ用：選択されたカードID（"random"でランダム、カードIDで特定のカード）
   // Debug: selected card ID for demo/gacha ("random" for random selection, card ID for specific card)
   const [selectedCardId, setSelectedCardId] = useState<string>("random");
@@ -170,6 +192,13 @@ export default function OverlayPreview({
   useEffect(() => {
     isFirstRender.current = true;
     setShowUrlUpdated(false);
+    // 配信者切り替え（storageKey変更）時は直近デモ状態も引き継がずリセットする
+    isFirstOptionsChange.current = true;
+    lastDemoAtRef.current = null;
+    if (autoRedemoTimerRef.current) {
+      clearTimeout(autoRedemoTimerRef.current);
+      autoRedemoTimerRef.current = null;
+    }
   }, [storageKey]);
 
   // ブラウザごとに最後に使ったオーバーレイ設定を復元する
@@ -286,8 +315,54 @@ export default function OverlayPreview({
         demoUrl += `&cardId=${selectedCardId}`;
       }
       iframeRef.current.src = demoUrl;
+      // Issue #532: 自動再デモの起点として実行時刻を記録する
+      lastDemoAtRef.current = Date.now();
     }
   }, [overlayUrl, urlParams, selectedCardId]);
+
+  // triggerDemoの最新版を常に参照できるようにするref。
+  // 自動再デモのuseEffectはselectedCardId変更（triggerDemoの依存の一つ）では
+  // 再発火させたくない（対象はあくまで「表示オプション」の変更のため）ので、
+  // 関数そのものをeffectの依存に含めず、refで最新のクロージャを参照する。
+  const triggerDemoRef = useRef(triggerDemo);
+  useEffect(() => {
+    triggerDemoRef.current = triggerDemo;
+  }, [triggerDemo]);
+
+  // Issue #532: デモ実行後にオプションを変更した場合、iframeのURL自体は
+  // 正しく更新されていても、カードが表示されていないアイドル状態では見た目が
+  // 変わらずユーザーが変化に気づけない。直近にプレビューDEMOを実行していた
+  // 場合のみ、オプション変更をデバウンスして自動的にプレビューDEMOを再実行する。
+  // - デモを一度も実行していない場合（初回表示・OBS URLコピーのみの利用等）は発火しない
+  // - 直近のデモから RECENT_DEMO_WINDOW_MS を超えている場合も発火しない（無関係な変更で
+  //   勝手にカードが出るのを防ぐ）
+  // - urlParams は options の全フィールドを反映して生成されるため、これを監視すれば
+  //   表示に影響するオプション変更を過不足なく検知できる
+  useEffect(() => {
+    if (initializedStorageKey !== storageKey) {
+      return;
+    }
+    if (isFirstOptionsChange.current) {
+      isFirstOptionsChange.current = false;
+      return;
+    }
+    if (lastDemoAtRef.current === null || Date.now() - lastDemoAtRef.current > RECENT_DEMO_WINDOW_MS) {
+      return;
+    }
+    if (autoRedemoTimerRef.current) {
+      clearTimeout(autoRedemoTimerRef.current);
+    }
+    autoRedemoTimerRef.current = setTimeout(() => {
+      triggerDemoRef.current();
+    }, AUTO_REDEMO_DEBOUNCE_MS);
+    return () => {
+      if (autoRedemoTimerRef.current) {
+        clearTimeout(autoRedemoTimerRef.current);
+      }
+    };
+    // triggerDemoRef経由で最新のtriggerDemoを参照するため、triggerDemo自体をこのeffectの
+    // 依存に含める必要はない（含めるとselectedCardId変更だけでも誤発火してしまう）。
+  }, [initializedStorageKey, storageKey, urlParams]);
 
   // OBS DEMOを実行（Supabase Realtimeでブロードキャスト）
   // OBSに設定したオーバーレイにも反映される
@@ -356,6 +431,27 @@ export default function OverlayPreview({
       ...prev,
       [key]: !prev[key],
     }));
+  };
+
+  // アクティブなカードのみフィルタリング（デモ/ガチャで使用）
+  // Filter only active cards for demo/gacha
+  const activeCards = cards.filter(card => card.is_active);
+
+  // Issue #532: effectStyle（confetti/hearts等）はlegendaryカードにのみ表示される
+  // （overlay page側の shouldShowEffects 条件）ため、ランダムデモがlegendary以外を
+  // 引くと変更してもエフェクトが確認できない。効果種類を変えたら、選択可能な
+  // legendaryカードがあればプレビュー用カードを自動的にそちらへ寄せる。
+  // legendaryカードが存在しない場合は選択を変更しない（存在しないカードを捏造しない）。
+  const handleEffectStyleChange = (value: string) => {
+    setOptions(prev => ({
+      ...prev,
+      effectStyle: readStoredEffectStyle(value),
+    }));
+
+    const legendaryCard = activeCards.find((card) => card.rarity === "legendary");
+    if (legendaryCard) {
+      setSelectedCardId(legendaryCard.id);
+    }
   };
 
   // URLセクションのコンテンツ
@@ -478,10 +574,7 @@ export default function OverlayPreview({
               <select
                 aria-label={t("options.effectStyle")}
                 value={options.effectStyle}
-                onChange={(e) => setOptions(prev => ({
-                  ...prev,
-                  effectStyle: readStoredEffectStyle(e.target.value),
-                }))}
+                onChange={(e) => handleEffectStyleChange(e.target.value)}
                 className="w-full rounded-lg border border-gray-600 bg-gray-700 px-3 py-2 text-sm text-white focus:border-purple-500 focus:outline-none"
               >
                 {OVERLAY_EFFECT_STYLES.map((style) => (
@@ -626,10 +719,6 @@ export default function OverlayPreview({
       </div>
     </div>
   );
-
-  // アクティブなカードのみフィルタリング（デモ/ガチャで使用）
-  // Filter only active cards for demo/gacha
-  const activeCards = cards.filter(card => card.is_active);
 
   // プレビューセクションのコンテンツ
   // Preview section content

--- a/tests/unit/components/overlay-preview.test.tsx
+++ b/tests/unit/components/overlay-preview.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { NextIntlClientProvider } from 'next-intl'
 import OverlayPreview from '@/components/OverlayPreview'
+import type { Card } from '@/types/database'
 
 const STORAGE_KEY = 'twica:overlay-options:streamer-1'
 
@@ -67,6 +68,33 @@ const renderWithIntl = (component: React.ReactElement) => {
   )
 }
 
+// Issue #532 のテスト用カードフィクスチャ。tests/unit/components/sorted-card-grid.test.tsx の
+// baseCard パターンを踏襲し、Card型の必須フィールドを一箇所にまとめる。
+const baseCard = (overrides: Partial<Card>): Card => ({
+  id: 'card-1',
+  streamer_id: 'streamer-1',
+  name: 'カードA',
+  description: null,
+  image_url: null,
+  rarity: 'common',
+  card_number: null,
+  max_issuance_count: null,
+  collection_name: null,
+  drop_rate: 25,
+  intra_rarity_weight: 1,
+  is_active: true,
+  hp: 10,
+  atk: 5,
+  def: 5,
+  spd: 5,
+  skill_type: 'attack',
+  skill_name: 'たいあたり',
+  skill_power: 10,
+  created_at: '2026-04-01T00:00:00Z',
+  updated_at: '2026-04-01T00:00:00Z',
+  ...overrides,
+})
+
 function createLocalStorageMock() {
   const store = new Map<string, string>()
 
@@ -98,6 +126,8 @@ describe('OverlayPreview', () => {
     // vi.stubGlobal で書き換えた window.localStorage を必ずリセットし、
     // 同一プロセス内の他テストファイルへ漏出しないようにする
     vi.unstubAllGlobals()
+    // 一部テストで vi.useFakeTimers() を使うため、他テストへ影響しないよう必ず実タイマーへ戻す
+    vi.useRealTimers()
   })
 
   it('localStorage に保存されたオーバーレイ設定を復元する', async () => {
@@ -247,6 +277,148 @@ describe('OverlayPreview', () => {
       expect(savedOptions).toMatchObject({
         effectStyle: 'confetti',
       })
+    })
+  })
+
+  // Issue #532: オプション変更はiframeのURLには正しく反映されるが、カード非表示中は
+  // 見た目が変わらずユーザーが変化に気づけない。デモ実行直後のオプション変更では
+  // 自動的にプレビューDEMOを再実行し、変更を視覚的に確認できるようにする。
+  describe('Issue #532: デモ実行後のオプション変更で自動再デモ', () => {
+    it('プレビューDEMO実行後にオプションを変更すると、デバウンス後に自動的にプレビューDEMOを再実行する', async () => {
+      vi.useFakeTimers()
+
+      renderWithIntl(
+        <OverlayPreview streamerId="streamer-1" baseUrl="https://example.com" />
+      )
+
+      const iframe = screen.getByTitle('Overlay Preview') as HTMLIFrameElement
+
+      // まず手動でプレビューDEMOを実行する
+      fireEvent.click(screen.getByRole('button', { name: 'プレビューDEMO' }))
+      expect(iframe.src).toContain('demo=true')
+
+      // オプションを変更する（imageOnlyをON）
+      // iframeのsrcはReactが制御するprop（overlayUrlWithParams）にも束縛されているため、
+      // オプション変更直後は通常の再レンダリングで一旦demoパラメータなしのURLに戻る
+      // （triggerDemoによるsrcへの命令的な上書きがReactの再レンダリングで上書き返されるため）。
+      fireEvent.click(screen.getByRole('button', { name: 'オーバーレイカスタマイズ' }))
+      fireEvent.click(screen.getByText('正方形でも画像のみ表示'))
+
+      // デバウンス時間が経過するまでは自動再デモ（demo=trueの付与）はまだ起きない
+      expect(iframe.src).toContain('imageOnly=true')
+      expect(iframe.src).not.toContain('demo=true')
+
+      // デバウンス（800ms）経過後、自動的にプレビューDEMOが再実行され、
+      // 変更後のオプション（imageOnly=true）が反映されたURLになる
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(800)
+      })
+
+      expect(iframe.src).toContain('imageOnly=true')
+      expect(iframe.src).toContain('demo=true')
+    })
+
+    it('プレビューDEMOを一度も実行していない場合はオプションを変更しても自動的に再デモしない', async () => {
+      vi.useFakeTimers()
+
+      renderWithIntl(
+        <OverlayPreview streamerId="streamer-1" baseUrl="https://example.com" />
+      )
+
+      const iframe = screen.getByTitle('Overlay Preview') as HTMLIFrameElement
+
+      // プレビューDEMOは実行せず、オプションのみ変更する
+      fireEvent.click(screen.getByRole('button', { name: 'オーバーレイカスタマイズ' }))
+      fireEvent.click(screen.getByText('正方形でも画像のみ表示'))
+
+      // デバウンス時間を十分超えて待つ
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000)
+      })
+
+      // iframeのsrcはoptions変更を通常通り反映するが、demo=trueは付与されない
+      // （自動デモが誤って発火していないことの確認）
+      expect(iframe.src).toContain('imageOnly=true')
+      expect(iframe.src).not.toContain('demo=true')
+    })
+
+    it('デモ実行から30秒より後のオプション変更では自動的に再デモしない', async () => {
+      vi.useFakeTimers()
+
+      renderWithIntl(
+        <OverlayPreview streamerId="streamer-1" baseUrl="https://example.com" />
+      )
+
+      const iframe = screen.getByTitle('Overlay Preview') as HTMLIFrameElement
+
+      fireEvent.click(screen.getByRole('button', { name: 'プレビューDEMO' }))
+      expect(iframe.src).toContain('demo=true')
+
+      // 直近デモから30秒(RECENT_DEMO_WINDOW_MS)を超えて時間が経過
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_001)
+      })
+      const srcBeforeOptionChange = iframe.src
+
+      fireEvent.click(screen.getByRole('button', { name: 'オーバーレイカスタマイズ' }))
+      fireEvent.click(screen.getByText('正方形でも画像のみ表示'))
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000)
+      })
+
+      // 30秒ウィンドウを過ぎているため、iframeのsrcはデモ再実行によっては変わらない
+      // （通常のoptions反映によるURL更新は起きるため、demo=trueが付与されないことを確認する）
+      expect(iframe.src).not.toBe(srcBeforeOptionChange)
+      expect(iframe.src).toContain('imageOnly=true')
+      expect(iframe.src).not.toContain('demo=true')
+    })
+  })
+
+  // Issue #532: effectStyle（confetti/hearts等）はlegendaryカードにのみ表示されるため、
+  // ランダムデモがlegendary以外を引くと変更してもエフェクトが確認できない。
+  // 効果種類の変更時にlegendaryカードがあれば自動的にプレビュー用カードへ寄せる。
+  describe('Issue #532: エフェクト種類変更時のlegendaryカード自動選択', () => {
+    it('legendaryカードが存在する場合、エフェクト種類を変更するとそのカードが自動選択される', async () => {
+      const cards: Card[] = [
+        baseCard({ id: 'common-1', name: 'コモンカード', rarity: 'common' }),
+        baseCard({ id: 'legendary-1', name: 'レジェンダリーカード', rarity: 'legendary' }),
+      ]
+
+      renderWithIntl(
+        <OverlayPreview streamerId="streamer-1" baseUrl="https://example.com" cards={cards} />
+      )
+
+      // 変更前はデフォルトの「ランダム」が選択されている
+      expect(screen.getByDisplayValue('ランダム')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole('button', { name: 'オーバーレイカスタマイズ' }))
+      fireEvent.change(screen.getByLabelText('エフェクト種類'), { target: { value: 'confetti' } })
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('レジェンダリーカード (legendary)')).toBeInTheDocument()
+      })
+    })
+
+    it('legendaryカードが存在しない場合、エフェクト種類を変更してもカード選択は変わらない', async () => {
+      const cards: Card[] = [
+        baseCard({ id: 'common-1', name: 'コモンカード', rarity: 'common' }),
+        baseCard({ id: 'rare-1', name: 'レアカード', rarity: 'rare' }),
+      ]
+
+      renderWithIntl(
+        <OverlayPreview streamerId="streamer-1" baseUrl="https://example.com" cards={cards} />
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'オーバーレイカスタマイズ' }))
+      fireEvent.change(screen.getByLabelText('エフェクト種類'), { target: { value: 'confetti' } })
+
+      await waitFor(() => {
+        expect(screen.getByDisplayValue('https://example.com/overlay/streamer-1?effect=confetti')).toBeInTheDocument()
+      })
+
+      // legendaryカードが存在しないため、カード選択はデフォルトの「ランダム」のまま
+      expect(screen.getByDisplayValue('ランダム')).toBeInTheDocument()
     })
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,17 @@ export default defineConfig({
     include: ['tests/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['node_modules', '.next', 'dist'],
     environment: 'happy-dom',
+    // Issue #532: OverlayPreviewのiframeテストでsrcを実際に書き換えると、happy-domが
+    // 本物のネットワークfetchを試みてしまう（サンドボックス環境ではNetworkErrorのstderrノイズ、
+    // 実ネットワークがあるCIでは意図しない外部通信・遅延の原因になる）。
+    // iframeの実ページ読み込みを無効化し、単体テストがネットワークに依存しないようにする。
+    environmentOptions: {
+      happyDOM: {
+        settings: {
+          disableIframePageLoading: true,
+        },
+      },
+    },
     globals: true,
     setupFiles: ['tests/setup.ts'],
     // プロセスリーク対策: タイムアウトとクリーンアップ設定


### PR DESCRIPTION
## 概要

Fixes #532

調査結果（issue記載）: iframe URL更新は正しく動作していたが、カード非表示のアイドル状態は透明背景のみのためオプション変更の効果に気づけないUX問題。

## 変更内容

- 直近30秒以内にデモ実行していた場合、オプション変更を800msデバウンスして自動的にプレビューDEMOを再実行
- エフェクトスタイル変更時、レジェンダリー限定エフェクト（#587）を確認できるようプレビュー対象カードを自動フォーカス
- happy-domのiframeページ読み込みを無効化（テストのネットワーク非依存化）

## テスト（実測）

- vitest.config.tsのグローバル変更含め108 files/1228 tests green / eslint clean / `npm run workers:build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn