### PR TITLE
fix(upload): 高解像度画像アップロード時の明度低下を修正 (#615)

### DIFF
--- a/src/components/ImageCropper.tsx
+++ b/src/components/ImageCropper.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useCallback, useMemo } from "react";
 import ReactCrop, { type Crop, centerCrop, makeAspectCrop } from "react-image-crop";
 import "react-image-crop/dist/ReactCrop.css";
+import { getColorManaged2DContext } from "@/lib/canvas-color-space";
 
 // Crop mode type: square or portrait
 // トリミングモードの型：正方形またはポートレイト
@@ -139,7 +140,10 @@ export default function ImageCropper({ imageFile, cropMode, onCropComplete, onCa
     // Create an offscreen canvas for the crop operation
     // クロップ操作用のオフスクリーンCanvasを作成
     const canvas = document.createElement("canvas");
-    const ctx = canvas.getContext("2d");
+    // Display P3等の広色域で撮影された高解像度写真をsRGB canvasに描画すると
+    // 色域がクリップされ明度・彩度が下がって見えるため（#615）、可能な場合は
+    // Display P3 コンテキストを使用し、非対応環境ではsRGBにフォールバックする
+    const ctx = getColorManaged2DContext(canvas);
     if (!ctx) return null;
 
     // Calculate the actual pixel values from the percentage-based crop

--- a/src/lib/canvas-color-space.ts
+++ b/src/lib/canvas-color-space.ts
@@ -1,0 +1,47 @@
+/**
+ * Canvas 2D コンテキストの色空間ユーティリティ
+ *
+ * 背景 (Issue #615): 高解像度画像をアップロードすると明度が下がって見える問題
+ *
+ * iPhone等の最近のスマートフォンで撮影された高解像度写真は、多くの場合
+ * Display P3 の広色域で撮影され、そのICCプロファイルが埋め込まれている。
+ * これを何も指定しない（既定でsRGBの）canvas 2Dコンテキストに drawImage すると、
+ * ブラウザは仕様通り色管理された変換を行い、Display P3の色域をsRGBへ
+ * クリップ（gamut mapping）する。sRGBはDisplay P3より狭い色域のため、
+ * P3でしか表現できない明るく鮮やかな色（特に赤・緑系統の高彩度色）が
+ * sRGBの境界に丸められ、結果として彩度・明度が下がって見える。
+ *
+ * 参考: https://webkit.org/blog/12058/wide-gamut-2d-graphics-using-html-canvas/
+ * 「Colors are muted when an sRGB canvas is used... When converting from the
+ * wider Display P3 gamut to the narrower sRGB gamut, saturated colors appear
+ * less vibrant or darker.」
+ *
+ * 対策: 可能であれば Display P3 の canvas コンテキストを使用することで、
+ * P3画像をP3のままcanvasに描画でき、色域のクリップ（＝明度低下）を回避できる。
+ * canvas.toBlob('image/jpeg') は Display P3 コンテキストに対しては、対応
+ * ブラウザでは適切なカラープロファイルを埋め込んだJPEGを出力する。
+ *
+ * ブラウザ対応状況:
+ * - Chrome 94+: 対応
+ * - Safari (macOS 12.1+ / iOS 15.1+): 対応
+ * - Safari (上記バージョン未満): colorSpace: 'display-p3' 指定時にTypeErrorを送出
+ * - Firefox: 現時点で未対応
+ *
+ * 非対応環境では例外を捕捉し、通常の（sRGB）2Dコンテキストにフォールバックする。
+ * フォールバック時は本修正前と同じ挙動（sRGBへのクリップ）になるだけで、
+ * 新たな不具合は生じない（既存動作からの後退なし）。
+ */
+export function getColorManaged2DContext(
+  canvas: HTMLCanvasElement
+): CanvasRenderingContext2D | null {
+  try {
+    const p3Context = canvas.getContext("2d", { colorSpace: "display-p3" });
+    if (p3Context) {
+      return p3Context;
+    }
+  } catch {
+    // colorSpace 未対応環境（要件を満たさないSafariバージョン等）。
+    // 通常の sRGB コンテキストにフォールバックする。
+  }
+  return canvas.getContext("2d");
+}

--- a/tests/unit/canvas-color-space.test.ts
+++ b/tests/unit/canvas-color-space.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getColorManaged2DContext } from '@/lib/canvas-color-space'
+
+// getColorManaged2DContext は Issue #615（高解像度画像アップロード時の明度低下）対策として
+// Display P3 canvas コンテキストを優先的に取得し、非対応環境ではsRGBにフォールバックする。
+// 実際のcanvas 2Dレンダリング（ピクセル/色の検証）はこの環境では検証できないため、
+// canvas.getContext の呼び出しに対するフォールバック制御フローのみを検証する。
+
+type FakeContext = { __brand: string }
+
+function createFakeCanvas(
+  getContextImpl: (contextId: string, options?: { colorSpace?: string }) => FakeContext | null
+): HTMLCanvasElement {
+  return {
+    getContext: vi.fn(getContextImpl),
+  } as unknown as HTMLCanvasElement
+}
+
+describe('getColorManaged2DContext', () => {
+  it('display-p3 コンテキストが取得できる場合はそれを返す', () => {
+    const p3Context: FakeContext = { __brand: 'p3' }
+    const canvas = createFakeCanvas((_id, options) =>
+      options?.colorSpace === 'display-p3' ? p3Context : { __brand: 'srgb' }
+    )
+
+    const ctx = getColorManaged2DContext(canvas)
+
+    expect(ctx).toBe(p3Context)
+    expect(canvas.getContext).toHaveBeenCalledWith('2d', { colorSpace: 'display-p3' })
+    // sRGBへのフォールバックは発生しない（P3が取得できた時点で追加呼び出し不要）
+    expect(canvas.getContext).toHaveBeenCalledTimes(1)
+  })
+
+  it('display-p3 指定でTypeErrorが投げられる場合（例: 要件を満たさないSafari）はsRGBにフォールバックする', () => {
+    const srgbContext: FakeContext = { __brand: 'srgb' }
+    const canvas = createFakeCanvas((_id, options) => {
+      if (options?.colorSpace === 'display-p3') {
+        throw new TypeError('display-p3 not supported on this system')
+      }
+      return srgbContext
+    })
+
+    const ctx = getColorManaged2DContext(canvas)
+
+    expect(ctx).toBe(srgbContext)
+    expect(canvas.getContext).toHaveBeenNthCalledWith(1, '2d', { colorSpace: 'display-p3' })
+    expect(canvas.getContext).toHaveBeenNthCalledWith(2, '2d')
+  })
+
+  it('display-p3 指定でnullが返る場合（例: Firefox等の非対応ブラウザ）はsRGBにフォールバックする', () => {
+    const srgbContext: FakeContext = { __brand: 'srgb' }
+    const canvas = createFakeCanvas((_id, options) =>
+      options?.colorSpace === 'display-p3' ? null : srgbContext
+    )
+
+    const ctx = getColorManaged2DContext(canvas)
+
+    expect(ctx).toBe(srgbContext)
+  })
+
+  it('sRGBコンテキストも取得できない場合はnullを返す', () => {
+    const canvas = createFakeCanvas(() => null)
+
+    const ctx = getColorManaged2DContext(canvas)
+
+    expect(ctx).toBeNull()
+  })
+})


### PR DESCRIPTION
## 概要

Fixes #615

## 根本原因

画像トリミング処理（`ImageCropper.tsx`、唯一の画像加工経路）が bare な `canvas.getContext("2d")`（既定sRGB）を使用。iPhone等の高解像度写真の多くは Display P3 の広色域で撮影されており、ブラウザは仕様通り drawImage 時に P3→sRGB の色域クリップ（gamut mapping）を行うため、彩度の高い色を中心に暗く/くすんで見える（[WebKit公式ブログ](https://webkit.org/blog/12058/wide-gamut-2d-graphics-using-html-canvas/)で同現象を確認）。「高解像度画像ほど明度低下」という報告は、高解像度写真ほど最近のスマホカメラ（P3）由来である可能性が高いことと整合。

## 変更内容

- `src/lib/canvas-color-space.ts`（新規）: `getColorManaged2DContext()` — `colorSpace: 'display-p3'` を優先試行し、非対応環境（要件を満たさないSafari・Firefox等）は try/catch で既存の sRGB コンテキストへ安全にフォールバック（後退なし）
- `ImageCropper.tsx`: bare な `getContext("2d")` を上記に置換（1行の変更）

## テスト（実測）

- 116 files/1363 tests green / eslint clean / `npm run workers:build` 成功
- 実ピクセル・色のレンダリング検証はこの環境では実施不可のため未実測。理論的裏付け（WebKit公式仕様）とコード制御フロー（P3取得成功/例外/nullの分岐）の単体テストのみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn