### PR TITLE
feat(ops): デプロイ後スモークテスト・運用ドキュメント整備 (#536)

### DIFF
--- a/.github/workflows/smoke-check.yml
+++ b/.github/workflows/smoke-check.yml
@@ -1,0 +1,127 @@
+# Post-deploy Smoke Check (#536)
+# デプロイ後スモークテスト
+#
+# Cloudflare Workers Builds は GitHub Actions とは独立して Git push をトリガーに
+# デプロイを実行するため、「Supabase マイグレーション成功をデプロイの条件にする」
+# 真のデプロイゲートはこのアーキテクチャ上実現できない (#536 で検討済み、既存の
+# Cloudflare Workers Builds 連携を崩さずに実現する方法がないため見送り)。
+#
+# 代わりに、本番デプロイ後 最大15分以内に主要ページとDBスキーマの整合性を
+# 定期チェックし、異常があれば GitHub Issue でアラートする「検知して知らせる」
+# 方式を採用する。デプロイを自動でブロック・ロールバックするものではない
+# (ALERTのみ)。#525-527 のようにコードがマイグレーション未適用のDB列/テーブルを
+# 前提にしてしまう事故を、本番影響が続く前に検知することが目的。
+#
+# See also: docs/cloudflare-workers-builds.md
+# ("Operational Runbook: Repairing Migration History")
+#
+# 必要な Secrets (Production 環境, Settings → Environments → Production):
+#   - NEXT_PUBLIC_SUPABASE_URL: 既存の Production 環境シークレットを再利用。
+#   - SUPABASE_SECRET_KEY (または レガシー名の SUPABASE_SERVICE_ROLE_KEY):
+#     DBスキーマチェック用の Supabase 管理者キー。
+#     この Environment には本ワークフロー作成時点でまだ設定されていないため、
+#     有効化前に追加が必要 (追加するまではDBスキーマチェックが失敗として
+#     報告され続ける — これはフェイルセーフとして意図した挙動であり、
+#     チェックを静かにスキップしない)。
+
+name: Smoke Check
+
+on:
+  schedule:
+    # 15分ごとに実行 (UTC)。デプロイの反映漏れをできるだけ早く検知するための頻度。
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "チェック対象のベースURL (空欄なら本番URLを使用)"
+        required: false
+        default: ""
+
+# 前回実行が長引いていても15分ごとの新規実行が積み重ならないようにする
+concurrency:
+  group: smoke-check
+  cancel-in-progress: false
+
+jobs:
+  smoke-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # NEXT_PUBLIC_SUPABASE_URL 等、既存の Production 環境シークレットを再利用する
+    environment: production
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # continue-on-error + 後続ステップでの outcome 判定により、失敗時も
+      # Issue 作成ステップまでワークフローを継続させる。
+      - name: Run smoke check
+        id: smoke
+        continue-on-error: true
+        run: npm run smoke-check 2>&1 | tee smoke-check-output.log
+        env:
+          SMOKE_TEST_BASE_URL: ${{ github.event.inputs.base_url }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+      # 失敗時のみ実行。同一の障害で15分ごとにIssueが乱立しないよう、
+      # "production-incident" ラベル + 固定タイトルで既存のオープンIssueを検索し、
+      # あればコメント追記、無ければ新規作成する (シンプルな重複防止。
+      # これはあくまでアラート機構であり、厳密な重複排除は行わない)。
+      - name: File or update incident issue on failure
+        if: steps.smoke.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          TITLE="[smoke-check] 本番スモークテストが失敗しています"
+          BODY_FILE="$(mktemp)"
+          {
+            echo "## 自動検知: 本番スモークテスト失敗 (#536)"
+            echo ""
+            echo "- Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo "- Detected at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo ""
+            echo '```'
+            cat smoke-check-output.log
+            echo '```'
+            echo ""
+            echo "このIssueは \`.github/workflows/smoke-check.yml\` (#536) により自動生成/更新されました。"
+            echo "デプロイを自動でブロック・ロールバックする仕組みではないため、内容を確認し手動で対応してください。"
+            echo "マイグレーション不整合が疑われる場合は \`docs/cloudflare-workers-builds.md\` の"
+            echo "\"Operational Runbook: Repairing Migration History\" を参照してください。"
+          } > "$BODY_FILE"
+
+          EXISTING_NUMBER="$(gh issue list --repo "${{ github.repository }}" \
+            --label production-incident --state open \
+            --search "\"$TITLE\" in:title" \
+            --json number --jq '.[0].number')"
+
+          if [ -n "$EXISTING_NUMBER" ]; then
+            echo "Existing incident issue #$EXISTING_NUMBER found; adding a comment"
+            gh issue comment "$EXISTING_NUMBER" --repo "${{ github.repository }}" --body-file "$BODY_FILE"
+          else
+            echo "No existing open incident issue found; creating a new one"
+            gh issue create --repo "${{ github.repository }}" \
+              --title "$TITLE" \
+              --body-file "$BODY_FILE" \
+              --label "bug,production-incident"
+          fi
+
+      # Issue 作成後もジョブ自体は失敗として表示させ、Actions タブからも一目で分かるようにする
+      - name: Fail the job if the smoke check failed
+        if: steps.smoke.outcome == 'failure'
+        run: exit 1

--- a/docs/cloudflare-workers-builds.md
+++ b/docs/cloudflare-workers-builds.md
@@ -79,3 +79,97 @@ feature branch to the preview deployment.
   Variables should only contain values required by the Next.js build.
 - Do not enable the GitHub repository variable until Cloudflare Builds has
   successfully deployed both Workers once.
+
+## Operational Runbook: Repairing Migration History
+
+Background: issue #536 (5/31 incident postmortem). Cloudflare Workers Builds
+deploys the app independently of GitHub Actions, so a Worker build can go live
+before (or without) `supabase db push` having applied the matching migration.
+`.github/workflows/ci.yml`'s migration-order check (#541,
+`scripts/check-migration-order.js`) catches the common authoring mistake (a
+new migration numbered lower than what's already merged), and
+`.github/workflows/smoke-check.yml` (#536) alerts after the fact if a deploy
+went out with schema the DB doesn't have yet. This section covers the manual
+recovery tools for when the remote migration history has actually diverged
+from local files or from the live schema. This is a break-glass procedure,
+not a routine step.
+
+### The two tools, and how they differ
+
+- `supabase migration repair <version> --status applied|reverted` only
+  mutates the remote bookkeeping table
+  (`supabase_migrations.schema_migrations`). It does not run any SQL and does
+  not change the actual schema.
+  - `--status applied`: inserts a history row marking `<version>` as applied,
+    without executing it. Use this when the migration's SQL was already run
+    against the remote DB by some other means (applied manually, or applied
+    by a previous `db push` that then failed to record it) and only the
+    history bookkeeping is missing or wrong.
+  - `--status reverted`: deletes the history row for `<version>`. Use this to
+    remove a stale or incorrect entry, e.g. a migration file was deleted or
+    renumbered (as happened repeatedly around #531/#562) and an old number is
+    still recorded remotely.
+- `supabase db push --include-all` force-applies migrations that are missing
+  from the remote history table, bypassing the normal "not in history, so
+  apply" bookkeeping check that also drives the "out of order" rejection.
+  Unlike `migration repair`, this actually executes the migration's SQL
+  against the remote DB.
+
+### When to use which
+
+- `db push` rejects a migration as "out of order", or as already having a
+  lower number than the latest applied migration, but the listed migrations
+  are confirmed genuinely new and unapplied remotely: run
+  `supabase db push --include-all --dry-run` first to see exactly which files
+  it would apply, verify each one against the live schema (Supabase dashboard
+  SQL editor, or `select column_name from information_schema.columns where
+  table_name = '...'`), then run it for real without `--dry-run`.
+- A migration's schema change is confirmed already live remotely, but
+  `supabase migration list --linked` (`npm run db:status`) shows it as
+  missing or unrecorded: use `migration repair <version> --status applied`.
+  Do not use `db push --include-all` for this case. Most of this repo's
+  migrations use `IF NOT EXISTS` guards so a re-run is often harmless, but any
+  migration that isn't idempotent (a bare `INSERT` without `ON CONFLICT`, a
+  one-off data backfill, etc.) can fail loudly or silently duplicate/corrupt
+  data if re-executed.
+- The history table has an entry for a migration number that no longer
+  corresponds to any file in `supabase/migrations/` (deleted or renumbered):
+  `migration repair <old-version> --status reverted`.
+
+### Commands
+
+```bash
+# Inspect remote history vs local files first (npm run db:status)
+npx supabase migration list --linked
+
+# Preview what db push --include-all would apply, before running for real
+npx supabase db push --include-all --dry-run
+
+# Force-apply migrations missing from remote history
+npx supabase db push --include-all
+
+# Mark a migration as applied in history WITHOUT executing its SQL
+npx supabase migration repair <version> --status applied
+
+# Remove a stale/incorrect history entry
+npx supabase migration repair <version> --status reverted
+```
+
+### Do NOT
+
+- Do not run `--include-all` just to make the error go away without first
+  running `--dry-run` and manually checking, for each migration it lists,
+  whether that schema change is already present on the live DB.
+- Do not `migration repair --status applied` a migration whose schema change
+  has not actually been applied remotely. This only edits the bookkeeping
+  table, not the schema, so the app will behave as if the column, table, or
+  function exists and hit the exact #525-527 failure mode (code referencing
+  schema that was never applied).
+- If it's unclear which specific migrations are safe to mark-applied versus
+  safe to re-run, treat it as a P0/P1 incident: get a second engineer to
+  verify against the live schema before mutating remote migration history,
+  rather than guessing under pressure.
+- The flag semantics above are summarized from the official CLI reference; if
+  behavior is ever in doubt, defer to the docs rather than this summary:
+  https://supabase.com/docs/reference/cli/supabase-migration-repair and
+  https://supabase.com/docs/reference/cli/supabase-db-push

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "db:push": "npx supabase db push",
     "db:push:dry": "npx supabase db push --dry-run",
     "check:migration-order": "node scripts/check-migration-order.js",
+    "smoke-check": "node scripts/smoke-check.js",
     "migrate:vercel-to-r2": "node scripts/migrate-vercel-blob-to-r2.js",
     "migrate:vercel-to-r2:dry": "node scripts/migrate-vercel-blob-to-r2.js --dry-run",
     "error-reporter:deploy": "cd workers/error-reporter && npx wrangler deploy",

--- a/scripts/smoke-check.js
+++ b/scripts/smoke-check.js
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+
+/**
+ * デプロイ後スモークテスト / Post-deploy smoke check (#536)
+ *
+ * 背景:
+ * Cloudflare Workers Builds は GitHub Actions とは独立して Git push をトリガーに
+ * アプリをデプロイする。Supabase マイグレーションは GitHub Actions
+ * (.github/workflows/deploy-cloudflare.yml) が別途 `supabase db push` で適用するため、
+ * 両者の実行タイミングが完全に同期している保証がない。#525-527 の本番障害は、
+ * コードが参照する列・関数がまだマイグレーション未適用のDBに対して実行され、
+ * 500エラーやガチャ機能全停止を引き起こしたことが原因だった。
+ *
+ * このアーキテクチャでは「マイグレーション成功を条件にデプロイをブロックする」
+ * 真のデプロイゲートは実現できない(#536 で検討済み、既存の Cloudflare Workers
+ * Builds 連携を崩さずに実現する方法がないため見送り)。代わりに、デプロイ後
+ * (最大15分以内)に本番の主要ページとDBスキーマの整合性を定期チェックし、
+ * 異常があれば GitHub Issue でアラートする「検知して知らせる」方式を採用する。
+ * これはデプロイを止める・ロールバックするものではない (ALERTのみ)。
+ *
+ * チェック内容:
+ *   1. 主要ページが 2xx を返すか (HTTPスモークテスト)
+ *   2. 直近の数マイグレーションが追加した列・テーブルが実在するか
+ *      (これが #525-527 と同型の「コードは新列を前提にしているが
+ *      マイグレーションが本番に未適用」を検知する最も高シグナルなチェック)
+ *
+ * 使い方:
+ *   node scripts/smoke-check.js
+ *   npm run smoke-check
+ *   SMOKE_TEST_BASE_URL=https://twica-preview.example.workers.dev npm run smoke-check
+ *
+ * 必要な環境変数:
+ *   - SMOKE_TEST_BASE_URL (任意): チェック対象のベースURL。省略時は本番URL。
+ *   - NEXT_PUBLIC_SUPABASE_URL: SupabaseプロジェクトURL (DBスキーマチェックに必要)
+ *   - SUPABASE_SECRET_KEY または SUPABASE_SERVICE_ROLE_KEY: Supabase管理者キー
+ *     (DBスキーマチェックに必要。未設定の場合はDBチェックを失敗として報告する)
+ */
+
+'use strict'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { createClient } = require('@supabase/supabase-js')
+
+/** SMOKE_TEST_BASE_URL 未設定時に使うデフォルトの本番URL */
+const DEFAULT_BASE_URL = 'https://twica.bluemoon.works'
+
+/** HTTPスモークテスト対象のパス一覧 (2xxを期待する主要ページ) */
+const SMOKE_TEST_PATHS = ['/', '/plans']
+
+/**
+ * DBスキーマ整合性チェック対象一覧。
+ *
+ * 「直近の数マイグレーションが追加した列・テーブル」を優先して選ぶ方針
+ * (#536 の設計判断): 全カラムを網羅するのではなく、#525-527 と同型の
+ * 「コードが新しいスキーマを前提にしているが、そのマイグレーションが
+ * 本番にまだ適用されていない」事故を検知する上で最もシグナルの強い、
+ * 最新のマイグレーションが追加した列・テーブルだけを対象にする。
+ *
+ * column が null の場合はテーブル自体の存在確認のみ行う。
+ */
+const SCHEMA_CHECKS = [
+  // 00067_add_card_issuance_limits.sql
+  { table: 'cards', column: 'max_issuance_count' },
+  // 00065_add_pack_rarity_weights.sql
+  { table: 'streamers', column: 'pack_rarity_weights' },
+  { table: 'streamers', column: 'rarity_weights_scope' },
+  // 00066_add_gacha_sound_rules.sql
+  { table: 'streamers', column: 'gacha_sound_rules' },
+  // ガチャ抽選履歴テーブル自体の存在確認 (最も基礎的なテーブル)
+  { table: 'gacha_history', column: null },
+]
+
+/**
+ * env オブジェクトからチェック対象のベースURLを解決する純粋関数。
+ * 末尾のスラッシュは正規化のため除去する。
+ *
+ * @param {Record<string, string | undefined>} env
+ * @returns {string}
+ */
+function resolveBaseUrl(env) {
+  const raw = env.SMOKE_TEST_BASE_URL
+  if (raw && raw.trim()) {
+    return raw.trim().replace(/\/+$/, '')
+  }
+  return DEFAULT_BASE_URL
+}
+
+/**
+ * ベースURLとパス一覧から、チェック対象の完全なURL一覧を組み立てる純粋関数。
+ *
+ * @param {string} baseUrl
+ * @param {string[]} paths
+ * @returns {string[]}
+ */
+function buildCheckUrls(baseUrl, paths) {
+  const trimmedBase = baseUrl.replace(/\/+$/, '')
+  return paths.map((p) => `${trimmedBase}${p.startsWith('/') ? p : `/${p}`}`)
+}
+
+/**
+ * URLチェック失敗時の説明メッセージを組み立てる純粋関数。
+ * error があればネットワークエラー、なければステータスコード異常として報告する。
+ *
+ * @param {{ status?: number, error?: unknown }} info
+ * @returns {string}
+ */
+function formatUrlCheckFailure({ status, error }) {
+  if (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return `HTTPリクエストが失敗しました (${message})`
+  }
+  return `期待した2xxではなく ${status} が返却されました`
+}
+
+/**
+ * table/column のラベル文字列を組み立てる純粋関数 (テーブルのみの場合は "(table)" と表記)。
+ *
+ * @param {{ table: string, column: string | null }} entry
+ * @returns {string}
+ */
+function schemaEntryLabel(entry) {
+  return entry.column ? `${entry.table}.${entry.column}` : `${entry.table} (table)`
+}
+
+/**
+ * DBスキーマチェック失敗時の説明メッセージを組み立てる純粋関数。
+ *
+ * @param {{ table: string, column: string | null, error: { code?: string, message?: string } }} info
+ * @returns {string}
+ */
+function formatSchemaCheckFailure({ table, column, error }) {
+  const target = schemaEntryLabel({ table, column })
+  const code = error && error.code ? error.code : 'unknown'
+  const message = error && error.message ? error.message : String(error)
+  return `${target} の存在確認に失敗しました (code=${code}, message=${message})`
+}
+
+/**
+ * PostgREST/PostgreSQL が返す「テーブル・列が存在しない」系エラーかどうかを判定する純粋関数。
+ *
+ * 既存コード (src/lib/collections/collection-existence.ts の
+ * isMissingCollectionNameColumn 等、src/lib/twitch/token-manager.ts の
+ * isMissingBotSchemaError) と同じ判定慣習を踏襲する:
+ *   - 42703: PostgreSQL の undefined_column (SELECT等の読み取りパスで発生)
+ *   - 42P01: PostgreSQL の undefined_table
+ *   - PGRST204: PostgRESTのスキーマキャッシュに列が見つからない (書き込みパスで発生しやすい)
+ *   - PGRST205: PostgRESTのスキーマキャッシュにテーブルが見つからない
+ *   - メッセージ本文に "does not exist" / "schema cache" を含む場合も同様に扱う
+ * このスクリプトは対象の table/column を自分で指定してSELECTするため、
+ * 既存コードのような「列名で結果をゲートする」処理は不要 (誤検知の余地がない)。
+ *
+ * @param {{ code?: string, message?: string, details?: string, hint?: string } | null | undefined} error
+ * @returns {boolean}
+ */
+function isSchemaMissingError(error) {
+  if (!error || typeof error !== 'object') return false
+
+  const text = [error.message, error.details, error.hint]
+    .map((value) => String(value || ''))
+    .join(' ')
+
+  return (
+    error.code === '42703' ||
+    error.code === '42P01' ||
+    error.code === 'PGRST204' ||
+    error.code === 'PGRST205' ||
+    text.includes('does not exist') ||
+    text.includes('schema cache')
+  )
+}
+
+/**
+ * 個々のチェック結果 (URL/DBスキーマ共通の形) から、成否のサマリメッセージを組み立てる純粋関数。
+ *
+ * @param {Array<{ ok: boolean, name: string, detail?: string }>} results
+ * @returns {{ ok: boolean, message: string }}
+ */
+function summarizeResults(results) {
+  const failures = results.filter((r) => !r.ok)
+
+  if (failures.length > 0) {
+    const lines = [
+      `[smoke-check] NG: ${failures.length}/${results.length} 件のチェックに失敗しました:`,
+      '',
+      ...failures.map((f) => `  - ${f.name}: ${f.detail || '不明なエラー'}`),
+    ]
+    return { ok: false, message: lines.join('\n') }
+  }
+
+  return {
+    ok: true,
+    message: `[smoke-check] OK: ${results.length} 件のチェックに全て成功しました`,
+  }
+}
+
+/** 1つのURLに GET リクエストを送り、2xx かどうかを確認する (ネットワークI/Oあり、単体テスト対象外)。 */
+async function checkUrlEntry(url) {
+  try {
+    const res = await fetch(url, { redirect: 'follow' })
+    if (res.ok) {
+      return { ok: true, name: `GET ${url}` }
+    }
+    return { ok: false, name: `GET ${url}`, detail: formatUrlCheckFailure({ status: res.status }) }
+  } catch (error) {
+    return { ok: false, name: `GET ${url}`, detail: formatUrlCheckFailure({ error }) }
+  }
+}
+
+/**
+ * 1つの table/column の存在確認を行う (DB I/Oあり、単体テスト対象外)。
+ * 対象列 (またはテーブル丸ごとの場合は "*") を limit(1) で1件だけ読み取り、
+ * 列/テーブル不在エラーを isSchemaMissingError で判定する。
+ */
+async function checkSchemaEntry(supabase, entry) {
+  const label = schemaEntryLabel(entry)
+  const selectExpr = entry.column || '*'
+
+  try {
+    const { error } = await supabase.from(entry.table).select(selectExpr).limit(1)
+
+    if (error) {
+      if (isSchemaMissingError(error)) {
+        return { ok: false, name: label, detail: formatSchemaCheckFailure({ ...entry, error }) }
+      }
+      // スキーマ不在以外の予期しないDBエラー (権限エラー等) も失敗として報告する。
+      return {
+        ok: false,
+        name: label,
+        detail: `予期しないDBエラー (code=${error.code || 'unknown'}, message=${error.message})`,
+      }
+    }
+
+    return { ok: true, name: label }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return { ok: false, name: label, detail: `例外が発生しました (${message})` }
+  }
+}
+
+/**
+ * env から Supabase 管理者クライアントを組み立てる。
+ * SUPABASE_SECRET_KEY (新名称) / SUPABASE_SERVICE_ROLE_KEY (レガシー名称) の
+ * どちらでも動くようにする (src/lib/env-validation.ts の requiredEnvVarGroups と同じ方針)。
+ *
+ * @returns {{ client: import('@supabase/supabase-js').SupabaseClient | null, missing: string[] }}
+ */
+function buildSupabaseAdmin(env) {
+  const url = env.NEXT_PUBLIC_SUPABASE_URL
+  const key = env.SUPABASE_SECRET_KEY || env.SUPABASE_SERVICE_ROLE_KEY
+  const missing = []
+
+  if (!url) missing.push('NEXT_PUBLIC_SUPABASE_URL')
+  if (!key) missing.push('SUPABASE_SECRET_KEY (or SUPABASE_SERVICE_ROLE_KEY)')
+
+  if (missing.length > 0) {
+    return { client: null, missing }
+  }
+
+  return { client: createClient(url, key), missing: [] }
+}
+
+async function main() {
+  const baseUrl = resolveBaseUrl(process.env)
+  const urls = buildCheckUrls(baseUrl, SMOKE_TEST_PATHS)
+
+  console.log(`[smoke-check] 対象URL: ${baseUrl}`)
+
+  const urlResults = await Promise.all(urls.map((url) => checkUrlEntry(url)))
+
+  const { client: supabase, missing } = buildSupabaseAdmin(process.env)
+
+  let schemaResults
+  if (!supabase) {
+    // DBスキーマチェックに必要な環境変数が無い場合、チェックをスキップせず
+    // 明示的な失敗として報告する (本番運用ではこの環境変数は必ず設定されているべきで、
+    // 未設定のまま「チェック省略」を成功扱いにすると設定ミスを検知できなくなるため)。
+    schemaResults = [
+      {
+        ok: false,
+        name: 'schema-checks',
+        detail: `DBスキーマチェックに必要な環境変数が未設定です: ${missing.join(', ')}`,
+      },
+    ]
+  } else {
+    schemaResults = await Promise.all(SCHEMA_CHECKS.map((entry) => checkSchemaEntry(supabase, entry)))
+  }
+
+  const summary = summarizeResults([...urlResults, ...schemaResults])
+
+  if (!summary.ok) {
+    console.error(summary.message)
+    process.exit(1)
+  }
+
+  console.log(summary.message)
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[smoke-check] 予期しない例外で終了しました:', error)
+    process.exit(1)
+  })
+}
+
+module.exports = {
+  resolveBaseUrl,
+  buildCheckUrls,
+  formatUrlCheckFailure,
+  schemaEntryLabel,
+  formatSchemaCheckFailure,
+  isSchemaMissingError,
+  summarizeResults,
+  SMOKE_TEST_PATHS,
+  SCHEMA_CHECKS,
+  DEFAULT_BASE_URL,
+}

--- a/tests/unit/smoke-check.test.ts
+++ b/tests/unit/smoke-check.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveBaseUrl,
+  buildCheckUrls,
+  formatUrlCheckFailure,
+  schemaEntryLabel,
+  formatSchemaCheckFailure,
+  isSchemaMissingError,
+  summarizeResults,
+  SMOKE_TEST_PATHS,
+  SCHEMA_CHECKS,
+  DEFAULT_BASE_URL,
+} from '../../scripts/smoke-check.js'
+
+describe('resolveBaseUrl', () => {
+  it('SMOKE_TEST_BASE_URL が設定されていればそれを使う (末尾スラッシュは除去)', () => {
+    expect(resolveBaseUrl({ SMOKE_TEST_BASE_URL: 'https://twica-preview.example.workers.dev/' })).toBe(
+      'https://twica-preview.example.workers.dev'
+    )
+  })
+
+  it('SMOKE_TEST_BASE_URL が空文字/未設定ならデフォルトの本番URLを使う', () => {
+    expect(resolveBaseUrl({})).toBe(DEFAULT_BASE_URL)
+    expect(resolveBaseUrl({ SMOKE_TEST_BASE_URL: '' })).toBe(DEFAULT_BASE_URL)
+    expect(resolveBaseUrl({ SMOKE_TEST_BASE_URL: '   ' })).toBe(DEFAULT_BASE_URL)
+  })
+
+  it('前後の空白を除去する', () => {
+    expect(resolveBaseUrl({ SMOKE_TEST_BASE_URL: '  https://example.com  ' })).toBe('https://example.com')
+  })
+})
+
+describe('buildCheckUrls', () => {
+  it('ベースURLと各パスを結合する', () => {
+    expect(buildCheckUrls('https://example.com', ['/', '/plans'])).toEqual([
+      'https://example.com/',
+      'https://example.com/plans',
+    ])
+  })
+
+  it('ベースURLの末尾スラッシュを正規化する', () => {
+    expect(buildCheckUrls('https://example.com/', ['/plans'])).toEqual(['https://example.com/plans'])
+  })
+
+  it('先頭にスラッシュの無いパスも許容する', () => {
+    expect(buildCheckUrls('https://example.com', ['plans'])).toEqual(['https://example.com/plans'])
+  })
+
+  it('本番のスモークテスト対象パスに / と /plans を含む', () => {
+    expect(SMOKE_TEST_PATHS).toContain('/')
+    expect(SMOKE_TEST_PATHS).toContain('/plans')
+  })
+})
+
+describe('formatUrlCheckFailure', () => {
+  it('ステータスコード異常の場合はステータスコードを含める', () => {
+    expect(formatUrlCheckFailure({ status: 500 })).toContain('500')
+  })
+
+  it('ネットワークエラーの場合はエラーメッセージを含める', () => {
+    const message = formatUrlCheckFailure({ error: new Error('fetch failed') })
+    expect(message).toContain('fetch failed')
+  })
+
+  it('Errorインスタンスでない値も文字列化して含める', () => {
+    const message = formatUrlCheckFailure({ error: 'boom' })
+    expect(message).toContain('boom')
+  })
+})
+
+describe('schemaEntryLabel', () => {
+  it('column があれば table.column 形式', () => {
+    expect(schemaEntryLabel({ table: 'cards', column: 'max_issuance_count' })).toBe('cards.max_issuance_count')
+  })
+
+  it('column が null ならテーブル名 + (table) 表記', () => {
+    expect(schemaEntryLabel({ table: 'gacha_history', column: null })).toBe('gacha_history (table)')
+  })
+})
+
+describe('formatSchemaCheckFailure', () => {
+  it('table/column/エラーコード/メッセージを含む説明文を組み立てる', () => {
+    const message = formatSchemaCheckFailure({
+      table: 'cards',
+      column: 'max_issuance_count',
+      error: { code: '42703', message: 'column "max_issuance_count" does not exist' },
+    })
+    expect(message).toContain('cards.max_issuance_count')
+    expect(message).toContain('42703')
+    expect(message).toContain('does not exist')
+  })
+})
+
+describe('isSchemaMissingError', () => {
+  it('null/undefined は false', () => {
+    expect(isSchemaMissingError(null)).toBe(false)
+    expect(isSchemaMissingError(undefined)).toBe(false)
+  })
+
+  it('42703 (undefined_column, 読み取りパス) を検知する', () => {
+    expect(isSchemaMissingError({ code: '42703', message: 'column does not exist' })).toBe(true)
+  })
+
+  it('42P01 (undefined_table) を検知する', () => {
+    expect(isSchemaMissingError({ code: '42P01', message: 'relation does not exist' })).toBe(true)
+  })
+
+  it('PGRST204 (PostgRESTスキーマキャッシュ: 列不在) を検知する', () => {
+    expect(isSchemaMissingError({ code: 'PGRST204', message: "Could not find the 'foo' column" })).toBe(true)
+  })
+
+  it('PGRST205 (PostgRESTスキーマキャッシュ: テーブル不在) を検知する', () => {
+    expect(isSchemaMissingError({ code: 'PGRST205', message: "Could not find the table 'foo'" })).toBe(true)
+  })
+
+  it('コードが無くてもメッセージに "schema cache" を含めば検知する', () => {
+    expect(isSchemaMissingError({ message: 'not present in schema cache' })).toBe(true)
+  })
+
+  it('無関係なDBエラー (例: 権限エラー) は検知しない', () => {
+    expect(isSchemaMissingError({ code: '42501', message: 'permission denied for table cards' })).toBe(false)
+  })
+})
+
+describe('summarizeResults', () => {
+  it('全て成功なら ok:true で件数を報告する', () => {
+    const result = summarizeResults([
+      { ok: true, name: 'a' },
+      { ok: true, name: 'b' },
+    ])
+    expect(result.ok).toBe(true)
+    expect(result.message).toContain('OK')
+    expect(result.message).toContain('2')
+  })
+
+  it('一部失敗があれば ok:false で失敗内容を列挙する', () => {
+    const result = summarizeResults([
+      { ok: true, name: 'a' },
+      { ok: false, name: 'b', detail: 'それは無い' },
+    ])
+    expect(result.ok).toBe(false)
+    expect(result.message).toContain('NG')
+    expect(result.message).toContain('b')
+    expect(result.message).toContain('それは無い')
+  })
+
+  it('detail が無い失敗は「不明なエラー」で埋める', () => {
+    const result = summarizeResults([{ ok: false, name: 'x' }])
+    expect(result.message).toContain('不明なエラー')
+  })
+})
+
+describe('SCHEMA_CHECKS', () => {
+  it('直近マイグレーション由来の高シグナルな table/column を含む (#525-527と同型の検知)', () => {
+    const labels = SCHEMA_CHECKS.map((entry: { table: string; column: string | null }) =>
+      schemaEntryLabel(entry)
+    )
+    expect(labels).toContain('cards.max_issuance_count')
+    expect(labels).toContain('streamers.pack_rarity_weights')
+    expect(labels).toContain('gacha_history (table)')
+  })
+})

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -77,22 +77,38 @@ preview_bucket_name = "twica-sound-dev"
 [vars]
 NEXT_PUBLIC_TWITCH_CLIENT_ID = "okxjgv064gr80kcijf1b0e182x394o"
 
-# Environment variables are configured in Cloudflare Pages dashboard
-# 環境変数はCloudflare Pagesダッシュボードで設定
+# Environment variables are configured via Cloudflare secrets / dashboard, not
+# by adding entries to this file (the [vars] block above is the one exception,
+# kept here specifically so it survives Dashboard-only overwrites).
+# 環境変数はこのファイルに追記するのではなく Cloudflare Secrets /
+# ダッシュボードで設定する（上の [vars] は Dashboard 専用設定の上書きに
+# 対抗するための唯一の例外）。
 #
-# Required environment variables:
-# 必要な環境変数:
-# - NEXT_PUBLIC_SUPABASE_URL
-# - NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY (or legacy NEXT_PUBLIC_SUPABASE_ANON_KEY)
-# - NEXT_PUBLIC_TWITCH_CLIENT_ID
-# - NEXT_PUBLIC_APP_URL
-# - TWITCH_CLIENT_ID
-# - TWITCH_CLIENT_SECRET
-# - TWITCH_EVENTSUB_SECRET
-# - SUPABASE_SECRET_KEY (or legacy SUPABASE_SERVICE_ROLE_KEY)
-# - R2_PUBLIC_URL (public URL for image R2 bucket)
-# - R2_SOUND_PUBLIC_URL (public URL for sound R2 bucket)
-# - CSRF_TOKEN_SALT
+# Canonical list (#536): the actual runtime source of truth for which
+# environment variables are required is `src/lib/env-validation.ts`
+# (`requiredEnvVars` / `requiredEnvVarGroups`), which throws at startup if any
+# are missing. Do not maintain a second hand-written list here — a prior
+# version of this comment drifted out of sync with env-validation.ts and
+# became misleading. Check that file, not this comment, for what is actually
+# required.
+# 必須環境変数の正本(#536): 実際にランタイムで何が必須かは
+# `src/lib/env-validation.ts` の `requiredEnvVars` / `requiredEnvVarGroups`
+# （起動時に不足があると例外を投げる）。ここに別の手書きリストを維持しない
+# （以前のコメントは env-validation.ts と乖離してしまっていた）。必須項目は
+# このコメントではなく同ファイルを参照すること。
+#
+# Wrangler-specific operational note: server-side / non-NEXT_PUBLIC_* secrets
+# are set with `wrangler secret put <NAME>` (or the Cloudflare dashboard) —
+# never commit them to this file. `NEXT_PUBLIC_*` build-time vars are supplied
+# by Cloudflare Workers Builds / the CI build step (see
+# docs/cloudflare-workers-builds.md), not by [vars] here, so production and
+# preview can use different values without editing this file.
+# Wrangler固有の運用メモ: サーバー側（非NEXT_PUBLIC_*）のシークレットは
+# `wrangler secret put <NAME>`（またはCloudflareダッシュボード）で設定し、
+# このファイルにはコミットしない。`NEXT_PUBLIC_*` のビルド時変数は
+# Cloudflare Workers Builds / CIビルドステップから供給される
+# (docs/cloudflare-workers-builds.md 参照) ため、[vars] ではなく本番/
+# プレビューで異なる値を、このファイルを編集せずに持てる。
 #
 # Note: R2_ENDPOINT, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY are no longer needed
 # in Workers environment (R2 is accessed via native bindings above).


