### PR TITLE
docs(cards): 発行上限が現在所有数基準であることを明記 (#592)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -61,7 +61,7 @@
       "cardNumberHelp": "Leave blank to auto-number",
       "maxIssuanceCount": "Issue Limit",
       "maxIssuanceCountPlaceholder": "e.g. 1 / 100",
-      "maxIssuanceCountHelp": "Blank is unlimited. 1 makes it unique-only. (max 1,000,000)",
+      "maxIssuanceCountHelp": "Blank is unlimited. 1 makes it unique-only. (max 1,000,000) The limit is based on current holder count — a slot reopens if a copy is removed or exchanged.",
       "collectionName": "Card Pack",
       "collectionNameUnclassified": "{name} (all cards)",
       "collectionNameHelp": "Only cards in the same pack are eligible for that channel point reward's gacha. Register pack names in \"Pack Management\" first.",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -61,7 +61,7 @@
       "cardNumberHelp": "空欄なら自動採番されます",
       "maxIssuanceCount": "発行可能枚数",
       "maxIssuanceCountPlaceholder": "例: 1 / 100",
-      "maxIssuanceCountHelp": "空欄なら無制限、1なら完全ユニークです（最大1,000,000まで）",
+      "maxIssuanceCountHelp": "空欄なら無制限、1なら完全ユニークです（最大1,000,000まで）。上限は「現在の所持者数」を基準に判定します（カードが削除・交換等で手放されると枠が空きます）",
       "collectionName": "カードパック",
       "collectionNameUnclassified": "{name}（すべてのカード）",
       "collectionNameHelp": "同じパック名のカードだけがチャネポ報酬の抽選対象になります。パック名は「パック管理」で事前に登録してください。",


### PR DESCRIPTION
## 概要

Fixes #592

## 方針（issue コメントで確定済み）

発行上限（`max_issuance_count`）のカウント基準は「現在所有数」のままとする（生涯発行数には変更しない）。カードストーン交換機能（現在未使用）実装時にこの相互作用を再検討する。

現時点で実害なし（交換RPCの呼び出し箇所ゼロ）のため、フォームのヘルプ文言に仕様を明記するのみ。ロジック変更なし。

## テスト（実測）

- 115 files/1359 tests green / `npm run workers:build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn