### PR TITLE
feat(chat): ガチャ通知テンプレートにパック名プレースホルダを追加 (#597)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -499,7 +499,7 @@
       "multiTemplate": "Multi-draw Template (optional)",
       "multiTemplatePlaceholder": "@'{'user'}' got '{'rarityCounts'}' from a '{'draws'}'-draw gacha! '{'cards'}'",
       "multiShowCards": "Include card-name list in multi-draw announcements",
-      "placeholderHelp": "Available placeholders: '{'user'}'=username, '{'card'}'=first card name, '{'rarity'}'=rarity, '{'num'}'=owned count, '{'unique'}'=unique types owned, '{'all'}'=total types, '{'detail'}'=card description, '{'url'}'=collection URL",
+      "placeholderHelp": "Available placeholders: '{'user'}'=username, '{'card'}'=first card name, '{'rarity'}'=rarity, '{'num'}'=owned count, '{'unique'}'=unique types owned, '{'all'}'=total types, '{'detail'}'=card description, '{'url'}'=collection URL, '{'packName'}'=name of the pack the obtained card belongs to (empty string when the draw wasn't restricted to a pack)",
       "multiPlaceholderHelp": "Multi-draw only: '{'draws'}'=draw count, '{'rarityCounts'}'=rarity counts (e.g. Rare x3, Common x3), '{'cards'}'=card-name list, '{'newCards'}'=newly obtained card names this draw, '{'newCardCount'}'=count of newly obtained card types this draw",
       "previewLength": "Preview length: {current} / {max} characters"
     },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -499,7 +499,7 @@
       "multiTemplate": "N連ガチャ用テンプレート（任意）",
       "multiTemplatePlaceholder": "@'{'user'}' が'{'draws'}'連ガチャで '{'rarityCounts'}' を獲得しました！'{'cards'}'",
       "multiShowCards": "N連通知にカード名一覧を含める",
-      "placeholderHelp": "使用可能なプレースホルダー: '{'user'}'=ユーザー名, '{'card'}'=先頭カード名, '{'rarity'}'=レアリティ, '{'num'}'=所持枚数, '{'unique'}'=所持種類数, '{'all'}'=全種類数, '{'detail'}'=カード説明, '{'url'}'=コレクションURL",
+      "placeholderHelp": "使用可能なプレースホルダー: '{'user'}'=ユーザー名, '{'card'}'=先頭カード名, '{'rarity'}'=レアリティ, '{'num'}'=所持枚数, '{'unique'}'=所持種類数, '{'all'}'=全種類数, '{'detail'}'=カード説明, '{'url'}'=コレクションURL, '{'packName'}'=獲得カードが属するパック名（パック未指定の抽選では空文字）",
       "multiPlaceholderHelp": "N連用: '{'draws'}'=抽選回数, '{'rarityCounts'}'=レアリティ別枚数（例: レアx3、コモンx3）, '{'cards'}'=カード名一覧, '{'newCards'}'=今回初めて獲得したカード名一覧, '{'newCardCount'}'=今回初めて獲得したカード種類数",
       "previewLength": "プレビュー文字数: {current} / {max}文字"
     },

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -11,12 +11,19 @@ import { TwitchChatService, DEFAULT_CHAT_TEMPLATE, type ChatMessagePlaceholders 
 import type { GachaCard, EventSubStreamerInfo } from "@/lib/services/gacha";
 import { CARD_ISSUANCE_MESSAGES } from "@/lib/card-issuance";
 import { countCharacters } from "@/lib/text-utils";
+import { resolvePackDisplayName } from "@/lib/collection-packs";
 
 const MESSAGE_TYPE_VERIFICATION = "webhook_callback_verification";
 const MESSAGE_TYPE_NOTIFICATION = "notification";
 const MESSAGE_TYPE_REVOCATION = "revocation";
 const CARD_LIST_SEPARATOR = "、";
 const DEFAULT_MULTI_DRAW_CHAT_TEMPLATE = '@{user} が{draws}連ガチャで {rarityCounts} を獲得しました！{cards}';
+// Issue #597: {packName} でデフォルト(未分類)パックの表示名オーバーライドが
+// 未設定の場合のフォールバックラベル。チャット文言は他の箇所(rarityMap等)と
+// 同様に i18n非対応でハードコードする。messages/*.json の
+// "collections.defaultOnlyName"（コレクションページのパックタブ用ラベル）と
+// 同じ文言に揃えている。
+const DEFAULT_PACK_CHAT_FALLBACK_LABEL = "デフォルトパック";
 
 function formatCardNamesForChat(cardNames: string[], maxCharacters: number): string {
   if (cardNames.length === 0) return "";
@@ -437,6 +444,9 @@ interface RedemptionNotifyData {
     cards?: GachaCard[];
     userTwitchUsername: string;
     rewardId?: string | null;
+    // Issue #597: {packName} プレースホルダ解決用。抽選がパックに絞られて
+    // いない場合(無制限ガチャ、raid gacha 等)は null/undefined。
+    collectionName?: string | null;
   };
   broadcasterTwitchUserId: string;
   streamer: EventSubStreamerInfo;
@@ -464,7 +474,8 @@ async function postRedemptionNotify(data: RedemptionNotifyData): Promise<void> {
       data.gachaResult.card,
       data.gachaResult.userTwitchUsername,
       data.userId,
-      data.gachaResult.cards
+      data.gachaResult.cards,
+      data.gachaResult.collectionName
     ),
   ]);
 
@@ -623,6 +634,7 @@ async function handleRedemption(messageId: string, event: {
       cards: result.data.cards,
       userTwitchUsername: result.data.userTwitchUsername,
       rewardId: result.data.rewardId ?? event.reward.id,
+      collectionName: result.data.collectionName ?? null,
     };
 
     logger.info('[handleRedemption] END', { messageId });
@@ -651,6 +663,7 @@ async function handleRedemption(messageId: string, event: {
  * @param userName - ガチャを引いたユーザー名
  * @param userId - ガチャを引いたユーザーのTwitch ID
  * @param cards - 複数枚ガチャ時の獲得カード一覧
+ * @param collectionName - 抽選が絞られたパックの collection_name（無制限ガチャは null/undefined、Issue #597）
  */
 async function sendChatAnnouncement(
   broadcasterTwitchUserId: string,
@@ -660,11 +673,13 @@ async function sendChatAnnouncement(
     chat_announcement_template: string | null;
     chat_announcement_multi_template: string | null;
     chat_announcement_multi_show_cards: boolean;
+    default_card_pack_name?: string | null;
   },
   card: GachaCard,
   userName: string,
   userId: string,
-  cards?: GachaCard[]
+  cards?: GachaCard[],
+  collectionName?: string | null
 ): Promise<void> {
   const drawnCards = cards && cards.length > 0 ? cards : [card];
   const isMultiDraw = drawnCards.length > 1;
@@ -828,6 +843,17 @@ async function sendChatAnnouncement(
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://twica.live';
   const collectionUrl = `${baseUrl}/collection/${streamer.id}`;
 
+  // Issue #597: {packName} 用に、抽選が絞られたパックの表示名を解決する。
+  // DBクエリ不要（collectionName/default_card_pack_name は既に取得済み）のため
+  // 他プレースホルダーのような needsX ガードは不要。
+  // Resolve the {packName} display name. No extra DB query needed (both inputs
+  // are already fetched), unlike the other placeholders gated behind needsX.
+  const packName = resolvePackDisplayName(
+    collectionName,
+    streamer.default_card_pack_name ?? null,
+    DEFAULT_PACK_CHAT_FALLBACK_LABEL
+  );
+
   // メッセージのプレースホルダーを構築
   // Build message placeholders
   const placeholders: ChatMessagePlaceholders = {
@@ -848,6 +874,7 @@ async function sendChatAnnouncement(
     unique: uniqueCount,
     all: allCount,
     url: collectionUrl,
+    packName: packName || undefined,
   };
 
   // チャットサービスでメッセージを構築・送信

--- a/src/components/ChatAnnouncementSettings.tsx
+++ b/src/components/ChatAnnouncementSettings.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { logger } from "@/lib/logger";
 import { CARD_DESCRIPTION_MAX_CHARACTERS, TWITCH_CHAT_MESSAGE_MAX_CHARACTERS } from "@/lib/constants";
 import { countCharacters } from "@/lib/text-utils";
+import { MAX_COLLECTION_NAME_LENGTH } from "@/lib/validation/collection-name";
 
 interface ChatAnnouncementSettingsProps {
   streamerId: string;
@@ -40,6 +41,9 @@ const MAX_TEMPLATE_PLACEHOLDER_LENGTHS = {
   // newCards mirrors `cards` length; runtime reserves space for the "初出: " suffix
   newCards: 300,
   newCardCount: 4,
+  // パック名の上限はDBのCHECK制約（MAX_COLLECTION_NAME_LENGTH）に合わせる
+  // Pack name limit mirrors the DB CHECK constraint (MAX_COLLECTION_NAME_LENGTH)
+  packName: MAX_COLLECTION_NAME_LENGTH,
 } as const;
 
 function buildChatPreviewMessage(
@@ -58,6 +62,7 @@ function buildChatPreviewMessage(
     url: string;
     newCards: string;
     newCardCount: string;
+    packName: string;
   }
 ): string {
   return template
@@ -74,6 +79,7 @@ function buildChatPreviewMessage(
     .replace(/\{url\}/g, placeholders.url)
     .replace(/\{newCards\}/g, placeholders.newCards)
     .replace(/\{newCardCount\}/g, placeholders.newCardCount)
+    .replace(/\{packName\}/g, placeholders.packName)
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -134,6 +140,7 @@ export default function ChatAnnouncementSettings({
       url: `https://twica.live/collection/${streamerId}`,
       newCards: "レジェンダリーカード、レアカード",
       newCardCount: "2",
+      packName: "サンプルパック",
     });
   }, [activeTemplate, streamerId]);
 
@@ -152,6 +159,7 @@ export default function ChatAnnouncementSettings({
       url: `https://twica.live/collection/${streamerId}`,
       newCards: multiShowCards ? "レジェンダリーカード、レアカード" : "",
       newCardCount: multiShowCards ? "2" : "",
+      packName: "サンプルパック",
     });
   }, [activeMultiTemplate, multiShowCards, streamerId]);
 
@@ -176,6 +184,7 @@ export default function ChatAnnouncementSettings({
         url: `https://twica.live/collection/${streamerId}`,
         newCards: "カ".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.newCards),
         newCardCount: "9".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.newCardCount),
+        packName: "パ".repeat(MAX_TEMPLATE_PLACEHOLDER_LENGTHS.packName),
       })
     );
   }, [activeTemplate, streamerId]);

--- a/src/lib/collection-packs.ts
+++ b/src/lib/collection-packs.ts
@@ -120,3 +120,38 @@ export function computePackProgress(
     total: packActiveIds.size,
   };
 }
+
+/**
+ * Issue #597: resolve the display name of the pack a gacha draw was scoped
+ * to, for the `{packName}` chat announcement placeholder.
+ *
+ * Mirrors the 3 states the collection page (page.tsx) already distinguishes
+ * for `CollectionPackDisplay.displayName`, just resolved eagerly instead of
+ * being left for a client component to fall back on:
+ * - `collectionName` is null/undefined — the draw was NOT restricted to any
+ *   pack (unrestricted gacha) → `''` (stripped by chat-service's optional
+ *   placeholder handling, same convention as `{newCards}` when absent).
+ * - `collectionName === DEFAULT_PACK_SENTINEL` — restricted to the default
+ *   (unclassified) pseudo-pack → the streamer's override (`defaultPackName`,
+ *   i.e. `streamers.default_card_pack_name`), or `defaultPackFallbackLabel`
+ *   when no override is set (same fallback pattern as
+ *   ChannelPointSettings' `defaultPackDisplayName`, #554).
+ * - any other `collectionName` IS the display name (named packs don't have a
+ *   separate display-name column — the registered pack name itself is shown
+ *   everywhere else, see #393) → returned verbatim.
+ *
+ * `defaultPackFallbackLabel` is injected by the caller (rather than hardcoded
+ * here) so this module stays free of display strings/i18n, matching how
+ * `CollectionPackDisplay.displayName` also leaves that resolution to callers.
+ */
+export function resolvePackDisplayName(
+  collectionName: string | null | undefined,
+  defaultPackName: string | null,
+  defaultPackFallbackLabel: string
+): string {
+  if (!collectionName) return "";
+  if (collectionName === DEFAULT_PACK_SENTINEL) {
+    return defaultPackName ?? defaultPackFallbackLabel;
+  }
+  return collectionName;
+}

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -47,6 +47,11 @@ export interface EventSubStreamerInfo {
   chat_announcement_template: string | null
   chat_announcement_multi_template: string | null
   chat_announcement_multi_show_cards: boolean
+  // Issue #597: {packName} プレースホルダでデフォルト(未分類)パックの表示名
+  // オーバーライドとして使う(#554 の default_card_pack_name)。raid gacha 経路
+  // (executeGachaForRaidEvent)はパックに絞られることが無いため未取得のまま
+  // (undefined)でもよいよう optional にする。
+  default_card_pack_name?: string | null
 }
 
 export interface GachaResult {
@@ -54,6 +59,10 @@ export interface GachaResult {
   cards?: GachaCard[]
   userTwitchUsername: string
   rewardId?: string | null
+  // Issue #597: 抽選をパックに絞った際の collection_name(DEFAULT_PACK_SENTINEL
+  // を含む)。無制限抽選(パック指定なし)の場合は null/undefined。チャット通知
+  // の {packName} プレースホルダ解決に使う。
+  collectionName?: string | null
   /** EventSub経由の場合のみ設定。クエリ統合のためガチャ結果と一緒に返す */
   streamer?: EventSubStreamerInfo
 }
@@ -588,10 +597,12 @@ export class GachaService {
       // chat_announcement_enabled/template も同時取得してクエリ統合（CPU時間削減）
       // rarity_weights / rarity_weights_scope / pack_rarity_weights は Issue #579
       // (#576 フェーズ2) のパック内レアリティ自動配分に使う。
+      // default_card_pack_name (migration 00063, Issue #554) は {packName} プレースホルダで
+      // デフォルト(未分類)パックの表示名オーバーライドとして使う(Issue #597)。
       let { data: streamer, error: streamerError } = await withRetry(
         () => this.supabase
           .from('streamers')
-          .select('id, channel_point_reward_id, channel_point_collection_name, chat_announcement_enabled, chat_announcement_template, chat_announcement_multi_template, chat_announcement_multi_show_cards, raid_gacha_active_until, rarity_weights, rarity_weights_scope, pack_rarity_weights')
+          .select('id, channel_point_reward_id, channel_point_collection_name, chat_announcement_enabled, chat_announcement_template, chat_announcement_multi_template, chat_announcement_multi_show_cards, raid_gacha_active_until, rarity_weights, rarity_weights_scope, pack_rarity_weights, default_card_pack_name')
           .eq('twitch_user_id', event.broadcaster_user_id)
           .maybeSingle(),
         'gacha:executeGachaForEventSub:streamer',
@@ -612,10 +623,13 @@ export class GachaService {
         streamerError &&
         (isMissingRarityWeightsScopeColumnError(streamerError) || isMissingPackRarityWeightsColumnError(streamerError))
       ) {
+        // default_card_pack_name (00063) は rarity_weights_scope/pack_rarity_weights
+        // (00065) より先行するマイグレーションのため、この分岐に来る時点で確実に
+        // デプロイ済み。選択して問題ない。
         const weightsFallback = await withRetry(
           () => this.supabase
             .from('streamers')
-            .select('id, channel_point_reward_id, channel_point_collection_name, chat_announcement_enabled, chat_announcement_template, chat_announcement_multi_template, chat_announcement_multi_show_cards, raid_gacha_active_until, rarity_weights')
+            .select('id, channel_point_reward_id, channel_point_collection_name, chat_announcement_enabled, chat_announcement_template, chat_announcement_multi_template, chat_announcement_multi_show_cards, raid_gacha_active_until, rarity_weights, default_card_pack_name')
             .eq('twitch_user_id', event.broadcaster_user_id)
             .maybeSingle(),
           'gacha:executeGachaForEventSub:streamer:weights-fallback',
@@ -650,6 +664,10 @@ export class GachaService {
               channel_point_collection_name: null,
               rarity_weights_scope: null,
               pack_rarity_weights: null,
+              // default_card_pack_name (00063) は channel_point_collection_name (00061)
+              // より後発のマイグレーションのため、この分岐に来る時点で確実に未デプロイ。
+              // 選択せず null 固定にする(Issue #597)。
+              default_card_pack_name: null,
             }
           : collectionFallback.data
         streamerError = collectionFallback.error
@@ -677,6 +695,10 @@ export class GachaService {
               rarity_weights: null,
               rarity_weights_scope: null,
               pack_rarity_weights: null,
+              // Issue #597: この分岐は channel_point_collection_name(00061)より
+              // 前段の欠落まで拾う最も古いフォールバックのため、default_card_pack_name
+              // (00063)も確実に未デプロイ。選択せず null 固定にする。
+              default_card_pack_name: null,
             }
           : fallbackResult.data
         streamerError = fallbackResult.error
@@ -714,12 +736,16 @@ export class GachaService {
         return ok({
           ...result.data,
           rewardId: event.reward.id,
+          // Issue #597: {packName} プレースホルダ解決用に、この抽選が絞られた
+          // パックの collection_name をそのまま結果に持たせる。
+          collectionName: collectionName ?? null,
           streamer: {
             id: streamer.id,
             chat_announcement_enabled: streamer.chat_announcement_enabled,
             chat_announcement_template: streamer.chat_announcement_template,
             chat_announcement_multi_template: streamer.chat_announcement_multi_template,
             chat_announcement_multi_show_cards: streamer.chat_announcement_multi_show_cards ?? true,
+            default_card_pack_name: streamer.default_card_pack_name ?? null,
           },
         })
       }

--- a/src/lib/twitch/chat-service.ts
+++ b/src/lib/twitch/chat-service.ts
@@ -65,6 +65,12 @@ export interface ChatMessagePlaceholders {
   // コンプ進捗用: 配信者のアクティブカードの総種類数（オプション）
   // Collection progress: total number of active card types for this streamer (optional)
   all?: number
+  // 獲得したカードが属するパックの表示名（オプション）。抽選がパックに絞られて
+  // いない場合や値が空文字の場合は未指定として扱われ、プレースホルダーは空文字に置換される
+  // Display name of the pack the obtained card belongs to (optional). Treated as
+  // unset when the draw wasn't restricted to a pack or the value is an empty
+  // string; the placeholder is then replaced with an empty string (Issue #597)
+  packName?: string
 }
 
 /**
@@ -366,6 +372,14 @@ export class TwitchChatService {
       message = message.replace(/\{newCardCount\}/g, String(placeholders.newCardCount))
     } else {
       message = message.replace(/\{newCardCount\}/g, '')
+    }
+
+    if (placeholders.packName) {
+      message = message.replace(/\{packName\}/g, placeholders.packName)
+    } else {
+      // パック未指定の抽選（無制限ガチャ）の場合は空文字に置換
+      // Strip the placeholder when the draw wasn't restricted to a pack
+      message = message.replace(/\{packName\}/g, '')
     }
 
     // 連続する空白を1つにまとめ、前後の空白を削除

--- a/tests/unit/chat-service.test.ts
+++ b/tests/unit/chat-service.test.ts
@@ -569,4 +569,49 @@ describe('TwitchChatService', () => {
       expect(message).toBe('SampleUser が Legendary Card を獲得！');
     });
   });
+
+  // Issue #597: ガチャ報告チャットにカードコレクション(パック)名を出すための {packName}
+  describe('buildMessage - パック名プレースホルダー ({packName})', () => {
+    const basePlaceholders = {
+      user: 'SampleUser',
+      card: 'Legendary Card',
+      rarity: 'レジェンダリー',
+    };
+
+    it('{packName} が値に置換される', () => {
+      const message = service.buildMessage(
+        '{user}が『{packName}』パックから{card}を獲得！',
+        { ...basePlaceholders, packName: 'スターターパック' },
+      );
+
+      expect(message).toBe('SampleUserが『スターターパック』パックからLegendary Cardを獲得！');
+    });
+
+    it('{packName} 未指定時（パックに絞られていない抽選）は空文字に置換される', () => {
+      const message = service.buildMessage(
+        '{user}が{card}を獲得！パック: {packName}',
+        basePlaceholders,
+      );
+
+      expect(message).toBe('SampleUserがLegendary Cardを獲得！パック:');
+    });
+
+    it('{packName} が空文字の場合も未指定と同様に空文字へ置換される', () => {
+      const message = service.buildMessage(
+        '{user}が{card}を獲得！パック: {packName}',
+        { ...basePlaceholders, packName: '' },
+      );
+
+      expect(message).toBe('SampleUserがLegendary Cardを獲得！パック:');
+    });
+
+    it('既存プレースホルダーと併用できる', () => {
+      const message = service.buildMessage(
+        '@{user} が【{rarity}】{card}（{packName}）を獲得！',
+        { ...basePlaceholders, packName: 'レアパック' },
+      );
+
+      expect(message).toBe('@SampleUser が【レジェンダリー】Legendary Card（レアパック）を獲得！');
+    });
+  });
 });

--- a/tests/unit/collection-packs.test.ts
+++ b/tests/unit/collection-packs.test.ts
@@ -3,6 +3,7 @@ import {
   cardMatchesPackKey,
   computePackProgress,
   deriveCollectionPackGroups,
+  resolvePackDisplayName,
 } from "@/lib/collection-packs";
 import { DEFAULT_PACK_SENTINEL } from "@/lib/validation/collection-name";
 
@@ -114,6 +115,35 @@ describe("collection-packs", () => {
         owned: 0,
         total: 0,
       });
+    });
+  });
+
+  // Issue #597: {packName} チャット通知プレースホルダの表示名解決。
+  describe("resolvePackDisplayName", () => {
+    it("returns an empty string when the draw was not restricted to any pack (null)", () => {
+      expect(resolvePackDisplayName(null, "レアパック", "デフォルトパック")).toBe("");
+    });
+
+    it("returns an empty string when collectionName is undefined", () => {
+      expect(resolvePackDisplayName(undefined, "レアパック", "デフォルトパック")).toBe("");
+    });
+
+    it("returns the streamer's override for the default (unclassified) pseudo-pack", () => {
+      expect(
+        resolvePackDisplayName(DEFAULT_PACK_SENTINEL, "スターターパック", "デフォルトパック")
+      ).toBe("スターターパック");
+    });
+
+    it("falls back to the generic label when the default pack has no override", () => {
+      expect(resolvePackDisplayName(DEFAULT_PACK_SENTINEL, null, "デフォルトパック")).toBe(
+        "デフォルトパック"
+      );
+    });
+
+    it("returns the named pack's collection_name verbatim, ignoring defaultPackName", () => {
+      expect(resolvePackDisplayName("weapons", "スターターパック", "デフォルトパック")).toBe(
+        "weapons"
+      );
     });
   });
 });


### PR DESCRIPTION
## 概要

Fixes #597

配信者がチャット通知テンプレートに `{packName}` を書けるようにする（例: "{userName}が『{packName}』パックから{cardName}を獲得！"）。

## 変更内容

- `resolvePackDisplayName`(collection-packs.ts): collectionNameの3状態(未指定/デフォルトパック/named pack)をコレクションページと同じ規則で表示名に解決
- `GachaResult.collectionName` / `EventSubStreamerInfo.default_card_pack_name` を配線
- デプロイ窓: `default_card_pack_name`(00063)は`rarity_weights_scope`等(00065)より先行するため、既存フォールバック分岐の順序を踏まえて正しく取得/null固定

## テスト（実測）

- 108 files/1232 tests green / eslint clean / `npm run workers:build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn