### PR TITLE
fix(gacha): N連ドローの部分失敗を誤ってok()にせず、再送時は未完了分から再開する

### DIFF
--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -662,24 +662,29 @@ async function handleRedemption(messageId: string, event: {
     rewardTitle: event.reward.title,
   });
 
-  const supabaseAdmin = getSupabaseAdmin();
-
-  // 事前の冪等性チェック：既に処理済みのイベントはスキップ
-  // RPC内でもON CONFLICTで重複を検知するが、事前チェックがないと
-  // ストリーマー設定やカード構成が変わった後のリトライで
-  // "Reward ID mismatch" や "No cards available" として誤報告されるため、
-  // この事前SELECTは必要（レビュー指摘 P2）
-  const { data: existingHistory } = await supabaseAdmin
-    .from('gacha_history')
-    .select('id')
-    .eq('event_id', messageId)
-    .maybeSingle();
-
-  if (existingHistory) {
-    logger.info('[handleRedemption] Skipped - already processed', { messageId });
-    return null;
-  }
-
+  // Issue #512: 以前はここで「event_id=messageId(N連の1枚目)の行が存在
+  // するか」だけを見て、存在すれば必ずバッチ全体をスキップしていた。しかし
+  // N連ドロー(追加報酬のdraw_count>1)がバッチ途中で失敗し、EventSub再送が
+  // 残りのドローを完了させようとしても、1枚目が既に存在するというだけで
+  // 再送全体をスキップしてしまい、残りのカードが永久に付与されないバグが
+  // あった。完了済み件数の判定は executeGachaDraws 内の resumeFromIndex
+  // 起点の再開ロジック(countCompletedDrawPrefix)に一本化したため、ここでの
+  // 事前チェックは冗長になった。
+  //
+  // トレードオフ: このチェックはもともと「ストリーマー設定/カード構成が
+  // 変わった後の再送を "Reward ID mismatch" 等の誤ったカテゴリでログ分類
+  // しない」ためのものだった(レビュー指摘 P2)。削除すると、設定変更を
+  // 挟んだ再送は executeGachaForEventSub を毎回最初からやり直すため、
+  // 再送時点の(変更後の)設定でリワード一致判定・draw_count解決が行われる。
+  // 通常の完全一致再送(設定変更なし)は countCompletedDrawPrefix が全件
+  // 一致を検知して従来どおり 'Duplicate event' で静かにスキップするため
+  // 影響はないが、元の処理から再送までの間に「同じreward_idのdraw_countを
+  // 変更する」ような設定変更が挟まった極めて稀なケースでは、変更後のdraw_countを
+  // 基準に不足分(または解釈によっては超過分)が再試行されうる。
+  // gacha_history には各ドローが event_id 付きで確定記録されるため事後に
+  // 監査可能であり、無限に増幅する類の不整合ではないこと、また
+  // このチェックを残したままだと上記の「再送が永久にスキップされる」
+  // バグを再発させてしまうことから、この限定的なリスクは許容する。
   try {
     const gachaService = new GachaService();
     const result = await gachaService.executeGachaForEventSub(event, messageId);

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -113,6 +113,19 @@ function isRaidGachaActive(activeUntil: string | null | undefined, now = new Dat
   return Number.isFinite(activeUntilTime) && activeUntilTime > now.getTime()
 }
 
+/**
+ * Issue #512: N連ドローの各カードに割り当てる event_id を計算する。
+ * 1枚目は eventId そのもの、2枚目以降は `${eventId}:${連番}` を使う
+ * (execute_gacha_transaction RPC の event_id UNIQUE制約により1枚ずつ
+ * 独立して重複検知できるようにするため)。executeGachaDraws のループと
+ * countCompletedDrawPrefix の両方がこの式を使う — 別々に書くと将来
+ * ズレて再開位置の判定が壊れるため、共通化して1箇所にする。
+ */
+function buildDrawEventId(eventId: string | undefined, index: number): string | undefined {
+  if (!eventId) return eventId
+  return index > 0 ? `${eventId}:${index + 1}` : eventId
+}
+
 export class GachaService {
   private supabase = getSupabaseAdmin()
 
@@ -518,6 +531,48 @@ export class GachaService {
     }
   }
 
+  /**
+   * Issue #512: N連ドロー(executeGachaDraws)の [eventId, eventId:2, ...] のうち、
+   * 先頭から連続して何件が既に gacha_history に存在する(=完了済みである)かを
+   * 数える。EventSub再送(redelivery)がバッチ途中までしか完了していない
+   * ドローのリトライを兼ねるケースで、どこから再開すべきかを判定するために使う。
+   *
+   * event_id は migration 00001 で TEXT UNIQUE(グローバルに一意)なので、
+   * 単純な IN 句の存在チェックだけで安全に判定できる(排他ロックは不要 —
+   * 既にCOMMIT済みの行を読むだけで書き込みとは競合しない)。「先頭から連続」で
+   * カウントを打ち切るのは、ドローループが index=0 から順番にしか進まないため
+   * 通常は歯抜けが起きない前提の下、万一歯抜けがあってもそこで止めて以降を
+   * 未完了扱いにする(実際には完了していない枠を誤ってスキップしない)安全側の
+   * 判定にするため。
+   */
+  private async countCompletedDrawPrefix(eventId: string, drawCount: number): Promise<Result<number>> {
+    const candidateEventIds = Array.from(
+      { length: drawCount },
+      (_, index) => buildDrawEventId(eventId, index) as string
+    )
+
+    const { data, error } = await withRetry(
+      () => this.supabase
+        .from('gacha_history')
+        .select('event_id')
+        .in('event_id', candidateEventIds),
+      'gacha:executeGachaDraws:completedPrefix',
+    )
+
+    if (error) {
+      return err(`Database error: ${error.message}`)
+    }
+
+    const completedEventIds = new Set(
+      (data ?? []).map((row) => (row as { event_id: string | null }).event_id)
+    )
+    let prefixCount = 0
+    while (prefixCount < drawCount && completedEventIds.has(candidateEventIds[prefixCount])) {
+      prefixCount += 1
+    }
+    return ok(prefixCount)
+  }
+
   private async executeGachaDraws(
     streamerId: string,
     userTwitchId: string,
@@ -543,8 +598,33 @@ export class GachaService {
     const cards: GachaCard[] = []
     let firstResult: GachaResult | null = null
 
-    for (let index = 0; index < drawCount; index += 1) {
-      const drawEventId = eventId && index > 0 ? `${eventId}:${index + 1}` : eventId
+    // Issue #512: EventSub再送がバッチ途中(例: 5連中2枚目まで成功、3枚目で
+    // 失敗)のリトライを兼ねる場合、常に index=0 からやり直すと1枚目が
+    // is_duplicate と判定された時点でバッチ全体を「重複だから何もしない」と
+    // 打ち切ってしまい、3枚目以降が永久に実行されないバグがあった(下記
+    // resumeFromIndex 起点のループで解消)。単発ドロー(drawCount<=1)は
+    // 「1枚目のis_duplicate=バッチ全体が重複」が常に正しくこの問題が起きない
+    // ため、追加クエリも不要(ホットパスである単発ガチャに毎回1クエリ増える
+    // 無駄を避ける)。
+    let resumeFromIndex = 0
+    if (eventId && drawCount > 1) {
+      const prefixResult = await this.countCompletedDrawPrefix(eventId, drawCount)
+      if (!prefixResult.success) {
+        return err(prefixResult.error)
+      }
+      resumeFromIndex = prefixResult.data
+
+      // 全ドローが既に完了済み = 設定変更を挟まない通常のEventSub再送
+      // (完全な重複)。呼び出し元は単発ドローの is_duplicate と同じ
+      // 'Duplicate event' を「正常系・再通知不要」として静かにスキップする
+      // 既存分岐を持つため、同じ文言を返して単発ドローと観測可能な挙動を揃える。
+      if (resumeFromIndex >= drawCount) {
+        return err('Duplicate event')
+      }
+    }
+
+    for (let index = resumeFromIndex; index < drawCount; index += 1) {
+      const drawEventId = buildDrawEventId(eventId, index)
       const drawRewardCost = index === 0 ? rewardCost : undefined
       const result = await this.executeGacha(
         streamerId,
@@ -558,16 +638,38 @@ export class GachaService {
       )
 
       if (!result.success) {
-        if (cards.length > 0 && result.error !== 'Duplicate event') {
+        // resumeFromIndex(過去のリトライで既に完了した分)も合わせた、この
+        // バッチ全体での確定済み枚数。cards.length だけで判定すると、再開
+        // 直後の1件目で早速エラーになった場合に「0枚成功」扱いになり、実際は
+        // resumeFromIndex 枚が既に確定済みであるにもかかわらず生の
+        // soldOut/DBエラーがそのまま呼び出し元に伝播してしまう(soldOut側の
+        // 全額返還処理などが、既に一部カードを受け取ったユーザーに対して
+        // 誤って走りかねない)。
+        const totalCompleted = resumeFromIndex + cards.length
+        if (totalCompleted > 0 && result.error !== 'Duplicate event') {
           logger.warn('Multi-draw gacha stopped after partial success', {
             streamerId,
             userTwitchId,
             eventId,
-            completedDraws: cards.length,
+            resumedFromIndex: resumeFromIndex,
+            completedDraws: totalCompleted,
             requestedDraws: drawCount,
             error: result.error,
           })
-          break
+          // Issue #512: 以前はここで break し、firstResult があれば ok(部分的な
+          // cards配列)を返していた。呼び出し元はこれを「N連が要求どおり完了
+          // した」結果と区別できず、視聴者はチャネルポイントを消費したのに
+          // 一部カードしか受け取れないまま何のエラーも報告されなかった
+          // (通知の drawCount 表示も cards.length にフォールバックするため、
+          // 要求連数より少ない結果がそのまま「成功」として表示されてしまう)。
+          // エラーを返して呼び出し元の reportError 経路に乗せる。既に成功
+          // した分は gacha_history 上ロールバックしない(取り消す手段が
+          // なく、ユーザーは既にカードを受け取っているため取り消すべきでも
+          // ない)ため、EventSub再送があれば上の resumeFromIndex 起点の
+          // 再開ロジックにより残りだけ再試行される。
+          return err(
+            `Partial gacha completion: ${totalCompleted}/${drawCount} draws succeeded before error: ${result.error}`
+          )
         }
         return result
       }

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -1571,3 +1571,258 @@ describe('GachaService.executeGachaForRaidEvent', () => {
     expect(mockRpc).not.toHaveBeenCalled()
   })
 })
+
+// Issue #512: N連ドロー(executeGachaDraws)がバッチ途中の非重複エラーで
+// 部分的にしか完了しなかった場合に、旧実装は firstResult があれば
+// ok(部分的なcards配列)を返しており、呼び出し元(route.ts)からは要求どおり
+// 完了した成功と区別できなかった(視聴者はチャネルポイントを消費したのに
+// 一部カードしか受け取れず、エラーも報告されなかった)。
+// また、EventSub再送がバッチ途中までの完了を引き継いで残りを再開できず、
+// 1枚目が重複と判定された時点でバッチ全体を「再送は重複だから何もしない」
+// と誤って打ち切ってしまう問題もあった。
+// このdescribeブロックは、executeGachaForEventSub(追加報酬、drawCount>1)
+// を入口として、修正後の executeGachaDraws の挙動を検証する。
+describe('GachaService.executeGachaDraws 部分失敗・再送時の再開ロジック (Issue #512)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  /** N連(drawCount)の追加報酬に紐づくstreamer/additionalRewardの共通モック */
+  function mockStreamerWithAdditionalReward(drawCount: number) {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        id: 'streamer-1',
+        channel_point_reward_id: 'main-reward',
+        chat_announcement_enabled: false,
+        chat_announcement_template: null,
+        raid_gacha_active_until: null,
+      },
+      error: null,
+    })
+    const additionalRewardQuery = createMockQueryBuilder()
+    ;(additionalRewardQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: 'additional-1', draw_count: drawCount, is_raid_limited: false },
+      error: null,
+    })
+    return { streamerQuery, additionalRewardQuery }
+  }
+
+  it('N連ドローがバッチ途中の非重複エラーで失敗したら、部分的なcards配列でok()にせずerr()を返す', async () => {
+    const { streamerQuery, additionalRewardQuery } = mockStreamerWithAdditionalReward(3)
+    const cardsQuery = createCardsQuery(testCards)
+    // 初回実行(再送ではない)なので完了済みは0件
+    const historyQuery = createCardsQuery<{ event_id: string }>([])
+    const mockRpc = createRpcMock({
+      transactionResponses: [
+        { data: { is_duplicate: false }, error: null }, // 1枚目: 成功
+        { data: null, error: { message: 'Database connection failed' } }, // 2枚目: 非重複の実エラー
+      ],
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        if (table === 'streamer_additional_gacha_rewards') return additionalRewardQuery
+        if (table === 'cards') return cardsQuery
+        if (table === 'gacha_history') return historyQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'multi-reward', cost: 300 },
+    }, 'evt-partial')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toContain('Partial gacha completion: 1/3')
+    }
+    // 3枚目は試行されない(2枚目の実エラーでバッチを打ち切る)
+    expect(mockRpc).toHaveBeenCalledTimes(2)
+  })
+
+  it('N連ドローが全件完了済みの再送は1枚も引かずDuplicate eventを返す(旧実装と観測可能な挙動を一致させる)', async () => {
+    const { streamerQuery, additionalRewardQuery } = mockStreamerWithAdditionalReward(3)
+    // 3件とも既に gacha_history に存在する = 完全な重複再送。cardsテーブルへは
+    // 到達しないはずなので意図的にモックしない(未設定のまま呼ばれたら
+    // createMockQueryBuilder の既定値[data:null]で選択に失敗し、後続の
+    // アサーション以前に result.success が想定と食い違って検知できる)。
+    const historyQuery = createCardsQuery<{ event_id: string }>([
+      { event_id: 'evt-full' },
+      { event_id: 'evt-full:2' },
+      { event_id: 'evt-full:3' },
+    ])
+    const mockRpc = vi.fn()
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        if (table === 'streamer_additional_gacha_rewards') return additionalRewardQuery
+        if (table === 'gacha_history') return historyQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'multi-reward', cost: 300 },
+    }, 'evt-full')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error).toBe('Duplicate event')
+    }
+    expect(mockRpc).not.toHaveBeenCalled()
+  })
+
+  it('N連ドローが一部完了済みの再送は残りだけ再開し、reward_costを二重付与しない', async () => {
+    const { streamerQuery, additionalRewardQuery } = mockStreamerWithAdditionalReward(3)
+    const cardsQuery = createCardsQuery(testCards)
+    // 1,2枚目(evt-resume, evt-resume:2)は既に完了済み。3枚目だけ未完了。
+    const historyQuery = createCardsQuery<{ event_id: string }>([
+      { event_id: 'evt-resume' },
+      { event_id: 'evt-resume:2' },
+    ])
+    const mockRpc = createRpcMock({
+      transactionResponses: [
+        { data: { is_duplicate: false }, error: null }, // 3枚目のみ試行される
+      ],
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        if (table === 'streamer_additional_gacha_rewards') return additionalRewardQuery
+        if (table === 'cards') return cardsQuery
+        if (table === 'gacha_history') return historyQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'multi-reward', cost: 300 },
+    }, 'evt-resume')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      // このinvocationで新たに引いた分のみ(1,2枚目は前回の呼び出しで確定済み
+      // のためここには含まれない)。通知のdrawCount表示がこの枚数を使う点は
+      // 既知の限界として報告済み(gacha_history上の付与自体は正しく完結する)。
+      expect(result.data.cards).toHaveLength(1)
+    }
+    expect(mockRpc).toHaveBeenCalledTimes(1)
+    expect(mockRpc).toHaveBeenNthCalledWith(1, 'execute_gacha_transaction', expect.objectContaining({
+      p_event_id: 'evt-resume:3',
+      p_reward_id: 'multi-reward',
+      // グローバルindexが0でないため reward_cost は再付与しない(1枚目の行に
+      // 既に記録済み。ここで再付与すると集計上の消費ポイントが2重になる)。
+      p_reward_cost: null,
+    }))
+  })
+
+  it('gacha_historyの完了行が歯抜けの場合、先頭から連続する分だけを完了済みとして扱う', async () => {
+    const { streamerQuery, additionalRewardQuery } = mockStreamerWithAdditionalReward(4)
+    const cardsQuery = createCardsQuery(testCards)
+    // 1枚目(evt-gap)と3枚目(evt-gap:3)は存在するが2枚目(evt-gap:2)が存在しない
+    // 歯抜け状態(通常運用では起きない想定だが、安全側の挙動を保証する)。
+    // 「先頭から連続」でしか数えないため、2枚目の欠落で打ち切ってprefixCount=1
+    // となり、2枚目から再開するべき(3枚目が結果に含まれるからといって
+    // 4枚目まで一気に飛び越えてはならない)。
+    const historyQuery = createCardsQuery<{ event_id: string }>([
+      { event_id: 'evt-gap' },
+      { event_id: 'evt-gap:3' },
+    ])
+    const mockRpc = createRpcMock({
+      transactionResponses: [
+        { data: { is_duplicate: false }, error: null }, // 2枚目
+        { data: { is_duplicate: false }, error: null }, // 3枚目(結果はあったが再試行される)
+        { data: { is_duplicate: false }, error: null }, // 4枚目
+      ],
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === 'streamers') return streamerQuery
+        if (table === 'streamer_additional_gacha_rewards') return additionalRewardQuery
+        if (table === 'cards') return cardsQuery
+        if (table === 'gacha_history') return historyQuery
+        return createMockQueryBuilder()
+      }),
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'multi-reward', cost: 300 },
+    }, 'evt-gap')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.cards).toHaveLength(3)
+    }
+    expect(mockRpc).toHaveBeenCalledTimes(3)
+    expect(mockRpc).toHaveBeenNthCalledWith(1, 'execute_gacha_transaction', expect.objectContaining({ p_event_id: 'evt-gap:2' }))
+    expect(mockRpc).toHaveBeenNthCalledWith(2, 'execute_gacha_transaction', expect.objectContaining({ p_event_id: 'evt-gap:3' }))
+    expect(mockRpc).toHaveBeenNthCalledWith(3, 'execute_gacha_transaction', expect.objectContaining({ p_event_id: 'evt-gap:4' }))
+  })
+
+  it('単発ドロー(drawCount=1)ではgacha_historyの完了件数チェックを行わない(ホットパスに追加クエリを増やさない)', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: {
+        id: 'streamer-1',
+        channel_point_reward_id: 'main-reward',
+        chat_announcement_enabled: false,
+        chat_announcement_template: null,
+      },
+      error: null,
+    })
+    const cardsQuery = createCardsQuery(testCards)
+    const mockRpc = vi.fn().mockResolvedValue({ data: { is_duplicate: false }, error: null })
+    const fromMock = vi.fn((table: string) => {
+      if (table === 'streamers') return streamerQuery
+      if (table === 'cards') return cardsQuery
+      return createMockQueryBuilder()
+    })
+
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: fromMock,
+      rpc: mockRpc,
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const service = new GachaService()
+    const result = await service.executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'main-reward', cost: 100 },
+    }, 'evt-single')
+
+    expect(result.success).toBe(true)
+    expect(fromMock).not.toHaveBeenCalledWith('gacha_history')
+    expect(mockRpc).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## 背景

Fixes #512

`executeGachaDraws()`(N連/追加報酬ガチャの実行)は、1枚目以降の抽選で重複以外の実エラーが起きると `break` でループを抜け、`firstResult` があれば **`ok(部分的なcards配列)`** を返していた。呼び出し元の EventSub webhookハンドラ(`route.ts`)はこれを「要求どおり完了した成功」と区別できず、Twitchへ2xx ACKを返す。Twitchは一度ACKした redemption を再送しないため、視聴者はチャネルポイントを消費したのに一部カードしか受け取れないまま確定し、エラー報告も行われない状態になり得た。

さらに、EventSub再送(redelivery)の既存の重複チェックは「1枚目(`event_id`=messageId)が `gacha_history` に存在するか」だけを見ており、1枚目のみ成功・以降欠落のバッチが再送されても「既に処理済み」として即スキップしてしまい、自己修復できない欠陥もあった。

## 修正内容

- `gacha.ts`: 新規ヘルパー `countCompletedDrawPrefix()` で、バッチの `event_id`/`event_id:2`/... のうち先頭から連続して何件が `gacha_history` に確定済みかを数える。`executeGachaDraws` はこれを使って再開位置(`resumeFromIndex`)を計算し、全件完了済みなら単発ドローの重複判定と同じ `'Duplicate event'` を返す(静かにスキップ、二重付与なし)。単発ドロー(`drawCount<=1`)はこの追加クエリをスキップし、ホットパスへの影響をゼロにしている。
- バッチ途中の非重複エラーで `break` → `ok(部分的cards)` としていた箇所を、`return err('Partial gacha completion: X/Y draws succeeded...')` に変更。呼び出し元の `reportError` 経路に正しく乗り、運用側が検知できるようにした。
- `route.ts`: 上記ロジックと重複する事前の base-only チェックを削除(トレードオフはコードコメントで明記、下記参照)。
- 完了済み判定は「先頭から連続」でのみカウントし、歯抜けがあれば安全側でそこを再開点にする(スキップし過ぎない)。

## 既知のトレードオフ・限界(コード内コメントにも記載)

1. **設定変更を挟んだ再送**: 削除した事前チェックは元々「ストリーマーがリワード設定を変更した後の再送を誤ったエラー種別でログしない」ためのものだった。極めて稀に、バッチ途中失敗〜再送の間に同一リワードの `draw_count` が変更されると、変更後の値を基準に再開されうる。`gacha_history` に全ドローが `event_id` 付きで確定記録されるため事後監査可能で、無限増幅するような不整合ではないと判断し許容。
2. **同時再送(レース)時、通知が直近ぶんの枚数のみになる場合がある**: カード付与自体は正しく完結するが、チャット/オーバーレイ通知の枚数表示が今回呼び出し分のみを示すケースがある(既存のDuplicate分岐は今回変更していない)。
3. **部分失敗が最終的に解消しない場合の自動返還は無い**(元々存在しなかった機能。今回の修正は「サイレント失敗」を「検知可能な失敗」に変えることが目的で、按分返還のような新機能の追加はスコープ外)。

## 検証

- `npx vitest run`: 119ファイル/1399テスト全成功(新規5件 + 既存1394件、既存のN連/raidガチャテストに回帰無し)
- `npx tsc --noEmit`: 24件、originのベースライン(#588で追跡中の既知の問題)と完全一致、新規エラー無し
- 新規テストで以下を固定: (a) バッチ途中の非重複エラー→部分cardsでok()にせずerr()、(b) 全件完了済み再送→即Duplicate event(RPC呼び出し無し)、(c) 一部完了済み再送→残りだけ再開、reward_costを二重付与しない、(d) gacha_history上の完了行が歯抜けの場合に先頭連続分のみを完了済みとして扱う安全側の挙動、(e) 単発ドローは完了件数チェックのクエリを発行しない(ホットパス無影響)

🤖 Generated with [Claude Code](https://claude.com/claude-code)