### PR TITLE
fix(rarity): カスタムレアリティのソート順バグを修正 (#505)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,8 +3,8 @@ import Image from "next/image";
 import { getTranslations } from "next-intl/server";
 import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { getUserCards } from "@/lib/dashboard-data";
-import { RARITY_ORDER, VOTE_CAMPAIGN_CONFIG } from "@/lib/constants";
-import { getRarityDisplayInfo, aggregateCustomRarities } from "@/lib/rarity";
+import { VOTE_CAMPAIGN_CONFIG } from "@/lib/constants";
+import { getRarityDisplayInfo, aggregateCustomRarities, compareByRarity } from "@/lib/rarity";
 import { shouldShowVoteCampaign } from "@/lib/storage-db";
 import { getUnreadAnnouncements } from "@/lib/announcements";
 import { getOptimizedImageUrl } from "@/lib/image-utils";
@@ -61,11 +61,9 @@ export default async function DashboardPage() {
     isStreamer,
   });
 
-  // Sort cards by rarity (legendary first)
-  // レアリティでソート（レジェンダリーが先頭）
-  userCards.sort((a, b) => {
-    return RARITY_ORDER.indexOf(a.rarity) - RARITY_ORDER.indexOf(b.rarity);
-  });
+  // Sort cards by rarity (legendary first, custom rarities last; see compareByRarity)
+  // レアリティでソート（レジェンダリーが先頭、カスタムレアリティは末尾。compareByRarity参照）
+  userCards.sort(compareByRarity);
 
   // Calculate collection statistics
   const customRarities = aggregateCustomRarities(userCards);

--- a/src/lib/collection-utils.ts
+++ b/src/lib/collection-utils.ts
@@ -1,4 +1,4 @@
-import { RARITY_ORDER } from "@/lib/constants";
+import { getRarityRank } from "@/lib/rarity";
 import type { Card } from "@/types/database";
 
 export type CollectionSortMode = "rarity" | "number";
@@ -27,7 +27,9 @@ export function sortCollectedCards<T extends SortableCollectionCard>(
       if (numberDiff !== 0) return numberDiff;
     }
 
-    const rarityDiff = RARITY_ORDER.indexOf(a.rarity) - RARITY_ORDER.indexOf(b.rarity);
+    // getRarityRank: 未知の(カスタム)レアリティはビルトインより後ろに来るよう
+    // Number.POSITIVE_INFINITY を返す（Issue #505、gacha-sound-rules.ts と同じ考え方）
+    const rarityDiff = getRarityRank(a.rarity) - getRarityRank(b.rarity);
     if (rarityDiff !== 0) return rarityDiff;
 
     const createdAtDiff = new Date(b.created_at).getTime() - new Date(a.created_at).getTime();

--- a/src/lib/rarity.ts
+++ b/src/lib/rarity.ts
@@ -3,6 +3,7 @@ import {
   RARITY_COLORS,
   RARITY_GLOW,
   RARITY_GRADIENT_COLORS,
+  RARITY_ORDER,
 } from "./constants";
 
 export type DefaultRarity = (typeof RARITIES)[number]["value"];
@@ -70,6 +71,36 @@ export function aggregateCustomRarities(
 
 export function getRarityGradientClass(rarity: string): string {
   return RARITY_GRADIENT_COLORS[rarity] ?? DEFAULT_RARITY_GRADIENT_CLASS;
+}
+
+/**
+ * レアリティのソート優先順位（数値ランク）を返す。値が小さいほど希少
+ * （RARITY_ORDER の先頭 = legendary = 0）。
+ *
+ * RARITY_ORDER はビルトイン4種のみを含む固定配列のため、配信者が定義した
+ * カスタムレアリティは Array.prototype.indexOf で見つからず -1 になる。
+ * 呼び出し側がこの -1 をそのまま比較に使うと、"-1 - 0 = -1" となり
+ * カスタムレアリティが legendary (index 0) より希少と誤判定され、
+ * 一覧の先頭に来てしまうバグがあった（Issue #505）。
+ * ここでは -1 を Number.POSITIVE_INFINITY に変換し、カスタムレアリティが
+ * 常に一覧の最後に来るようにする。
+ *
+ * 同じ考え方は gacha-sound-rules.ts の pickSoundBearingCardIndex で
+ * 既に使われている（PR #451/#595 followup）。このヘルパーは
+ * dashboard/page.tsx と collection-utils.ts の同種のソート箇所で
+ * 重複していたロジックを1箇所に集約したもの。
+ */
+export function getRarityRank(rarity: string): number {
+  const index = RARITY_ORDER.indexOf(rarity);
+  return index === -1 ? Number.POSITIVE_INFINITY : index;
+}
+
+/**
+ * レアリティのみを基準にした Array.prototype.sort 用比較関数。
+ * legendary が先頭、カスタムレアリティは末尾に来る（getRarityRank 参照）。
+ */
+export function compareByRarity(a: { rarity: string }, b: { rarity: string }): number {
+  return getRarityRank(a.rarity) - getRarityRank(b.rarity);
 }
 
 export function getRarityGlowClass(rarity: string): string {

--- a/tests/unit/collection-utils.test.ts
+++ b/tests/unit/collection-utils.test.ts
@@ -23,6 +23,27 @@ describe("collection-utils", () => {
       ]);
     });
 
+    it("sorts custom rarities after all builtin rarities, not before them (Issue #505)", () => {
+      // 修正前は RARITY_ORDER.indexOf() の -1 をそのまま比較に使っていたため、
+      // カスタムレアリティ ("mythic") が legendary (index 0) より希少と
+      // 誤判定され、一覧の先頭に来てしまうバグがあった。
+      const cards = [
+        { id: "custom-mythic", rarity: "mythic" as const, created_at: "2026-03-05T00:00:00Z" },
+        { id: "common-new", rarity: "common" as const, created_at: "2026-03-03T00:00:00Z" },
+        { id: "legendary-old", rarity: "legendary" as const, created_at: "2026-03-01T00:00:00Z" },
+        { id: "legendary-new", rarity: "legendary" as const, created_at: "2026-03-02T00:00:00Z" },
+        { id: "rare-new", rarity: "rare" as const, created_at: "2026-03-04T00:00:00Z" },
+      ];
+
+      expect(sortCollectedCards(cards).map((card) => card.id)).toEqual([
+        "legendary-new",
+        "legendary-old",
+        "rare-new",
+        "common-new",
+        "custom-mythic",
+      ]);
+    });
+
     it("sorts by collection number when requested", () => {
       const cards = [
         { id: "third", rarity: "legendary" as const, created_at: "2026-03-03T00:00:00Z", collectionNumber: 3 },

--- a/tests/unit/rarity.test.ts
+++ b/tests/unit/rarity.test.ts
@@ -6,6 +6,8 @@ import {
   getRarityGradientClass,
   getRarityDisplayInfo,
   aggregateCustomRarities,
+  getRarityRank,
+  compareByRarity,
 } from "@/lib/rarity";
 
 describe("rarity helpers", () => {
@@ -59,6 +61,57 @@ describe("rarity helpers", () => {
       expect(
         aggregateCustomRarities([{ rarity: "common" }, { rarity: "rare" }]),
       ).toEqual([]);
+    });
+  });
+
+  describe("getRarityRank", () => {
+    it("ranks builtin rarities from legendary (0) to common (3)", () => {
+      expect(getRarityRank("legendary")).toBe(0);
+      expect(getRarityRank("epic")).toBe(1);
+      expect(getRarityRank("rare")).toBe(2);
+      expect(getRarityRank("common")).toBe(3);
+    });
+
+    it("ranks unknown (custom) rarities after all builtin rarities (Issue #505)", () => {
+      // 修正前は Array.prototype.indexOf の -1 をそのまま比較に使っており、
+      // カスタムレアリティが legendary (0) より「小さい」と誤判定されて
+      // 一覧の先頭に来てしまっていた。POSITIVE_INFINITY を返すことで
+      // 常に最後尾に並ぶことを保証する。
+      expect(getRarityRank("mythic")).toBe(Number.POSITIVE_INFINITY);
+      expect(getRarityRank("mythic")).toBeGreaterThan(getRarityRank("common"));
+    });
+  });
+
+  describe("compareByRarity", () => {
+    it("sorts builtin rarities from legendary to common", () => {
+      const cards = [
+        { rarity: "common" },
+        { rarity: "legendary" },
+        { rarity: "rare" },
+        { rarity: "epic" },
+      ];
+
+      expect(cards.sort(compareByRarity).map((c) => c.rarity)).toEqual([
+        "legendary",
+        "epic",
+        "rare",
+        "common",
+      ]);
+    });
+
+    it("sorts a custom rarity after legendary, not before it (Issue #505)", () => {
+      const cards = [
+        { rarity: "mythic" },
+        { rarity: "legendary" },
+        { rarity: "common" },
+      ];
+
+      // 修正前は "mythic" (custom) が先頭 (legendaryより希少扱い) に来ていた
+      expect(cards.sort(compareByRarity).map((c) => c.rarity)).toEqual([
+        "legendary",
+        "common",
+        "mythic",
+      ]);
     });
   });
 });


### PR DESCRIPTION
## 概要

Fixes #505

## 背景

事前調査の結果、issue本文が懸念していたRPC/生成列の核心部分（`execute_gacha_transaction`、`batch_update_card_drop_rates`、`calculateDropRates`、`computeEffectiveWeights`）は既にレアリティ非依存で安全（`get_gacha_drop_stats`も00050で修正済み）と確認できた一方、**未修正の実バグ**を発見: `RARITY_ORDER.indexOf(rarity)` を直接ソート比較に使う2箇所（dashboard/page.tsx、collection-utils.ts の `sortCollectedCards`）で、カスタムレアリティが `indexOf===-1` により `legendary` より上位と誤判定され一覧の先頭にソートされていた。

同種のバグは本日 `gacha-sound-rules.ts` の `pickSoundBearingCardIndex`（PR #595）で `rawRank===-1 ? Infinity : rawRank` として既に修正済み。

## 変更内容

- `src/lib/rarity.ts` に `getRarityRank()`/`compareByRarity()` を追加（未知レアリティは `Number.POSITIVE_INFINITY` で末尾ソート）
- `dashboard/page.tsx`・`collection-utils.ts` の重複ロジックをこのヘルパーに集約
- `gacha-sound-rules.ts` は既に正しいため無関係な変更を避け未修正

## テスト（実測）

- 112 files/1320 tests green（最新main含む）/ eslint clean / `npm run workers:build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn