### PR TITLE
feat(gacha): 売り切れ時のチャット通知とチャネルポイント自動返還 (#544, #546)

### DIFF
--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -8,6 +8,7 @@ import { checkRateLimit, rateLimits, getClientIp } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
 import { reportError } from "@/lib/sentry/error-handler";
 import { TwitchChatService, DEFAULT_CHAT_TEMPLATE, type ChatMessagePlaceholders } from "@/lib/twitch/chat-service";
+import { cancelRedemption } from "@/lib/twitch/channel-points";
 import type { GachaCard, EventSubStreamerInfo } from "@/lib/services/gacha";
 import { CARD_ISSUANCE_MESSAGES } from "@/lib/card-issuance";
 import { countCharacters } from "@/lib/text-utils";
@@ -17,6 +18,13 @@ const MESSAGE_TYPE_NOTIFICATION = "notification";
 const MESSAGE_TYPE_REVOCATION = "revocation";
 const CARD_LIST_SEPARATOR = "、";
 const DEFAULT_MULTI_DRAW_CHAT_TEMPLATE = '@{user} が{draws}連ガチャで {rarityCounts} を獲得しました！{cards}';
+
+// Issue #544: 売り切れ(発行枚数上限到達)時のチャット通知メッセージ。
+// 配信者ごとのカスタムテンプレートは設けず、固定文言にする
+// (Issue #544 の実装プラン通り。既存の chat_announcement_enabled フラグのみ再利用する)。
+// Issue #546 のポイント返還に成功した場合のみ、返還済みである旨を追記する。
+const SOLD_OUT_CHAT_MESSAGE = 'カードの発行枚数上限に達しているため、カードを付与できませんでした。';
+const SOLD_OUT_CHAT_MESSAGE_REFUNDED_SUFFIX = ' ポイントは返還されました。';
 
 function formatCardNamesForChat(cardNames: string[], maxCharacters: number): string {
   if (cardNames.length === 0) return "";
@@ -205,6 +213,34 @@ async function verifyTwitchSignature(
   }
 }
 
+/**
+ * Cloudflare Workers の waitUntil() でレスポンス返却後にバックグラウンド実行し、
+ * ローカル開発等 waitUntil が使えない環境では同期フォールバックする共通ヘルパー。
+ * ガチャ成功・レイド成功・売り切れ通知(Issue #544/#546)の3箇所で同一パターンが
+ * 必要なため、重複を避けてここに集約する。
+ *
+ * `task` は呼び出し時点で既に開始済みの Promise を渡すこと（この関数自身は
+ * 処理を起動しない）。waitUntil に登録できればそのまま非同期に流れ、登録できない
+ * 環境（ローカル開発等）では task の完了を待ってから返る。
+ *
+ * Run `task` in the background via Cloudflare Workers' waitUntil() so it executes
+ * after the response is returned. Falls back to awaiting synchronously when
+ * waitUntil is unavailable (e.g. local dev). Shared across the 3 call sites that
+ * need this exact pattern (gacha success, raid success, sold-out notification).
+ */
+async function runInBackground(label: string, task: Promise<void>): Promise<void> {
+  try {
+    const { getCloudflareContext } = await import('@opennextjs/cloudflare');
+    const { ctx } = await getCloudflareContext({ async: true });
+    ctx.waitUntil(task);
+  } catch (e) {
+    logger.warn(`[EventSub] waitUntil unavailable (${label}), falling back to sync`, {
+      error: e instanceof Error ? e.message : String(e),
+    });
+    await task;
+  }
+}
+
 export async function POST(request: NextRequest) {
   const body = await request.text();
   let data;
@@ -261,33 +297,12 @@ export async function POST(request: NextRequest) {
       // Only await gacha execution; defer notifications via waitUntil() to reduce CPU time
       const result = await handleRedemption(messageId, event);
       if (result) {
-        try {
-          // Cloudflare Workers の waitUntil() でレスポンス返却後にバックグラウンド実行
-          const { getCloudflareContext } = await import('@opennextjs/cloudflare');
-          const { ctx } = await getCloudflareContext({ async: true });
-          ctx.waitUntil(postRedemptionNotify(result));
-        } catch (e) {
-          // ローカル開発等で getCloudflareContext が使えない場合は同期フォールバック
-          // Fallback to sync execution when getCloudflareContext is unavailable (local dev)
-          logger.warn('[EventSub] waitUntil unavailable, falling back to sync', {
-            error: e instanceof Error ? e.message : String(e),
-          });
-          await postRedemptionNotify(result);
-        }
+        await runInBackground('gacha redemption', postRedemptionNotify(result));
       }
     } else if (subscriptionType === TWITCH_SUBSCRIPTION_TYPE.CHANNEL_RAID) {
       const result = await handleRaidNotification(messageId, event);
       if (result) {
-        try {
-          const { getCloudflareContext } = await import('@opennextjs/cloudflare');
-          const { ctx } = await getCloudflareContext({ async: true });
-          ctx.waitUntil(postRedemptionNotify(result));
-        } catch (e) {
-          logger.warn('[EventSub] waitUntil unavailable for raid gift, falling back to sync', {
-            error: e instanceof Error ? e.message : String(e),
-          });
-          await postRedemptionNotify(result);
-        }
+        await runInBackground('raid gift', postRedemptionNotify(result));
       }
     }
 
@@ -488,6 +503,130 @@ async function postRedemptionNotify(data: RedemptionNotifyData): Promise<void> {
   }
 }
 
+/** postSoldOutNotify に渡すデータ（Issue #544/#546） */
+interface SoldOutNotifyData {
+  broadcasterTwitchUserId: string;
+  userName: string;
+  rewardId: string;
+  /** EventSub payload の event.id（redemption ID）。無い場合は返還を試みない */
+  redemptionId?: string;
+}
+
+/**
+ * 売り切れ(発行枚数上限到達)確定後の通知処理（チャンネルポイント返還 + チャット通知）。
+ * waitUntil() でレスポンス返却後にバックグラウンド実行される。
+ *
+ * Issue #546: redemptionId がある場合のみチャンネルポイント返還(CANCELED更新)を試みる。
+ * 返還APIの失敗はログ + reportError するのみで、例外を伝播させない
+ * （ガチャ自体は既に失敗しているため、この救済処理の失敗でEventSubレスポンスを悪化させない）。
+ *
+ * Issue #544: 返還の成否に応じてメッセージ文言を変え、chat_announcement_enabled が
+ * 有効な配信者にのみチャット通知する。ガチャ成功時と同じ設定フラグを再利用し、
+ * 売り切れ通知専用のON/OFF設定は追加しない（Issue #544 の実装プラン通り）。
+ *
+ * Post sold-out notifications (channel points refund + chat announcement) run after
+ * response via waitUntil(). A refund failure is logged/reported but never thrown —
+ * the gacha draw has already failed, so a refund-API failure must not cascade into a
+ * worse response to Twitch's EventSub webhook.
+ */
+async function postSoldOutNotify(data: SoldOutNotifyData): Promise<void> {
+  const { broadcasterTwitchUserId, userName, rewardId, redemptionId } = data;
+  let refunded = false;
+
+  if (redemptionId) {
+    try {
+      const result = await cancelRedemption({ broadcasterTwitchUserId, rewardId, redemptionId });
+      refunded = result.success;
+
+      if (result.success) {
+        logger.info('[postSoldOutNotify] Channel points refunded', {
+          broadcasterTwitchUserId,
+          rewardId,
+          redemptionId,
+        });
+      } else {
+        logger.warn('[postSoldOutNotify] Failed to refund channel points', {
+          broadcasterTwitchUserId,
+          rewardId,
+          redemptionId,
+          reason: result.reason,
+        });
+        await reportError(new Error(`cancelRedemption failed: ${result.reason ?? 'unknown'}`), {
+          context: 'eventsub:postSoldOutNotify:cancelRedemption',
+          broadcasterTwitchUserId,
+          rewardId,
+          redemptionId,
+        });
+      }
+    } catch (error) {
+      // cancelRedemption 自体は例外を投げない設計だが、念のため二重に防御する。
+      // cancelRedemption never throws by design, but defend defensively anyway.
+      logger.error('[postSoldOutNotify] cancelRedemption threw unexpectedly', {
+        broadcasterTwitchUserId,
+        rewardId,
+        redemptionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      await reportError(error, {
+        context: 'eventsub:postSoldOutNotify:cancelRedemption',
+        broadcasterTwitchUserId,
+        rewardId,
+        redemptionId,
+      });
+    }
+  } else {
+    // EventSubのサブスクリプション種別によっては redemption id が payload に
+    // 含まれない可能性があるため、その場合は返還を試みずチャット通知のみ行う。
+    logger.info('[postSoldOutNotify] No redemption id available - skipping refund attempt', {
+      broadcasterTwitchUserId,
+      rewardId,
+    });
+  }
+
+  try {
+    const supabaseAdmin = getSupabaseAdmin();
+    const { data: streamer, error } = await supabaseAdmin
+      .from('streamers')
+      .select('chat_announcement_enabled')
+      .eq('twitch_user_id', broadcasterTwitchUserId)
+      .maybeSingle();
+
+    if (error) {
+      logger.warn('[postSoldOutNotify] Failed to fetch chat announcement settings', {
+        broadcasterTwitchUserId,
+        error: error.message,
+      });
+      return;
+    }
+
+    if (!streamer?.chat_announcement_enabled) {
+      logger.info('[postSoldOutNotify] Chat announcement skipped - feature disabled', {
+        broadcasterTwitchUserId,
+      });
+      return;
+    }
+
+    const message = `@${userName} ${SOLD_OUT_CHAT_MESSAGE}${refunded ? SOLD_OUT_CHAT_MESSAGE_REFUNDED_SUFFIX : ''}`;
+    const chatService = new TwitchChatService();
+    const success = await chatService.sendChatMessage(broadcasterTwitchUserId, message);
+
+    if (success) {
+      logger.info('[postSoldOutNotify] Sold-out chat announcement sent', { broadcasterTwitchUserId, refunded });
+    } else {
+      logger.warn('[postSoldOutNotify] Sold-out chat announcement failed', { broadcasterTwitchUserId, refunded });
+    }
+  } catch (error) {
+    logger.warn('[postSoldOutNotify] Chat announcement threw unexpectedly', {
+      broadcasterTwitchUserId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    await reportError(error, {
+      context: 'eventsub:postSoldOutNotify:chatAnnouncement',
+      broadcasterTwitchUserId,
+    });
+  }
+}
+
 /**
  * ガチャ実行とデータ準備を行い、通知に必要なデータを返す。
  * 通知処理自体は呼び出し元で waitUntil() により遅延実行される。
@@ -498,6 +637,7 @@ async function postRedemptionNotify(data: RedemptionNotifyData): Promise<void> {
  * @returns 通知データ（通知不要な場合はnull）
  */
 async function handleRedemption(messageId: string, event: {
+  id?: string;
   broadcaster_user_id: string;
   user_id: string;
   user_login: string;
@@ -567,21 +707,51 @@ async function handleRedemption(messageId: string, event: {
         });
         return null;
       }
-      // カード発行可能枚数の上限到達はストリーマーの設定運用の結果であり、
-      // システムバグではない。Sentry/Issue 化を抑止し warn ログのみに留める。
-      // RPC からの 'limit_reached' と、事前フィルタからの soldOut メッセージの両方を扱う。
-      // Card issuance limit reached is the result of streamer configuration, not a system bug.
-      // Suppress Sentry/Issue reporting and emit a warn log only.
+      // カード発行可能枚数の上限到達（本物のsoldOut）、またはRPC未デプロイに
+      // 起因するlegacyフォールバックの拒否(limitUnavailable、#594)。
+      // どちらの場合も視聴者は既にチャンネルポイントを消費済みでカードを
+      // 受け取れていないため、Issue #544/#546 の返還・チャット通知は両方の
+      // ケースで実施する。一方 limitUnavailable は「RPCが本来存在すべきなのに
+      // 存在しない」という異常系(#594で意図的に soldOut と別メッセージに
+      // 分離した)なので、こちらは通常のsoldOutと違い reportError で運用に
+      // 通知する(視聴者救済と運用アラートは独立した関心事のため両方行う)。
+      //
+      // Card issuance limit reached (soldOut) is the result of streamer
+      // configuration, not a system bug — no reportError. limitUnavailable
+      // means the RPC is unexpectedly missing (see #594) — still refund/notify
+      // the viewer (they already spent points), but ALSO reportError since an
+      // unexpectedly-missing RPC is an operational issue that needs attention.
       if (
-        result.error === 'limit_reached' ||
         result.error === CARD_ISSUANCE_MESSAGES.soldOut ||
-        result.error.includes('発行可能枚数')
+        result.error === CARD_ISSUANCE_MESSAGES.limitUnavailable
       ) {
+        const isUnexpectedRpcMissing = result.error === CARD_ISSUANCE_MESSAGES.limitUnavailable;
+
         logger.warn('[handleRedemption] Card issuance limit reached', {
           messageId,
           broadcasterUserId: event.broadcaster_user_id,
           gachaError: result.error,
+          isUnexpectedRpcMissing,
         });
+
+        if (isUnexpectedRpcMissing) {
+          await reportError(new Error(`Gacha execution failed (RPC unexpectedly missing): ${result.error}`), {
+            context: 'eventsub:handleRedemption:limitUnavailable',
+            messageId,
+            broadcasterUserId: event.broadcaster_user_id,
+          });
+        }
+
+        // Issue #544/#546: 視聴者はチャンネルポイントを消費済みなので、
+        // ポイント返還を試み、結果に応じたチャット通知を送る。
+        // 通知処理自体はレスポンスをブロックしないよう waitUntil() で遅延実行する
+        // （ガチャ成功時の postRedemptionNotify と同じパターン）。
+        await runInBackground('soldOut notification', postSoldOutNotify({
+          broadcasterTwitchUserId: event.broadcaster_user_id,
+          userName: event.user_name,
+          rewardId: event.reward.id,
+          redemptionId: event.id,
+        }));
         return null;
       }
 

--- a/src/lib/twitch/channel-points.ts
+++ b/src/lib/twitch/channel-points.ts
@@ -1,0 +1,104 @@
+import { getEnvVar } from '@/lib/env-validation'
+import { getTwitchAccessToken } from './token-manager'
+import { logger } from '@/lib/logger'
+
+const TWITCH_API_URL = 'https://api.twitch.tv/helix'
+
+export interface CancelRedemptionParams {
+  /** 配信者のTwitchユーザーID（数値ID文字列。EventSub payload の broadcaster_user_id） */
+  broadcasterTwitchUserId: string
+  /** チャンネルポイント報酬ID（EventSub payload の reward.id） */
+  rewardId: string
+  /** 返還対象のredemption ID（EventSub payload の event.id） */
+  redemptionId: string
+}
+
+export interface CancelRedemptionResult {
+  success: boolean
+  /** 失敗理由（ログ/reportError用の分類文字列。成功時はundefined） */
+  reason?: string
+}
+
+/**
+ * Twitch の Update Redemption Status API で redemption を CANCELED に更新し、
+ * 視聴者のチャンネルポイントを自動返還する (Issue #546)。
+ *
+ * 背景: カード発行枚数の上限到達等でガチャが失敗しても、EventSub は
+ * チャンネルポイント消費後に発火するため、視聴者のポイントは既に消費されている。
+ * このアプリが作成するカスタム報酬は `should_redemptions_skip_request_queue` を
+ * 設定していない(= デフォルトfalse)ため、redemption は明示的に FULFILLED/CANCELED
+ * へ更新するまで「未処理」のまま残り続ける。CANCELED に更新すると Twitch 側が
+ * ポイントを自動返還する(Twitch公式仕様)。
+ *
+ * 認証には配信者本人のアクセストークンを使う。チャンネルポイント連携を有効化した
+ * 配信者は `channel:manage:redemptions` スコープを既に付与済みの想定
+ * (src/lib/twitch/scopes.ts の CHANNEL_POINT_SCOPES)。
+ *
+ * 呼び出し元 (eventsub route の売り切れハンドリング) は「ガチャ自体は既に失敗
+ * している」状態からさらに呼ばれる副次的な救済処理であり、この関数の失敗を
+ * 致命的エラーとして扱わない。そのため例外を投げず、必ず CancelRedemptionResult
+ * を返す設計にしている。
+ *
+ * Calls Twitch's "Update Redemption Status" API to set a redemption to CANCELED,
+ * which makes Twitch automatically refund the viewer's channel points (Issue #546).
+ * Uses the broadcaster's own access token (requires `channel:manage:redemptions`).
+ * Never throws — callers treat a refund failure as non-fatal (the gacha draw has
+ * already failed by the time this runs), so this always resolves to a result object.
+ *
+ * @see https://dev.twitch.tv/docs/api/reference/#update-redemption-status
+ */
+export async function cancelRedemption(params: CancelRedemptionParams): Promise<CancelRedemptionResult> {
+  const { broadcasterTwitchUserId, rewardId, redemptionId } = params
+
+  try {
+    const accessToken = await getTwitchAccessToken(broadcasterTwitchUserId)
+    if (!accessToken) {
+      logger.warn('[cancelRedemption] No access token available for broadcaster', {
+        broadcasterTwitchUserId,
+        rewardId,
+        redemptionId,
+      })
+      return { success: false, reason: 'no_access_token' }
+    }
+
+    const clientId = getEnvVar('NEXT_PUBLIC_TWITCH_CLIENT_ID', true)!
+    const query = new URLSearchParams({
+      broadcaster_id: broadcasterTwitchUserId,
+      reward_id: rewardId,
+      id: redemptionId,
+    })
+
+    const response = await fetch(`${TWITCH_API_URL}/channel_points/custom_rewards/redemptions?${query.toString()}`, {
+      method: 'PATCH',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Client-Id': clientId,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ status: 'CANCELED' }),
+    })
+
+    if (response.ok) {
+      return { success: true }
+    }
+
+    const errorBody = await response.text().catch(() => '')
+    logger.warn('[cancelRedemption] Twitch API returned an error response', {
+      broadcasterTwitchUserId,
+      rewardId,
+      redemptionId,
+      status: response.status,
+      errorBody,
+    })
+    return { success: false, reason: `http_${response.status}` }
+  } catch (error) {
+    // ネットワーク例外等。呼び出し元でreportErrorするため、ここではwarnログのみ。
+    logger.error('[cancelRedemption] Request failed', {
+      broadcasterTwitchUserId,
+      rewardId,
+      redemptionId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return { success: false, reason: 'exception' }
+  }
+}

--- a/tests/unit/eventsub-redemption-limit.test.ts
+++ b/tests/unit/eventsub-redemption-limit.test.ts
@@ -3,6 +3,17 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // Issue #108 / PR #450: カード発行可能枚数の上限到達はストリーマーの設定運用上の正常イベントなので、
 // EventSub の redemption ハンドラーで reportError (= GitHub Issue 化) を呼ばずに warn ログのみで終わること。
 // We verify that limit_reached errors do not trigger reportError, while unrelated errors still do.
+//
+// Issue #544/#546: 上記の売り切れ確定後に、チャンネルポイント返還(cancelRedemption)と
+// チャット通知(TwitchChatService.sendChatMessage)が正しい条件で呼ばれることも検証する。
+
+const mocks = vi.hoisted(() => ({
+  cancelRedemption: vi.fn(),
+  sendChatMessage: vi.fn(),
+  // streamers.select('chat_announcement_enabled') の返り値。テストごとに上書きする。
+  // デフォルトはnull(=行なし)とし、既存テストの「チャット通知は送られない」挙動を維持する。
+  streamerSettings: null as { chat_announcement_enabled: boolean } | null,
+}))
 
 vi.mock('@/lib/services/gacha', () => {
   return {
@@ -19,7 +30,9 @@ vi.mock('@/lib/realtime', () => ({
 }))
 
 vi.mock('@/lib/twitch/chat-service', () => ({
-  TwitchChatService: vi.fn(),
+  TwitchChatService: vi.fn().mockImplementation(() => ({
+    sendChatMessage: mocks.sendChatMessage,
+  })),
   DEFAULT_CHAT_TEMPLATE: '',
 }))
 
@@ -27,17 +40,35 @@ vi.mock('@/lib/twitch/token-manager', () => ({
   hasScope: vi.fn().mockResolvedValue(true),
 }))
 
+vi.mock('@/lib/twitch/channel-points', () => ({
+  cancelRedemption: mocks.cancelRedemption,
+}))
+
 // 既存履歴チェック (gacha_history.select.eq.maybeSingle) を「未処理」として返すための supabase admin モック。
 // New event id → no existing history row → handleRedemption proceeds to gachaService call.
+// streamers テーブルへのクエリ (Issue #544 のチャット通知設定取得) は mocks.streamerSettings を返す。
 vi.mock('@/lib/supabase/admin', () => ({
   getSupabaseAdmin: vi.fn(() => ({
-    from: vi.fn(() => ({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+    from: vi.fn((table: string) => {
+      if (table === 'streamers') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn().mockImplementation(() =>
+                Promise.resolve({ data: mocks.streamerSettings, error: null })
+              ),
+            })),
+          })),
+        }
+      }
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          })),
         })),
-      })),
-    })),
+      }
+    }),
   })),
   getSupabaseAdminNoCache: vi.fn(),
 }))
@@ -63,6 +94,9 @@ const ORIGINAL_SECRET = process.env.TWITCH_EVENTSUB_SECRET
 beforeEach(() => {
   process.env.TWITCH_EVENTSUB_SECRET = TEST_SECRET
   vi.clearAllMocks()
+  mocks.streamerSettings = null
+  mocks.cancelRedemption.mockResolvedValue({ success: true })
+  mocks.sendChatMessage.mockResolvedValue(true)
 })
 
 afterEach(() => {
@@ -91,10 +125,14 @@ async function signMessage(messageId: string, timestamp: string, body: string): 
   return 'sha256=' + hex
 }
 
-async function buildRedemptionRequest(messageId: string): Promise<Request> {
+async function buildRedemptionRequest(messageId: string, redemptionId?: string): Promise<Request> {
   const body = JSON.stringify({
     subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
     event: {
+      // Twitch の実 payload では channel_points_custom_reward_redemption.add イベントに
+      // redemption ID がトップレベルの `id` として含まれる。テストでは省略可能にして、
+      // 「redemption id が無い場合は返還を試みない」ケースを再現できるようにする。
+      ...(redemptionId ? { id: redemptionId } : {}),
       broadcaster_user_id: 'broadcaster-1',
       user_id: 'user-1',
       user_login: 'tester',
@@ -118,11 +156,18 @@ async function buildRedemptionRequest(messageId: string): Promise<Request> {
 }
 
 describe('EventSub redemption: card issuance limit error handling', () => {
-  it("limit_reached を返した場合 reportError を呼ばず warn ログのみで 200 を返す", async () => {
+  it("soldOut(発行可能枚数到達)を返した場合 reportError を呼ばず warn ログのみで 200 を返す", async () => {
+    // 実際に GachaService.executeGacha / executeGachaForEventSub が返すのは
+    // CARD_ISSUANCE_MESSAGES.soldOut であり、'limit_reached' という文字列
+    // (RPCの内部フィールド名)がエラーとして返ることはない。past実装の
+    // route.ts側の条件分岐に 'limit_reached' との文字列比較が残っていたが、
+    // 実際には到達しないデッドコードだったため、実態に合わせて修正した
+    // (#544/#546フォローアップでの気づき)。
+    const { CARD_ISSUANCE_MESSAGES } = await import('@/lib/card-issuance')
     const { GachaService } = await import('@/lib/services/gacha')
     const { reportError } = await import('@/lib/sentry/error-handler')
     const mockReport = vi.mocked(reportError)
-    const mockExecute = vi.fn().mockResolvedValue({ success: false, error: 'limit_reached' })
+    const mockExecute = vi.fn().mockResolvedValue({ success: false, error: CARD_ISSUANCE_MESSAGES.soldOut })
     vi.mocked(GachaService).mockImplementation(() => ({
       executeGachaForEventSub: mockExecute,
     }) as unknown as InstanceType<typeof GachaService>)
@@ -156,14 +201,17 @@ describe('EventSub redemption: card issuance limit error handling', () => {
     expect(mockReport).not.toHaveBeenCalled()
   })
 
-  it('R2 (PR #450 follow-up): レガシーフォールバックの拒否(limitUnavailable)は genuine soldOut と区別され reportError を呼ぶ', async () => {
+  it('R2 (PR #450 follow-up) + #544/#546: レガシーフォールバックの拒否(limitUnavailable)は reportError も呼びつつ、視聴者への返還・チャット通知も行う', async () => {
     // execute_gacha_transaction RPC が未デプロイのまま limited カードが選ばれた
     // 場合、GachaService.executeGachaLegacy は CARD_ISSUANCE_MESSAGES.soldOut
     // ではなく専用の limitUnavailable を返す(src/lib/services/gacha.ts)。
     // これは「発行枚数上限に達した」という運用上正常な状態ではなく、
     // 「RPC関数が本番に存在しない」という本来あってはならない異常事態なので、
-    // eventsub route のソフトフェイル抑止リストに含めず reportError を発火させ、
-    // 確実にアラートされることを検証する。
+    // reportError で確実にアラートされることを検証する。
+    // 一方で視聴者は soldOut のときと同様に既にチャンネルポイントを消費済みで
+    // カードを受け取れていないため、reportError とは独立に #544/#546 の
+    // 返還・チャット通知も必ず行われることを検証する(このガードが漏れていると、
+    // 視聴者はポイントを失ったまま何の救済も受けられなくなる)。
     const { CARD_ISSUANCE_MESSAGES } = await import('@/lib/card-issuance')
     const { GachaService } = await import('@/lib/services/gacha')
     const { reportError } = await import('@/lib/sentry/error-handler')
@@ -174,13 +222,25 @@ describe('EventSub redemption: card issuance limit error handling', () => {
         error: CARD_ISSUANCE_MESSAGES.limitUnavailable,
       }),
     }) as unknown as InstanceType<typeof GachaService>)
+    mocks.streamerSettings = { chat_announcement_enabled: true }
+    mocks.cancelRedemption.mockResolvedValue({ success: true })
 
     const { POST } = await import('@/app/api/twitch/eventsub/route')
-    const req = await buildRedemptionRequest('msg-limit-unavailable-1')
+    const req = await buildRedemptionRequest('msg-limit-unavailable-1', 'redemption-limit-unavailable-1')
     const res = await POST(req as unknown as import('next/server').NextRequest)
 
     expect(res.status).toBe(200)
     expect(mockReport).toHaveBeenCalledTimes(1)
+    expect(mockReport).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ context: 'eventsub:handleRedemption:limitUnavailable' }),
+    )
+    expect(mocks.cancelRedemption).toHaveBeenCalledWith({
+      broadcasterTwitchUserId: 'broadcaster-1',
+      rewardId: 'reward-1',
+      redemptionId: 'redemption-limit-unavailable-1',
+    })
+    expect(mocks.sendChatMessage).toHaveBeenCalledTimes(1)
   })
 
   it('limit_reached 以外のエラーは引き続き reportError を呼ぶ (回帰防止)', async () => {
@@ -200,5 +260,120 @@ describe('EventSub redemption: card issuance limit error handling', () => {
 
     expect(res.status).toBe(200)
     expect(mockReport).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('EventSub redemption: sold-out chat notification + channel points refund (Issue #544, #546)', () => {
+  async function mockSoldOut() {
+    // 実際に返るのは CARD_ISSUANCE_MESSAGES.soldOut('このカードは発行可能枚数に
+    // 達しています')。'limit_reached' は RPC の内部フィールド名であり
+    // エラー文字列としては返らないため、実態に合わせて修正した。
+    const { CARD_ISSUANCE_MESSAGES } = await import('@/lib/card-issuance')
+    const { GachaService } = await import('@/lib/services/gacha')
+    vi.mocked(GachaService).mockImplementation(() => ({
+      executeGachaForEventSub: vi.fn().mockResolvedValue({ success: false, error: CARD_ISSUANCE_MESSAGES.soldOut }),
+    }) as unknown as InstanceType<typeof GachaService>)
+  }
+
+  it('返還成功時: cancelRedemption が正しい引数で呼ばれ、返還済み文言でチャット通知される', async () => {
+    await mockSoldOut()
+    mocks.streamerSettings = { chat_announcement_enabled: true }
+    mocks.cancelRedemption.mockResolvedValue({ success: true })
+
+    const { POST } = await import('@/app/api/twitch/eventsub/route')
+    const req = await buildRedemptionRequest('msg-refund-success-1', 'redemption-1')
+    const res = await POST(req as unknown as import('next/server').NextRequest)
+
+    expect(res.status).toBe(200)
+    expect(mocks.cancelRedemption).toHaveBeenCalledWith({
+      broadcasterTwitchUserId: 'broadcaster-1',
+      rewardId: 'reward-1',
+      redemptionId: 'redemption-1',
+    })
+    expect(mocks.sendChatMessage).toHaveBeenCalledTimes(1)
+    const [broadcasterId, message] = mocks.sendChatMessage.mock.calls[0]
+    expect(broadcasterId).toBe('broadcaster-1')
+    expect(message).toContain('@Tester')
+    expect(message).toContain('返還されました')
+  })
+
+  it('返還API失敗時: reportError で記録されるが例外を投げず200を返し、通常文言でチャット通知される', async () => {
+    await mockSoldOut()
+    mocks.streamerSettings = { chat_announcement_enabled: true }
+    mocks.cancelRedemption.mockResolvedValue({ success: false, reason: 'http_401' })
+    const { reportError } = await import('@/lib/sentry/error-handler')
+    const mockReport = vi.mocked(reportError)
+
+    const { POST } = await import('@/app/api/twitch/eventsub/route')
+    const req = await buildRedemptionRequest('msg-refund-fail-1', 'redemption-2')
+    const res = await POST(req as unknown as import('next/server').NextRequest)
+
+    // 返還APIが失敗してもEventSubへのレスポンスは200のまま(クラッシュしない)
+    expect(res.status).toBe(200)
+    expect(mocks.cancelRedemption).toHaveBeenCalledTimes(1)
+    // 返還失敗はSentry/Issue化のためreportErrorに記録される
+    expect(mockReport).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ context: 'eventsub:postSoldOutNotify:cancelRedemption' }),
+    )
+    expect(mocks.sendChatMessage).toHaveBeenCalledTimes(1)
+    const [, message] = mocks.sendChatMessage.mock.calls[0]
+    expect(message).not.toContain('返還されました')
+  })
+
+  it('cancelRedemptionが例外をthrowしても200を返し、握りつぶされる', async () => {
+    await mockSoldOut()
+    mocks.streamerSettings = { chat_announcement_enabled: true }
+    mocks.cancelRedemption.mockRejectedValue(new Error('network error'))
+
+    const { POST } = await import('@/app/api/twitch/eventsub/route')
+    const req = await buildRedemptionRequest('msg-refund-throw-1', 'redemption-3')
+    const res = await POST(req as unknown as import('next/server').NextRequest)
+
+    expect(res.status).toBe(200)
+    // 返還は失敗扱いなので通常文言でチャット通知は継続される
+    expect(mocks.sendChatMessage).toHaveBeenCalledTimes(1)
+    const [, message] = mocks.sendChatMessage.mock.calls[0]
+    expect(message).not.toContain('返還されました')
+  })
+
+  it('redemption id が無い場合: 返還は試みず、チャット通知のみ行われる', async () => {
+    await mockSoldOut()
+    mocks.streamerSettings = { chat_announcement_enabled: true }
+
+    const { POST } = await import('@/app/api/twitch/eventsub/route')
+    // redemptionId を渡さない = event.id が payload に含まれないケース
+    const req = await buildRedemptionRequest('msg-no-redemption-id-1')
+    const res = await POST(req as unknown as import('next/server').NextRequest)
+
+    expect(res.status).toBe(200)
+    expect(mocks.cancelRedemption).not.toHaveBeenCalled()
+    expect(mocks.sendChatMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('chat_announcement_enabled が false の場合: 返還は試みるがチャット通知はしない', async () => {
+    await mockSoldOut()
+    mocks.streamerSettings = { chat_announcement_enabled: false }
+    mocks.cancelRedemption.mockResolvedValue({ success: true })
+
+    const { POST } = await import('@/app/api/twitch/eventsub/route')
+    const req = await buildRedemptionRequest('msg-chat-disabled-1', 'redemption-4')
+    const res = await POST(req as unknown as import('next/server').NextRequest)
+
+    expect(res.status).toBe(200)
+    expect(mocks.cancelRedemption).toHaveBeenCalledTimes(1)
+    expect(mocks.sendChatMessage).not.toHaveBeenCalled()
+  })
+
+  it('streamerSettings が無い(行なし)場合: 既存挙動どおりチャット通知しない', async () => {
+    await mockSoldOut()
+    mocks.streamerSettings = null
+
+    const { POST } = await import('@/app/api/twitch/eventsub/route')
+    const req = await buildRedemptionRequest('msg-no-streamer-row-1')
+    const res = await POST(req as unknown as import('next/server').NextRequest)
+
+    expect(res.status).toBe(200)
+    expect(mocks.sendChatMessage).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/twitch-channel-points.test.ts
+++ b/tests/unit/twitch-channel-points.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Issue #546: cancelRedemption() が Twitch の Update Redemption Status API を
+// 正しいURL/メソッド/認証ヘッダーで呼び、成功/失敗を正しく分類することを検証する。
+// この関数は「呼び出し元 (eventsub route) に対して例外を投げない」という契約を持つため、
+// あらゆる失敗パターンで success:false を返すことも合わせて検証する。
+
+const mocks = vi.hoisted(() => ({
+  getTwitchAccessToken: vi.fn(),
+}))
+
+vi.mock('@/lib/twitch/token-manager', () => ({
+  getTwitchAccessToken: mocks.getTwitchAccessToken,
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const originalFetch = global.fetch
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.getTwitchAccessToken.mockResolvedValue('broadcaster-access-token')
+})
+
+afterEach(() => {
+  global.fetch = originalFetch
+})
+
+describe('cancelRedemption', () => {
+  it('正しいURL・メソッド・ヘッダー・bodyでTwitch APIを呼び、成功時はsuccess:trueを返す', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const { cancelRedemption } = await import('@/lib/twitch/channel-points')
+    const result = await cancelRedemption({
+      broadcasterTwitchUserId: 'broadcaster-1',
+      rewardId: 'reward-1',
+      redemptionId: 'redemption-1',
+    })
+
+    expect(result).toEqual({ success: true })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(
+      'https://api.twitch.tv/helix/channel_points/custom_rewards/redemptions?broadcaster_id=broadcaster-1&reward_id=reward-1&id=redemption-1'
+    )
+    expect(init.method).toBe('PATCH')
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer broadcaster-access-token',
+      'Client-Id': 'test-client-id',
+      'Content-Type': 'application/json',
+    })
+    expect(JSON.parse(init.body)).toEqual({ status: 'CANCELED' })
+  })
+
+  it('アクセストークンが取得できない場合はfetchを呼ばずsuccess:falseを返す', async () => {
+    mocks.getTwitchAccessToken.mockResolvedValue(null)
+    const fetchMock = vi.fn()
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const { cancelRedemption } = await import('@/lib/twitch/channel-points')
+    const result = await cancelRedemption({
+      broadcasterTwitchUserId: 'broadcaster-1',
+      rewardId: 'reward-1',
+      redemptionId: 'redemption-1',
+    })
+
+    expect(result).toEqual({ success: false, reason: 'no_access_token' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('Twitch APIが4xx/5xxを返した場合、例外を投げずsuccess:falseを返す', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: vi.fn().mockResolvedValue('{"message":"Insufficient authorization"}'),
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const { cancelRedemption } = await import('@/lib/twitch/channel-points')
+    const result = await cancelRedemption({
+      broadcasterTwitchUserId: 'broadcaster-1',
+      rewardId: 'reward-1',
+      redemptionId: 'redemption-1',
+    })
+
+    expect(result).toEqual({ success: false, reason: 'http_401' })
+  })
+
+  it('fetchが例外をthrowしても、呼び出し元に伝播させずsuccess:falseを返す', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network down'))
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const { cancelRedemption } = await import('@/lib/twitch/channel-points')
+    await expect(
+      cancelRedemption({
+        broadcasterTwitchUserId: 'broadcaster-1',
+        rewardId: 'reward-1',
+        redemptionId: 'redemption-1',
+      })
+    ).resolves.toEqual({ success: false, reason: 'exception' })
+  })
+})


### PR DESCRIPTION
## 概要

Fixes #544
Fixes #546

視聴者はチャンネルポイント消費後にガチャが失敗しても、これまでサイレント失敗（warnログのみ）だった。

## 変更内容

- `src/lib/twitch/channel-points.ts`: `cancelRedemption()`がTwitchのUpdate Redemption Status APIでredemptionをCANCELEDに更新し、Twitch側でポイントを自動返還。例外を投げず必ず結果オブジェクトを返す設計（救済処理の失敗でEventSubレスポンスを悪化させない）
- `postSoldOutNotify`: 返還(redemption idがある場合のみ)→結果に応じた文言でチャット通知。waitUntil()でレスポンスをブロックしない

## QAで発見・修正した実バグ

初回実装は soldOut/limit_reached の2値のみ判定しており、今日 #594 で追加した `limitUnavailable`（RPC未デプロイ時のlegacy拒否）がこの救済処理から漏れていた（reportErrorは呼ばれるが返還・通知はされない＝視聴者が何の救済も受けられない）。soldOut/limitUnavailable の両方で返還・通知を行い、limitUnavailableのみ追加でreportErrorも呼ぶよう修正。また実際には発生しない`'limit_reached'`という文字列比較（RPC内部フィールド名の誤用、デッドコード）を削除し、既存テストも実態（`CARD_ISSUANCE_MESSAGES.soldOut`）に合わせて修正。回帰テスト追加済み。

## テスト（実測）

- 109 files/1233 tests green（修正含む）/ eslint clean / `npm run workers:build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn