### PR TITLE
feat(gacha): gacha_history に reward_id を追加しポーリング経路の報酬別効果音を修復 (#591)

### DIFF
--- a/src/app/api/overlay/[streamerId]/events/route.ts
+++ b/src/app/api/overlay/[streamerId]/events/route.ts
@@ -28,8 +28,41 @@ interface OverlayHistoryRow {
   event_id: string | null;
   redeemed_at: string;
   user_twitch_username: string | null;
+  // Issue #591: migration 00070 で追加。デプロイ窓では未選択(下のフォールバック
+  // クエリ)になりうるため undefined も許容する。
+  reward_id?: string | null;
   cards: OverlayHistoryCard | OverlayHistoryCard[] | null;
 }
+
+/**
+ * Issue #591: gacha_history.reward_id (migration 00070) が未デプロイのDBに
+ * ローリングデプロイ中の新アプリコードが SELECT すると発生する読み取りエラーを
+ * 検知する。書き込み経路の PGRST204 とは異なり、SELECT/ORDER/フィルタでの
+ * 列欠落は PostgreSQL が直接 42703 ("column ... does not exist") を返す
+ * (このモジュールでは書き込みは発生しないため 42703 が主だが、PostgREST の
+ * スキーマキャッシュ経由のPGRST204も念のため許容する)。
+ * collection-existence.ts の isMissingCollectionNameColumn 等と同じ判定パターン。
+ */
+function isMissingRewardIdColumnError(
+  error: { message?: string; code?: string; details?: string; hint?: string } | null | undefined
+): boolean {
+  if (!error) return false;
+  const text = [error.message, error.details, error.hint]
+    .map((value) => String(value ?? ""))
+    .join(" ");
+
+  return (
+    text.includes("reward_id") &&
+    (error.code === "PGRST204" ||
+      text.includes("does not exist") ||
+      text.includes("schema cache"))
+  );
+}
+
+const OVERLAY_HISTORY_SELECT_WITH_REWARD_ID =
+  "id, event_id, redeemed_at, user_twitch_username, reward_id, cards(id, name, description, image_url, rarity)";
+const OVERLAY_HISTORY_SELECT_WITHOUT_REWARD_ID =
+  "id, event_id, redeemed_at, user_twitch_username, cards(id, name, description, image_url, rarity)";
 
 function normalizeDateParam(value: string | null): string | null {
   if (!value) return null;
@@ -116,13 +149,11 @@ export async function GET(
     }
 
     const supabaseAdmin = getSupabaseAdmin();
-    const { data, error } = await withRetry(
+    let { data, error } = await withRetry(
       () =>
         supabaseAdmin
           .from("gacha_history")
-          .select(
-            "id, event_id, redeemed_at, user_twitch_username, cards(id, name, description, image_url, rarity)"
-          )
+          .select(OVERLAY_HISTORY_SELECT_WITH_REWARD_ID)
           .eq("streamer_id", streamerId)
           .gt("redeemed_at", since)
           .order("redeemed_at", { ascending: true })
@@ -130,6 +161,33 @@ export async function GET(
       "overlayEvents",
       { maxRetries: 1 }
     );
+
+    // Issue #591 デプロイ窓フォールバック: gacha_history.reward_id (migration 00070)
+    // がまだ本番DBに適用されていない状態で新アプリコードがSELECTすると読み取り
+    // エラーになる。列を含めない従来のクエリへ1回だけ再試行し、rewardId は
+    // null(=既存の rarity/all ルールへのフォールバック挙動)として扱う。
+    // isMissingCollectionNameColumn 等(collection-existence.ts)と同じ
+    // 「列剥がして再試行」パターン。
+    if (error && isMissingRewardIdColumnError(error)) {
+      const fallback = await withRetry(
+        () =>
+          supabaseAdmin
+            .from("gacha_history")
+            .select(OVERLAY_HISTORY_SELECT_WITHOUT_REWARD_ID)
+            .eq("streamer_id", streamerId)
+            .gt("redeemed_at", since)
+            .order("redeemed_at", { ascending: true })
+            .limit(10),
+        "overlayEvents:reward-id-fallback",
+        { maxRetries: 1 }
+      );
+      // supabase-js は select() の*リテラル*文字列からRow型を推論するため、列数が
+      // 異なる2つのSELECTは互換性の無い別々の型になる(gacha.ts の
+      // executeGacha 内 max_issuance_count フォールバックと同じ制約)。fallback行に
+      // reward_id: null を明示的に補って、上のwith-reward-id型と構造的に一致させる。
+      data = fallback.data?.map((row) => ({ ...row, reward_id: null })) ?? null;
+      error = fallback.error;
+    }
 
     if (error) {
       return handleDatabaseError(error, "Overlay Events API");
@@ -144,6 +202,11 @@ export async function GET(
           eventId: row.event_id,
           redeemedAt: row.redeemed_at,
           userTwitchUsername: row.user_twitch_username ?? "Unknown",
+          // Issue #591: ポーリング経路でも報酬別効果音ルールが評価できるよう、
+          // gacha_history.reward_id をそのまま公開する。列未デプロイ時
+          // (上のフォールバック後)は常に undefined ?? null = null になり、
+          // 従来どおり rarity/all ルールへ安全にフォールバックする。
+          rewardId: row.reward_id ?? null,
           card,
         };
       })

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -128,7 +128,15 @@ export class GachaService {
     // Issue #579 (#576 フェーズ2): パック内レアリティ自動配分に使う配信者の
     // 重み設定。collectionName が未指定の場合や手動モードの場合は無視され、
     // 従来どおり drop_rate ベースの抽選になる。
-    weightsConfig?: RarityWeightsDrawConfig
+    weightsConfig?: RarityWeightsDrawConfig,
+    // Issue #591: Twitchチャネルポイント報酬ID(streamer_additional_gacha_rewards.reward_id
+    // / GachaResult.rewardId と同じ形の値、cards.id とは無関係)。execute_gacha_transaction
+    // RPC経由でgacha_history.reward_idに永続化することで、Realtime broadcastが届かない
+    // ポーリング経路(/api/overlay/[streamerId]/events)でも報酬別効果音ルール
+    // (gacha-sound-rules.ts の targetType: 'reward', #451/#586)が発火するようにする。
+    // EventSub経由(executeGachaForEventSub)のみ利用可能。レイドガチャ
+    // (executeGachaForRaidEvent)はチャネルポイント報酬に紐付かないため常にundefined。
+    rewardId?: string | null
   ): Promise<Result<GachaResult>> {
     try {
       // Get active cards for this streamer (optionally scoped to a pack).
@@ -323,6 +331,7 @@ export class GachaService {
             p_card_id: selectedCard.id,
             p_streamer_id: streamerId,
             p_reward_cost: rewardCost ?? null,
+            p_reward_id: rewardId ?? null,
           }),
           'gacha:executeGacha:rpc',
         )
@@ -332,6 +341,17 @@ export class GachaService {
           // 無停止デプロイ時にアプリコードが先にデプロイされても、
           // ユーザーのチャネルポイントが消費されカード未付与になることを防ぐ
           // TODO: マイグレーション適用確認後にフォールバックを削除
+          //
+          // Issue #591 (p_reward_id追加): PostgREST はRPCを名前付き引数で呼ぶため、
+          // 本アプリコードが先にデプロイされ p_reward_id を送っても、DB側が
+          // migration 00070 未適用(旧6引数版のまま)だと該当パラメータ名を
+          // 解決できず 42883 になる — 00033 で p_reward_cost を追加した際と
+          // 全く同じ性質のデプロイ窓リスクであり、この既存フォールバックが
+          // そのまま吸収する。列とRPCは同一migrationファイル内でアトミックに
+          // 追加されるため、この42883の間は gacha_history.reward_id 列も
+          // 未デプロイ — だからこそ下の executeGachaLegacy は reward_id を
+          // 書き込まない(書けば列不在でPGRST204になるため、詳細は
+          // executeGachaLegacy 内のコメント参照)。
           if (rpcError.code === '42883') {
             logger.warn('execute_gacha_transaction not found, falling back to legacy operations', {
               streamerId, userTwitchId, eventId,
@@ -509,7 +529,16 @@ export class GachaService {
     collectionName?: string | null,
     // Issue #579 (#576 フェーズ2): 各ドローに同じ重み設定を forward する
     // (複数枚ドローでも同じレアリティ配分を一貫して適用するため)。
-    weightsConfig?: RarityWeightsDrawConfig
+    weightsConfig?: RarityWeightsDrawConfig,
+    // Issue #591: 各ドローに同じ報酬IDを forward する。rewardCost(下記
+    // drawRewardCost)とは異なり index===0 に限定しない — reward_cost は
+    // 「引換1回で消費した合計ポイント数」なので1件だけに紐付けるが、
+    // reward_id は「どの報酬から起点になったガチャか」というN連の全カード
+    // 共通の属性であり、ポーリング経路(events API)は履歴行ごとに独立して
+    // サウンドルールを判定する(pickSoundBearingCardIndexへ1件ずつ渡す)ため、
+    // 1枚目以外が reward_id=null のままだと2枚目以降だけ報酬別ルールが
+    // 発火しないバグになる。
+    rewardId?: string | null
   ): Promise<Result<GachaResult>> {
     const cards: GachaCard[] = []
     let firstResult: GachaResult | null = null
@@ -524,7 +553,8 @@ export class GachaService {
         drawEventId,
         drawRewardCost,
         collectionName,
-        weightsConfig
+        weightsConfig,
+        rewardId
       )
 
       if (!result.success) {
@@ -591,6 +621,15 @@ export class GachaService {
     }
 
     // gacha_history upsert（冪等性のためevent_idで重複チェック）
+    //
+    // Issue #591: ここでは意図的に reward_id を書き込まない。この legacy パスに
+    // 到達するのは execute_gacha_transaction RPC が 42883 (未デプロイ) の場合のみ
+    // で、gacha_history.reward_id 列と当該RPCは同一migrationファイル(00070)で
+    // アトミックに追加されるため、RPCが無い=列も無い状態が保証される。ここで
+    // reward_id キーを含めると、PostgREST の書き込み経路は列不在を PGRST204
+    // として返す — つまり「RPC未デプロイ時の安全弁」であるこの legacy パス
+    // 自体を、列追加のせいで壊してしまう。ポーリング経路の報酬別サウンドは
+    // このデプロイ窓の間だけ rarity/all ルールにフォールバックする(=許容範囲)。
     const { error: historyError } = await this.supabase
       .from('gacha_history')
       .upsert({
@@ -797,7 +836,11 @@ export class GachaService {
             rarityWeightsScope: streamer.rarity_weights_scope,
             rarityWeights: streamer.rarity_weights,
             packRarityWeights: streamer.pack_rarity_weights,
-          }
+          },
+          // Issue #591: gacha_history.reward_id に永続化するため、実際に
+          // マッチした報酬ID(メイン報酬 or 追加報酬、いずれも event.reward.id
+          // は同一のEventSub通知由来)をそのまま forward する。
+          event.reward.id
         )
         if (!result.success) return result
         return ok({

--- a/supabase/migrations/00070_add_gacha_history_reward_id.sql
+++ b/supabase/migrations/00070_add_gacha_history_reward_id.sql
@@ -1,0 +1,117 @@
+-- Issue #591: gacha_history に reward_id 列を追加し、ポーリング経路
+-- (/api/overlay/[streamerId]/events) でも報酬別効果音ルールが発火するようにする。
+--
+-- 背景:
+-- 報酬別サウンドルール({targetType: 'reward'} in gacha-sound-rules.ts, #451/#586)
+-- の判定に使う rewardId は、これまで Supabase Realtime のブロードキャスト payload
+-- 経由でのみ配信オーバーレイに届いていた(GachaResult.rewardId — executeGachaForEventSub
+-- が event.reward.id を結果へ付加。src/lib/services/gacha.ts)。WebSocket が切断され
+-- ポーリングフォールバックへ縮退すると、/api/overlay/[streamerId]/events は
+-- gacha_history テーブルを読むが、この列が存在しなかったため rewardId は常に
+-- null になり、報酬別ルールが一切発火せず rarity/all ルールへ静かにフォールバック
+-- していた。
+--
+-- 対応: gacha_history.reward_id (Twitchチャネルポイント報酬ID文字列。
+-- streamer_additional_gacha_rewards.reward_id / GachaResult.rewardId と同じ形の値。
+-- cards.id とは無関係) を追加し、execute_gacha_transaction RPC の書き込み経路で
+-- 一緒に永続化する。events API 側の読み出し変更は
+-- src/app/api/overlay/[streamerId]/events/route.ts (本Issueの別ファイル) で行う。
+
+ALTER TABLE gacha_history
+  ADD COLUMN IF NOT EXISTS reward_id TEXT;
+
+COMMENT ON COLUMN gacha_history.reward_id IS
+  'ガチャ実行の起点になったTwitchチャネルポイント報酬ID (streamer_additional_gacha_rewards.reward_id / GachaResult.rewardId と同じ形)。cards.id とは別物。EventSub経由以外(レイドガチャ等)や既存レコードはNULL。Issue #591: ポーリング経路(/api/overlay/[streamerId]/events)の報酬別効果音ルール判定に使う。';
+
+-- execute_gacha_transaction RPC に reward_id パラメータを追加する。
+-- パラメータ追加はシグネチャ変更になるため、旧6引数版をDROPしてから7引数版を
+-- 再作成する(00033_add_reward_cost_to_gacha_history.sql が reward_cost を追加した
+-- 際と全く同じ理由: CREATE OR REPLACE だけでは「引数の型リストが異なる関数」は
+-- 別オーバーロードとして新規作成されてしまい、旧6引数版と新7引数版が共存して
+-- 呼び出し側の解決先が不定になる)。
+--
+-- デプロイ窓の互換性 (Issue #591 レビューで検証済み):
+-- (a) 旧アプリコード(p_reward_id を送らない6引数呼び出し) + 新DB(本migration適用済み):
+--     p_reward_id は DEFAULT NULL のため、6引数呼び出しはそのまま新関数(7引数版)に
+--     解決される。標準的な「末尾に DEFAULT 付きパラメータを追加」の後方互換パターンで
+--     安全。
+-- (b) 新アプリコード(p_reward_id を含む7引数呼び出し) + 旧DB(本migration未適用、
+--     旧6引数版のまま): Supabase-js の .rpc() は PostgREST 経由で名前付き引数として
+--     RPCを呼ぶため、旧関数に存在しないパラメータ名 p_reward_id を送ると
+--     42883 (undefined_function) になる。これは 00033 で p_reward_cost を追加した
+--     際と全く同じ性質のデプロイ窓リスクであり、GachaService.executeGacha に既に
+--     存在する 42883 → executeGachaLegacy フォールバック(src/lib/services/gacha.ts)が
+--     そのまま吸収する。列とRPCは本ファイル内でアトミックに追加されるため、この
+--     42883 が起きている間は gacha_history.reward_id 列も未デプロイであり、
+--     executeGachaLegacy は意図的に reward_id を書き込まない(書けば列不在で
+--     PGRST204 になり、legacy パス自体が壊れるため。詳細は gacha.ts 内コメント参照)。
+--     → 追加のフォールバックコードは不要と判断。
+DROP FUNCTION IF EXISTS execute_gacha_transaction(TEXT, TEXT, TEXT, UUID, UUID, INTEGER);
+
+CREATE OR REPLACE FUNCTION execute_gacha_transaction(
+  p_event_id TEXT,
+  p_user_twitch_id TEXT,
+  p_user_twitch_username TEXT,
+  p_card_id UUID,
+  p_streamer_id UUID,
+  p_reward_cost INTEGER DEFAULT NULL,
+  p_reward_id TEXT DEFAULT NULL
+) RETURNS JSONB AS $$
+DECLARE
+  v_user_id UUID;
+  v_history_id UUID;
+  v_max_issuance_count INTEGER;
+  v_issued_count INTEGER;
+BEGIN
+  -- Lock the selected card row so concurrent draws cannot exceed its issuance limit.
+  SELECT max_issuance_count
+    INTO v_max_issuance_count
+    FROM cards
+    WHERE id = p_card_id
+      AND streamer_id = p_streamer_id
+      AND is_active = true
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('is_duplicate', false, 'limit_reached', true);
+  END IF;
+
+  IF v_max_issuance_count IS NOT NULL THEN
+    SELECT COUNT(*) INTO v_issued_count
+      FROM user_cards
+      WHERE card_id = p_card_id;
+
+    IF v_issued_count >= v_max_issuance_count THEN
+      RETURN jsonb_build_object('is_duplicate', false, 'limit_reached', true);
+    END IF;
+  END IF;
+
+  INSERT INTO gacha_history (event_id, user_twitch_id, user_twitch_username, card_id, streamer_id, reward_cost, reward_id)
+  VALUES (p_event_id, p_user_twitch_id, p_user_twitch_username, p_card_id, p_streamer_id, p_reward_cost, p_reward_id)
+  ON CONFLICT (event_id) DO NOTHING
+  RETURNING id INTO v_history_id;
+
+  IF v_history_id IS NULL AND p_event_id IS NOT NULL THEN
+    RETURN jsonb_build_object('is_duplicate', true);
+  END IF;
+
+  INSERT INTO users (twitch_user_id, twitch_username, twitch_display_name)
+  VALUES (p_user_twitch_id, p_user_twitch_username, p_user_twitch_username)
+  ON CONFLICT (twitch_user_id) DO NOTHING;
+
+  SELECT id INTO v_user_id FROM users WHERE twitch_user_id = p_user_twitch_id;
+
+  IF v_user_id IS NOT NULL THEN
+    INSERT INTO user_cards (user_id, card_id, obtained_at)
+    VALUES (v_user_id, p_card_id, NOW());
+  END IF;
+
+  RETURN jsonb_build_object('is_duplicate', false, 'limit_reached', false, 'history_id', v_history_id);
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION execute_gacha_transaction(TEXT, TEXT, TEXT, UUID, UUID, INTEGER, TEXT) IS
+  'ガチャのDB操作を1トランザクションで実行し、カード発行可能枚数の上限検証と報酬ID(reward_id)の記録を同時に行う(Issue #591)';
+
+REVOKE ALL ON FUNCTION execute_gacha_transaction(TEXT, TEXT, TEXT, UUID, UUID, INTEGER, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION execute_gacha_transaction(TEXT, TEXT, TEXT, UUID, UUID, INTEGER, TEXT) TO service_role;

--- a/tests/unit/gacha-history-reward-id-migration.test.ts
+++ b/tests/unit/gacha-history-reward-id-migration.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+// Issue #591: gacha_history.reward_id 列の追加と execute_gacha_transaction RPC
+// のシグネチャ拡張。card-issuance-migration.test.ts (00067) / pack-rarity-weights
+// -migration.test.ts (00065) と同じく、SQLテキストへの静的正規表現アサーション
+// であり、実DB実行はしない。
+describe('gacha_history reward_id migration (00070)', () => {
+  const migration = readFileSync(
+    resolve(__dirname, '../../supabase/migrations/00070_add_gacha_history_reward_id.sql'),
+    'utf-8'
+  )
+
+  it('adds a nullable reward_id column to gacha_history', () => {
+    expect(migration).toContain('ADD COLUMN IF NOT EXISTS reward_id TEXT')
+    // NOT NULL/CHECK 制約を付けていないこと(既存行のバックフィルが無いため必須)
+    expect(migration).not.toMatch(/reward_id TEXT NOT NULL/i)
+  })
+
+  it('documents the column with COMMENT ON COLUMN', () => {
+    expect(migration).toMatch(/COMMENT ON COLUMN gacha_history\.reward_id IS/i)
+  })
+
+  it('drops the old 6-arg signature before recreating (avoids overload coexistence, mirrors 00033)', () => {
+    const dropIndex = migration.indexOf(
+      'DROP FUNCTION IF EXISTS execute_gacha_transaction(TEXT, TEXT, TEXT, UUID, UUID, INTEGER);'
+    )
+    const createIndex = migration.indexOf('CREATE OR REPLACE FUNCTION execute_gacha_transaction(')
+
+    expect(dropIndex).toBeGreaterThan(-1)
+    expect(createIndex).toBeGreaterThan(dropIndex)
+  })
+
+  it('extends the RPC signature with p_reward_id as a trailing DEFAULT NULL parameter', () => {
+    expect(migration).toMatch(
+      /CREATE OR REPLACE FUNCTION execute_gacha_transaction\(\s*p_event_id TEXT,\s*p_user_twitch_id TEXT,\s*p_user_twitch_username TEXT,\s*p_card_id UUID,\s*p_streamer_id UUID,\s*p_reward_cost INTEGER DEFAULT NULL,\s*p_reward_id TEXT DEFAULT NULL\s*\) RETURNS JSONB/i
+    )
+  })
+
+  it('inserts reward_id into gacha_history alongside the other columns', () => {
+    expect(migration).toMatch(
+      /INSERT INTO gacha_history \(event_id, user_twitch_id, user_twitch_username, card_id, streamer_id, reward_cost, reward_id\)/i
+    )
+    expect(migration).toMatch(
+      /VALUES \(p_event_id, p_user_twitch_id, p_user_twitch_username, p_card_id, p_streamer_id, p_reward_cost, p_reward_id\)/i
+    )
+  })
+
+  it('preserves the issuance-limit enforcement (FOR UPDATE lock before history/card inserts) from 00067', () => {
+    const lockIndex = migration.indexOf('FOR UPDATE')
+    const countIndex = migration.indexOf('SELECT COUNT(*) INTO v_issued_count')
+    const historyInsertIndex = migration.indexOf('INSERT INTO gacha_history')
+    const userCardInsertIndex = migration.indexOf('INSERT INTO user_cards')
+
+    expect(lockIndex).toBeGreaterThan(-1)
+    expect(countIndex).toBeGreaterThan(lockIndex)
+    expect(historyInsertIndex).toBeGreaterThan(countIndex)
+    expect(userCardInsertIndex).toBeGreaterThan(historyInsertIndex)
+    expect(migration).toContain("'limit_reached', true")
+  })
+
+  it('keeps RPC execution limited to service_role under the new 7-arg signature', () => {
+    expect(migration).toMatch(
+      /REVOKE ALL ON FUNCTION execute_gacha_transaction\(TEXT, TEXT, TEXT, UUID, UUID, INTEGER, TEXT\) FROM PUBLIC/i
+    )
+    expect(migration).toMatch(
+      /GRANT EXECUTE ON FUNCTION execute_gacha_transaction\(TEXT, TEXT, TEXT, UUID, UUID, INTEGER, TEXT\) TO service_role/i
+    )
+  })
+
+  it('documents the deploy-window compatibility analysis (both directions)', () => {
+    // (a) old app code + new DB: DEFAULT param resolves safely
+    expect(migration).toMatch(/DEFAULT NULL のため/)
+    // (b) new app code + old DB: 42883 via PostgREST named-argument dispatch,
+    // absorbed by the existing executeGachaLegacy fallback
+    expect(migration).toContain('42883')
+    expect(migration).toMatch(/executeGachaLegacy/)
+  })
+
+  it('does not introduce permissive public RLS policies', () => {
+    expect(migration).not.toMatch(/FOR ALL\s+USING\s*\(true\)/i)
+    expect(migration).not.toMatch(/TO\s+authenticated/i)
+    expect(migration).not.toMatch(/TO\s+anon/i)
+  })
+})

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -101,7 +101,36 @@ describe('GachaService.executeGacha', () => {
       p_card_id: 'card-1',
       p_streamer_id: 'streamer-1',
       p_reward_cost: null,
+      p_reward_id: null,
     })
+  })
+
+  it('rewardId指定時: execute_gacha_transaction RPCにp_reward_idとして渡される(Issue #591)', async () => {
+    const cardsQuery = createCardsQuery(testCards)
+    const mockRpc = vi.fn().mockResolvedValue({
+      data: { is_duplicate: false, history_id: 'h-reward-id' },
+      error: null,
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'cards') return cardsQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    // executeGacha の8番目の引数(rewardId)を直接渡す
+    const result = await service.executeGacha(
+      'streamer-1', 'user-1', 'testuser', 'event-reward-id',
+      undefined, undefined, undefined, 'reward-abc'
+    )
+
+    expect(result.success).toBe(true)
+    expect(mockRpc).toHaveBeenCalledWith('execute_gacha_transaction', expect.objectContaining({
+      p_reward_id: 'reward-abc',
+    }))
   })
 
   it('drop_rate が DECIMAL 文字列で返っても、結果カードの drop_rate は number に正規化される', async () => {
@@ -1116,14 +1145,20 @@ describe('GachaService.executeGachaForEventSub', () => {
     expect(mockRpc).toHaveBeenNthCalledWith(1, 'execute_gacha_transaction', expect.objectContaining({
       p_event_id: 'event-raid',
       p_reward_cost: 500,
+      // Issue #591: reward_id は reward_cost と異なり「消費ポイント」ではなく
+      // 「起点になった報酬」というN連の全カード共通属性なので、1枚目以外も
+      // 同じ reward_id を持つ必要がある(下の2枚目・3枚目のアサーション参照)。
+      p_reward_id: 'raid-reward',
     }))
     expect(mockRpc).toHaveBeenNthCalledWith(2, 'execute_gacha_transaction', expect.objectContaining({
       p_event_id: 'event-raid:2',
       p_reward_cost: null,
+      p_reward_id: 'raid-reward',
     }))
     expect(mockRpc).toHaveBeenNthCalledWith(3, 'execute_gacha_transaction', expect.objectContaining({
       p_event_id: 'event-raid:3',
       p_reward_cost: null,
+      p_reward_id: 'raid-reward',
     }))
   })
 
@@ -1259,6 +1294,10 @@ describe('GachaService.executeGachaForEventSub', () => {
 
     expect(result.success).toBe(true)
     expect(cardsQuery.eq).toHaveBeenCalledWith('collection_name', 'weapons')
+    // Issue #591: メイン報酬一致時も event.reward.id がp_reward_idとしてRPCへ渡る
+    expect(mockRpc).toHaveBeenCalledWith('execute_gacha_transaction', expect.objectContaining({
+      p_reward_id: 'main-reward',
+    }))
   })
 
   // Issue #579 (#576 フェーズ2): executeGachaForEventSubが取得したstreamer行の
@@ -1486,11 +1525,14 @@ describe('GachaService.executeGachaForRaidEvent', () => {
       p_event_id: 'raid-event-1',
       p_user_twitch_id: 'raider-1',
       p_reward_cost: null,
+      // Issue #591: raid gacha is not tied to a channel-point reward, always null
+      p_reward_id: null,
     }))
     expect(mockRpc).toHaveBeenNthCalledWith(2, 'execute_gacha_transaction', expect.objectContaining({
       p_event_id: 'raid-event-1:2',
       p_user_twitch_id: 'raider-1',
       p_reward_cost: null,
+      p_reward_id: null,
     }))
   })
 

--- a/tests/unit/overlay-events-api.test.ts
+++ b/tests/unit/overlay-events-api.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/overlay/[streamerId]/events/route";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { createMockQueryBuilder } from "../utils/supabase-mock";
+
+vi.mock("@/lib/rate-limit");
+vi.mock("@/lib/supabase/admin", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/supabase/admin")>();
+  return { ...actual, getSupabaseAdmin: vi.fn() };
+});
+vi.mock("@/lib/sentry/error-handler", () => ({
+  reportError: vi.fn(),
+  reportApiError: vi.fn(),
+  logErrorFromLogger: vi.fn(),
+}));
+
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin);
+
+function createRequest(streamerId: string, params: Record<string, string> = {}): NextRequest {
+  const url = new URL(`http://localhost/api/overlay/${streamerId}/events`);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url);
+}
+
+function createRouteParams(streamerId: string) {
+  return { params: Promise.resolve({ streamerId }) };
+}
+
+/** gacha_history クエリの共通モック生成。thenableにしてawait対応 */
+function createHistoryQuery(response: { data: unknown; error: unknown }) {
+  const q = createMockQueryBuilder();
+  (q as unknown as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
+    resolve(response);
+    return q;
+  };
+  return q;
+}
+
+// Issue #591: gacha_history.reward_id (migration 00070) がポーリング経路の
+// レスポンスに正しく反映されること、および列未デプロイ時のデプロイ窓フォール
+// バックを検証する。
+describe("GET /api/overlay/[streamerId]/events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 120,
+      remaining: 119,
+      reset: Date.now() + 60000,
+    });
+  });
+
+  it("returns 400 when since is missing/invalid", async () => {
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn(),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await GET(createRequest("streamer-1"), createRouteParams("streamer-1"));
+    expect(res.status).toBe(400);
+  });
+
+  it("reward_id列の値をrewardIdとしてそのまま返す(Issue #591)", async () => {
+    const historyQuery = createHistoryQuery({
+      data: [
+        {
+          id: "h1",
+          event_id: "event-1",
+          redeemed_at: "2026-01-01T00:00:01Z",
+          user_twitch_username: "viewer1",
+          reward_id: "reward-abc",
+          cards: { id: "c1", name: "Card1", description: null, image_url: null, rarity: "rare" },
+        },
+      ],
+      error: null,
+    });
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn(() => historyQuery),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await GET(
+      createRequest("streamer-1", { since: "2026-01-01T00:00:00Z" }),
+      createRouteParams("streamer-1")
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].rewardId).toBe("reward-abc");
+  });
+
+  it("reward_idがnullの行はrewardId: nullを返す(レイドガチャ等)", async () => {
+    const historyQuery = createHistoryQuery({
+      data: [
+        {
+          id: "h2",
+          event_id: null,
+          redeemed_at: "2026-01-01T00:00:02Z",
+          user_twitch_username: "viewer2",
+          reward_id: null,
+          cards: { id: "c2", name: "Card2", description: null, image_url: null, rarity: "common" },
+        },
+      ],
+      error: null,
+    });
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn(() => historyQuery),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await GET(
+      createRequest("streamer-1", { since: "2026-01-01T00:00:00Z" }),
+      createRouteParams("streamer-1")
+    );
+
+    const body = await res.json();
+    expect(body.events[0].rewardId).toBeNull();
+  });
+
+  it("reward_id列未デプロイ時(42703)は列無しSELECTへフォールバックしrewardId: nullを返す(デプロイ窓, Issue #591)", async () => {
+    const failingQuery = createHistoryQuery({
+      data: null,
+      error: { message: "column gacha_history.reward_id does not exist", code: "42703" },
+    });
+    const fallbackQuery = createHistoryQuery({
+      data: [
+        {
+          id: "h3",
+          event_id: "event-3",
+          redeemed_at: "2026-01-01T00:00:03Z",
+          user_twitch_username: "viewer3",
+          cards: { id: "c3", name: "Card3", description: null, image_url: null, rarity: "epic" },
+        },
+      ],
+      error: null,
+    });
+
+    const fromMock = vi.fn((table: string) => {
+      if (table !== "gacha_history") return createMockQueryBuilder();
+      return fromMock.mock.calls.filter(([name]) => name === "gacha_history").length === 1
+        ? failingQuery
+        : fallbackQuery;
+    });
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: fromMock,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await GET(
+      createRequest("streamer-1", { since: "2026-01-01T00:00:00Z" }),
+      createRouteParams("streamer-1")
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].rewardId).toBeNull();
+    expect(fromMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("列未デプロイ以外のDBエラーはフォールバックせず500を返す", async () => {
+    const failingQuery = createHistoryQuery({
+      data: null,
+      error: { message: "connection reset", code: "08006" },
+    });
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn(() => failingQuery),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await GET(
+      createRequest("streamer-1", { since: "2026-01-01T00:00:00Z" }),
+      createRouteParams("streamer-1")
+    );
+
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## 概要

Fixes #591

報酬別効果音ルール（`{targetType: 'reward'}`、#451/#586）は Realtime ブロードキャスト経由でのみ `rewardId` が届いており、WebSocket 切断時のポーリングフォールバック（`/api/overlay/[streamerId]/events`）は `gacha_history` に該当列が無いため常に `rewardId: null` となり、報酬別ルールが縮退中は一切発火しなかった問題への対応。

## 変更内容

- **migration 00070**: `gacha_history.reward_id` 追加＋`execute_gacha_transaction` RPC を7引数版（`p_reward_id TEXT DEFAULT NULL`）へ拡張。00033（reward_cost追加）と同じ DROP+CREATE OR REPLACE パターン。デプロイ窓の両方向互換性（旧コード+新DB／新コード+旧DB）を検証しコメントに記録。新コード+旧DBの `42883` は既存の `executeGachaLegacy` フォールバックがそのまま吸収するため追加コード不要と判断
- **gacha.ts**: `executeGacha`/`executeGachaDraws` に `rewardId` を追加。`reward_cost` と異なり **N連の全ドローに同じ値を forward**（reward_id は全カード共通属性で、ポーリング経路は履歴行ごとに独立してサウンドルールを判定するため、1枚目限定だと2枚目以降で報酬別ルールが発火しない）。`executeGachaLegacy` は意図的に `reward_id` を書き込まない（デプロイ窓中は列も未デプロイのため書けば `PGRST204` になる）
- **events API**: SELECT に `reward_id` を追加、列未デプロイ時（42703/PGRST204）は列無しSELECTへ1回フォールバックする既存パターンを踏襲

## テスト（実測）

- 114 files/1330 tests green（最新main含む）/ eslint clean / `npm run workers:build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn