### PR TITLE
docs(chat): 空文字置換されるプレースホルダーの説明を追加 (#504)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -506,7 +506,7 @@
       "multiTemplatePlaceholder": "@'{'user'}' got '{'rarityCounts'}' from a '{'draws'}'-draw gacha! '{'cards'}'",
       "multiShowCards": "Include card-name list in multi-draw announcements",
       "placeholderHelp": "Available placeholders: '{'user'}'=username, '{'card'}'=first card name, '{'rarity'}'=rarity, '{'num'}'=owned count, '{'unique'}'=unique types owned, '{'all'}'=total types, '{'detail'}'=card description, '{'url'}'=collection URL, '{'packName'}'=name of the pack the obtained card belongs to (empty string when the draw wasn't restricted to a pack)",
-      "multiPlaceholderHelp": "Multi-draw only: '{'draws'}'=draw count, '{'rarityCounts'}'=rarity counts (e.g. Rare x3, Common x3), '{'cards'}'=card-name list, '{'newCards'}'=newly obtained card names this draw, '{'newCardCount'}'=count of newly obtained card types this draw",
+      "multiPlaceholderHelp": "Multi-draw only: '{'draws'}'=draw count, '{'rarityCounts'}'=rarity counts (e.g. Rare x3, Common x3), '{'cards'}'=card-name list, '{'newCards'}'=newly obtained card names this draw, '{'newCardCount'}'=count of newly obtained card types this draw ('{'newCards'}'/'{'newCardCount'}' only have content when \"Include card-name list in multi-draw announcements\" is enabled; otherwise they are replaced with an empty string)",
       "previewLength": "Preview length: {current} / {max} characters"
     },
     "buttons": {
@@ -524,6 +524,7 @@
       "checkingScope": "Checking permissions...",
       "saved": "Settings saved",
       "lengthWarning": "If the card description or URL is long, the outgoing message may reach about {estimated} characters. Anything over {max} characters will be truncated when sent.",
+      "newCardPlaceholderWarning": "\"Include card-name list in multi-draw announcements\" is disabled, so '{'newCards'}' / '{'newCardCount'}' in your template will be replaced with an empty string when sent. Enable the checkbox above if you want them to show content.",
       "botDisconnected": "Linked account disconnected"
     },
     "errors": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -506,7 +506,7 @@
       "multiTemplatePlaceholder": "@'{'user'}' が'{'draws'}'連ガチャで '{'rarityCounts'}' を獲得しました！'{'cards'}'",
       "multiShowCards": "N連通知にカード名一覧を含める",
       "placeholderHelp": "使用可能なプレースホルダー: '{'user'}'=ユーザー名, '{'card'}'=先頭カード名, '{'rarity'}'=レアリティ, '{'num'}'=所持枚数, '{'unique'}'=所持種類数, '{'all'}'=全種類数, '{'detail'}'=カード説明, '{'url'}'=コレクションURL, '{'packName'}'=獲得カードが属するパック名（パック未指定の抽選では空文字）",
-      "multiPlaceholderHelp": "N連用: '{'draws'}'=抽選回数, '{'rarityCounts'}'=レアリティ別枚数（例: レアx3、コモンx3）, '{'cards'}'=カード名一覧, '{'newCards'}'=今回初めて獲得したカード名一覧, '{'newCardCount'}'=今回初めて獲得したカード種類数",
+      "multiPlaceholderHelp": "N連用: '{'draws'}'=抽選回数, '{'rarityCounts'}'=レアリティ別枚数（例: レアx3、コモンx3）, '{'cards'}'=カード名一覧, '{'newCards'}'=今回初めて獲得したカード名一覧, '{'newCardCount'}'=今回初めて獲得したカード種類数（'{'newCards'}'・'{'newCardCount'}'は「N連通知にカード名一覧を含める」を有効にしている場合のみ値が入ります。無効の場合は空文字に置き換わります）",
       "previewLength": "プレビュー文字数: {current} / {max}文字"
     },
     "buttons": {
@@ -524,6 +524,7 @@
       "checkingScope": "権限を確認中...",
       "saved": "設定を保存しました",
       "lengthWarning": "カード説明やURLが長い場合、送信メッセージが最大 {estimated} 文字程度になる可能性があります。{max}文字を超えた分は送信時に切り詰められます。",
+      "newCardPlaceholderWarning": "「N連通知にカード名一覧を含める」が無効なため、テンプレート内の '{'newCards'}' / '{'newCardCount'}' は送信時に空文字に置き換わります。内容を表示したい場合は上のチェックボックスを有効にしてください。",
       "botDisconnected": "別アカウント連携を解除しました"
     },
     "errors": {

--- a/src/components/ChatAnnouncementSettings.tsx
+++ b/src/components/ChatAnnouncementSettings.tsx
@@ -125,6 +125,19 @@ export default function ChatAnnouncementSettings({
   const activeMultiTemplate = multiTemplate || DEFAULT_MULTI_DRAW_CHAT_TEMPLATE;
   const canSendChat = hasScope || botConnected;
 
+  // {newCards}/{newCardCount} は multiShowCards（カード名一覧表示）が有効なときのみ値が入り、
+  // 無効時は本文生成ロジック側で空文字に置換される（#487仕様、本PRでは変更しない）。
+  // 誤設定に気づきにくいため、テンプレートがこれらを使っているのに表示設定がOFFの場合は警告する。
+  // {newCards}/{newCardCount} only get content when multiShowCards (card-name list display) is
+  // enabled; otherwise the message-building logic replaces them with an empty string (existing
+  // #487 behavior, unchanged by this PR). Since that's easy to misconfigure without noticing,
+  // warn when the template references them while the display toggle is off.
+  const usesNewCardPlaceholders = useMemo(
+    () => /\{newCards\}|\{newCardCount\}/.test(activeMultiTemplate),
+    [activeMultiTemplate]
+  );
+  const showNewCardPlaceholderWarning = usesNewCardPlaceholders && !multiShowCards;
+
   const demoMessage = useMemo(() => {
     return buildChatPreviewMessage(activeTemplate, {
       user: "SampleUser",
@@ -586,6 +599,15 @@ export default function ChatAnnouncementSettings({
             />
             {t("form.multiShowCards")}
           </label>
+          {/* #504: multiShowCards無効時に{newCards}/{newCardCount}が空文字化される仕様は */}
+          {/* 誤設定に見えやすいため、テンプレートがこれらを使っている場合のみ警告を表示する */}
+          {/* #504: warn when the template uses {newCards}/{newCardCount} while multiShowCards */}
+          {/* is off, since the resulting empty-string substitution otherwise looks like a bug */}
+          {showNewCardPlaceholderWarning && (
+            <div className="mt-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3 text-xs text-yellow-300">
+              {t("messages.newCardPlaceholderWarning")}
+            </div>
+          )}
         </div>
 
         {/* ボタン群 */}

--- a/tests/unit/components/chat-announcement-settings.test.tsx
+++ b/tests/unit/components/chat-announcement-settings.test.tsx
@@ -1,18 +1,29 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ChatAnnouncementSettings from "@/components/ChatAnnouncementSettings";
 import jaMessages from "../../../messages/ja.json";
 
-function renderSettings() {
+// next-intl unescapes the ICU '{'...'}' sequences from messages/ja.json into literal
+// {newCards}/{newCardCount} at render time, so the expectation here is the rendered
+// text rather than the raw JSON string.
+const NEW_CARD_WARNING_TEXT =
+  "「N連通知にカード名一覧を含める」が無効なため、テンプレート内の {newCards} / {newCardCount} は送信時に空文字に置き換わります。内容を表示したい場合は上のチェックボックスを有効にしてください。";
+
+function renderSettings(
+  overrides: Partial<{
+    currentMultiTemplate: string | null;
+    currentMultiShowCards: boolean;
+  }> = {}
+) {
   return render(
     <NextIntlClientProvider locale="ja" messages={jaMessages}>
       <ChatAnnouncementSettings
         streamerId="streamer-1"
         currentEnabled={false}
         currentTemplate={null}
-        currentMultiTemplate={null}
-        currentMultiShowCards={true}
+        currentMultiTemplate={overrides.currentMultiTemplate ?? null}
+        currentMultiShowCards={overrides.currentMultiShowCards ?? true}
         botAccount={null}
       />
     </NextIntlClientProvider>
@@ -42,5 +53,66 @@ describe("ChatAnnouncementSettings", () => {
     expect(screen.getByText("N連ガチャ用テンプレート（任意）")).toBeInTheDocument();
     expect(screen.getByText("N連通知にカード名一覧を含める")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "チャットデモ" })).toBeInTheDocument();
+  });
+
+  // Issue #504: {newCards}/{newCardCount} is silently replaced with an empty string
+  // when multi_show_cards is off, which looks like a misconfiguration. The UI must
+  // surface a warning whenever the template references those placeholders while the
+  // "show card names" toggle is disabled, and stay quiet otherwise.
+  describe("newCards/newCardCount placeholder warning (#504)", () => {
+    it("is hidden when multiShowCards is enabled even if the template uses {newCards}", async () => {
+      renderSettings({
+        currentMultiTemplate: "@{user} が新規カード {newCards} を獲得！",
+        currentMultiShowCards: true,
+      });
+
+      await screen.findByText("N連ガチャ用テンプレート（任意）");
+      expect(screen.queryByText(NEW_CARD_WARNING_TEXT)).not.toBeInTheDocument();
+    });
+
+    it("is hidden when multiShowCards is disabled but the template does not reference the placeholders", async () => {
+      renderSettings({
+        currentMultiTemplate: "@{user} が{draws}連ガチャを引きました！",
+        currentMultiShowCards: false,
+      });
+
+      await screen.findByText("N連ガチャ用テンプレート（任意）");
+      expect(screen.queryByText(NEW_CARD_WARNING_TEXT)).not.toBeInTheDocument();
+    });
+
+    it("is shown when multiShowCards is disabled and the template uses {newCards}", async () => {
+      renderSettings({
+        currentMultiTemplate: "@{user} が新規カード {newCards} を獲得！",
+        currentMultiShowCards: false,
+      });
+
+      expect(await screen.findByText(NEW_CARD_WARNING_TEXT)).toBeInTheDocument();
+    });
+
+    it("is shown when multiShowCards is disabled and the template uses {newCardCount}", async () => {
+      renderSettings({
+        currentMultiTemplate: "@{user} が新規カードを{newCardCount}種類獲得！",
+        currentMultiShowCards: false,
+      });
+
+      expect(await screen.findByText(NEW_CARD_WARNING_TEXT)).toBeInTheDocument();
+    });
+
+    it("toggles live as the user flips the multiShowCards checkbox", async () => {
+      renderSettings({
+        currentMultiTemplate: "@{user} が新規カード {newCards} を獲得！",
+        currentMultiShowCards: true,
+      });
+
+      await screen.findByText("N連ガチャ用テンプレート（任意）");
+      expect(screen.queryByText(NEW_CARD_WARNING_TEXT)).not.toBeInTheDocument();
+
+      const checkbox = screen.getByRole("checkbox", { name: "N連通知にカード名一覧を含める" });
+      fireEvent.click(checkbox);
+      expect(await screen.findByText(NEW_CARD_WARNING_TEXT)).toBeInTheDocument();
+
+      fireEvent.click(checkbox);
+      expect(screen.queryByText(NEW_CARD_WARNING_TEXT)).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## 概要

Fixes #504

`usesNewCardPlaceholders=true` かつ `multi_show_cards=false` の場合、`{newCards}`/`{newCardCount}` が空文字に置換される既存仕様（#487）が誤設定に見えにくいという指摘への対応。**本文生成ロジック・DBスキーマは変更なし**、説明改善のみ。

## 変更内容

- N連テンプレートのヘルプ文に、`{newCards}`/`{newCardCount}` は「N連通知にカード名一覧を含める」有効時のみ値が入る旨を明記
- `multi_show_cards` 無効かつテンプレートがこれらのプレースホルダーを使用している場合、設定UIに警告ヒントを表示（既存の `usesNewCardPlaceholders` 検出ロジックと同じ判定式を流用）
- i18n（ja/en）・表示テスト追加

## テスト（実測）

- 112 files/1315 tests green / eslint clean / `npm run workers:build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn