### PR TITLE
fix(db): migration 00071のbattlesインデックス作成を存在チェックで保護

### DIFF
--- a/supabase/migrations/00071_add_card_delete_cascade_indexes.sql
+++ b/supabase/migrations/00071_add_card_delete_cascade_indexes.sql
@@ -56,12 +56,27 @@
 --
 -- 命名規則は既存の idx_user_cards_card_id (00001) に倣い
 -- idx_<table>_<column> とする。
+--
+-- battles テーブルのみ存在チェックで囲む: 00024_fix_rls_policies_security.sql
+-- が明記する通り、本番環境には battles/battle_stats テーブルが存在しない
+-- (battle 機能はどのナビゲーションからもリンクされていない未使用機能で、
+-- テーブル自体がマイグレーション経路外で欠落している)。無条件の
+-- CREATE INDEX ON battles(...) は本番で
+-- "relation battles does not exist" (42P01) で失敗し、本ファイルは
+-- 単一トランザクションのため他3つのインデックスも道連れでロールバックし、
+-- 後続マイグレーションを全てブロックしていた。00024 と同じ
+-- pg_class 存在チェックで回避する。
 
 CREATE INDEX IF NOT EXISTS idx_gacha_history_card_id
   ON gacha_history(card_id);
 
-CREATE INDEX IF NOT EXISTS idx_battles_opponent_card_id
-  ON battles(opponent_card_id);
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_class WHERE relname = 'battles') THEN
+    EXECUTE 'CREATE INDEX IF NOT EXISTS idx_battles_opponent_card_id ON battles(opponent_card_id)';
+  END IF;
+END
+$$;
 
 CREATE INDEX IF NOT EXISTS idx_card_owner_stats_card_id
   ON card_owner_stats(card_id);

--- a/tests/unit/card-delete-cascade-indexes-migration.test.ts
+++ b/tests/unit/card-delete-cascade-indexes-migration.test.ts
@@ -17,13 +17,19 @@ describe('card delete cascade indexes migration (00071, Issue #614)', () => {
   )
 
   // 実際の CREATE INDEX 文だけを抽出する(先頭が `--` のコメント行は除外)。
+  // battles 向けの1文は pg_class 存在チェック(DO $$ ... EXECUTE '...' $$)で
+  // 囲まれ EXECUTE 文字列の中に埋め込まれているため、行頭一致ではなく
+  // 非コメント行を連結したテキストに対する正規表現マッチで抽出する
+  // (トップレベルの文・EXECUTE 文字列内の文の両方を同じ形で拾える)。
   // 説明コメント中で「CONCURRENTLY」「CREATE INDEX IF NOT EXISTS」という
-  // 語句そのものに触れているため、行頭アンカー無しの単純な文字列一致だと
-  // コメントを誤検出する。以降の全アサーションはこのフィルタ済み配列を使う。
-  const statementLines = migration
+  // 語句そのものに触れているため、コメント行は事前に除外する。
+  const nonCommentText = migration
     .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.startsWith('CREATE INDEX'))
+    .filter((line) => !line.trim().startsWith('--'))
+    .join('\n')
+  const statementLines = [
+    ...nonCommentText.matchAll(/CREATE INDEX IF NOT EXISTS \w+\s*\n?\s*ON \w+\([^)]+\)/g),
+  ].map((m) => m[0].replace(/\s+/g, ' '))
 
   it('references Issue #614', () => {
     expect(migration).toMatch(/#614/)
@@ -88,6 +94,26 @@ describe('card delete cascade indexes migration (00071, Issue #614)', () => {
     for (const statement of statementLines) {
       expect(statement).toContain('IF NOT EXISTS')
     }
+  })
+
+  it('guards only the battles index behind a pg_class existence check (production lacks the battles table per 00024 precedent)', () => {
+    // battles/battle_stats は 00024_fix_rls_policies_security.sql の時点で
+    // 既に本番に存在しないことが判明していたテーブル(battle機能はナビゲーション
+    // からリンクされていない未使用機能で、テーブルがマイグレーション経路外で
+    // 欠落している)。無条件の CREATE INDEX ON battles(...) は本番で
+    // "relation battles does not exist" (42P01) で失敗し、単一トランザクション
+    // のため他3インデックスも巻き添えでロールバックする
+    // (これが実際にこのmigrationを本番で失敗させた障害そのもの)。
+    expect(migration).toMatch(
+      /IF EXISTS \(SELECT 1 FROM pg_class WHERE relname = 'battles'\)[\s\S]*?EXECUTE 'CREATE INDEX IF NOT EXISTS idx_battles_opponent_card_id ON battles\(opponent_card_id\)'/
+    )
+    // gacha_history / card_owner_stats / card_stone_transactions は実在が
+    // 確定しているテーブルなので無条件のままであるべき(過剰な防御は避ける)。
+    // ガードが1箇所(battles)にしか存在しないことで、それを確認する
+    // (説明コメント中の「pg_class」という語自体への言及は除外するため、
+    // コメント除去済みの nonCommentText を数える)。
+    const pgClassGuardCount = (nonCommentText.match(/pg_class/g) || []).length
+    expect(pgClassGuardCount).toBe(1)
   })
 
   it('does not introduce permissive public RLS policies', () => {


### PR DESCRIPTION
## 背景

#614 のマイグレーション `00071_add_card_delete_cascade_indexes.sql` が本番デプロイで失敗し続けている。

```
ERROR: relation "battles" does not exist (SQLSTATE 42P01)
CREATE INDEX IF NOT EXISTS idx_battles_opponent_card_id
  ON battles(opponent_card_id)
```

調査の結果、本番環境に `battles`/`battle_stats` テーブルが存在しないのは**今回のリグレッションではなく既知の状態**であることを確認した。`00024_fix_rls_policies_security.sql`(2026-02-28)が既に同じ理由でRLSポリシー作成を存在チェックで囲んでおり、コミットメッセージにも「production環境にbattlesテーブルが存在しない場合」と明記されている。battle機能(`/battle`, `/battle/stats`)はコード上は残っているが、ナビゲーション/ダッシュボードのどこからもリンクされていない未使用機能で、テーブルはマイグレーション経路外で本番から欠落したまま今日に至る。

`00071`はCONCURRENTLYを使わず単一トランザクションで4つのCREATE INDEXを実行するため、2番目の`battles`向けインデックスが失敗すると他3つ(`gacha_history`, `card_owner_stats`, `card_stone_transactions`向け、いずれも実在テーブル)も道連れでロールバックし、`supabase-migrations`ジョブ全体が失敗、後続マイグレーションの適用がブロックされていた。

## 修正内容

`00024`と同じ`pg_class`存在チェックパターンで、`battles`向けのインデックス作成のみを条件分岐する。他3つのインデックスは無条件のまま(対象テーブルは全て実在するため)。

## 検証

- ローカルDocker上のSupabaseで `supabase db reset` を実行し、00001〜00071の全71マイグレーションが最初から通しで適用できることを確認
- ローカル環境では `battles` テーブルが実在するため存在チェックの`IF`分岐が実行され、`idx_battles_opponent_card_id` を含む4インデックス全てが作成されることを `pg_indexes` で確認
- `npm run check:migration-order -- --base=origin/main` 実行してマイグレーション採番順序に問題がないことを確認

## マージ後の確認事項

マージ後、GitHub Actionsの `supabase-migrations` ジョブが成功し、本番に4インデックスが適用されることを確認する。battle機能自体(テーブル欠落)は本PRのスコープ外(未使用機能であり、必要なら別issueで扱う)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)