### PR TITLE
fix(cards): パック名変更後のカード状態リフレッシュとIME誤送信を修正 (#605, #613)

### DIFF
--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -942,6 +942,26 @@ export default function CardManager({
     []
   );
 
+  // Issue #605: CardPackModal でパック名のリネームが成功した際のコールバック。
+  // サーバー側(rename_card_pack RPC)は cards.collection_name を含めて既に
+  // カスケード更新済みだが、CardPackModal はカタログ配列(パック名一覧)しか
+  // 知らず onSaved 経由でもそれしか渡せない。そのため、既存カードの表示が
+  // ここでローカルパッチしない限り旧パック名のまま取り残され、リロードするまで
+  // 「別パックのカード」に見えてしまっていた。handleToggleActive 等と同じ
+  // 「サーバーの実際の変更をローカル state に反映するだけ」の楽観的更新パターン。
+  const handlePackRenamed = useCallback((oldName: string, newName: string) => {
+    setCards((prev) =>
+      prev.map((card) =>
+        card.collection_name === oldName ? { ...card, collection_name: newName } : card
+      )
+    );
+    // 選択中のパックフィルタが今リネームされたパックを指していた場合、新名へ
+    // 追従させる。追従させないと、カタログには存在しない旧名で絞り込んだままになり
+    // (packFilterOptions は cardPackNames ∪ cards の collection_name から作られる
+    // ため、旧名は両方から消える)、フィルタ結果が意図せず0件に見えてしまう。
+    setPackFilter((prev) => (prev === oldName ? newName : prev));
+  }, []);
+
   // Calculate total weight and actual probability
   // 合計重みと実際の確率を計算
   const calculateActualProbability = (dropRate: number): number => {
@@ -2743,6 +2763,7 @@ export default function CardManager({
         isPremium={isPremium}
         onSaved={setCardPackNames}
         onDefaultPackNameSaved={setDefaultPackName}
+        onPackRenamed={handlePackRenamed}
       />
 
       {/* Emote Import Modal */}

--- a/src/components/CardPackModal.tsx
+++ b/src/components/CardPackModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/constants";
 import { MAX_COLLECTION_NAME_LENGTH, isReservedCollectionName } from "@/lib/validation/collection-name";
 import { logger } from "@/lib/logger";
+import { isEnterKeySubmit } from "@/lib/keyboard-utils";
 
 // ここでの事前検証は UX 向上のためで、最終的な検証はサーバーが行う
 // (POST /api/streamer/settings, PATCH /api/cards/collections)。検証規則は
@@ -27,6 +28,12 @@ interface CardPackModalProps {
   onSaved: (next: string[]) => void;
   // Issue #554: デフォルトパックの表示名リネームが成功した際に親へ通知する。
   onDefaultPackNameSaved: (next: string | null) => void;
+  // Issue #605: 通常パックのリネームが成功した際、旧名→新名を親へ通知する。
+  // onSaved はリネーム後のカタログ配列(string[])のみを渡すため、親
+  // (CardManager)が保持する cards ステートの collection_name 追従には使えない。
+  // このコールバックで親がカード側をローカルパッチできるようにする
+  // (呼び出し側がカードを持たない場合に備え任意propとする)。
+  onPackRenamed?: (oldName: string, newName: string) => void;
 }
 
 /**
@@ -84,6 +91,7 @@ export default function CardPackModal({
   isPremium = false,
   onSaved,
   onDefaultPackNameSaved,
+  onPackRenamed,
 }: CardPackModalProps) {
   const t = useTranslations("cardManager");
   const tCommon = useTranslations("common");
@@ -289,6 +297,12 @@ export default function CardPackModal({
         : list.map((v) => (v === oldName ? newName : v));
       setList(nextList);
       onSaved(nextList);
+      // Issue #605: カタログ配列の更新(onSaved)だけでは、親が保持する既存カード
+      // の collection_name が旧パック名のまま取り残される(サーバー側は
+      // rename_card_pack RPC でカード側も含めて既にカスケード更新済み)。
+      // 親側のカード表示がリロードするまで「別パックのカード」に見えてしまう
+      // 不具合の原因だったため、専用コールバックで旧名→新名を明示的に伝える。
+      onPackRenamed?.(oldName, newName);
       cancelRename();
     } catch (err) {
       logger.error("Failed to rename card pack:", err);
@@ -411,7 +425,8 @@ export default function CardPackModal({
                 placeholder={t("cardPackModal.addPlaceholder")}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") {
+                  // Issue #613: IME変換確定のEnterで誤って追加が走らないようにする
+                  if (isEnterKeySubmit(e)) {
                     e.preventDefault();
                     handleAdd();
                   }
@@ -463,7 +478,8 @@ export default function CardPackModal({
                         placeholder={t("cardPackModal.defaultName")}
                         onChange={(e) => setRenameInput(e.target.value)}
                         onKeyDown={(e) => {
-                          if (e.key === "Enter") {
+                          // Issue #613: IME変換確定のEnterで誤って保存が走らないようにする
+                          if (isEnterKeySubmit(e)) {
                             e.preventDefault();
                             handleRenameDefaultSave();
                           } else if (e.key === "Escape") {
@@ -541,7 +557,8 @@ export default function CardPackModal({
                           disabled={renameSaving}
                           onChange={(e) => setRenameInput(e.target.value)}
                           onKeyDown={(e) => {
-                            if (e.key === "Enter") {
+                            // Issue #613: IME変換確定のEnterで誤って保存が走らないようにする
+                            if (isEnterKeySubmit(e)) {
                               e.preventDefault();
                               handleRenamePackSave();
                             } else if (e.key === "Escape") {

--- a/src/components/CustomRarityModal.tsx
+++ b/src/components/CustomRarityModal.tsx
@@ -10,6 +10,7 @@ import {
   RARITY_BIDI_OVERRIDE_REGEX as BIDI_OVERRIDE_REGEX,
 } from "@/lib/constants";
 import { logger } from "@/lib/logger";
+import { isEnterKeySubmit } from "@/lib/keyboard-utils";
 
 // ここでの事前検証は UX 向上のためで、最終的な検証はサーバーが行う
 // (POST /api/streamer/settings)。検証規則は constants の共通定数を共有する。
@@ -207,7 +208,9 @@ export default function CustomRarityModal({
                 placeholder={t("customRarity.addPlaceholder")}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") {
+                  // CardPackModal (#613) と同種のIME誤送信バグの再発防止として、
+                  // 同じガードをここにも適用する。
+                  if (isEnterKeySubmit(e)) {
                     e.preventDefault();
                     handleAdd();
                   }

--- a/src/lib/keyboard-utils.ts
+++ b/src/lib/keyboard-utils.ts
@@ -1,0 +1,20 @@
+/**
+ * IME(日本語・中国語・韓国語などの変換)入力中に変換を確定するEnterキー押下を
+ * 「送信操作」として誤検知しないための判定。
+ *
+ * IME変換中にEnterキーを押すと、ブラウザは変換確定のためのkeydownイベント
+ * (key === "Enter")を発火する。これを通常の送信/追加/保存トリガーと区別しないと、
+ * ユーザーが変換を確定しただけのつもりで、意図せず保存・追加操作が走ってしまう
+ * (Issue #613)。isComposing 中はここで弾き、Enterキー本来の送信動作は
+ * 呼び出し側で e.preventDefault() 等と併せて行う。
+ *
+ * React合成イベントの isComposing は型上 nativeEvent 経由でのみ公開される
+ * (React.KeyboardEvent 自体はこのフィールドを型に持たない)ため、構造的な型で
+ * nativeEvent.isComposing を参照する(React.KeyboardEvent はこれを満たす)。
+ */
+export function isEnterKeySubmit(e: {
+  key: string;
+  nativeEvent: { isComposing: boolean };
+}): boolean {
+  return e.key === "Enter" && !e.nativeEvent.isComposing;
+}

--- a/tests/unit/components/card-manager-card-packs.test.tsx
+++ b/tests/unit/components/card-manager-card-packs.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { screen, fireEvent, within } from '@testing-library/react'
+import { screen, fireEvent, within, waitFor } from '@testing-library/react'
 import { DEFAULT_PACK_SENTINEL } from '@/lib/validation/collection-name'
 import { baseCard, renderCardManager } from '../../utils/card-manager-test-helpers'
 
@@ -141,5 +141,82 @@ describe('CardManager pack-relative probability (Issue #565)', () => {
     // 未分類は U1 のみ → 100%
     expect(screen.getByText('100.0%')).toBeInTheDocument()
     expect(screen.getByText(HINT)).toBeInTheDocument()
+  })
+})
+
+// Issue #605: パック名リネーム成功時、CardPackModal はカタログ配列(パック名一覧)
+// しか親に伝えられない(onSaved)。バグ修正前は、親(CardManager)が保持する
+// 既存カードの collection_name が旧パック名のまま取り残され、リロードするまで
+// 「別パック(孤立参照)のカード」のように見えてしまっていた。
+// onPackRenamed コールバックで CardManager 側の cards ステートをローカルパッチし、
+// 選択中のパックフィルタも新名へ追従することを、CardManager 経由(単体の
+// CardPackModal ではなく実際の親子配線込み)でエンドツーエンドに検証する。
+describe('CardManager cards follow a pack rename without a reload (Issue #605)', () => {
+  const weaponsCards = [
+    baseCard({ id: 'w1', name: '武器1', collection_name: 'weapons' }),
+    baseCard({ id: 'w2', name: '武器2', collection_name: 'weapons' }),
+  ]
+
+  const selectPackFilter = (value: string) => {
+    fireEvent.change(
+      screen.getByRole('combobox', { name: 'カードパックで絞り込む' }),
+      { target: { value } }
+    )
+  }
+
+  it('re-associates existing cards with the new pack name and keeps an active pack filter following the rename', async () => {
+    // PATCH /api/cards/collections 含め、このテストで発生する全fetchに対して
+    // 一律でリネーム成功レスポンスを返す(card-pack-modal.test.tsx と同じ簡略化。
+    // マウント時の /api/storage-status 取得もこれを受け取るが、storageStatus は
+    // このテストでは未使用/未検証なので実害はない)。
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      new Response(JSON.stringify({ success: true, cardPackNames: ['armory'] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderCardManager(weaponsCards, {
+      initialCardPackNames: ['weapons'],
+      viewMode: 'list',
+    })
+
+    // リネーム前から "weapons" で絞り込んでいたユーザーのシナリオを再現する。
+    selectPackFilter('weapons')
+    expect(screen.getByText('武器1')).toBeInTheDocument()
+    expect(screen.getByText('武器2')).toBeInTheDocument()
+
+    // パック管理モーダルを開き、weapons → armory にインラインリネームする。
+    fireEvent.click(screen.getByRole('button', { name: 'パック管理' }))
+    const renameTrigger = screen.getByLabelText('Rename weapons')
+    const row = renameTrigger.closest('li')!
+    fireEvent.click(renameTrigger)
+    fireEvent.change(within(row).getByRole('textbox'), { target: { value: 'armory' } })
+    fireEvent.click(within(row).getByRole('button', { name: '保存' }))
+
+    // モーダル内のカタログ表示が新名に切り替わるまで待つ
+    // (list の key が変わるため row 参照は以降使い回さない)。
+    await waitFor(() => expect(screen.queryByLabelText('Rename weapons')).not.toBeInTheDocument())
+    expect(screen.getByLabelText('Rename armory')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    // 修正前: パックフィルタは "weapons" のまま残り、cards[].collection_name も
+    // 旧名のままなので、絞り込み結果が(存在しないパックへの絞り込みで)空になる。
+    // 修正後: フィルタは自動的に新名 "armory" へ追従し、カードも armory 所属として
+    // 表示され続ける。
+    const filterSelect = screen.getByRole('combobox', { name: 'カードパックで絞り込む' })
+    expect(filterSelect).toHaveValue('armory')
+    expect(screen.getByText('武器1')).toBeInTheDocument()
+    expect(screen.getByText('武器2')).toBeInTheDocument()
+
+    // packFilterOptions は cardPackNames ∪ cards[].collection_name の和集合な
+    // ので、どちらか一方でも旧名のままだと選択肢に残ってしまう。
+    const optionLabels = within(filterSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent)
+    expect(optionLabels).toContain('armory')
+    expect(optionLabels).not.toContain('weapons')
   })
 })

--- a/tests/unit/components/card-pack-modal.test.tsx
+++ b/tests/unit/components/card-pack-modal.test.tsx
@@ -367,4 +367,84 @@ describe("CardPackModal", () => {
       await waitFor(() => expect(onDefaultPackNameSaved).toHaveBeenCalledWith(null));
     });
   });
+
+  // Issue #613: IME(日本語入力等)の変換確定Enterで、追加/保存が誤って
+  // 走ってしまっていた。isComposing中のEnterは無視し、通常のEnterでは
+  // 従来通り動作することを検証する。
+  describe("IME composition guards (Issue #613)", () => {
+    it("does not add a pack on a composing Enter, but does on a normal Enter", () => {
+      renderModal({ isPremium: true, cardPackNames: ["weapons"] });
+
+      const input = screen.getByPlaceholderText("新しいパック名");
+      fireEvent.change(input, { target: { value: "characters" } });
+
+      // IME変換確定中のEnter(isComposing: true) → 追加されない
+      fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+      expect(screen.queryByText("characters")).not.toBeInTheDocument();
+
+      // 変換確定後の通常のEnter(isComposing: false) → 追加される
+      fireEvent.keyDown(input, { key: "Enter", isComposing: false });
+      expect(screen.getByText("characters")).toBeInTheDocument();
+    });
+
+    it("does not save a pack rename on a composing Enter, but does on a normal Enter", async () => {
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ success: true, cardPackNames: ["armory"] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      );
+      renderModal({ cardPackNames: ["weapons"] });
+
+      const renameTrigger = screen.getByLabelText("Rename weapons");
+      const row = renameTrigger.closest("li")!;
+      fireEvent.click(renameTrigger);
+      const textbox = within(row).getByRole("textbox");
+      fireEvent.change(textbox, { target: { value: "armory" } });
+
+      fireEvent.keyDown(textbox, { key: "Enter", isComposing: true });
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(textbox, { key: "Enter", isComposing: false });
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          "/api/cards/collections",
+          expect.objectContaining({
+            method: "PATCH",
+            body: JSON.stringify({ streamerId: "streamer-1", oldName: "weapons", newName: "armory" }),
+          })
+        );
+      });
+    });
+
+    it("does not save the default pack rename on a composing Enter, but does on a normal Enter", async () => {
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      );
+      renderModal({ defaultPackName: null });
+
+      const renameTrigger = screen.getByLabelText("Rename default pack");
+      const row = renameTrigger.closest("li")!;
+      fireEvent.click(renameTrigger);
+      const textbox = within(row).getByRole("textbox");
+      fireEvent.change(textbox, { target: { value: "オリジナルカード" } });
+
+      fireEvent.keyDown(textbox, { key: "Enter", isComposing: true });
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(textbox, { key: "Enter", isComposing: false });
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledWith(
+          "/api/streamer/settings",
+          expect.objectContaining({
+            method: "POST",
+            body: JSON.stringify({ streamerId: "streamer-1", defaultCardPackName: "オリジナルカード" }),
+          })
+        );
+      });
+    });
+  });
 });

--- a/tests/unit/keyboard-utils.test.ts
+++ b/tests/unit/keyboard-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+
+import { isEnterKeySubmit } from "@/lib/keyboard-utils"
+
+// Issue #613: IME(日本語入力等)の変換確定Enterを、追加/保存の送信操作として
+// 誤検知しないための判定関数。CardPackModal / CustomRarityModal の複数箇所で
+// 共有される単純な述語なので、コンポーネントを介さず直接検証する。
+describe("isEnterKeySubmit", () => {
+  it("returns true for a normal (non-composing) Enter key press", () => {
+    expect(
+      isEnterKeySubmit({ key: "Enter", nativeEvent: { isComposing: false } })
+    ).toBe(true)
+  })
+
+  it("returns false for an Enter key press while IME composition is active", () => {
+    expect(
+      isEnterKeySubmit({ key: "Enter", nativeEvent: { isComposing: true } })
+    ).toBe(false)
+  })
+
+  it("returns false for non-Enter keys regardless of composition state", () => {
+    expect(
+      isEnterKeySubmit({ key: "a", nativeEvent: { isComposing: false } })
+    ).toBe(false)
+    expect(
+      isEnterKeySubmit({ key: "Escape", nativeEvent: { isComposing: true } })
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## 概要

Fixes #605
Fixes #613

## Issue #605: パック名変更で既存カードが「別扱い」になる
DB/API層（`rename_card_pack` RPC、migration 00065）は正常にカスケード更新済みだったが、**クライアント側のみ**バグがあった: `CardPackModal.handleRenamePackSave` は `onSaved(nextList)` でリネーム後のカタログ配列（`string[]`）しか親へ渡しておらず、`CardManager` の `cards` state は旧パック名のまま取り残されていた。

- `CardPackModal` に `onPackRenamed?: (oldName, newName) => void` を追加
- `CardManager.handlePackRenamed` で `cards[].collection_name` をローカルパッチ（既存の `handleToggleActive` と同じ楽観的更新パターン）。選択中の `packFilter` が旧名を指していた場合は新名へ自動追従

## Issue #613: パック名変更時、IME確定Enterで保存が誤発火する
`CardPackModal.tsx` の3箇所（新規パック追加/デフォルトパックのリネーム/通常パックのインラインリネーム）全てで `isComposing` 判定漏れ。

- 新規 `src/lib/keyboard-utils.ts` に `isEnterKeySubmit(e)` 共有ヘルパーを追加
- 3箇所に適用。同種バグが `CustomRarityModal.tsx` にもあったため軽微な横展開として併せて修正

## Issue #601 の調査結論（このPRには含めず）
静的解析＋実際のRTL再現テストで検証したが、現行コードでは再現せず。`hasPacks`/`packActiveCounts` は毎レンダー props から直接算出されておりキャッシュ問題は無く、モーダルは閉じるたびに完全アンマウントされ最新propsで再構築される。コード変更は行わず、ユーザー側での実機再現有無の確認を推奨。

## テスト（実測）

- #605/#613 とも修正を一時的に外した状態でテストが実際に失敗すること（red）を確認した上で実装（green）
- 117 files/1370 tests green（最新main含む）/ eslint clean / `npm run workers:build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AwKByC1KL2p8LifAn999tn