### PR DESCRIPTION
## 概要

Fixes #536

Cloudflare Workers Builds は GitHub Actions と独立してデプロイするため、「Supabase マイグレーション成功をデプロイの条件にする」真のゲートはアーキテクチャ上実現できない（検討済み・ユーザー承認）。代替として3点を実装。

### A. 運用ランブック（docs/cloudflare-workers-builds.md）
`supabase migration repair --status applied|reverted` と `supabase db push --include-all` の用途・使い分け・やってはいけないことを追記（公式CLIリファレンスの実仕様に基づく）。

### B. 必須環境変数ドキュメントの重複排除（wrangler.toml）
`[vars]` 直下のプレーンコメントが実際の正本 `src/lib/env-validation.ts` と乖離していた（`TWITCH_CLIENT_ID`/`R2_PUBLIC_URL` 等、正本には無い項目が残存）ため、正本を参照する注記に置き換え。設定自体は無変更。

### C. デプロイ後スモークテスト（cron・アラートのみ、ユーザー承認）
- `scripts/smoke-check.js`: 主要ページの2xx確認＋直近マイグレーション（00065-00067）が追加した高シグナルな列/テーブルの存在確認。フェイルセーフ設計（環境変数未設定を成功扱いにしない）
- `.github/workflows/smoke-check.yml`: 15分毎cron。失敗時は `production-incident` ラベル付きIssueを検索し無ければ新規作成・あれば追記（乱立防止）。デプロイをブロック/ロールバックしないALERT専用

**要対応（コード外）**: DBスキーマチェックには Supabase 管理者キーが必要ですが、GitHub Production Environment に `SUPABASE_SECRET_KEY`/`SUPABASE_SERVICE_ROLE_KEY` が未設定です（`SUPABASE_DB_URL` のみ設定済み。実測確認済み — 既存の `error-reporter` Worker 用のキーは Cloudflare Dashboard 側にあり、GitHub Actions からは参照不可）。設定するまでDBスキーマチェック部分は失敗を報告し続けます（意図したフェイルセーフ）。マージ後、Settings → Environments → Production への追加をお願いします。

## テスト（実測）

- 113 files/1339 tests green（最新main含む）/ eslint clean / `npm run workers:build` 成功
- `SMOKE_TEST_BASE_URL=https://twica.bluemoon.works node scripts/smoke-check.js` 実測: `/`・`/plans` は2xx成功、DBスキーマチェックはローカルに認証情報が無いため想定通り失敗（クラッシュなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn