### PR TITLE
perf(db): カード削除カスケードの未インデックスFKにインデックスを追加 (#614)

### DIFF
--- a/supabase/migrations/00071_add_card_delete_cascade_indexes.sql
+++ b/supabase/migrations/00071_add_card_delete_cascade_indexes.sql
@@ -1,0 +1,70 @@
+-- Issue #614: DELETE /api/cards/[id] が本番で Postgres の
+-- statement timeout (57014 "canceling statement due to statement timeout")
+-- を起こした障害の恒久対策。
+--
+-- 実際に発生したログパターン: DELETE /api/cards/[id] リクエストの
+-- 約11秒後に statement timeout が発生。src/app/api/cards/[id]/route.ts の
+-- DELETE ハンドラ(514-517行目)は `DELETE FROM cards WHERE id = $1` を
+-- 1回発行するだけで、事前チェックや分割削除は行っていない。実際の削除コストは
+-- cards.id を参照する5本の外部キーに対する Postgres の
+-- ON DELETE CASCADE / ON DELETE SET NULL に委ねられている。
+--
+-- FK列にインデックスが無いと、カスケード処理は各子テーブルに対して
+-- `WHERE fk_col = $1`(SET NULLの場合は `UPDATE ... SET fk_col = NULL
+-- WHERE fk_col = $1`)を子テーブル全件のシーケンシャルスキャンで実行する。
+-- cards.id を参照する5列のうち、user_cards.card_id のみ 00001 で索引済み
+-- (idx_user_cards_card_id, 00001_initial_schema.sql:70)。残り4列は
+-- 無索引だったため、本migrationで以下を追加する:
+--
+-- 1. gacha_history.card_id (00001_initial_schema.sql:61, ON DELETE CASCADE)
+--    gacha_history はプラットフォーム最大のイベントログテーブル
+--    (00051_add_card_owner_stats.sql:1-6 で言及の通り、旧実装は
+--    PostgREST の1万件フェッチ上限に達した実績がある)。索引なしの
+--    カスケードDELETEは同テーブルの全件シーケンシャルスキャンになり、
+--    本障害の主因と推定される。
+--
+-- 2. battles.opponent_card_id (00002_add_battle_features.sql:18,
+--    ON DELETE CASCADE)
+--    対戦相手カードとして参照する battles 行の削除も同様に全件スキャンになる。
+--
+-- 3. card_owner_stats.card_id (00051_add_card_owner_stats.sql:21,
+--    ON DELETE CASCADE)
+--    既存の複合索引 idx_card_owner_stats_card_rank
+--    (streamer_id, card_id, owned_count DESC, last_obtained_at DESC ;
+--    00051_add_card_owner_stats.sql:34-40) はリーディング列が streamer_id
+--    のため、card_id 単独条件のカスケード検索には使えない。加えて、
+--    cards 削除に伴う user_cards の CASCADE DELETE は行ごとに
+--    trg_sync_card_owner_stat トリガー(00051_add_card_owner_stats.sql:149-153)
+--    を発火し、削除された user_cards 1行につき
+--    sync_card_owner_stat()/refresh_card_owner_stat() が SELECT 2回 + 書き込み
+--    1回を実行する(00051_add_card_owner_stats.sql:73-124)。これは
+--    所有者数の多い人気カードほどコストが乗算される別経路だが、
+--    トリガー自体のロジックは正しく Issue #614 のスコープ外のため変更しない。
+--    ここでは card_owner_stats 自身の CASCADE DELETE を高速化する。
+--
+-- 4. card_stone_transactions.card_id (00059_add_card_stones_exchange.sql:18,
+--    ON DELETE SET NULL)
+--    索引なしでは `UPDATE card_stone_transactions SET card_id = NULL
+--    WHERE card_id = $1` が全件スキャンになる。
+--
+-- CONCURRENTLY は使わない: 00032_add_get_gacha_users_for_streamer.sql の
+-- 先例と同じ理由で、CREATE INDEX CONCURRENTLY はトランザクションブロック内
+-- では実行できず、supabase db push によるマイグレーション適用は
+-- トランザクション内で行われるため、通常の CREATE INDEX IF NOT EXISTS を
+-- 使う。将来、本番の巨大テーブルに無停止で適用し直したい場合は、
+-- 手動で CONCURRENTLY 版を個別実行することを検討する。
+--
+-- 命名規則は既存の idx_user_cards_card_id (00001) に倣い
+-- idx_<table>_<column> とする。
+
+CREATE INDEX IF NOT EXISTS idx_gacha_history_card_id
+  ON gacha_history(card_id);
+
+CREATE INDEX IF NOT EXISTS idx_battles_opponent_card_id
+  ON battles(opponent_card_id);
+
+CREATE INDEX IF NOT EXISTS idx_card_owner_stats_card_id
+  ON card_owner_stats(card_id);
+
+CREATE INDEX IF NOT EXISTS idx_card_stone_transactions_card_id
+  ON card_stone_transactions(card_id);

--- a/tests/unit/card-delete-cascade-indexes-migration.test.ts
+++ b/tests/unit/card-delete-cascade-indexes-migration.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+// Issue #614: DELETE /api/cards/[id] が本番で Postgres の statement timeout
+// (57014) を起こした障害の恒久対策。cards.id を参照する5本のFKのうち
+// user_cards.card_id 以外の4本(gacha_history.card_id / battles.opponent_card_id /
+// card_owner_stats.card_id / card_stone_transactions.card_id)が無索引だったため
+// カスケードDELETE/SET NULLが子テーブル全件スキャンになっていたことが根本原因。
+// pack-rarity-weights-migration.test.ts (00065) / gacha-history-reward-id
+// -migration.test.ts (00070) と同じく、SQLテキストへの静的正規表現アサーション
+// であり、実DB実行はしない。
+describe('card delete cascade indexes migration (00071, Issue #614)', () => {
+  const migration = readFileSync(
+    resolve(__dirname, '../../supabase/migrations/00071_add_card_delete_cascade_indexes.sql'),
+    'utf-8'
+  )
+
+  // 実際の CREATE INDEX 文だけを抽出する(先頭が `--` のコメント行は除外)。
+  // 説明コメント中で「CONCURRENTLY」「CREATE INDEX IF NOT EXISTS」という
+  // 語句そのものに触れているため、行頭アンカー無しの単純な文字列一致だと
+  // コメントを誤検出する。以降の全アサーションはこのフィルタ済み配列を使う。
+  const statementLines = migration
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('CREATE INDEX'))
+
+  it('references Issue #614', () => {
+    expect(migration).toMatch(/#614/)
+  })
+
+  it('adds an index on gacha_history.card_id (ON DELETE CASCADE, 00001)', () => {
+    expect(migration).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_gacha_history_card_id\s*\n?\s*ON gacha_history\(card_id\)/
+    )
+  })
+
+  it('adds an index on battles.opponent_card_id (ON DELETE CASCADE, 00002)', () => {
+    expect(migration).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_battles_opponent_card_id\s*\n?\s*ON battles\(opponent_card_id\)/
+    )
+  })
+
+  it('adds an index on card_owner_stats.card_id (ON DELETE CASCADE, 00051)', () => {
+    expect(migration).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_card_owner_stats_card_id\s*\n?\s*ON card_owner_stats\(card_id\)/
+    )
+  })
+
+  it('adds an index on card_stone_transactions.card_id (ON DELETE SET NULL, 00059)', () => {
+    expect(migration).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_card_stone_transactions_card_id\s*\n?\s*ON card_stone_transactions\(card_id\)/
+    )
+  })
+
+  it('creates exactly these 4 indexes (no more, no fewer)', () => {
+    const names = statementLines.map((line) => line.match(/idx_\w+/)?.[0]).sort()
+    expect(names).toEqual(
+      [
+        'idx_battles_opponent_card_id',
+        'idx_card_owner_stats_card_id',
+        'idx_card_stone_transactions_card_id',
+        'idx_gacha_history_card_id',
+      ].sort()
+    )
+  })
+
+  it('follows the idx_<table>_<column> naming convention used by idx_user_cards_card_id (00001)', () => {
+    expect(statementLines.some((line) => line.includes('idx_gacha_history_card_id'))).toBe(true)
+    expect(statementLines.some((line) => line.includes('idx_battles_opponent_card_id'))).toBe(true)
+    expect(statementLines.some((line) => line.includes('idx_card_owner_stats_card_id'))).toBe(true)
+    expect(statementLines.some((line) => line.includes('idx_card_stone_transactions_card_id'))).toBe(true)
+  })
+
+  it('uses plain CREATE INDEX (not CONCURRENTLY), matching the 00032 precedent for transaction-wrapped migrations', () => {
+    // supabase db push applies migrations inside a transaction block, and
+    // CREATE INDEX CONCURRENTLY cannot run inside one (00032 established this
+    // precedent). Every statement here must be a plain, transaction-safe
+    // CREATE INDEX IF NOT EXISTS.
+    expect(statementLines.length).toBeGreaterThan(0)
+    for (const statement of statementLines) {
+      expect(statement).not.toMatch(/CONCURRENTLY/i)
+    }
+  })
+
+  it('is idempotent (IF NOT EXISTS) so re-running the migration is safe', () => {
+    expect(statementLines.length).toBe(4)
+    for (const statement of statementLines) {
+      expect(statement).toContain('IF NOT EXISTS')
+    }
+  })
+
+  it('does not introduce permissive public RLS policies', () => {
+    expect(migration).not.toMatch(/FOR ALL\s+USING\s*\(true\)/i)
+    expect(migration).not.toMatch(/TO\s+authenticated/i)
+    expect(migration).not.toMatch(/TO\s+anon/i)
+  })
+})


### PR DESCRIPTION
## 概要

Fixes #614

## 根本原因

本番エラーログ（`DELETE /api/cards/[id]` の約11秒後に statement timeout）を調査した結果、`cards.id` を参照する5本のFKのうち4本（`gacha_history.card_id`, `battles.opponent_card_id`, `card_owner_stats.card_id`, `card_stone_transactions.card_id`）にインデックスが無いことを確認。カード削除時の `ON DELETE CASCADE`/`SET NULL` カスケードが、無索引の子テーブル全件シーケンシャルスキャンになっていたと推定。`gacha_history` はプラットフォーム最大のイベントログテーブル（既存コメント: 旧実装がPostgRESTの1万件フェッチ上限に達した実績あり）で最有力の主因。

## 変更内容

- migration 00071: 4つのFK列にインデックス追加（`CREATE INDEX IF NOT EXISTS`。00032の先例に倣い `CONCURRENTLY` は不使用 — トランザクション内では実行不可のため）
- `handleDatabaseError` へのエラーコンテキスト追加は、シグネチャ変更が必要なためスコープ外として見送り（別issue化を検討）

## テスト（実測）

- 117 files/1373 tests green（最新main含む）/ eslint clean / `npm run workers:build` 成功
- **未実測の事項**: 実DBへの適用による EXPLAIN ANALYZE before/after 比較は本環境では実施不可。効果はPostgresのFK/カスケード処理の一般的挙動と既存コメント（00032, 00051）に基づく推定。ステージング/本番適用後の実測が次のステップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn