### PR TITLE
feat(cards): 発行済み枚数・残余枚数をCardManagerに表示 (#542)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -156,8 +156,14 @@
       "rarity": "Rarity",
       "weight": "Weight",
       "probability": "Probability",
+      "issuance": "Issued",
       "status": "Status",
       "actions": "Actions"
+    },
+    "issuance": {
+      "issuedOfMax": "{issued} / {max} issued",
+      "soldOut": "Sold out",
+      "lowRemaining": "Low stock"
     },
     "status": {
       "distributing": "Active",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -156,8 +156,14 @@
       "rarity": "レアリティ",
       "weight": "重み",
       "probability": "確率",
+      "issuance": "発行数",
       "status": "ステータス",
       "actions": "操作"
+    },
+    "issuance": {
+      "issuedOfMax": "{issued} / {max} 発行済み",
+      "soldOut": "売り切れ",
+      "lowRemaining": "残りわずか"
     },
     "status": {
       "distributing": "配布中",

--- a/src/app/api/cards/route.ts
+++ b/src/app/api/cards/route.ts
@@ -332,6 +332,68 @@ type SortDirection = typeof VALID_SORT_DIRECTIONS[number];
 const VALID_STATUS_FILTERS = ["all", "active", "inactive"] as const;
 type StatusFilter = typeof VALID_STATUS_FILTERS[number];
 
+// Issue #542: cards一覧に「発行済み枚数」を付与する際に参照する最小限の形状
+// Minimal shape needed to attach issued counts to a cards-list row
+type CardWithIssuanceLimit = { id: string; max_issuance_count?: number | null };
+
+/**
+ * Issue #542 (CardManagerで発行済み枚数・残余枚数を表示する):
+ * max_issuance_count が設定された「限定カード」のみ、user_cards から発行済み
+ * 枚数を取得して issued_count として付与する。
+ *
+ * - 限定カードが0件（大多数のケース = 無制限カードのみ）なら user_cards への
+ *   問い合わせ自体をスキップし、不要なDB負荷を避ける（Issueの受け入れ条件）。
+ * - Supabase(PostgREST)クライアントは任意のGROUP BY集計をサポートしないため、
+ *   対象カードのuser_cards.card_idを1クエリで取得し、アプリ側でCOUNTする
+ *   （Issue #548と同様の「limited-card subsetのみ対象にする」考え方）。
+ *   行数は対象カードの発行上限に頭打ちされるため、無制限カードを含む全件
+ *   カウントより大幅に軽い。
+ * - 取得に失敗してもカード一覧自体は返す（ベストエフォート）。issued_countが
+ *   付与されないだけで、UI側は無制限カードと同様に枚数表示をスキップする。
+ *
+ * Only cards with max_issuance_count set ("limited cards") get an issued_count
+ * looked up from user_cards. Skips the query entirely when there are no limited
+ * cards on the page (the common case) to avoid unnecessary DB load. PostgREST
+ * has no arbitrary GROUP BY, so we fetch card_id rows for the limited subset in
+ * a single query and COUNT them in application code (bounded by each card's
+ * issuance cap, not the whole table). Failures are best-effort: the card list
+ * is still returned, just without issued_count.
+ */
+async function attachIssuedCounts<T extends CardWithIssuanceLimit>(
+  supabaseAdmin: ReturnType<typeof getSupabaseAdmin>,
+  cards: T[]
+): Promise<Array<T & { issued_count?: number }>> {
+  const limitedCardIds = cards
+    .filter((card) => card.max_issuance_count !== null && card.max_issuance_count !== undefined)
+    .map((card) => card.id);
+
+  if (limitedCardIds.length === 0) {
+    return cards;
+  }
+
+  const { data: issuedRows, error } = await supabaseAdmin
+    .from("user_cards")
+    .select("card_id")
+    .in("card_id", limitedCardIds);
+
+  if (error) {
+    logger.error("Cards API: Failed to fetch issued counts (Issue #542)", error);
+    return cards;
+  }
+
+  const issuedCounts = new Map<string, number>();
+  for (const row of (issuedRows || []) as { card_id: string }[]) {
+    issuedCounts.set(row.card_id, (issuedCounts.get(row.card_id) || 0) + 1);
+  }
+
+  return cards.map((card) => {
+    if (card.max_issuance_count === null || card.max_issuance_count === undefined) {
+      return card;
+    }
+    return { ...card, issued_count: issuedCounts.get(card.id) ?? 0 };
+  });
+}
+
 /**
  * Internal function to fetch cards from database (used for caching)
  * データベースからカードを取得する内部関数（キャッシュ用）
@@ -406,9 +468,15 @@ async function fetchCardsFromDB(
   }
   if (error) throw error;
 
+  // Issue #542: 限定カードにのみ発行済み枚数(issued_count)を付与する
+  const cardsWithIssuedCounts = await attachIssuedCounts(
+    supabaseAdmin,
+    normalizeDropRate((cards || []) as Array<{ drop_rate: unknown } & CardWithIssuanceLimit>)
+  );
+
   logger.info(`[Perf] fetchCardsFromDB: ${Date.now() - start}ms (${cards?.length || 0} cards)`);
 
-  return { cards: normalizeDropRate(cards || []), count };
+  return { cards: cardsWithIssuedCounts, count };
 }
 
 export async function GET(request: NextRequest) {

--- a/src/components/CardList.tsx
+++ b/src/components/CardList.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import type { Card, Rarity } from "@/types/database";
 import { formatRarityLabel, getRarityDisplayInfo } from "@/lib/rarity";
 import { getOptimizedImageUrl } from "@/lib/image-utils";
+import { getIssuanceInfo } from "@/lib/card-issuance";
 import ExpandableDescription from "./ExpandableDescription";
 
 interface CardListProps {
@@ -115,6 +116,9 @@ export default function CardList({
             {/* 確率列：固定幅 80px */}
             {/* Probability column: fixed width 80px */}
             <th className="px-4 py-3 w-20">{t("table.probability")}</th>
+            {/* 発行数列：固定幅 112px（Issue #542。無制限カードは"-"のみで空欄） */}
+            {/* Issuance column: fixed width 112px (Issue #542. Shows "-" for unlimited cards) */}
+            <th className="px-4 py-3 w-28">{t("table.issuance")}</th>
             {/* ステータス列：固定幅 100px */}
             {/* Status column: fixed width 100px */}
             <th className="px-4 py-3 w-24">{t("table.status")}</th>
@@ -130,6 +134,8 @@ export default function CardList({
             // First 4 rows get priority for LCP optimization
             // 最初の4行はLCP最適化のためpriority設定
             const isPriority = index < 4;
+            // Issue #542: limited-issuance cards only (null for unlimited cards)
+            const issuanceInfo = getIssuanceInfo(card.max_issuance_count, card.issued_count);
 
             return (
               <tr
@@ -226,6 +232,38 @@ export default function CardList({
                 {/* 出現確率（重みから計算された実際の確率） */}
                 <td className="px-4 py-3 text-sm text-green-400 font-medium">
                   {calculateActualProbability(card)}
+                </td>
+
+                {/* Issued / max issuance count (Issue #542) */}
+                {/* 発行済み / 発行可能枚数（Issue #542） */}
+                <td className="px-4 py-3 text-sm">
+                  {issuanceInfo ? (
+                    <div className="flex flex-col items-start gap-1">
+                      <span
+                        className={
+                          issuanceInfo.soldOut
+                            ? "font-medium text-red-400"
+                            : issuanceInfo.lowRemaining
+                              ? "font-medium text-yellow-400"
+                              : "text-gray-300"
+                        }
+                      >
+                        {t("issuance.issuedOfMax", { issued: issuanceInfo.issued, max: issuanceInfo.max })}
+                      </span>
+                      {issuanceInfo.soldOut && (
+                        <span className="inline-flex items-center rounded-full bg-red-500/20 px-2 py-0.5 text-xs text-red-400">
+                          {t("issuance.soldOut")}
+                        </span>
+                      )}
+                      {!issuanceInfo.soldOut && issuanceInfo.lowRemaining && (
+                        <span className="inline-flex items-center rounded-full bg-yellow-500/20 px-2 py-0.5 text-xs text-yellow-400">
+                          {t("issuance.lowRemaining")}
+                        </span>
+                      )}
+                    </div>
+                  ) : (
+                    <span className="text-gray-500">-</span>
+                  )}
                 </td>
 
                 {/* Status */}

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -14,7 +14,7 @@ import { DEFAULT_PACK_SENTINEL } from "@/lib/validation/collection-name";
 import { cardMatchesPackKey } from "@/lib/collection-packs";
 import { computeEffectiveWeights, resolveRarityWeightsForPool } from "@/lib/rarity-weight-calculator";
 import { isAllowedCardUploadFile, shouldPreserveOriginalCardUpload } from "@/lib/card-upload-mode";
-import { MAX_ISSUANCE_COUNT_CAP } from "@/lib/card-issuance";
+import { MAX_ISSUANCE_COUNT_CAP, getIssuanceInfo } from "@/lib/card-issuance";
 import ImageCropper, { type CropMode, getCropModes } from "./ImageCropper";
 import CardViewToggle, { type ViewMode } from "./CardViewToggle";
 import CardList from "./CardList";
@@ -2364,19 +2364,42 @@ export default function CardManager({
                   // First 4 cards get priority for LCP optimization
                   // 最初の4枚のカードはLCP最適化のためpriority設定
                   const isPriority = index < 4;
+                  // Issue #542: 上限付きカードのみ発行済み/上限を計算（無制限カードはnull）
+                  const issuanceInfo = getIssuanceInfo(card.max_issuance_count, card.issued_count);
+                  // 既存の「配布停止中」バナー（絶対配置・カード上部フルwidth）と同じ
+                  // 見た目で「売り切れ/残りわずか」も積み重ねて表示する。両方同時に
+                  // 該当するケース（配布停止中 かつ 売り切れ、等）もあり得るため、
+                  // 表示すべきバナーを配列に集約してから描画する。
+                  // Reuse the existing "paused" top banner styling for sold-out /
+                  // low-remaining state. Both can be true at once (e.g. paused AND
+                  // sold out), so collect the banners to render into an array first.
+                  const banners: { key: string; className: string; label: string }[] = [];
+                  if (isPaused) {
+                    banners.push({ key: "paused", className: "bg-yellow-600", label: t("status.paused") });
+                  }
+                  if (issuanceInfo?.soldOut) {
+                    banners.push({ key: "soldOut", className: "bg-red-600", label: t("issuance.soldOut") });
+                  } else if (issuanceInfo?.lowRemaining) {
+                    banners.push({ key: "lowRemaining", className: "bg-yellow-700", label: t("issuance.lowRemaining") });
+                  }
                   return (
                     <div
                       key={card.id}
-                      className={`group relative overflow-hidden rounded-lg bg-gray-700 ${isPaused ? 'opacity-60' : ''}`}
+                      className={`group relative overflow-hidden rounded-lg bg-gray-700 ${isPaused || issuanceInfo?.soldOut ? 'opacity-60' : ''}`}
                     >
-                      {/* Paused badge / 一時停止中バッジ */}
-                      {isPaused && (
-                        <div className="absolute top-0 left-0 right-0 bg-yellow-600 text-white text-xs text-center py-1 z-10">
-                          {t("status.paused")}
+                      {/* Paused / sold-out / low-remaining banners (stacked) */}
+                      {/* 配布停止中・売り切れ・残りわずかバッジ（積み重ね表示） */}
+                      {banners.length > 0 && (
+                        <div className="absolute top-0 left-0 right-0 z-10">
+                          {banners.map((banner) => (
+                            <div key={banner.key} className={`${banner.className} text-white text-xs text-center py-1`}>
+                              {banner.label}
+                            </div>
+                          ))}
                         </div>
                       )}
                       {/* 名前とレアリティを一番上に配置 */}
-                      <div className={`p-3 pb-2 ${isPaused ? 'pt-8' : ''}`}>
+                      <div className={`p-3 pb-2 ${banners.length === 2 ? 'pt-16' : banners.length === 1 ? 'pt-8' : ''}`}>
                         <div className="flex items-center justify-between">
                           <h3 className="font-semibold text-white truncate">{card.name}</h3>
                           <span
@@ -2385,6 +2408,21 @@ export default function CardManager({
                             {getRarityLabel(card.rarity)}
                           </span>
                         </div>
+                        {/* 発行済み / 発行可能枚数（Issue #542。無制限カードは非表示） */}
+                        {/* Issued / max issuance count (Issue #542. Hidden for unlimited cards) */}
+                        {issuanceInfo && (
+                          <p
+                            className={`mt-1 text-xs ${
+                              issuanceInfo.soldOut
+                                ? "text-red-400"
+                                : issuanceInfo.lowRemaining
+                                  ? "text-yellow-400"
+                                  : "text-gray-400"
+                            }`}
+                          >
+                            {t("issuance.issuedOfMax", { issued: issuanceInfo.issued, max: issuanceInfo.max })}
+                          </p>
+                        )}
                       </div>
                       {/* 正方形画像（トリミング） */}
                       {/* 画像がある場合のみクリック可能なボタンでラップし、拡大モーダルを開く */}

--- a/src/lib/card-issuance.ts
+++ b/src/lib/card-issuance.ts
@@ -62,3 +62,50 @@ export function isMissingCardIssuanceColumnError(error: unknown): boolean {
     err.code === "PGRST204"
   );
 }
+
+// Issue #542: 配信者がCardManagerで「あと何枚発行できるか」を一目で把握できる
+// よう、上限付きカードの発行済み枚数から売り切れ/残りわずかを判定する。
+// 閾値(10%)はIssue本文の受け入れ条件「残り10%以下のカードに警告表示」に合わせた。
+// Determines sold-out / low-remaining state for a limited-issuance card so
+// CardManager can surface it. Threshold (10%) matches the issue's acceptance
+// criteria ("残り10%以下のカードに警告表示がある").
+export const LOW_REMAINING_THRESHOLD_RATIO = 0.1;
+
+export interface IssuanceInfo {
+  // 発行可能枚数の上限（呼び出し元がnull/undefinedを弾いた後の非null値）
+  max: number;
+  // 現在の発行済み枚数
+  issued: number;
+  // 上限に到達済みか（issued >= max）
+  soldOut: boolean;
+  // 残り枚数が上限の10%以下か（soldOutの場合はfalse。売り切れ表示と警告表示を
+  // 同時に出さないための排他制御）
+  lowRemaining: boolean;
+}
+
+/**
+ * カードの発行状況（売り切れ/残りわずか）を判定する。
+ * max_issuance_count が null/undefined（無制限カード）の場合は null を返し、
+ * 呼び出し元（CardList/CardManagerのグリッド表示）で枚数表示自体を出さない
+ * ようにする。
+ *
+ * Computes issuance status (sold out / low remaining) for a card.
+ * Returns null for unlimited cards (max_issuance_count is null/undefined) so
+ * callers (CardList / CardManager thumbnail grid) skip rendering the count
+ * entirely.
+ */
+export function getIssuanceInfo(
+  maxIssuanceCount: number | null | undefined,
+  issuedCount: number | null | undefined
+): IssuanceInfo | null {
+  if (maxIssuanceCount === null || maxIssuanceCount === undefined) return null;
+
+  const issued = issuedCount ?? 0;
+  const soldOut = issued >= maxIssuanceCount;
+  const lowRemaining =
+    !soldOut &&
+    maxIssuanceCount > 0 &&
+    (maxIssuanceCount - issued) / maxIssuanceCount <= LOW_REMAINING_THRESHOLD_RATIO;
+
+  return { max: maxIssuanceCount, issued, soldOut, lowRemaining };
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -759,7 +759,17 @@ export interface Database {
 
 // Helper types
 export type Streamer = Database['public']['Tables']['streamers']['Row']
-export type Card = Database['public']['Tables']['cards']['Row']
+// Issue #542: issued_count is not a DB column — it's computed by GET /api/cards
+// (COUNT of user_cards grouped by card_id) and attached only to cards that have
+// max_issuance_count set. Unlimited cards omit the field entirely to avoid the
+// extra join/response payload for the common case.
+// issued_countはDBカラムではなく、GET /api/cardsが計算して付与するフィールド
+// （user_cardsをcard_idでグルーピングしたCOUNT）。max_issuance_countが設定された
+// カードのみに付与される。無制限カードでは不要なJOIN/レスポンス増を避けるため
+// フィールド自体を省略する。
+export type Card = Database['public']['Tables']['cards']['Row'] & {
+  issued_count?: number
+}
 export type User = Database['public']['Tables']['users']['Row']
 export type UserCard = Database['public']['Tables']['user_cards']['Row']
 export type GachaHistory = Database['public']['Tables']['gacha_history']['Row']

--- a/tests/unit/card-issuance.test.ts
+++ b/tests/unit/card-issuance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isMissingCardIssuanceColumnError, parseCardIssuanceLimit } from '@/lib/card-issuance'
+import { getIssuanceInfo, isMissingCardIssuanceColumnError, parseCardIssuanceLimit } from '@/lib/card-issuance'
 
 describe('parseCardIssuanceLimit', () => {
   it('treats empty values as unlimited', () => {
@@ -49,5 +49,44 @@ describe('isMissingCardIssuanceColumnError', () => {
       code: 'PGRST204',
       message: "Could not find the 'card_number' column of 'cards' in the schema cache",
     })).toBe(false)
+  })
+})
+
+// Issue #542: CardManagerで発行済み枚数・残余枚数を表示する
+describe('getIssuanceInfo', () => {
+  it('returns null for unlimited cards (max_issuance_count is null/undefined)', () => {
+    expect(getIssuanceInfo(null, 5)).toBeNull()
+    expect(getIssuanceInfo(undefined, 5)).toBeNull()
+  })
+
+  it('reports neither soldOut nor lowRemaining well below the limit', () => {
+    expect(getIssuanceInfo(10, 3)).toEqual({ max: 10, issued: 3, soldOut: false, lowRemaining: false })
+  })
+
+  it('treats a missing issued count as 0', () => {
+    expect(getIssuanceInfo(10, null)).toEqual({ max: 10, issued: 0, soldOut: false, lowRemaining: false })
+    expect(getIssuanceInfo(10, undefined)).toEqual({ max: 10, issued: 0, soldOut: false, lowRemaining: false })
+  })
+
+  // 受け入れ条件: 残り10%以下のカードに警告表示がある
+  it('flags lowRemaining once remaining stock drops to 10% or below', () => {
+    // 残り 1/10 = 10% ちょうど → 該当
+    expect(getIssuanceInfo(10, 9)).toEqual({ max: 10, issued: 9, soldOut: false, lowRemaining: true })
+    // 残り 2/10 = 20% → 非該当
+    expect(getIssuanceInfo(10, 8)).toEqual({ max: 10, issued: 8, soldOut: false, lowRemaining: false })
+  })
+
+  it('flags soldOut once issued reaches the cap, and never both soldOut and lowRemaining', () => {
+    expect(getIssuanceInfo(10, 10)).toEqual({ max: 10, issued: 10, soldOut: true, lowRemaining: false })
+  })
+
+  it('treats over-issued counts (e.g. concurrent legacy draws) as soldOut', () => {
+    expect(getIssuanceInfo(10, 11)).toEqual({ max: 10, issued: 11, soldOut: true, lowRemaining: false })
+  })
+
+  it('handles a fully-unique card (max=1)', () => {
+    // 未発行時点では残り100%なのでlowRemainingにはならない（発行された瞬間に即soldOutへ遷移する）
+    expect(getIssuanceInfo(1, 0)).toEqual({ max: 1, issued: 0, soldOut: false, lowRemaining: false })
+    expect(getIssuanceInfo(1, 1)).toEqual({ max: 1, issued: 1, soldOut: true, lowRemaining: false })
   })
 })

--- a/tests/unit/cards-get-api.test.ts
+++ b/tests/unit/cards-get-api.test.ts
@@ -49,6 +49,10 @@ function setupCardsMock(options: {
   streamer?: { id: string } | null
   cards?: Record<string, unknown>[]
   cardsError?: Error | null
+  // Issue #542: user_cards から取得する発行済みカード行（issued_count集計の元データ）
+  // user_cards rows fed into the issued_count aggregation (Issue #542)
+  userCards?: Record<string, unknown>[]
+  userCardsError?: Error | null
 }) {
   // ストリーマー確認用クエリビルダー
   const streamerQuery = createMockQueryBuilder()
@@ -70,17 +74,32 @@ function setupCardsMock(options: {
     return cardsQuery
   }
 
-  mockGetSupabaseAdmin.mockReturnValue({
-    from: vi.fn((table: string) => {
-      if (table === 'streamers') return streamerQuery
-      if (table === 'cards') {
-        return cardsQuery
-      }
-      return createMockQueryBuilder()
-    }),
-  } as ReturnType<typeof getSupabaseAdmin>)
+  // Issue #542: 発行済み枚数集計用のuser_cardsクエリビルダー（暗黙のawaitに対応）
+  // user_cards query builder for the issued_count aggregation (implicit await)
+  const userCardsQuery = createMockQueryBuilder()
+  // Note: 既存の cardsQuery 等は `as Record<string, unknown>` で直接キャストしているが、
+  // MockQueryBuilder<unknown> と Record<string, unknown> は型として十分重ならず
+  // TS2352になる（tsc baseline比較のため、新規コードではここだけ `as unknown` を
+  // 経由してこのエラーパターンを増やさないようにする）。
+  ;(userCardsQuery as unknown as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
+    resolve({ data: options.userCards ?? [], error: options.userCardsError ?? null })
+    return userCardsQuery
+  }
 
-  return { streamerQuery, cardsQuery }
+  const from = vi.fn((table: string) => {
+    if (table === 'streamers') return streamerQuery
+    if (table === 'cards') {
+      return cardsQuery
+    }
+    if (table === 'user_cards') {
+      return userCardsQuery
+    }
+    return createMockQueryBuilder()
+  })
+
+  mockGetSupabaseAdmin.mockReturnValue({ from } as ReturnType<typeof getSupabaseAdmin>)
+
+  return { streamerQuery, cardsQuery, userCardsQuery, from }
 }
 
 function setupCardsMockWithRetry(options: {
@@ -347,6 +366,85 @@ describe('GET /api/cards', () => {
 
       const response = await GET(createRequest({ streamerId: 'nonexistent' }))
       expect(response.status).toBe(403)
+    })
+  })
+
+  // Issue #542: CardManagerで発行済み枚数・残余枚数を表示する
+  describe('issued_count (Issue #542)', () => {
+    it('無制限カードのみの場合、user_cardsへの問い合わせをスキップし issued_count を付与しない', async () => {
+      const { from } = setupCardsMock({
+        streamer: { id: 'streamer-1' },
+        cards: [
+          { id: 'card-1', drop_rate: 0.5, max_issuance_count: null },
+          { id: 'card-2', drop_rate: 0.5, max_issuance_count: undefined },
+        ],
+      })
+
+      const response = await GET(createRequest({ streamerId: 'streamer-1' }))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      // 無駄なJOINを避けるため、限定カードが1件も無ければuser_cardsは問い合わせない
+      expect(from).toHaveBeenCalledWith('cards')
+      expect(from).not.toHaveBeenCalledWith('user_cards')
+      expect(body.cards[0].issued_count).toBeUndefined()
+      expect(body.cards[1].issued_count).toBeUndefined()
+    })
+
+    it('上限付きカードのみ user_cards をcard_idでグルーピングしたCOUNTを issued_count として付与する', async () => {
+      const { userCardsQuery } = setupCardsMock({
+        streamer: { id: 'streamer-1' },
+        cards: [
+          { id: 'card-limited', drop_rate: 0.5, max_issuance_count: 10 },
+          { id: 'card-unlimited', drop_rate: 0.5, max_issuance_count: null },
+        ],
+        // card-limited が3枚発行済み。card-unlimitedは対象外なので行が来ても無視される想定は無い
+        // (実際のクエリは limitedCardIds のみで絞り込むため、ここではlimited分のみ用意)
+        userCards: [
+          { card_id: 'card-limited' },
+          { card_id: 'card-limited' },
+          { card_id: 'card-limited' },
+        ],
+      })
+
+      const response = await GET(createRequest({ streamerId: 'streamer-1' }))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      // 限定カードのIDのみでuser_cardsを絞り込むこと（無制限カードは対象外）
+      expect(userCardsQuery.in).toHaveBeenCalledWith('card_id', ['card-limited'])
+
+      const limited = body.cards.find((c: { id: string }) => c.id === 'card-limited')
+      const unlimited = body.cards.find((c: { id: string }) => c.id === 'card-unlimited')
+      expect(limited.issued_count).toBe(3)
+      expect(unlimited.issued_count).toBeUndefined()
+    })
+
+    it('発行済み0枚の限定カードは issued_count: 0 になる', async () => {
+      setupCardsMock({
+        streamer: { id: 'streamer-1' },
+        cards: [{ id: 'card-limited', drop_rate: 0.5, max_issuance_count: 5 }],
+        userCards: [],
+      })
+
+      const response = await GET(createRequest({ streamerId: 'streamer-1' }))
+      const body = await response.json()
+
+      expect(body.cards[0].issued_count).toBe(0)
+    })
+
+    it('user_cardsの取得に失敗してもカード一覧自体は200で返す（ベストエフォート、issued_countは付与しない）', async () => {
+      setupCardsMock({
+        streamer: { id: 'streamer-1' },
+        cards: [{ id: 'card-limited', drop_rate: 0.5, max_issuance_count: 5 }],
+        userCardsError: new Error('db unavailable'),
+      })
+
+      const response = await GET(createRequest({ streamerId: 'streamer-1' }))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body.cards[0].issued_count).toBeUndefined()
     })
   })
 })

--- a/tests/unit/components/card-manager-issuance.test.tsx
+++ b/tests/unit/components/card-manager-issuance.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { baseCard, renderCardManager } from '../../utils/card-manager-test-helpers'
+
+vi.mock('@/lib/logger')
+
+// Issue #542: CardManagerで発行済み枚数・残余枚数を表示する
+//
+// 受け入れ条件:
+// - max_issuance_count が設定されたカードに 発行済み/上限 の枚数が表示される
+// - 上限到達カードに「売り切れ」バッジが表示される
+// - 残り10%以下のカードに警告表示がある
+// - max_issuance_count = null（無制限）カードには枚数表示が出ない
+
+describe('CardManager issuance count display (Issue #542)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // reloadCards()のfetchはpendingのままにして、initialCardsのみで検証する
+    // (他のCardManagerテストと同じパターン)
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+  })
+
+  describe('thumbnail grid view (default)', () => {
+    it('shows no issuance text for an unlimited card', () => {
+      renderCardManager([
+        baseCard({ id: 'unlimited', name: 'Unlimited Card', max_issuance_count: null }),
+      ])
+
+      expect(screen.getByText('Unlimited Card')).toBeInTheDocument()
+      expect(screen.queryByText(/発行済み/)).not.toBeInTheDocument()
+      expect(screen.queryByText('売り切れ')).not.toBeInTheDocument()
+      expect(screen.queryByText('残りわずか')).not.toBeInTheDocument()
+    })
+
+    it('shows "issued / max 発行済み" for a limited card with plenty of stock left', () => {
+      renderCardManager([
+        baseCard({ id: 'limited', name: 'Limited Card', max_issuance_count: 10, issued_count: 3 }),
+      ])
+
+      expect(screen.getByText('3 / 10 発行済み')).toBeInTheDocument()
+      expect(screen.queryByText('売り切れ')).not.toBeInTheDocument()
+      expect(screen.queryByText('残りわずか')).not.toBeInTheDocument()
+    })
+
+    it('shows a "売り切れ" banner once issued reaches the cap', () => {
+      renderCardManager([
+        baseCard({ id: 'sold-out', name: 'Sold Out Card', max_issuance_count: 5, issued_count: 5 }),
+      ])
+
+      expect(screen.getByText('5 / 5 発行済み')).toBeInTheDocument()
+      expect(screen.getByText('売り切れ')).toBeInTheDocument()
+      expect(screen.queryByText('残りわずか')).not.toBeInTheDocument()
+    })
+
+    it('shows a "残りわずか" banner once remaining stock drops to 10% or below', () => {
+      renderCardManager([
+        baseCard({ id: 'low', name: 'Low Stock Card', max_issuance_count: 10, issued_count: 9 }),
+      ])
+
+      expect(screen.getByText('9 / 10 発行済み')).toBeInTheDocument()
+      expect(screen.getByText('残りわずか')).toBeInTheDocument()
+      expect(screen.queryByText('売り切れ')).not.toBeInTheDocument()
+    })
+
+    it('treats a missing issued_count (e.g. join skipped) as 0 issued', () => {
+      renderCardManager([
+        baseCard({ id: 'no-count', name: 'No Count Card', max_issuance_count: 10, issued_count: undefined }),
+      ])
+
+      expect(screen.getByText('0 / 10 発行済み')).toBeInTheDocument()
+    })
+  })
+
+  describe('list (table) view', () => {
+    it('shows "-" in the issuance column for an unlimited card', () => {
+      renderCardManager(
+        [baseCard({ id: 'unlimited', name: 'Unlimited Card', max_issuance_count: null })],
+        { viewMode: 'list' }
+      )
+
+      expect(screen.getByText('Unlimited Card')).toBeInTheDocument()
+      expect(screen.queryByText(/発行済み/)).not.toBeInTheDocument()
+      // 発行数列ヘッダーは存在する
+      expect(screen.getByText('発行数')).toBeInTheDocument()
+    })
+
+    it('shows the issued/max count and a sold-out badge for a fully-issued card', () => {
+      renderCardManager(
+        [baseCard({ id: 'sold-out', name: 'Sold Out Card', max_issuance_count: 1, issued_count: 1 })],
+        { viewMode: 'list' }
+      )
+
+      expect(screen.getByText('1 / 1 発行済み')).toBeInTheDocument()
+      expect(screen.getByText('売り切れ')).toBeInTheDocument()
+    })
+
+    it('shows a low-remaining badge without a sold-out badge near the limit', () => {
+      renderCardManager(
+        [baseCard({ id: 'low', name: 'Low Stock Card', max_issuance_count: 10, issued_count: 9 })],
+        { viewMode: 'list' }
+      )
+
+      expect(screen.getByText('9 / 10 発行済み')).toBeInTheDocument()
+      expect(screen.getByText('残りわずか')).toBeInTheDocument()
+      expect(screen.queryByText('売り切れ')).not.toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## 概要

Fixes #542（#539の一部）

配信者が「あと何枚発行できるか」をCardManagerで確認できず、上限到達まで気づけなかった問題への対応。

## 変更内容

- `/api/cards`: 限定カード(max_issuance_count設定済み)のみuser_cardsから`issued_count`を付与。限定カード0件のページはクエリ自体スキップ
- `getIssuanceInfo`(card-issuance.ts): 売り切れ/残り10%以下の警告を判定する純粋関数
- CardList・CardManagerサムネイルグリッド: 発行数列/バッジ追加。配布停止中バナーと併記可能

## テスト（実測）

- 109 files/1242 tests green / eslint clean / `npm run workers:build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn