### PR TITLE
feat: Add Drizzle ORM schema and overlay auto-reload mechanism

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -86,3 +86,12 @@ R2_SOUND_PUBLIC_URL=https://your-sound-bucket.your-domain.com
 # CloudflareダッシュボードでWeb Analyticsを有効にしてトークンを取得
 # 設定しない場合、アナリティクスは無効になります
 NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
+
+# DB 直結ドライバ (#570, optional)
+# next dev で pg 直結経路（DB_DRIVER=pg-read/pg）を試す場合のみ必要。
+# 未設定なら従来どおり PostgREST (supabase-js) 経路で動作する。
+# 詳細: docs/db-driver-migration.md
+# DATABASE_URL は Supabase の Direct connection 文字列（sslmode パラメータは削らないこと）
+# DATABASE_URL=postgres://twica_app:password@db.your-project.supabase.co:5432/postgres?sslmode=require
+# DB_DRIVER=pg-read
+# GACHA_DB_DRIVER=postgrest

--- a/docs/db-driver-migration.md
+++ b/docs/db-driver-migration.md
@@ -1,0 +1,101 @@
+# DB ドライバ移行 (PostgREST → postgres.js + Drizzle 直結) 運用ガイド
+
+Issue #570 / #568 Phase 1。DB は Supabase のまま、データアクセス層を
+PostgREST (supabase-js) から Hyperdrive + postgres.js + Drizzle 直結へ段階的に
+切り替えるための基盤とその運用手順。**DB スキーマは一切変更しない。**
+
+## 全体像とフラグ構成
+
+```
+DB_DRIVER (全体フラグ、実行時に毎回評価)
+  未設定 / 'postgrest'  → 完全に従来どおり (supabase-js)。デプロイしても挙動不変
+  'pg-read'             → 読み取りのみ pg 直結。書き込みは PostgREST のまま
+  'pg'                  → 読み書きとも pg 直結
+
+GACHA_DB_DRIVER (ガチャ経路専用の緊急スイッチ、#573)
+  'pg' / 'postgrest'    → ガチャ経路だけ DB_DRIVER より優先して切替
+  未設定                → DB_DRIVER に従う (pg のときのみ pg)
+```
+
+実装: `src/lib/db/`（flags / client / retry / errors）。パイロット適用箇所は
+`src/lib/announcements.ts` の `getUnreadAnnouncements`（読み取り1本）。
+
+## セットアップ手順（リポジトリオーナー作業）
+
+1. **Hyperdrive 接続用の専用ロールを作成する（既定の `postgres` ロールを使わない）**。
+   Supabase SQL Editor で prod / preview 各プロジェクトに対して実行:
+   ```sql
+   -- 既定の postgres ロールは superuser 相当で権限過剰。専用ロールを
+   -- service_role のメンバーにすることで、PostgREST service-role と同等の権限
+   -- （00047 等の明示 GRANT と、00024/00045/00051/00059 等の
+   --  「FOR ALL TO service_role」RLS ポリシー）をそのまま継承する。
+   create role twica_app login password '<強力なパスワード>';
+   grant service_role to twica_app;
+   ```
+2. Supabase ダッシュボード → プロジェクトの **Connect** → **Direct connection** の
+   接続文字列を取得し、ユーザー名/パスワードを手順 1 の専用ロールに差し替える
+   （prod / preview の 2 プロジェクト分）。
+   - **sslmode の注意**: 接続文字列に付いている `sslmode` パラメータは削らず
+     そのまま使うこと（平文接続へのダウングレード防止）。
+   - **IPv6 直結の注意**: Supabase の Direct connection は IPv4 アドオン未購入だと
+     IPv6 のみの場合があり、`wrangler hyperdrive create` が到達性検証で失敗しうる。
+     失敗する場合は IPv4 アドオンの購入か、Supavisor session mode の接続文字列の
+     利用を検討する。
+3. Hyperdrive config を 2 つ作成する（**`--caching-disabled` 必須**）:
+   ```bash
+   wrangler hyperdrive create twica-hyperdrive-prod \
+     --connection-string="<本番の Direct connection 文字列（twica_app ロール）>" --caching-disabled
+   wrangler hyperdrive create twica-hyperdrive-preview \
+     --connection-string="<preview の Direct connection 文字列（twica_app ロール）>" --caching-disabled
+   ```
+   `--caching-disabled` の理由: Hyperdrive のクエリキャッシュはデフォルト有効
+   (max_age 60s)。Phase 1 は PostgREST（毎回実クエリ）との完全パリティが目的で、
+   キャッシュが有効だと overlay ポーリングの新着イベントが最大 60 秒遅延する等の
+   挙動差が出る。
+4. 出力された id を `wrangler.toml` の `[[hyperdrive]]` / `[[env.preview.hyperdrive]]`
+   ブロック（現在コメントアウト）に記入し、コメントを解除してデプロイする。
+
+## ローカル開発
+
+- `next dev`（`npm run dev:next`）: `DATABASE_URL` を使う（`.env.local` 等に設定）。
+- `wrangler dev`（`npm run dev`）: `[[hyperdrive]]` の `localConnectionString` を使う。
+
+## 権限に関する注意
+
+Hyperdrive に設定する接続は Postgres ロール直結であり、**RLS の外側**
+（service-role 相当）で動く。既存の PostgREST 経由の service-role アクセスと
+同等の権限であり、権限モデル上の変化はない（アプリ層の認可がこれまでどおり唯一の防壁）。
+
+## 切替運用
+
+env 変更はビルド不要で秒単位で反映される（Cloudflare では新デプロイ扱い）。
+ロールバックは env を戻すだけ。必ず以下の順で行う:
+
+1. フラグ未設定でマージ・デプロイ（挙動不変を確認）
+2. preview に `DB_DRIVER=pg-read` → 検証 → `DB_DRIVER=pg` → 検証
+3. prod で同順（pg-read → 検証 → pg）
+4. 問題発生時: env を戻す（ガチャ経路のみ戻す場合は `GACHA_DB_DRIVER=postgrest`）
+
+## 検証
+
+- 切替前: `scripts/verify-db-schema.js` を preview / prod それぞれの
+  `DATABASE_URL` で実行し、schema.ts と実 DB の差分ゼロを確認する
+  （DB 接続が必要なため CI では実行しない）:
+  ```bash
+  DATABASE_URL="<Direct connection 文字列>" node scripts/verify-db-schema.js
+  ```
+- 切替後: `wrangler tail` で `[db:pg]` タグのエラーと `CONNECTION_*` 系エラーを監視する。
+- preview で `DB_DRIVER=pg-read` にした際、ダッシュボードのお知らせバナー表示
+  （パイロット経路 `getUnreadAnnouncements`）が postgrest 時と同一であることを
+  目視確認する（日付シリアライズ差の実機確認を兼ねる）。
+- preview での確認項目:
+  - `statement_timeout` が Hyperdrive を透過するか未確認（既知リスク）。
+    長時間クエリの打ち切り挙動を preview で確認すること
+  - 連続リクエスト時に `Cannot perform I/O on behalf of a different request`
+    エラーがゼロであること（クライアントのリクエストスコープ管理の検証）
+
+## スコープ外 / 未実施事項
+
+- 旧経路（supabase-js）の削除は Phase 4（#568）で実施する。それまで両経路を維持する。
+- Hyperdrive config は**未作成**（上記セットアップはユーザー操作待ち）。
+  このコードはフラグ未設定なら Hyperdrive なしで安全にデプロイできる。

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,52 @@
 import createNextIntlPlugin from "next-intl/plugin";
 import type { NextConfig } from "next";
+import { execSync } from "child_process";
 
 // Create next-intl plugin with custom request config path
 // next-intlプラグインを作成（カスタムリクエスト設定パス指定）
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
+/**
+ * Issue #569: overlay(src/app/overlay/[streamerId]/page.tsx)は何週間も
+ * リロードされずに動き続けるため、クライアント側の変更を全クライアントへ
+ * 浸透させる手段として「ビルドごとに一意なバージョン識別子」を注入する。
+ *
+ * 解決順序:
+ * 1. WORKERS_CI_COMMIT_SHA — Cloudflare Workers Builds がCIビルド時に自動的に
+ *    提供するコミットSHA。本番/プレビューのCI経由ビルドでは常にこれが使える。
+ * 2. `git rev-parse` でローカルHEADのSHAを取得する。CI変数が無い
+ *    ローカル `next build` 実行時のフォールバック。
+ * 3. 上記がいずれも失敗した場合(gitが無い/.gitが無い環境、shallow clone等)は
+ *    'dev' を返す。バージョン識別子が取れないという理由でビルド自体を
+ *    失敗させたくないため、execSyncはtry/catchで包む。
+ *
+ * 12桁に揃えるのは、GitHub/CloudflareのUIで通常表示されるSHA桁数と
+ * 揃えつつ、衝突確率を十分に低く保つため。
+ */
+function resolveOverlayVersion(): string {
+  if (process.env.WORKERS_CI_COMMIT_SHA) {
+    return process.env.WORKERS_CI_COMMIT_SHA.slice(0, 12);
+  }
+  try {
+    return execSync("git rev-parse --short=12 HEAD", {
+      encoding: "utf-8",
+      // ビルドプロセスの標準エラー出力にgitの警告等を漏らさない
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    // git 不在 / .git 不在(Dockerビルド等)でもビルドを落とさない
+    return "dev";
+  }
+}
+
 const nextConfig: NextConfig = {
+  // next.config の `env` はここで解決した値をビルド時に文字列としてサーバー・
+  // クライアント両方のバンドルへインライン化する(process.env.NEXT_PUBLIC_*の
+  // ような静的置換と同じ扱いで、実行時にサーバー環境変数を追加設定する必要はない)。
+  // https://nextjs.org/docs/pages/api-reference/next-config-js/env
+  env: {
+    NEXT_PUBLIC_OVERLAY_VERSION: resolveOverlayVersion(),
+  },
   images: {
     remotePatterns: [
       // Allow any HTTPS host for external card images

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "dependencies": {
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.90.0",
+        "drizzle-orm": "^0.45.2",
         "next": "16.1.6",
         "next-intl": "^4.7.0",
+        "postgres": "^3.4.9",
         "react": "^19.0.0-rc.1",
         "react-dom": "^19.0.0-rc.1",
         "react-image-crop": "^11.0.10"
@@ -12925,6 +12927,131 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/drizzle-orm": {
+      "version": "0.45.2",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
+      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -16935,6 +17062,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.9.tgz",
+      "integrity": "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
   "dependencies": {
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.90.0",
+    "drizzle-orm": "^0.45.2",
     "next": "16.1.6",
     "next-intl": "^4.7.0",
+    "postgres": "^3.4.9",
     "react": "^19.0.0-rc.1",
     "react-dom": "^19.0.0-rc.1",
     "react-image-crop": "^11.0.10"
@@ -44,7 +46,6 @@
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.972.0",
     "@opennextjs/cloudflare": "^1.16.1",
-    "@vercel/blob": "^0.27.1",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -52,6 +53,7 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@vercel/blob": "^0.27.1",
     "@vitest/ui": "^3.2.4",
     "dotenv": "^17.2.3",
     "dotenv-cli": "^11.0.0",
@@ -59,7 +61,6 @@
     "eslint-config-next": "16.1.6",
     "happy-dom": "^20.3.3",
     "jsdom": "^27.0.1",
-
     "supabase": "^2.72.8",
     "tailwindcss": "^4",
     "typescript": "^5",

--- a/scripts/verify-db-schema.js
+++ b/scripts/verify-db-schema.js
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+
+/**
+ * Drizzle スキーマ定義と実 DB の突き合わせ検証スクリプト (#570)
+ *
+ * 目的:
+ * src/lib/db/schema.ts（手書きの Drizzle スキーマ）が実 DB（Supabase の
+ * information_schema）と一致していることを、pg 直結経路（DB_DRIVER=pg-read/pg）へ
+ * 切り替える「前」に確認する。列名・データ型・NOT NULL 制約の3点を照合し、
+ * 差分を表形式で出力する。テーブルの抜け漏れは双方向で検出する
+ * （schema.ts にあって DB に無いテーブル / DB の public スキーマにあって
+ * schema.ts に定義が無いテーブルの両方）。差分ゼロなら exit 0、差分ありなら
+ * exit 1（接続失敗などの運用エラーは exit 2）。
+ *
+ * 使い方:
+ *   DATABASE_URL="postgres://..." node scripts/verify-db-schema.js
+ *   （preview / prod それぞれの Supabase Direct connection 文字列で実行する。
+ *    docs/db-driver-migration.md 参照。DB 接続が必要なため CI では実行しない）
+ *
+ * 実装方針（重要）:
+ * schema.ts の解析は「正規表現ベースの簡易パーサ」で行う。TypeScript コンパイラや
+ * drizzle-kit を依存に加えれば厳密に解析できるが、このスクリプトは切替前の補助
+ * 検証ツールであり、厳密性より依存ゼロ（プロジェクトに既にある postgres パッケージ
+ * 以外を要求しない）を優先する。schema.ts は列定義が
+ * 「プロパティ名: 型関数('列名', ...)」という一様なスタイルで書かれており、
+ * その前提の範囲で十分正確に抽出できる。スタイルが大きく変わった場合は
+ * このパーサも追随が必要（その場合も「差分が出る」方向に壊れるため、
+ * 一致しているのに見逃す方向の事故にはなりにくい）。
+ */
+
+'use strict'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const fs = require('fs')
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require('path')
+
+const SCHEMA_PATH = path.join(__dirname, '..', 'src', 'lib', 'db', 'schema.ts')
+
+// Drizzle の型関数名 → information_schema.columns.data_type の対応表
+// （schema.ts で実際に使われている型のみ。増えたらここに追加する）
+const TYPE_FN_TO_DATA_TYPE = {
+  uuid: 'uuid',
+  text: 'text',
+  boolean: 'boolean',
+  jsonb: 'jsonb',
+  integer: 'integer',
+  numeric: 'numeric',
+  bigint: 'bigint',
+  smallint: 'smallint',
+  varchar: 'character varying',
+  // timestamp は withTimezone の有無で分岐するため parseColumnChunk 内で処理
+}
+
+/**
+ * schema.ts のソースから解析の邪魔になる部分を除去する。
+ * - テンプレートリテラル（sql`...`）: 中に '{}' や引用符を含み（例: '{}'::text[]）、
+ *   ブレース深度カウントや列名抽出を壊すため中身を空にする
+ * - 行コメント: 列定義の説明コメントに型関数名などが含まれても誤検出しないように除去
+ */
+function stripNoise(source) {
+  return source
+    .replace(/`[^`]*`/gs, '``')
+    .replace(/\/\/[^\n]*/g, '')
+}
+
+/**
+ * pgTable('name', { ... }) の列定義オブジェクト部分をブレース深度カウントで
+ * 切り出し、テーブルごとの列定義を抽出する。
+ *
+ * @returns {Map<string, Map<string, { dataType: string, notNull: boolean }>>}
+ *   テーブル名 → (列名 → { dataType, notNull })
+ */
+function parseSchemaFile(source) {
+  const cleaned = stripNoise(source)
+  const tables = new Map()
+
+  const tableRe = /pgTable\(\s*'([^']+)'\s*,\s*\{/g
+  let match
+  while ((match = tableRe.exec(cleaned)) !== null) {
+    const tableName = match[1]
+    // 列定義オブジェクトの開始 '{'（tableRe が消費した最後の1文字）から
+    // 対応する '}' までを深度カウントで探す
+    const start = tableRe.lastIndex - 1
+    let depth = 0
+    let end = -1
+    for (let i = start; i < cleaned.length; i++) {
+      const ch = cleaned[i]
+      if (ch === '{') depth++
+      else if (ch === '}') {
+        depth--
+        if (depth === 0) {
+          end = i
+          break
+        }
+      }
+    }
+    if (end === -1) {
+      throw new Error(`Unbalanced braces while parsing table '${tableName}' in schema.ts`)
+    }
+    const block = cleaned.slice(start + 1, end)
+    tables.set(tableName, parseColumns(tableName, block))
+  }
+
+  return tables
+}
+
+/**
+ * テーブルの列定義ブロックから列を抽出する。
+ * 列は「プロパティ名: 型関数('列名'」で始まり、次の列定義の開始（または
+ * ブロック末尾）までを1チャンクとして修飾子（.notNull() 等）を判定する。
+ * 修飾子が複数行にまたがるスタイル（.default() が次行など）にも対応できる。
+ */
+function parseColumns(tableName, block) {
+  const columns = new Map()
+  const columnRe = /(?:^|\n)\s*\w+:\s*(uuid|text|boolean|jsonb|timestamp|integer|numeric|bigint|smallint|varchar)\(\s*'([^']+)'/g
+
+  const starts = []
+  let m
+  while ((m = columnRe.exec(block)) !== null) {
+    starts.push({ index: m.index, typeFn: m[1], columnName: m[2] })
+  }
+
+  starts.forEach((col, i) => {
+    const chunkEnd = i + 1 < starts.length ? starts[i + 1].index : block.length
+    const chunk = block.slice(col.index, chunkEnd)
+
+    let dataType
+    if (col.typeFn === 'timestamp') {
+      dataType = /withTimezone:\s*true/.test(chunk)
+        ? 'timestamp with time zone'
+        : 'timestamp without time zone'
+    } else if (col.typeFn === 'text' && /\.array\(\)/.test(chunk)) {
+      // text[] は information_schema 上 data_type='ARRAY'（udt_name='_text'）
+      dataType = 'ARRAY'
+    } else {
+      dataType = TYPE_FN_TO_DATA_TYPE[col.typeFn]
+    }
+
+    // NOT NULL 判定: .notNull() 明示、または単一列 .primaryKey()（PG では PK 列は
+    // 暗黙に NOT NULL になる）。複合 PK（第3引数の primaryKey({...})）の列は
+    // schema.ts 側で全列に .notNull() が明示されている前提（現状すべて明示済み）。
+    const notNull = /\.notNull\(\)/.test(chunk) || /\.primaryKey\(\)/.test(chunk)
+
+    columns.set(col.columnName, { dataType, notNull })
+  })
+
+  if (columns.size === 0) {
+    throw new Error(`No columns parsed for table '${tableName}' (schema.ts style changed?)`)
+  }
+
+  return columns
+}
+
+/**
+ * 実 DB の public スキーマに存在する全テーブル名を取得する。
+ * schema.ts 側の定義漏れ（DB にだけ存在するテーブル）の検出に使う。
+ * VIEW は型付け対象外のため BASE TABLE のみ。
+ */
+async function fetchDbTableNames(sql) {
+  const rows = await sql`
+    select table_name
+    from information_schema.tables
+    where table_schema = 'public'
+      and table_type = 'BASE TABLE'
+    order by table_name
+  `
+  return rows.map((row) => row.table_name)
+}
+
+/** 実 DB から対象テーブルの列情報を取得する */
+async function fetchDbColumns(sql, tableNames) {
+  const rows = await sql`
+    select table_name, column_name, data_type, is_nullable, udt_name
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = any(${tableNames})
+    order by table_name, ordinal_position
+  `
+  const tables = new Map()
+  for (const row of rows) {
+    if (!tables.has(row.table_name)) {
+      tables.set(row.table_name, new Map())
+    }
+    tables.get(row.table_name).set(row.column_name, {
+      dataType: row.data_type,
+      udtName: row.udt_name,
+      notNull: row.is_nullable === 'NO',
+    })
+  }
+  return tables
+}
+
+/** schema.ts と DB の列情報を照合し、差分の配列を返す */
+function diffSchemas(schemaTables, dbTables, allDbTableNames = []) {
+  const diffs = []
+  const push = (table, column, kind, expected, actual) =>
+    diffs.push({ table, column, kind, expected, actual })
+
+  // DB の public スキーマにあるが schema.ts に定義が無いテーブル（定義漏れ）。
+  // schema.ts は「実 DB への完全な型付け」を方針としているため差分として扱う。
+  for (const tableName of allDbTableNames) {
+    if (!schemaTables.has(tableName)) {
+      push(tableName, '*', 'table missing in schema.ts', 'missing', 'exists')
+    }
+  }
+
+  for (const [tableName, schemaColumns] of schemaTables) {
+    const dbColumns = dbTables.get(tableName)
+    if (!dbColumns) {
+      push(tableName, '*', 'table missing in DB', 'exists', 'missing')
+      continue
+    }
+
+    for (const [columnName, schemaCol] of schemaColumns) {
+      const dbCol = dbColumns.get(columnName)
+      if (!dbCol) {
+        push(tableName, columnName, 'column missing in DB', schemaCol.dataType, 'missing')
+        continue
+      }
+      // 型比較: ARRAY は udt_name（_text）まで見て text[] であることを確認する
+      if (schemaCol.dataType === 'ARRAY') {
+        if (dbCol.dataType !== 'ARRAY' || dbCol.udtName !== '_text') {
+          push(tableName, columnName, 'type mismatch', 'text[] (ARRAY/_text)', `${dbCol.dataType}/${dbCol.udtName}`)
+        }
+      } else if (schemaCol.dataType !== dbCol.dataType) {
+        push(tableName, columnName, 'type mismatch', schemaCol.dataType, dbCol.dataType)
+      }
+      if (schemaCol.notNull !== dbCol.notNull) {
+        push(
+          tableName,
+          columnName,
+          'nullability mismatch',
+          schemaCol.notNull ? 'NOT NULL' : 'NULLABLE',
+          dbCol.notNull ? 'NOT NULL' : 'NULLABLE'
+        )
+      }
+    }
+
+    // DB 側にだけ存在する列（schema.ts の定義漏れ）も差分として報告する。
+    // schema.ts は「実 DB への完全な型付け」を方針としているため、片方向ではなく
+    // 双方向で照合する。
+    for (const columnName of dbColumns.keys()) {
+      if (!schemaColumns.has(columnName)) {
+        push(tableName, columnName, 'column missing in schema.ts', 'missing', dbColumns.get(columnName).dataType)
+      }
+    }
+  }
+
+  return diffs
+}
+
+/** 差分を表形式（列幅を揃えたプレーンテキスト）で出力する */
+function printDiffTable(diffs) {
+  const headers = ['TABLE', 'COLUMN', 'ISSUE', 'SCHEMA.TS', 'DB']
+  const rows = diffs.map((d) => [d.table, d.column, d.kind, String(d.expected), String(d.actual)])
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)))
+  const line = (cells) => cells.map((c, i) => c.padEnd(widths[i])).join('  ')
+
+  console.log(line(headers))
+  console.log(line(widths.map((w) => '-'.repeat(w))))
+  for (const row of rows) {
+    console.log(line(row))
+  }
+}
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL
+  if (!databaseUrl) {
+    console.error('Usage: DATABASE_URL="postgres://..." node scripts/verify-db-schema.js')
+    console.error('DATABASE_URL is not set (use the Supabase Direct connection string).')
+    process.exit(2)
+  }
+
+  const source = fs.readFileSync(SCHEMA_PATH, 'utf8')
+  const schemaTables = parseSchemaFile(source)
+  console.log(`Parsed ${schemaTables.size} tables from src/lib/db/schema.ts`)
+
+  // プロジェクトにインストール済みの postgres パッケージで接続する（新規依存なし）。
+  // 検証用の単発接続なので max: 1。fetch_types は既定（true）のまま
+  // （information_schema しか読まないが、配列パラメータの型解決を postgres.js に任せる）。
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const postgres = require('postgres')
+  const sql = postgres(databaseUrl, { max: 1, connect_timeout: 15 })
+
+  // process.exit() は finally の await を待たずにプロセスを落とすため、
+  // 終了コードを変数に持ち、接続クローズ後に一度だけ exit する
+  let exitCode = 0
+  try {
+    const dbTables = await fetchDbColumns(sql, [...schemaTables.keys()])
+    const allDbTableNames = await fetchDbTableNames(sql)
+    const diffs = diffSchemas(schemaTables, dbTables, allDbTableNames)
+
+    if (diffs.length === 0) {
+      console.log('OK: schema.ts matches the database (column names, data types, NOT NULL).')
+    } else {
+      console.error(`\nFound ${diffs.length} difference(s):\n`)
+      printDiffTable(diffs)
+      exitCode = 1
+    }
+  } catch (error) {
+    console.error('Failed to verify schema against the database:')
+    console.error(error instanceof Error ? error.message : error)
+    exitCode = 2
+  } finally {
+    await sql.end({ timeout: 5 })
+  }
+  process.exit(exitCode)
+}
+
+// 直接実行時のみ main を起動する。require された場合はパーサ・差分ロジックを
+// 公開し、DB 接続なしで動作確認できるようにする
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error)
+    process.exit(2)
+  })
+}
+
+module.exports = { parseSchemaFile, diffSchemas }

--- a/src/app/api/overlay/[streamerId]/events/route.ts
+++ b/src/app/api/overlay/[streamerId]/events/route.ts
@@ -212,7 +212,14 @@ export async function GET(
       })
       .filter((event): event is NonNullable<typeof event> => event !== null);
 
-    return NextResponse.json({ events });
+    // Issue #569: overlay クライアントのバージョン不一致検出用。既存キー(events)は
+    // そのままに overlayVersion を追加するだけなので後方互換(未知キーは無視される)。
+    // NEXT_PUBLIC_OVERLAY_VERSION は next.config.ts の env 設定でビルド時に
+    // インライン化される値(未設定になるケースは無いはずだが、念のため 'dev' にフォールバック)。
+    return NextResponse.json({
+      events,
+      overlayVersion: process.env.NEXT_PUBLIC_OVERLAY_VERSION ?? "dev",
+    });
   } catch (error) {
     return handleApiError(error, "Overlay Events API");
   }

--- a/src/app/api/overlay/[streamerId]/events/route.ts
+++ b/src/app/api/overlay/[streamerId]/events/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { and, asc, eq, gt } from "drizzle-orm";
 import { getSupabaseAdmin } from "@/lib/supabase/admin";
 import { withRetry } from "@/lib/supabase/retry";
 import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
@@ -10,6 +11,16 @@ import {
 import { ERROR_MESSAGES } from "@/lib/constants";
 import type { Rarity } from "@/types/database";
 import type { ApiRateLimitResponse } from "@/types/api";
+// Issue #571 (#570 パイロット踏襲): pg 直結の読み取り経路。
+// getDb() は withDbRetry の queryFn 内で呼ぶ規約(src/lib/db/retry.ts 参照)。
+import { getDb } from "@/lib/db/client";
+import { isPgReadEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+import { isPgMissingColumnError } from "@/lib/db/errors";
+import {
+  gachaHistory as gachaHistoryTable,
+  cards as cardsTable,
+} from "@/lib/db/schema";
 
 interface RouteParams {
   params: Promise<{ streamerId: string }>;
@@ -95,6 +106,241 @@ function resolveCard(cards: OverlayHistoryRow["cards"]): OverlayHistoryCard | nu
   return cards;
 }
 
+// -----------------------------------------------------------------------------
+// pg 直結経路 (#571, #570 パイロット踏襲)
+//
+// #570 で追加された src/lib/db/(flags/client/retry/errors) と、そのパイロット
+// 適用箇所である src/lib/announcements.ts の getUnreadAnnouncementsPg を踏襲する。
+// isPgReadEnabled() が true のときのみ以下のヘルパーが呼ばれ、フラグ未設定時
+// (既定 'postgrest') は下の GET ハンドラの else 節(既存 supabase-js 実装、無変更)
+// のみが実行される。
+//
+// redeemedAt の表現形式について(判断根拠):
+// pg 直結は drizzle-orm/postgres-js が timestamp/timestamptz パーサをパススルーに
+// 上書きするため、PG の ISO スタイルテキスト形式(例: "2026-03-10 12:34:56.123456+00"、
+// スペース区切り・オフセットは分が0なら "+00" のみ)の文字列を返す。一方 PostgREST は
+// ISO 8601 (例: "2026-03-10T12:34:56.123456+00:00"、T区切り)を返す
+// (src/lib/db/client.ts の createHandle コメント、src/lib/announcements.ts の
+// getUnreadAnnouncementsPg コメント参照)。
+// この差がクライアントに影響するかを実際に確認した:
+//   1. overlay クライアント(src/app/overlay/[streamerId]/page.tsx の
+//      pollOverlayEvents)は event.redeemedAt を Date.parse() 経由でのみ消費し、
+//      パース成功時は new Date(ms).toISOString() で正規化してから
+//      pollCursorRef(次回リクエストの ?since= の値)に格納する。文字列としての
+//      比較や画面への直接表示は一切行っていない。
+//   2. Node(V8)で実地検証済み: Date.parse("2026-03-10 12:34:56.123456+00") は
+//      2026-03-10T12:34:56.123Z 相当に正しくパースされる(PG の ISO スタイル
+//      出力を V8 の緩やかな日付パーサが解釈できる)。PostgREST 形式・pg 直結
+//      形式のどちらでパースしても同一時刻になる。
+//   3. クライアントは受信した redeemedAt の形式に関わらず必ず toISOString()
+//      (T区切り・Z終端)で再正規化してから since として送り返すため、pg 直結
+//      経路に切り替わってもポーリングカーソルの単調性・往復互換は既存
+//      (PostgREST)経路と同じ挙動になる。ミリ秒未満(マイクロ秒)の切り捨ては
+//      両経路で等しく発生する既存の性質であり、本対応による新規回帰ではない。
+// 以上より、redeemedAt は pg のテキスト形式のまま返し、追加の正規化ヘルパーは
+// 導入しない(getUnreadAnnouncementsPg と同じ判断)。
+//
+// leftJoin + flat 列エイリアスについて:
+// gacha_history.card_id は ON DELETE CASCADE (00071マイグレーション) のため
+// 実運用では常に一致するカードが存在するが、既存の resolveCard は防御的に
+// null card を許容しフィルタしている。この既存の防御的挙動を pg 経路でも
+// 1:1 再現するため leftJoin を用い、cards 側の列が全て null(=一致行なし)かを
+// card_id === null で判定する。ネストしたオブジェクト形式の select
+// (例: { card: { id: cardsTable.id, ... } }) は使わず個々の列を flat に
+// エイリアスする。理由: drizzle-orm の左外部結合時オブジェクト自動 null 化は
+// バージョン依存の内部挙動に頼ることになり、実装意図が読み取りにくい。flat
+// 列 + 明示的な null 判定のほうがテストしやすく既存 resolveCard の判定方法
+// (単一オブジェクト or null)とも対応が取りやすい。
+// -----------------------------------------------------------------------------
+
+/** pg 直結クエリが返す flat な行の形状(reward_id の有無に関わらず共通) */
+interface PgOverlayHistoryFlatRow {
+  id: string;
+  event_id: string | null;
+  redeemed_at: string | null;
+  user_twitch_username: string | null;
+  // leftJoin の右側(cards)は不一致行で null になるため、スキーマ上は
+  // notNull な列でも結果型は string | null になる(drizzle-orm の
+  // JoinNullability による型ワイド。select.types.d.ts で確認済み)。
+  card_id: string | null;
+  card_name: string | null;
+  card_description: string | null;
+  card_image_url: string | null;
+  card_rarity: string | null;
+}
+
+/**
+ * pg 直結: reward_id 列を含む本来のクエリ。
+ * supabase-js 版の OVERLAY_HISTORY_SELECT_WITH_REWARD_ID に対応する。
+ */
+async function fetchOverlayHistoryWithRewardIdPg(
+  streamerId: string,
+  since: string
+): Promise<(PgOverlayHistoryFlatRow & { reward_id: string | null })[]> {
+  const { db } = await getDb();
+  return db
+    .select({
+      id: gachaHistoryTable.id,
+      event_id: gachaHistoryTable.event_id,
+      redeemed_at: gachaHistoryTable.redeemed_at,
+      user_twitch_username: gachaHistoryTable.user_twitch_username,
+      reward_id: gachaHistoryTable.reward_id,
+      card_id: cardsTable.id,
+      card_name: cardsTable.name,
+      card_description: cardsTable.description,
+      card_image_url: cardsTable.image_url,
+      card_rarity: cardsTable.rarity,
+    })
+    .from(gachaHistoryTable)
+    .leftJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
+    .where(
+      and(
+        eq(gachaHistoryTable.streamer_id, streamerId),
+        gt(gachaHistoryTable.redeemed_at, since)
+      )
+    )
+    .orderBy(asc(gachaHistoryTable.redeemed_at))
+    .limit(10);
+}
+
+/**
+ * pg 直結: reward_id 列を含まないフォールバッククエリ(Issue #591 デプロイ窓対応)。
+ * supabase-js 版の OVERLAY_HISTORY_SELECT_WITHOUT_REWARD_ID に対応する。
+ *
+ * reward_id を select オブジェクトから丸ごと省いた別関数として定義する理由:
+ * supabase-js 版が「select() のリテラル文字列から列数の異なる2つの非互換な
+ * Row 型が推論される」ため2つの定数に分けているのと同じ理由で、Drizzle の
+ * select({...}) も渡したオブジェクトリテラルの形から結果型を推論するため、
+ * 条件分岐で選択列を動的に組み立てるより2つの独立した関数に分けたほうが
+ * 型安全性が高く可読性も良い。
+ */
+async function fetchOverlayHistoryWithoutRewardIdPg(
+  streamerId: string,
+  since: string
+): Promise<PgOverlayHistoryFlatRow[]> {
+  const { db } = await getDb();
+  return db
+    .select({
+      id: gachaHistoryTable.id,
+      event_id: gachaHistoryTable.event_id,
+      redeemed_at: gachaHistoryTable.redeemed_at,
+      user_twitch_username: gachaHistoryTable.user_twitch_username,
+      card_id: cardsTable.id,
+      card_name: cardsTable.name,
+      card_description: cardsTable.description,
+      card_image_url: cardsTable.image_url,
+      card_rarity: cardsTable.rarity,
+    })
+    .from(gachaHistoryTable)
+    .leftJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
+    .where(
+      and(
+        eq(gachaHistoryTable.streamer_id, streamerId),
+        gt(gachaHistoryTable.redeemed_at, since)
+      )
+    )
+    .orderBy(asc(gachaHistoryTable.redeemed_at))
+    .limit(10);
+}
+
+/**
+ * pg 直結クエリの flat 行を、既存 supabase-js 経路と共通の OverlayHistoryRow
+ * 形状(cards が単一オブジェクトまたは null のネスト)へ変換する。
+ * これにより GET ハンドラ末尾のイベント整形(resolveCard 経由のマッピング・
+ * フィルタ)を両経路で完全に共有できる(ロジックの重複を避ける)。
+ */
+function toOverlayHistoryRow(
+  row: PgOverlayHistoryFlatRow,
+  rewardId: string | null
+): OverlayHistoryRow {
+  return {
+    id: row.id,
+    event_id: row.event_id,
+    // where 句の gt(redeemed_at, since) を満たす行は NULL ではあり得ないため
+    // 実質非 null(既存 supabase-js 版の OverlayHistoryRow 型と同じ前提。
+    // スキーマ上 nullable なのは leftJoin と無関係にこの列自体が NOT NULL
+    // 制約を持たないため)。
+    redeemed_at: row.redeemed_at as string,
+    user_twitch_username: row.user_twitch_username,
+    reward_id: rewardId,
+    cards:
+      row.card_id === null
+        ? null
+        : {
+            id: row.card_id,
+            name: row.card_name as string,
+            description: row.card_description,
+            image_url: row.card_image_url,
+            rarity: row.card_rarity as Rarity,
+          },
+  };
+}
+
+/**
+ * pg 版: 42703(列欠落)のうち reward_id 列の欠落に限定して判定する。
+ *
+ * 自己レビュー指摘への対応: isPgMissingColumnError() 単体は列名を問わず
+ * true になるため、万一 gacha_history/cards の別列が欠落する事態(現行
+ * スキーマでは他列は初版 migration 00001 由来のため考えにくいが)が起きた
+ * 場合でも「reward_id 列欠落」と誤認してフォールバッククエリへ余計に
+ * 1往復してしまう。supabase-js 版の isMissingRewardIdColumnError(エラー
+ * メッセージに "reward_id" を含むかで絞り込む)と同じ精度に揃えることで、
+ * フォールバックの発火条件をより厳密にする。
+ */
+function isMissingRewardIdColumnErrorPg(error: unknown): boolean {
+  if (!isPgMissingColumnError(error)) return false;
+  const message = (error as { message?: unknown } | null)?.message;
+  return typeof message === "string" && message.includes("reward_id");
+}
+
+/**
+ * pg 直結: overlay ポーリング用の gacha_history + cards 取得。
+ * Issue #591 相当のデプロイ窓フォールバック(reward_id 列未デプロイ)を含む。
+ *
+ * 冪等な読み取りのため withDbRetry(..., { idempotent: true }) でラップする
+ * (getUnreadAnnouncementsPg と同じ規約)。
+ *
+ * maxRetries: 1 について(自己レビュー指摘への対応、実装計画からの逸脱):
+ * このエンドポイントの既存 supabase-js 実装(下の GET ハンドラの else 節)は
+ * withRetry(..., { maxRetries: 1 })を明示指定しており、getUnreadAnnouncementsPg
+ * (withDbRetry のデフォルト値[100,300,1000]ms・最大3回リトライを使う)とは
+ * 異なる、このエンドポイント固有のチューニングである。3秒間隔でポーリング
+ * される公開エンドポイントで DB 一時障害時にリトライ上限を既定の3回のままに
+ * すると、1リクエストあたり最大約1.4秒(かつフォールバック分も加わると
+ * 最大約2.8秒)応答が遅延し、多数の overlay クライアントからの同時ポーリングで
+ * Workers 側の滞留を招きうる。既存 postgrest 経路と同じ「1回だけ再試行」に
+ * 揃えることで、レイテンシ特性を含めた挙動不変の要件を満たす。
+ */
+async function getOverlayHistoryRowsPg(
+  streamerId: string,
+  since: string
+): Promise<OverlayHistoryRow[]> {
+  try {
+    const rows = await withDbRetry(
+      () => fetchOverlayHistoryWithRewardIdPg(streamerId, since),
+      "overlayEvents(pg)",
+      { idempotent: true, maxRetries: 1 }
+    );
+    return rows.map((row) => toOverlayHistoryRow(row, row.reward_id));
+  } catch (error) {
+    if (!isMissingRewardIdColumnErrorPg(error)) {
+      throw error;
+    }
+    // Issue #591 デプロイ窓フォールバック(pg版): gacha_history.reward_id
+    // (migration 00070)が未デプロイのDBに新アプリコードがSELECTすると
+    // 42703 undefined_column が発生する。列を含めない別クエリへ1回だけ
+    // フォールバックし、rewardId は null(既存の rarity/all ルールへの
+    // フォールバック挙動)として扱う。supabase-js 版の同名フォールバックと
+    // 同じ設計判断(コメント参照)。
+    const rows = await withDbRetry(
+      () => fetchOverlayHistoryWithoutRewardIdPg(streamerId, since),
+      "overlayEvents(pg):reward-id-fallback",
+      { idempotent: true, maxRetries: 1 }
+    );
+    return rows.map((row) => toOverlayHistoryRow(row, null));
+  }
+}
+
 /**
  * GET /api/overlay/[streamerId]/events
  *
@@ -148,52 +394,73 @@ export async function GET(
       );
     }
 
-    const supabaseAdmin = getSupabaseAdmin();
-    let { data, error } = await withRetry(
-      () =>
-        supabaseAdmin
-          .from("gacha_history")
-          .select(OVERLAY_HISTORY_SELECT_WITH_REWARD_ID)
-          .eq("streamer_id", streamerId)
-          .gt("redeemed_at", since)
-          .order("redeemed_at", { ascending: true })
-          .limit(10),
-      "overlayEvents",
-      { maxRetries: 1 }
-    );
+    // #571 (#570 パイロット踏襲): DB アクセス部分のみをフラグで分岐する。
+    // フラグ未設定(既定 'postgrest')時は else 節の既存 supabase-js 実装が
+    // そのまま実行され、挙動は完全に不変(1文字も変更していない。再インデント
+    // のみ)。overlayHistoryRows へ集約後の整形処理(events 構築)は両経路で
+    // 完全に共有する(下記、resolveCard 経由のロジックは無変更)。
+    let overlayHistoryRows: OverlayHistoryRow[];
 
-    // Issue #591 デプロイ窓フォールバック: gacha_history.reward_id (migration 00070)
-    // がまだ本番DBに適用されていない状態で新アプリコードがSELECTすると読み取り
-    // エラーになる。列を含めない従来のクエリへ1回だけ再試行し、rewardId は
-    // null(=既存の rarity/all ルールへのフォールバック挙動)として扱う。
-    // isMissingCollectionNameColumn 等(collection-existence.ts)と同じ
-    // 「列剥がして再試行」パターン。
-    if (error && isMissingRewardIdColumnError(error)) {
-      const fallback = await withRetry(
+    if (isPgReadEnabled()) {
+      try {
+        overlayHistoryRows = await getOverlayHistoryRowsPg(streamerId, since);
+      } catch (pgError) {
+        // 既存 postgrest 分岐の非列欠落エラーと同じ扱い(handleDatabaseError)に
+        // 揃える。汎用 catch(下の handleApiError)に落とすと
+        // ERROR_MESSAGES.INTERNAL_ERROR('Internal server error')という別文言に
+        // なり、DB起因エラーの応答本文が経路によって変わってしまうため。
+        return handleDatabaseError(pgError, "Overlay Events API");
+      }
+    } else {
+      const supabaseAdmin = getSupabaseAdmin();
+      let { data, error } = await withRetry(
         () =>
           supabaseAdmin
             .from("gacha_history")
-            .select(OVERLAY_HISTORY_SELECT_WITHOUT_REWARD_ID)
+            .select(OVERLAY_HISTORY_SELECT_WITH_REWARD_ID)
             .eq("streamer_id", streamerId)
             .gt("redeemed_at", since)
             .order("redeemed_at", { ascending: true })
             .limit(10),
-        "overlayEvents:reward-id-fallback",
+        "overlayEvents",
         { maxRetries: 1 }
       );
-      // supabase-js は select() の*リテラル*文字列からRow型を推論するため、列数が
-      // 異なる2つのSELECTは互換性の無い別々の型になる(gacha.ts の
-      // executeGacha 内 max_issuance_count フォールバックと同じ制約)。fallback行に
-      // reward_id: null を明示的に補って、上のwith-reward-id型と構造的に一致させる。
-      data = fallback.data?.map((row) => ({ ...row, reward_id: null })) ?? null;
-      error = fallback.error;
+
+      // Issue #591 デプロイ窓フォールバック: gacha_history.reward_id (migration 00070)
+      // がまだ本番DBに適用されていない状態で新アプリコードがSELECTすると読み取り
+      // エラーになる。列を含めない従来のクエリへ1回だけ再試行し、rewardId は
+      // null(=既存の rarity/all ルールへのフォールバック挙動)として扱う。
+      // isMissingCollectionNameColumn 等(collection-existence.ts)と同じ
+      // 「列剥がして再試行」パターン。
+      if (error && isMissingRewardIdColumnError(error)) {
+        const fallback = await withRetry(
+          () =>
+            supabaseAdmin
+              .from("gacha_history")
+              .select(OVERLAY_HISTORY_SELECT_WITHOUT_REWARD_ID)
+              .eq("streamer_id", streamerId)
+              .gt("redeemed_at", since)
+              .order("redeemed_at", { ascending: true })
+              .limit(10),
+          "overlayEvents:reward-id-fallback",
+          { maxRetries: 1 }
+        );
+        // supabase-js は select() の*リテラル*文字列からRow型を推論するため、列数が
+        // 異なる2つのSELECTは互換性の無い別々の型になる(gacha.ts の
+        // executeGacha 内 max_issuance_count フォールバックと同じ制約)。fallback行に
+        // reward_id: null を明示的に補って、上のwith-reward-id型と構造的に一致させる。
+        data = fallback.data?.map((row) => ({ ...row, reward_id: null })) ?? null;
+        error = fallback.error;
+      }
+
+      if (error) {
+        return handleDatabaseError(error, "Overlay Events API");
+      }
+
+      overlayHistoryRows = (data ?? []) as OverlayHistoryRow[];
     }
 
-    if (error) {
-      return handleDatabaseError(error, "Overlay Events API");
-    }
-
-    const events = ((data ?? []) as OverlayHistoryRow[])
+    const events = overlayHistoryRows
       .map((row) => {
         const card = resolveCard(row.cards);
         if (!card) return null;

--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -23,6 +23,15 @@ import {
   pickSoundBearingCardIndex,
   type GachaSoundRule,
 } from "@/lib/gacha-sound-rules";
+import {
+  shouldScheduleReload,
+  isReloadCooldownActive,
+  serializePollState,
+  parsePollState,
+  parseReloadCooldownRecord,
+  RELOAD_COOLDOWN_MS,
+  POLLSTATE_TTL_MS,
+} from "@/lib/overlay-version";
 
 // OBSブラウザソース（古いCEF）向けのqueueMicrotaskポリフィル
 // 一部のOBSバージョンではqueueMicrotaskがサポートされていないため
@@ -118,6 +127,25 @@ interface OverlayOptions {
   portraitShowUsername: boolean;
 }
 
+// Issue #569: このクライアント自身のビルドバージョン。next.config.ts の `env` 設定に
+// より、process.env.NEXT_PUBLIC_OVERLAY_VERSION はビルド時にリテラル文字列として
+// インライン化される(実行時にサーバーから取得するわけではない)。
+// 'dev' はローカル開発時などの既定値で、shouldScheduleReload 側で意図的に
+// リロード対象外として扱われる(overlay-version.ts 参照)。
+const CURRENT_OVERLAY_VERSION = process.env.NEXT_PUBLIC_OVERLAY_VERSION ?? "dev";
+
+// Issue #569: バージョン確認・自動リロード関連の時間定数。
+// 「10分」は設計上、(1)Realtime接続中にバージョン確認だけを行う間隔 と
+// (2)不一致検出からリロード実行までのランダムジッター上限 の両方に使われるため
+// 定数を共有する。
+const TEN_MINUTES_MS = 10 * 60 * 1000;
+// 演出中で実行を見送った場合の再試行間隔(演出を壊さないための待ち時間)
+const RELOAD_DEFER_RETRY_MS = 30 * 1000;
+
+// sessionStorage キー。リロード前後で状態を引き継ぐために使う
+const RELOAD_COOLDOWN_STORAGE_KEY = "twica-overlay-reload";
+const POLLSTATE_STORAGE_KEY = "twica-overlay-pollstate";
+
 export default function OverlayPage() {
   const params = useParams();
   const streamerId = params.streamerId as string;
@@ -183,6 +211,26 @@ export default function OverlayPage() {
   const pollCursorRef = useRef(new Date().toISOString());
   const seenHistoryIdsRef = useRef<Set<string>>(new Set());
   const lastPollingErrorLogRef = useRef(0);
+  // Issue #569: バージョン不一致検出＋自動リロード用のref群。
+  // showCardは演出中判定にrefで参照する必要がある(setTimeoutコールバック内で
+  // stateを直接読むとクロージャ生成時点の古い値のままになるため)。
+  const showCardRef = useRef(showCard);
+  // Realtime接続中にバージョン確認だけを行う最終実行時刻(10分に1回に絞るため)。
+  // 0で初期化し、接続後最初のポーリングTickで即座に1回だけ確認を行う(以降は
+  // 10分間隔に絞られる)。Date.now()はレンダー中に呼べない(React Compilerの
+  // purityルールで検出される)ため、ここでは呼ばずrefの初期値は0固定にする。
+  const lastVersionCheckAtRef = useRef(0);
+  // ジッター待機中/演出中の再試行待ち(＝リロードが予約済み)かどうか。
+  // 二重にsetTimeoutを積んでしまわないようにするフラグ
+  const reloadScheduledRef = useRef(false);
+  // 不一致検出時に受信した「新しい」バージョン文字列。ジッター発火時・
+  // 演出中の再試行時にクールダウン判定・記録で使う
+  const detectedNewVersionRef = useRef<string | null>(null);
+  // ジッター/再試行のsetTimeoutハンドル。アンマウント時にクリアするため保持する
+  const reloadTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // attemptReloadの再帰呼び出し用ref(processQueueRefと同じパターン)。
+  // useCallback内で自身の最新版を安全に参照するために使う
+  const attemptReloadRef = useRef<() => void>(() => {});
   // 効果音再生用のオーディオ要素キャッシュ
   // HTMLAudioElementを使用（R2パブリックURLはCORSヘッダーがないためfetch不可、
   // audioタグはCORS不要で読み込める）
@@ -199,6 +247,40 @@ export default function OverlayPage() {
   useEffect(() => {
     connectionStatusRef.current = connectionStatus;
   }, [connectionStatus]);
+
+  // Issue #569: showCardをrefにミラーする(setTimeoutコールバック内で
+  // 「今演出中かどうか」を古いクロージャ値ではなく最新値で判定するため)
+  useEffect(() => {
+    showCardRef.current = showCard;
+  }, [showCard]);
+
+  // Issue #569: マウント時、直前のバージョン起因リロードでpollCursor/
+  // seenHistoryIdsをsessionStorageに退避していた場合はここで復元する。
+  // TTL(15分)超過や壊れたJSONの場合はparsePollStateがnullを返すため、
+  // その場合は何も復元されず通常どおり「今」を起点にポーリングを開始する。
+  // このeffectは他のeffect(ポーリングスケジューラ・Realtime購読)より前に
+  // 定義しているため、それらが最初に動く前に確実に復元が完了する。
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem(POLLSTATE_STORAGE_KEY);
+      const restored = parsePollState(raw, Date.now(), POLLSTATE_TTL_MS);
+      if (restored) {
+        pollCursorRef.current = restored.pollCursor;
+        seenHistoryIdsRef.current = new Set(restored.seenHistoryIds);
+      }
+      // 復元の成否に関わらず使用後(またはTTL切れ)は必ず削除し、残骸を残さない
+      sessionStorage.removeItem(POLLSTATE_STORAGE_KEY);
+    } catch {
+      // OBSブラウザソース等でsessionStorageが無効/利用不可でも本体動作を壊さない
+    }
+
+    // アンマウント時、ジッター/演出中再試行待ちのタイマーが残っていればクリアする
+    return () => {
+      if (reloadTimeoutRef.current) {
+        clearTimeout(reloadTimeoutRef.current);
+      }
+    };
+  }, []);
 
   // 効果音設定を取得し、HTMLAudioElementでプリロード
   // オーバーレイ初期化時にstreamerの効果音設定をAPIから取得
@@ -516,21 +598,153 @@ export default function OverlayPage() {
   }, [enqueueResult]);
 
   /**
+   * Issue #569: バージョン不一致検出後、ジッター待機を経て実際にリロードするか
+   * どうかを判定・実行する。ジッター発火時と「演出中につき延期」からの再試行時の
+   * 両方からこの同じ関数が呼ばれる(再帰)。
+   *
+   * 自身の再帰呼び出しは attemptReloadRef 経由で行う(processQueueRef と同じ
+   * パターン)。useCallback内で定義中の変数を直接自己参照すると、ESLintの
+   * React Compiler向けルール(react-hooks/immutability)が
+   * 「宣言前アクセス」として検出するため、既存コードと同じ ref 間接参照に揃える。
+   */
+  const attemptReload = useCallback(() => {
+    // 演出中(キュー処理中・キュー待ち・カード表示中)は演出を壊さないよう
+    // 30秒後に同じ判定をやり直す(設計上の要件3番)
+    const isMidDisplay =
+      isDisplayingRef.current || queueRef.current.length > 0 || showCardRef.current;
+    if (isMidDisplay) {
+      addDebugLogRef.current("[version] reload deferred: display in progress");
+      reloadTimeoutRef.current = setTimeout(() => {
+        attemptReloadRef.current();
+      }, RELOAD_DEFER_RETRY_MS);
+      return;
+    }
+
+    // スケジュール時に必ず設定されるため通常は非nullだが、型上の防御として確認する
+    const targetVersion = detectedNewVersionRef.current;
+    if (!targetVersion) {
+      reloadScheduledRef.current = false;
+      return;
+    }
+
+    // 実行直前にクールダウン判定(sessionStorageアクセスはOBS等で無効な場合に
+    // 備えtry/catchで包む。読み取り失敗時はクールダウン無しとして扱う。
+    // JSONの形状検証はparseReloadCooldownRecord(overlay-version.ts)に委譲し、
+    // parsePollStateと同じ「壊れたデータでも例外を投げずnullを返す」方針に揃える)
+    let cooldownRecord: ReturnType<typeof parseReloadCooldownRecord> = null;
+    try {
+      cooldownRecord = parseReloadCooldownRecord(sessionStorage.getItem(RELOAD_COOLDOWN_STORAGE_KEY));
+    } catch {
+      cooldownRecord = null;
+    }
+
+    if (isReloadCooldownActive(cooldownRecord, targetVersion, Date.now(), RELOAD_COOLDOWN_MS)) {
+      addDebugLogRef.current(`[version] reload skipped: cooldown active for ${targetVersion}`);
+      // クールダウン明け後にもう一度チャンスを与えるため予約フラグを解除する。
+      // 次のポーリング/バージョン確認サイクルで不一致が再検出されれば再スケジュールされる。
+      reloadScheduledRef.current = false;
+      return;
+    }
+
+    // クールダウン記録と、リロード後に復元するポーリング状態をsessionStorageへ退避する。
+    // 退避に失敗してもリロード自体は続行する(取りこぼし防止より前進を優先)
+    try {
+      sessionStorage.setItem(
+        RELOAD_COOLDOWN_STORAGE_KEY,
+        JSON.stringify({ version: targetVersion, reloadedAt: Date.now() }),
+      );
+      sessionStorage.setItem(
+        POLLSTATE_STORAGE_KEY,
+        serializePollState({
+          pollCursor: pollCursorRef.current,
+          seenHistoryIds: Array.from(seenHistoryIdsRef.current),
+          savedAt: Date.now(),
+        }),
+      );
+    } catch {
+      // OBSブラウザソース等でsessionStorageが無効/利用不可でも本体動作を壊さない
+    }
+
+    addDebugLogRef.current(`[version] reloading to ${targetVersion}`);
+    // リロード窓での演出取りこぼしを防ぐため、演出中でなくクールダウンもクリアな
+    // 「今」のタイミングで遅延せず即座にリロードする
+    location.reload();
+  }, []);
+
+  // attemptReloadRefを最新のcallbackで更新(processQueueRefと同じパターン)
+  useEffect(() => {
+    attemptReloadRef.current = attemptReload;
+  }, [attemptReload]);
+
+  /**
+   * Issue #569: ポーリング応答のoverlayVersionを自身のビルドバージョンと比較し、
+   * 不一致ならリロードをスケジュールする。
+   */
+  const checkOverlayVersion = useCallback((received: string | undefined) => {
+    if (!shouldScheduleReload(CURRENT_OVERLAY_VERSION, received)) {
+      return;
+    }
+    if (reloadScheduledRef.current) {
+      // 既にジッター待機/演出中の再試行待ちの場合は再スケジュールしない(設計2番)
+      return;
+    }
+    reloadScheduledRef.current = true;
+    detectedNewVersionRef.current = received as string;
+    addDebugLogRef.current(`[version] mismatch detected: ${CURRENT_OVERLAY_VERSION} -> ${received}`);
+
+    // サンダリングハード回避: 全クライアントが同時に新バージョンを検知しても
+    // 一斉リロード→同時アクセス集中が起きないよう、0〜10分でランダムに散らす
+    const jitterMs = Math.floor(Math.random() * TEN_MINUTES_MS);
+    reloadTimeoutRef.current = setTimeout(() => {
+      attemptReload();
+    }, jitterMs);
+  }, [attemptReload]);
+
+  /**
    * Realtime が購読できない環境向けの polling fallback。
    * Supabase Realtime の public channel join が CHANNEL_ERROR になる場合でも、
    * ガチャ履歴から overlay 表示を継続できるようにする。
    */
   const pollOverlayEvents = useCallback(async () => {
+    // 3秒おきのポーリングURLは接続中/未接続どちらの経路でも同一なため共通化する
+    const buildEventsUrl = () => {
+      const url = new URL(`/api/overlay/${streamerId}/events`, window.location.origin);
+      url.searchParams.set("since", pollCursorRef.current);
+      url.searchParams.set("_", String(Date.now()));
+      return url.toString();
+    };
+
     if (connectionStatusRef.current === "connected") {
+      // Issue #569: Realtime接続中もこの関数は3秒おきに呼ばれ続けるが、
+      // 従来は何もせず早期returnしていた。ここに「10分に1回、バージョン確認だけ
+      // 行う」経路を追加する。
+      // 理由: Realtime受信イベントにはhistoryId/eventIdが無くseenHistoryIdsRefに
+      // 登録されないため、接続中にevents配列を処理すると同一演出がポーリング
+      // 経路からも再生され二重演出になる。そのため接続中は応答のoverlayVersion
+      // だけを読み、events配列には一切触れない(表示・カーソル前進・seen登録の
+      // いずれも行わない)。
+      const now = Date.now();
+      if (now - lastVersionCheckAtRef.current < TEN_MINUTES_MS) {
+        return;
+      }
+      lastVersionCheckAtRef.current = now;
+
+      try {
+        const data = await fetchJsonWithXhrFallback<{ overlayVersion?: string }>(buildEventsUrl());
+        checkOverlayVersion(data.overlayVersion);
+      } catch {
+        // バージョン確認専用の背景チェックであり演出表示には無関係なため、
+        // 失敗時はログを出さず静かに次の10分後の機会に委ねる
+      }
       return;
     }
 
     try {
-      const url = new URL(`/api/overlay/${streamerId}/events`, window.location.origin);
-      url.searchParams.set("since", pollCursorRef.current);
-      url.searchParams.set("_", String(Date.now()));
-
-      const data = await fetchJsonWithXhrFallback<{ events?: OverlayPollingEvent[] }>(url.toString());
+      const data = await fetchJsonWithXhrFallback<{
+        events?: OverlayPollingEvent[];
+        overlayVersion?: string;
+      }>(buildEventsUrl());
+      checkOverlayVersion(data.overlayVersion);
       const events = data.events ?? [];
       for (const event of events) {
         if (seenHistoryIdsRef.current.has(event.id)) {
@@ -558,7 +772,7 @@ export default function OverlayPage() {
         addDebugLogRef.current("Polling fallback network error; retrying");
       }
     }
-  }, [streamerId]);
+  }, [streamerId, checkOverlayVersion]);
 
   useEffect(() => {
     let stopped = false;

--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -134,11 +134,19 @@ interface OverlayOptions {
 // リロード対象外として扱われる(overlay-version.ts 参照)。
 const CURRENT_OVERLAY_VERSION = process.env.NEXT_PUBLIC_OVERLAY_VERSION ?? "dev";
 
-// Issue #569: バージョン確認・自動リロード関連の時間定数。
-// 「10分」は設計上、(1)Realtime接続中にバージョン確認だけを行う間隔 と
-// (2)不一致検出からリロード実行までのランダムジッター上限 の両方に使われるため
-// 定数を共有する。
-const TEN_MINUTES_MS = 10 * 60 * 1000;
+// Issue #569: Realtime接続中に「バージョン確認だけ」を行う間隔。
+// 接続中はフォールバックポーリング本来の目的(イベント取得)を行わず、
+// この間隔でoverlayVersionだけを軽量に確認する(pollOverlayEvents参照)。
+// レビュー指摘: 以前はリロードジッター上限(RELOAD_JITTER_MAX_MS)と同じ
+// 定数(TEN_MINUTES_MS)を共有していたが、「確認間隔」と「ジッター上限」は
+// 意味の異なる独立したチューニング値であり、結合していると片方だけを
+// 変更したい場合に紛らわしいため分離した。値は据え置き(10分)。
+const VERSION_CHECK_INTERVAL_MS = 10 * 60 * 1000;
+// Issue #569: バージョン不一致検出からリロード実行までのランダムジッター上限。
+// サンダリングハード回避のため、0〜この値の範囲でリロード実行タイミングを
+// 散らす(checkOverlayVersion参照)。VERSION_CHECK_INTERVAL_MSと値はどちらも
+// 10分だが、意味的に独立したチューニング値のため別定数として管理する。
+const RELOAD_JITTER_MAX_MS = 10 * 60 * 1000;
 // 演出中で実行を見送った場合の再試行間隔(演出を壊さないための待ち時間)
 const RELOAD_DEFER_RETRY_MS = 30 * 1000;
 
@@ -693,8 +701,8 @@ export default function OverlayPage() {
     addDebugLogRef.current(`[version] mismatch detected: ${CURRENT_OVERLAY_VERSION} -> ${received}`);
 
     // サンダリングハード回避: 全クライアントが同時に新バージョンを検知しても
-    // 一斉リロード→同時アクセス集中が起きないよう、0〜10分でランダムに散らす
-    const jitterMs = Math.floor(Math.random() * TEN_MINUTES_MS);
+    // 一斉リロード→同時アクセス集中が起きないよう、0〜RELOAD_JITTER_MAX_MSでランダムに散らす
+    const jitterMs = Math.floor(Math.random() * RELOAD_JITTER_MAX_MS);
     reloadTimeoutRef.current = setTimeout(() => {
       attemptReload();
     }, jitterMs);
@@ -716,15 +724,15 @@ export default function OverlayPage() {
 
     if (connectionStatusRef.current === "connected") {
       // Issue #569: Realtime接続中もこの関数は3秒おきに呼ばれ続けるが、
-      // 従来は何もせず早期returnしていた。ここに「10分に1回、バージョン確認だけ
-      // 行う」経路を追加する。
+      // 従来は何もせず早期returnしていた。ここに「VERSION_CHECK_INTERVAL_MSに
+      // 1回、バージョン確認だけ行う」経路を追加する。
       // 理由: Realtime受信イベントにはhistoryId/eventIdが無くseenHistoryIdsRefに
       // 登録されないため、接続中にevents配列を処理すると同一演出がポーリング
       // 経路からも再生され二重演出になる。そのため接続中は応答のoverlayVersion
       // だけを読み、events配列には一切触れない(表示・カーソル前進・seen登録の
       // いずれも行わない)。
       const now = Date.now();
-      if (now - lastVersionCheckAtRef.current < TEN_MINUTES_MS) {
+      if (now - lastVersionCheckAtRef.current < VERSION_CHECK_INTERVAL_MS) {
         return;
       }
       lastVersionCheckAtRef.current = now;

--- a/src/lib/announcements.ts
+++ b/src/lib/announcements.ts
@@ -7,8 +7,18 @@
  */
 
 import { cache } from 'react'
+import { desc, eq } from 'drizzle-orm'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { withRetry } from '@/lib/supabase/retry'
+import { getDb } from '@/lib/db/client'
+import { isPgReadEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+// schema のテーブル名（announcements）はこのモジュールのローカル変数名と紛らわしい
+// ため、Table サフィックスを付けて import する
+import {
+  announcementReads as announcementReadsTable,
+  announcements as announcementsTable,
+} from '@/lib/db/schema'
 import { logger } from './logger'
 
 export interface UnreadAnnouncement {
@@ -92,6 +102,112 @@ export function hasAnnouncementBeenPublishedAt(
 }
 
 /**
+ * getUnreadAnnouncements の Drizzle（pg 直結）実装 (#570 パイロット)
+ *
+ * DB_DRIVER=pg-read/pg のときのみ使われる、PostgREST 実装と同一のクエリ意味論を
+ * 持つ読み取り経路。戻り値の形状（snake_case キー、日付は文字列）を既存実装と
+ * 完全に一致させることが要件（呼び出し側は経路を意識しない）。
+ *
+ * PostgREST 実装との対応:
+ * - announcements: is_published = true を created_at 降順で取得
+ *   （表示期限の判定は既存実装と同じく isAnnouncementVisibleAt でサーバー側 JS 処理）
+ * - announcement_reads: twitch_user_id 一致の既読 ID を取得
+ * - いずれかが失敗したら空配列（バナー非表示の安全側）を返し、logger.error に記録
+ *   （既存実装の annError / readError / catch と同じ外部挙動）
+ *
+ * 読み取り専用クエリのため冪等（idempotent: true）としてリトライを opt-in する。
+ * timestamptz 列は Drizzle スキーマの mode: 'string' により文字列のまま返る
+ * （Date オブジェクトへの変換はしない。既存実装のパリティ要件）。
+ * 既知の表現差: pg 直結は PG テキスト形式（'2026-03-10 12:00:00.123456+00'）、
+ * PostgREST は ISO 8601（'2026-03-10T12:00:00.123456+00:00'）を返す。いずれも
+ * V8 の Date.parse で同一時刻に解釈され、本モジュールの消費側（isAnnouncementVisibleAt
+ * と AnnouncementBanner）は Date.parse 経由でしか日付を扱わないため影響はない。
+ * 文字列を直接パースする消費側を今後追加する場合はこの差に注意すること。
+ */
+async function getUnreadAnnouncementsPg(twitchUserId: string): Promise<UnreadAnnouncement[]> {
+  // どちらのクエリで失敗したかを catch 節のログで判別するためのフェーズタグ。
+  // PostgREST 経路が annError / readError を別メッセージでログしているのに合わせ、
+  // preview 切替検証（wrangler tail での原因切り分け）を容易にする。
+  let phase: 'announcements' | 'reads' = 'announcements'
+  try {
+    const now = new Date()
+
+    const announcements = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（リクエストスコープ破棄からの
+        // 回復にはクライアント再取得が必要。src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({
+            id: announcementsTable.id,
+            title: announcementsTable.title,
+            body: announcementsTable.body,
+            severity: announcementsTable.severity,
+            published_at: announcementsTable.published_at,
+            expires_at: announcementsTable.expires_at,
+            created_at: announcementsTable.created_at,
+          })
+          .from(announcementsTable)
+          .where(eq(announcementsTable.is_published, true))
+          .orderBy(desc(announcementsTable.created_at))
+      },
+      'getUnreadAnnouncements(announcements)',
+      { idempotent: true },
+    )
+
+    if (announcements.length === 0) {
+      return []
+    }
+
+    const visibleAnnouncements = announcements.filter((announcement) =>
+      isAnnouncementVisibleAt(announcement, now)
+    )
+
+    if (visibleAnnouncements.length === 0) {
+      return []
+    }
+
+    phase = 'reads'
+    const reads = await withDbRetry(
+      async () => {
+        const { db } = await getDb()
+        return db
+          .select({ announcement_id: announcementReadsTable.announcement_id })
+          .from(announcementReadsTable)
+          .where(eq(announcementReadsTable.twitch_user_id, twitchUserId))
+      },
+      'getUnreadAnnouncements(reads)',
+      { idempotent: true },
+    )
+
+    const readIds = new Set(reads.map(r => r.announcement_id))
+
+    return visibleAnnouncements
+      .filter(a => !readIds.has(a.id))
+      .map(a => ({
+        id: a.id,
+        title: a.title,
+        body: a.body,
+        // severity は DB の CHECK 制約で 'info' | 'warning' | 'critical' が保証
+        // されている。PostgREST 経路も型検証なしで同じ生値を返しており、既存の
+        // 戻り値型に合わせるキャスト（値の変換はしない）。
+        severity: a.severity as UnreadAnnouncement['severity'],
+        published_at: a.published_at,
+        // created_at の DDL は DEFAULT now()（NOT NULL なし）のため Drizzle 型は
+        // string | null だが、実運用で NULL にはならない。PostgREST 経路の
+        // 戻り値型（string）に合わせるキャスト（値の変換はしない）。
+        created_at: a.created_at as string,
+      }))
+  } catch (error) {
+    // 既存実装と同じく「取得失敗時は未読バナーを出さない」安全側の挙動。
+    // phase により announcements / reads どちらの取得で失敗したかを判別できる
+    // （PostgREST 経路の annError / readError 別ログと同等の粒度）。
+    logger.error(`Error in getUnreadAnnouncements (pg:${phase})`, { error })
+    return []
+  }
+}
+
+/**
  * 未読のお知らせを取得（ダッシュボードバナー表示用）
  * 公開中 かつ 期限内 かつ 未読 のお知らせを取得する
  *
@@ -99,6 +215,13 @@ export function hasAnnouncementBeenPublishedAt(
  * @returns 未読お知らせ一覧（公開日時の降順）
  */
 export const getUnreadAnnouncements = cache(async (twitchUserId: string): Promise<UnreadAnnouncement[]> => {
+  // #570 パイロット: DB_DRIVER=pg-read/pg のときのみ Drizzle 直結経路へ切り替える。
+  // フラグ未設定時（既定 'postgrest'）はこの分岐を素通りし、以下の既存 supabase-js
+  // 実装が従来と完全に同一に実行される（挙動不変が Phase 1 の最重要安全要件）。
+  if (isPgReadEnabled()) {
+    return getUnreadAnnouncementsPg(twitchUserId)
+  }
+
   try {
     const supabase = getSupabaseAdmin()
     const now = new Date()

--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -6,6 +6,40 @@ import { normalizeDropRate } from "@/lib/card-utils";
 import { reportError } from "@/lib/sentry/error-handler";
 import { withRetry } from "@/lib/supabase/retry";
 import { logPerf, perfStart } from "@/lib/perf";
+// ---------------------------------------------------------------------------
+// #571: pg 直結経路 (DB_DRIVER=pg-read/pg) 用の import。
+// フラグ未設定時（既定 'postgrest'）は isPgReadEnabled() が false を返すため
+// getDb() は一切呼ばれず、既存の supabase-js 経路が従来どおり実行される。
+// count は既存コードの `const { count } = await ...` 分割代入と名前が衝突する
+// ため countRows に alias する。
+// ---------------------------------------------------------------------------
+import {
+  and,
+  asc,
+  count as countRows,
+  desc,
+  eq,
+  getTableColumns,
+  gte,
+  ilike,
+  inArray,
+  lt,
+} from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
+import { isPgMissingColumnError } from "@/lib/db/errors";
+import { isPgReadEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+// schema のテーブル名（cards / streamers 等）は本モジュールのローカル変数名・
+// 型名と紛らわしいため、Table サフィックスを付けて import する
+// （announcements.ts パイロットと同じ規約）
+import {
+  cards as cardsTable,
+  collectionCompletions as collectionCompletionsTable,
+  gachaHistory as gachaHistoryTable,
+  streamers as streamersTable,
+  userCards as userCardsTable,
+  users as usersTable,
+} from "@/lib/db/schema";
 // Issue #557: デプロイ窓 (00064 未適用) の collection_name 列欠落検知に再利用。
 // 既存ヘルパは "collection_name" 文言でゲートしており、collection_completions
 // の同名列にもそのまま一致する。
@@ -22,6 +56,74 @@ interface GachaHistoryWithCard extends GachaHistory {
 }
 
 /**
+ * getStreamerData の Drizzle（pg 直結）実装 (#571)
+ *
+ * PostgREST 実装との対応:
+ * - `streamers.*, cards!cards_streamer_id_fkey(*)` の埋め込み1リクエストを、
+ *   streamers LEFT JOIN cards の1クエリで置き換える（往復回数のパリティ）。
+ *   JOIN 条件 cards.streamer_id = streamers.id は FK 制約
+ *   cards_streamer_id_fkey が表す関係そのものであり、PostgREST の埋め込みヒント
+ *   （PGRST201 回避）と同じリレーションを SQL で明示していることになる。
+ * - PostgREST の max-rows(1000) は「トップレベル行」にのみ適用され、埋め込み
+ *   配列は打ち切られない。よってこの JOIN にも LIMIT は付けない（カード全件）。
+ * - streamers.twitch_user_id は UNIQUE（migration 00001）のため streamer は
+ *   最大1行。JOIN の複数行はすべて同一 streamer で、カードだけが異なる。
+ * - .maybeSingle() のエラー（およびクエリ失敗全般）は既存実装が分割代入で
+ *   握り潰して null 扱いにしているため、pg 版も catch して null を返す
+ *   （外部挙動のパリティ。ログだけは切替検証のため残す）。
+ *
+ * 日付の既知の表現差（パイロット announcements.ts と同様）: pg 直結は PG テキスト
+ * 形式（'2026-03-10 12:00:00.123456+00'）、PostgREST は ISO 8601 を返す。本モジュール
+ * の消費側はすべて new Date() / Date.parse 経由で日付を扱うため影響はない
+ * （文字列を直接パースする消費側を追加する場合は注意）。他の xxxPg も同様。
+ */
+async function getStreamerDataPg(
+  twitchUserId: string
+): Promise<{ streamer: Streamer; cards: Card[] } | null> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（リクエストスコープ破棄からの
+        // 回復にはクライアント再取得が必要。src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select({ streamer: streamersTable, card: cardsTable })
+          .from(streamersTable)
+          .leftJoin(cardsTable, eq(cardsTable.streamer_id, streamersTable.id))
+          .where(eq(streamersTable.twitch_user_id, twitchUserId));
+      },
+      "getStreamerData",
+      { idempotent: true },
+    );
+
+    if (rows.length === 0) return null;
+
+    // LEFT JOIN なのでカード0枚でも streamer 行は1行返る（card は null）。
+    // PostgREST の cards: [] と同じく空配列に落とす。
+    // ソートは既存実装と同一の JS ソート（created_at 降順）。
+    // Drizzle スキーマの行は Card 型に無い生成カラム rarity_order も含むが、
+    // PostgREST の `cards(*)` も実 DB の全列（rarity_order 含む）を返すため
+    // むしろ形状は一致する。型だけ既存の戻り値型に合わせてキャストする
+    // （値の変換はしない）。
+    const cards = normalizeDropRate(
+      rows.flatMap((row) => (row.card ? [row.card as unknown as Card] : []))
+    ).sort(
+      (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
+
+    // 既存実装は `{ cards: _cardsNested, ...streamerData }` でネストを除いた
+    // streamer 列のみを返す。pg 版の streamer 行は最初からネストを含まない。
+    const streamer = rows[0].streamer as unknown as Streamer;
+    return { streamer, cards };
+  } catch (error) {
+    // 既存実装はエラー時に streamer=null → return null（呼び出し側は
+    // /dashboard へのリダイレクト等で扱う）。同じ外部挙動に合わせる。
+    logger.error("Error in getStreamerData (pg)", { error });
+    return null;
+  }
+}
+
+/**
  * Get streamer data with cards - cached per request
  * Single query using Supabase relations to reduce network round-trips
  *
@@ -29,6 +131,12 @@ interface GachaHistoryWithCard extends GachaHistory {
  * Supabaseのリレーションを使用して1回のクエリで取得し、ネットワーク往復を削減
  */
 export const getStreamerData = cache(async (twitchUserId: string) => {
+  // #571: DB_DRIVER=pg-read/pg のときのみ Drizzle 直結経路へ切り替える。
+  // フラグ未設定時は素通りし、以下の既存 supabase-js 実装が従来どおり実行される。
+  if (isPgReadEnabled()) {
+    return getStreamerDataPg(twitchUserId);
+  }
+
   const supabaseAdmin = getSupabaseAdmin();
 
   // Single query: get streamer with their cards using foreign key relation
@@ -74,6 +182,115 @@ export const getStreamerData = cache(async (twitchUserId: string) => {
 })
 
 /**
+ * getStreamerDataPaginated の Drizzle（pg 直結）実装 (#571)
+ *
+ * PostgREST 実装との対応（3クエリ構成をそのまま踏襲）:
+ * 1. streamers: .maybeSingle() 相当。twitch_user_id は UNIQUE のため LIMIT 1 で
+ *    0行 → null / 1行 → その行、という同じ外部挙動になる。
+ * 2. cards の総数: `{ count: "exact", head: true }` 相当を COUNT(*) で取得。
+ * 3. cards のページ: `.range(offset, offset + perPage - 1)` は
+ *    LIMIT perPage OFFSET offset と等価。
+ *
+ * エラー時の挙動は既存実装（分割代入でエラーを握り潰す）に合わせ、クエリ単位で
+ * catch して同じフォールバック値に落とす:
+ *   streamer 失敗 → null（関数全体が null）/ count 失敗 → 0 / cards 失敗 → []
+ */
+async function getStreamerDataPaginatedPg(
+  twitchUserId: string,
+  page: number,
+  perPage: number
+): Promise<{
+  streamer: Streamer;
+  cards: Card[];
+  pagination: { page: number; perPage: number; total: number; totalPages: number };
+} | null> {
+  const start = Date.now();
+
+  let streamer: Streamer | null;
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select()
+          .from(streamersTable)
+          .where(eq(streamersTable.twitch_user_id, twitchUserId))
+          .limit(1);
+      },
+      "getStreamerDataPaginated(streamer)",
+      { idempotent: true },
+    );
+    // Drizzle 行は NULL 制約の型差（DDL 準拠）があるが値は同一のため、既存の
+    // 戻り値型に合わせるキャストのみ行う（値の変換はしない）。
+    streamer = (rows[0] ?? null) as unknown as Streamer | null;
+  } catch (error) {
+    logger.error("Error in getStreamerDataPaginated (pg:streamer)", { error });
+    streamer = null;
+  }
+
+  if (!streamer) return null;
+  // クロージャ内での TS null 絞り込みを保つため id を確定させる
+  const streamerId = streamer.id;
+
+  let totalCount = 0;
+  try {
+    totalCount = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        const result = await db
+          .select({ count: countRows() })
+          .from(cardsTable)
+          .where(eq(cardsTable.streamer_id, streamerId));
+        return result[0]?.count ?? 0;
+      },
+      "getStreamerDataPaginated(count)",
+      { idempotent: true },
+    );
+  } catch (error) {
+    // 既存実装は count エラー時 null → `totalCount || 0` で 0 扱い
+    logger.error("Error in getStreamerDataPaginated (pg:count)", { error });
+    totalCount = 0;
+  }
+
+  const offset = (page - 1) * perPage;
+  let cards: Card[] = [];
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select()
+          .from(cardsTable)
+          .where(eq(cardsTable.streamer_id, streamerId))
+          .orderBy(desc(cardsTable.created_at))
+          .limit(perPage)
+          .offset(offset);
+      },
+      "getStreamerDataPaginated(cards)",
+      { idempotent: true },
+    );
+    cards = rows as unknown as Card[];
+  } catch (error) {
+    // 既存実装は cards エラー時 null → `cards || []` で [] 扱い
+    logger.error("Error in getStreamerDataPaginated (pg:cards)", { error });
+    cards = [];
+  }
+
+  logger.info(`[Perf] getStreamerDataPaginated: ${Date.now() - start}ms (page ${page}, ${cards.length} cards)`);
+
+  return {
+    streamer,
+    cards,
+    pagination: {
+      page,
+      perPage,
+      total: totalCount,
+      totalPages: Math.ceil(totalCount / perPage),
+    },
+  };
+}
+
+/**
  * Get streamer data with paginated cards
  * サーバーサイドページング対応の配信者データとカード取得
  */
@@ -82,6 +299,11 @@ export const getStreamerDataPaginated = cache(async (
   page: number = 1,
   perPage: number = 8
 ) => {
+  // #571: pg 直結経路（フラグ未設定時は素通り。getStreamerDataPg 参照）
+  if (isPgReadEnabled()) {
+    return getStreamerDataPaginatedPg(twitchUserId, page, perPage);
+  }
+
   const supabaseAdmin = getSupabaseAdmin();
   const start = Date.now();
 
@@ -252,7 +474,45 @@ export const getUserCards = cache(async (twitchUserId: string): Promise<CardWith
   return result;
 })
 
+/**
+ * getRecentGachaHistory の Drizzle（pg 直結）実装 (#571)
+ *
+ * PostgREST の `*, cards(*)` 埋め込みは、gacha_history.card_id → cards.id の
+ * 多対一 FK に基づき「単一オブジェクト（マッチなしなら null）」を cards キーに
+ * ネストする。pg 版は LEFT JOIN + ネスト選択（cards: cardsTable）で同じ形状を
+ * 直接得る（Drizzle は LEFT JOIN でマッチしなかったネストオブジェクトを null に
+ * する。card_id は NOT NULL FK のため実データでは常にオブジェクト）。
+ * エラー時は既存実装（分割代入で握り潰し → []）と同じ外部挙動。
+ */
+async function getRecentGachaHistoryPg(): Promise<GachaHistoryWithCard[]> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({ ...getTableColumns(gachaHistoryTable), cards: cardsTable })
+          .from(gachaHistoryTable)
+          .leftJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
+          .orderBy(desc(gachaHistoryTable.redeemed_at))
+          .limit(10);
+      },
+      "getRecentGachaHistory",
+      { idempotent: true },
+    );
+    // 既存実装と同じく戻り値型へのキャストのみ（値の変換はしない）
+    return rows as unknown as GachaHistoryWithCard[];
+  } catch (error) {
+    logger.error("Error in getRecentGachaHistory (pg)", { error });
+    return [];
+  }
+}
+
 export async function getRecentGachaHistory(): Promise<GachaHistoryWithCard[]> {
+  // #571: pg 直結経路（フラグ未設定時は素通り。getStreamerDataPg 参照）
+  if (isPgReadEnabled()) {
+    return getRecentGachaHistoryPg();
+  }
+
   const supabaseAdmin = getSupabaseAdmin();
 
   const { data: history } = await supabaseAdmin
@@ -297,6 +557,112 @@ interface PaginatedGachaHistory {
 }
 
 /**
+ * getGachaHistoryForStreamer の Drizzle（pg 直結）実装 (#571)
+ *
+ * PostgREST 実装との対応:
+ * - `*, cards(*)` / `cards!inner(*)` の埋め込み → LEFT JOIN + ネスト選択。
+ *   rarity フィルタ時に PostgREST が !inner を使うのは「埋め込みフィルタで
+ *   トップレベル行も絞り込む」ためだが、SQL では LEFT JOIN + WHERE
+ *   cards.rarity = X が INNER JOIN + 同条件と完全に等価（NULL 拡張行は WHERE で
+ *   落ちる）なので、JOIN 種別を分岐せず常に LEFT JOIN + WHERE で両ケースを表現
+ *   できる。rarity フィルタなしの場合も card_id は NOT NULL FK（cards.id への
+ *   参照）のため LEFT JOIN は行数を増減させず、!inner の有無による差は出ない。
+ * - `{ count: "exact" }` はフィルタ適用後のトップレベル行数 → 同じ WHERE の
+ *   COUNT(*) クエリ。上記と同じ理由で JOIN しても行数は変わらないため、rarity
+ *   条件が cards 列を参照できるよう count クエリにも同じ LEFT JOIN を張る。
+ * - `.ilike()` の LIKE パターン（% と _ を \ でエスケープ）はバインド値として
+ *   そのまま PostgreSQL に渡り、既定のエスケープ文字も \ なので意味論は同一。
+ * - `.range(offset, offset + perPage - 1)` = LIMIT perPage OFFSET offset。
+ * - エラー時: 既存実装は分割代入で握り潰し data=null / count=null →
+ *   { history: [], total: 0, totalPages: 0 }。単一リクエスト失敗で両方 null に
+ *   なる挙動に合わせ、pg 版も rows/count のどちらが失敗しても同じ空結果を返す。
+ */
+async function getGachaHistoryForStreamerPg(
+  streamerId: string,
+  filters: GachaHistoryFilters
+): Promise<PaginatedGachaHistory> {
+  const { page = 1, perPage = 20, username, rarity, cardId, userId, from, to } = filters;
+
+  // WHERE 条件は PostgREST 版のフィルタと1対1対応で組み立てる
+  const conditions = [eq(gachaHistoryTable.streamer_id, streamerId)];
+  if (username) {
+    // Escape LIKE pattern characters to prevent unintended matching
+    // LIKEパターン文字をエスケープして意図しないマッチを防止（既存実装と同一）
+    const escaped = username.replace(/%/g, "\\%").replace(/_/g, "\\_");
+    conditions.push(ilike(gachaHistoryTable.user_twitch_username, `%${escaped}%`));
+  }
+  if (rarity) {
+    conditions.push(eq(cardsTable.rarity, rarity));
+  }
+  if (cardId) {
+    conditions.push(eq(gachaHistoryTable.card_id, cardId));
+  }
+  if (userId) {
+    conditions.push(eq(gachaHistoryTable.user_twitch_id, userId));
+  }
+  if (from) {
+    conditions.push(gte(gachaHistoryTable.redeemed_at, from));
+  }
+  if (to) {
+    // 「次の日未満」で "to" 日付全体を含める（既存実装と同一のUTC解釈）
+    const nextDay = new Date(`${to}T00:00:00Z`);
+    nextDay.setUTCDate(nextDay.getUTCDate() + 1);
+    conditions.push(lt(gachaHistoryTable.redeemed_at, nextDay.toISOString()));
+  }
+  const whereClause = and(...conditions);
+  const offset = (page - 1) * perPage;
+
+  try {
+    const [rows, total] = await Promise.all([
+      withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          return db
+            .select({ ...getTableColumns(gachaHistoryTable), cards: cardsTable })
+            .from(gachaHistoryTable)
+            .leftJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
+            .where(whereClause)
+            .orderBy(desc(gachaHistoryTable.redeemed_at))
+            .limit(perPage)
+            .offset(offset);
+        },
+        "getGachaHistoryForStreamer(rows)",
+        { idempotent: true },
+      ),
+      withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          const result = await db
+            .select({ count: countRows() })
+            .from(gachaHistoryTable)
+            .leftJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
+            .where(whereClause);
+          return result[0]?.count ?? 0;
+        },
+        "getGachaHistoryForStreamer(count)",
+        { idempotent: true },
+      ),
+    ]);
+
+    return {
+      history: rows as unknown as GachaHistoryWithCard[],
+      pagination: {
+        page,
+        perPage,
+        total,
+        totalPages: Math.ceil(total / perPage),
+      },
+    };
+  } catch (error) {
+    logger.error("Error in getGachaHistoryForStreamer (pg)", { error });
+    return {
+      history: [],
+      pagination: { page, perPage, total: 0, totalPages: 0 },
+    };
+  }
+}
+
+/**
  * Get gacha history for a streamer with pagination and filters
  * Supports filtering by username, rarity, and date range
  * 配信者向け: ページネーション・フィルタ付きガチャ履歴取得
@@ -306,6 +672,11 @@ export async function getGachaHistoryForStreamer(
   streamerId: string,
   filters: GachaHistoryFilters = {}
 ): Promise<PaginatedGachaHistory> {
+  // #571: pg 直結経路（フラグ未設定時は素通り。getStreamerDataPg 参照）
+  if (isPgReadEnabled()) {
+    return getGachaHistoryForStreamerPg(streamerId, filters);
+  }
+
   const { page = 1, perPage = 20, username, rarity, cardId, userId, from, to } = filters;
   const supabaseAdmin = getSupabaseAdmin();
 
@@ -371,6 +742,80 @@ export async function getGachaHistoryForStreamer(
 }
 
 /**
+ * getGachaHistoryForUser の Drizzle（pg 直結）実装 (#571)
+ *
+ * PostgREST の `*, cards(*), streamers(twitch_display_name)` は、いずれも
+ * 多対一 FK（card_id → cards.id / streamer_id → streamers.id）に基づく
+ * 「単一オブジェクト」埋め込み。pg 版は 2 つの LEFT JOIN + ネスト選択で
+ * 同じ形状を得る。streamers は twitch_display_name の 1 列だけを選択した
+ * ネストオブジェクト（{ twitch_display_name } | null）にし、列を絞った埋め込み
+ * の形状（GachaHistoryTable が entry.streamers.twitch_display_name として消費）
+ * を厳密に再現する。count は WHERE のみで決まる（JOIN は多対一で行数不変）ため
+ * gacha_history 単独の COUNT(*) で等価。
+ * エラー時は getGachaHistoryForStreamerPg と同じく空結果（既存挙動どおり）。
+ */
+async function getGachaHistoryForUserPg(
+  userTwitchId: string,
+  filters: { page?: number; perPage?: number }
+): Promise<PaginatedGachaHistory> {
+  const { page = 1, perPage = 20 } = filters;
+  const offset = (page - 1) * perPage;
+
+  try {
+    const [rows, total] = await Promise.all([
+      withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          return db
+            .select({
+              ...getTableColumns(gachaHistoryTable),
+              cards: cardsTable,
+              streamers: { twitch_display_name: streamersTable.twitch_display_name },
+            })
+            .from(gachaHistoryTable)
+            .leftJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
+            .leftJoin(streamersTable, eq(gachaHistoryTable.streamer_id, streamersTable.id))
+            .where(eq(gachaHistoryTable.user_twitch_id, userTwitchId))
+            .orderBy(desc(gachaHistoryTable.redeemed_at))
+            .limit(perPage)
+            .offset(offset);
+        },
+        "getGachaHistoryForUser(rows)",
+        { idempotent: true },
+      ),
+      withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          const result = await db
+            .select({ count: countRows() })
+            .from(gachaHistoryTable)
+            .where(eq(gachaHistoryTable.user_twitch_id, userTwitchId));
+          return result[0]?.count ?? 0;
+        },
+        "getGachaHistoryForUser(count)",
+        { idempotent: true },
+      ),
+    ]);
+
+    return {
+      history: rows as unknown as GachaHistoryWithCard[],
+      pagination: {
+        page,
+        perPage,
+        total,
+        totalPages: Math.ceil(total / perPage),
+      },
+    };
+  } catch (error) {
+    logger.error("Error in getGachaHistoryForUser (pg)", { error });
+    return {
+      history: [],
+      pagination: { page, perPage, total: 0, totalPages: 0 },
+    };
+  }
+}
+
+/**
  * Get gacha history for a specific user with pagination
  * 視聴者向け: ページネーション付きの自分のガチャ履歴取得
  */
@@ -378,6 +823,11 @@ export async function getGachaHistoryForUser(
   userTwitchId: string,
   filters: { page?: number; perPage?: number } = {}
 ): Promise<PaginatedGachaHistory> {
+  // #571: pg 直結経路（フラグ未設定時は素通り。getStreamerDataPg 参照）
+  if (isPgReadEnabled()) {
+    return getGachaHistoryForUserPg(userTwitchId, filters);
+  }
+
   const { page = 1, perPage = 20 } = filters;
   const supabaseAdmin = getSupabaseAdmin();
 
@@ -1269,10 +1719,59 @@ async function fetchCardOwnerStatsFromUserCards(
 }
 
 /**
+ * fetchActiveCardsForStreamerFromDB の Drizzle（pg 直結）実装 (#571)
+ *
+ * フラグ分岐は unstable_cache の「中」（fetchActiveCardsForStreamerFromDB 冒頭）
+ * で行うため、キャッシュキー・タグ・TTL の構造は両経路で完全に同一
+ * （getActiveCardsForStreamer 側は無変更）。
+ *
+ * LIMIT 1000 の根拠: 既存 PostgREST 経路は Supabase 既定の max-rows=1000 で
+ * トップレベル行が暗黙に打ち切られる。1配信者のアクティブカードが 1000 を
+ * 超えることは実運用上考えにくいが、アプリ層に枚数上限の不変条件が無いため、
+ * 超えた場合の挙動も既存経路と一致するよう明示的に LIMIT 1000 を付ける
+ * （挙動パリティ優先。上限撤廃は移行完了後に別途判断する）。
+ * エラー時は既存実装（分割代入で握り潰し → cards=null → []）と同じ外部挙動。
+ */
+async function fetchActiveCardsForStreamerFromDBPg(streamerId: string): Promise<Card[]> {
+  const startTotal = Date.now();
+  const startQuery = Date.now();
+  try {
+    const cards = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select()
+          .from(cardsTable)
+          .where(and(eq(cardsTable.streamer_id, streamerId), eq(cardsTable.is_active, true)))
+          // generated column rarity_order によるレアリティ順の安定ソート
+          // （PostgREST 版と同一。asc/desc の NULL 順序は両経路とも PostgreSQL
+          // 既定（ASC=NULLS LAST / DESC=NULLS FIRST）で一致する）
+          .orderBy(asc(cardsTable.rarity_order), desc(cardsTable.created_at))
+          .limit(1000);
+      },
+      "getActiveCardsForStreamer",
+      { idempotent: true },
+    );
+    logger.info(`[Perf] getActiveCardsForStreamer query: ${Date.now() - startQuery}ms`);
+    logger.info(`[Perf] getActiveCardsForStreamer total: ${Date.now() - startTotal}ms`);
+    return normalizeDropRate(cards as unknown as Card[]);
+  } catch (error) {
+    logger.error("Error in getActiveCardsForStreamer (pg)", { error });
+    return [];
+  }
+}
+
+/**
  * Internal function to fetch active cards for a specific streamer from database
  * 内部関数: 特定配信者のアクティブカードをデータベースから取得
  */
 async function fetchActiveCardsForStreamerFromDB(streamerId: string): Promise<Card[]> {
+  // #571: pg 直結経路。unstable_cache の内側で分岐することでキャッシュ構造を
+  // 変えない（フラグ未設定時は素通り。getStreamerDataPg 参照）
+  if (isPgReadEnabled()) {
+    return fetchActiveCardsForStreamerFromDBPg(streamerId);
+  }
+
   const startTotal = Date.now();
   const supabaseAdmin = getSupabaseAdmin();
 
@@ -1317,9 +1816,89 @@ export interface ActiveCardCountForStreamer {
   activeCardIds: Set<string>;
 }
 
+/**
+ * getActiveCardCountsForStreamers の Drizzle（pg 直結）実装 (#571)
+ *
+ * 前処理（重複除去・空入力の早期 return）と JS 側集計は経路非依存だが、
+ * 「関数冒頭でのフラグ分岐 + 既存実装無変更」の規約を守るため、pg 版にも
+ * 同じ前処理を意図的に複製している（挙動パリティの検証容易性を優先）。
+ *
+ * LIMIT 1000 の根拠: 既存 PostgREST 経路は max-rows=1000 でトップレベル行が
+ * 暗黙に打ち切られる。この関数は複数配信者のアクティブカードを合算で取得する
+ * ため、コレクションの多いユーザーでは 1000 行超が現実に起こりうる。ここで
+ * LIMIT を外すと pg 経路だけカウントが変わってしまうため、明示 LIMIT 1000 で
+ * 既存挙動（打ち切りによる過少カウントも含めて）を再現する。
+ * エラー時は既存実装と同じく reportError + 全ゼロの counts を返す。
+ */
+async function getActiveCardCountsForStreamersPg(
+  streamerIds: string[]
+): Promise<Map<string, ActiveCardCountForStreamer>> {
+  const startedAt = perfStart();
+  const uniqueStreamerIds = Array.from(new Set(streamerIds.filter(Boolean)));
+  const counts = new Map<string, ActiveCardCountForStreamer>();
+  for (const streamerId of uniqueStreamerIds) {
+    counts.set(streamerId, { totalActive: 0, activeCardIds: new Set() });
+  }
+
+  if (uniqueStreamerIds.length === 0) {
+    logPerf("dashboard-data", "getActiveCardCountsForStreamers", startedAt, { streamerCount: 0 });
+    return counts;
+  }
+
+  let data: Array<{ id: string; streamer_id: string }>;
+  try {
+    data = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({ id: cardsTable.id, streamer_id: cardsTable.streamer_id })
+          .from(cardsTable)
+          .where(
+            and(
+              inArray(cardsTable.streamer_id, uniqueStreamerIds),
+              eq(cardsTable.is_active, true),
+            )
+          )
+          .limit(1000);
+      },
+      "getActiveCardCountsForStreamers",
+      { idempotent: true },
+    );
+  } catch (error) {
+    reportError(
+      new Error(
+        `active card count batch query failed: ${error instanceof Error ? error.message : String(error)}`
+      )
+    );
+    logPerf("dashboard-data", "getActiveCardCountsForStreamers", startedAt, {
+      streamerCount: uniqueStreamerIds.length,
+      failed: true,
+    });
+    return counts;
+  }
+
+  for (const row of data) {
+    const entry = counts.get(row.streamer_id);
+    if (!entry) continue;
+    entry.totalActive += 1;
+    entry.activeCardIds.add(row.id);
+  }
+
+  logPerf("dashboard-data", "getActiveCardCountsForStreamers", startedAt, {
+    streamerCount: uniqueStreamerIds.length,
+    activeCardCount: data.length,
+  });
+  return counts;
+}
+
 export async function getActiveCardCountsForStreamers(
   streamerIds: string[]
 ): Promise<Map<string, ActiveCardCountForStreamer>> {
+  // #571: pg 直結経路（フラグ未設定時は素通り。getStreamerDataPg 参照）
+  if (isPgReadEnabled()) {
+    return getActiveCardCountsForStreamersPg(streamerIds);
+  }
+
   const startedAt = perfStart();
   const uniqueStreamerIds = Array.from(new Set(streamerIds.filter(Boolean)));
   const counts = new Map<string, ActiveCardCountForStreamer>();
@@ -1477,10 +2056,45 @@ export const getUserCardsForStreamer = cache(async (
 });
 
 /**
+ * getStreamerById の Drizzle（pg 直結）実装 (#571)
+ *
+ * .maybeSingle() 相当: id は主キーのため最大1行。0行なら null。
+ * streamerId は URL パラメータ由来で不正な UUID 文字列が渡りうるが、その場合は
+ * PostgreSQL が 22P02 を返す。既存 PostgREST 経路も同様にエラー → data=null →
+ * null を返すため、pg 版も catch して null に落とす（外部挙動のパリティ）。
+ */
+async function getStreamerByIdPg(streamerId: string): Promise<Streamer | null> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select()
+          .from(streamersTable)
+          .where(eq(streamersTable.id, streamerId))
+          .limit(1);
+      },
+      "getStreamerById",
+      { idempotent: true },
+    );
+    // 既存の戻り値型に合わせるキャスト（値の変換はしない。getStreamerDataPg 参照）
+    return (rows[0] ?? null) as unknown as Streamer | null;
+  } catch (error) {
+    logger.error("Error in getStreamerById (pg)", { error });
+    return null;
+  }
+}
+
+/**
  * Get streamer info by ID
  * 配信者IDから配信者情報を取得
  */
 export const getStreamerById = cache(async (streamerId: string): Promise<Streamer | null> => {
+  // #571: pg 直結経路（フラグ未設定時は素通り。getStreamerDataPg 参照）
+  if (isPgReadEnabled()) {
+    return getStreamerByIdPg(streamerId);
+  }
+
   const supabaseAdmin = getSupabaseAdmin();
 
   const { data: streamer } = await supabaseAdmin
@@ -1493,6 +2107,122 @@ export const getStreamerById = cache(async (streamerId: string): Promise<Streame
 });
 
 /**
+ * getUserCardDetail の Drizzle（pg 直結）実装 (#571)
+ *
+ * PostgREST 実装との対応（3クエリ構成をそのまま踏襲）:
+ * 1. cards + streamers 埋め込み: `*, streamers!cards_streamer_id_fkey(*)` は
+ *    cards.streamer_id → streamers.id の多対一 FK に基づく単一オブジェクト埋め込み。
+ *    LEFT JOIN + ネスト選択（streamers: streamersTable）で同じ形状を得る。
+ *    重要: 既存実装は `{ ...cardWithStreamer, streamer, count }` と spread で返す
+ *    ため、戻り値には埋め込みキー `streamers` が残る。pg 版も同じ spread 構成に
+ *    して実行時形状（streamers と streamer の両方を含む）を厳密に一致させる。
+ * 2. users: twitch_user_id は UNIQUE のため LIMIT 1 で .maybeSingle() と同挙動。
+ * 3. user_cards の所持数: `{ count: "exact", head: true }` 相当の COUNT(*)。
+ *
+ * エラー時の挙動は既存実装（各クエリのエラーを分割代入で握り潰す）に合わせ、
+ * クエリ単位で catch して null / 0 に落とし、後続の [Perf] ログと return null の
+ * 流れ（card not found / user not found / user doesn't own card）を共有する。
+ * cardId / streamerId は URL 由来で不正 UUID がありうる（22P02 → null）。
+ */
+async function getUserCardDetailPg(
+  twitchUserId: string,
+  streamerId: string,
+  cardId: string
+): Promise<CardWithDetails | null> {
+  const start = Date.now();
+
+  let card: (Card & { streamers: Streamer }) | null;
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({ ...getTableColumns(cardsTable), streamers: streamersTable })
+          .from(cardsTable)
+          .leftJoin(streamersTable, eq(cardsTable.streamer_id, streamersTable.id))
+          // id は主キーのため最大1行（LIMIT 1 は .maybeSingle() と同挙動）
+          .where(and(eq(cardsTable.id, cardId), eq(cardsTable.streamer_id, streamerId)))
+          .limit(1);
+      },
+      "getUserCardDetail(card)",
+      { idempotent: true },
+    );
+    // streamer_id は NOT NULL FK のため streamers は実データで常に非 null。
+    // 既存の消費形状（Card & { streamers: Streamer }）へのキャストのみ行う。
+    card = (rows[0] ?? null) as unknown as (Card & { streamers: Streamer }) | null;
+  } catch (error) {
+    logger.error("Error in getUserCardDetail (pg:card)", { error });
+    card = null;
+  }
+
+  if (!card) {
+    logger.info(`[Perf] getUserCardDetail (card not found): ${Date.now() - start}ms`);
+    return null;
+  }
+
+  let user: { id: string } | null;
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({ id: usersTable.id })
+          .from(usersTable)
+          .where(eq(usersTable.twitch_user_id, twitchUserId))
+          .limit(1);
+      },
+      "getUserCardDetail(user)",
+      { idempotent: true },
+    );
+    user = rows[0] ?? null;
+  } catch (error) {
+    logger.error("Error in getUserCardDetail (pg:user)", { error });
+    user = null;
+  }
+
+  if (!user) {
+    logger.info(`[Perf] getUserCardDetail (user not found): ${Date.now() - start}ms`);
+    return null;
+  }
+  // クロージャ内での TS null 絞り込みを保つため id を確定させる
+  const userId = user.id;
+
+  let ownershipCount = 0;
+  try {
+    ownershipCount = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        const result = await db
+          .select({ count: countRows() })
+          .from(userCardsTable)
+          .where(and(eq(userCardsTable.user_id, userId), eq(userCardsTable.card_id, cardId)));
+        return result[0]?.count ?? 0;
+      },
+      "getUserCardDetail(count)",
+      { idempotent: true },
+    );
+  } catch (error) {
+    // 既存実装は count エラー時 null → `count ?? 0` で 0 扱い（= 未所持と同じ）
+    logger.error("Error in getUserCardDetail (pg:count)", { error });
+    ownershipCount = 0;
+  }
+
+  if (ownershipCount === 0) {
+    logger.info(`[Perf] getUserCardDetail (user doesn't own card): ${Date.now() - start}ms`);
+    return null;
+  }
+
+  logger.info(`[Perf] getUserCardDetail: ${Date.now() - start}ms`);
+
+  // 既存実装と同一の spread 構成（streamers キーも残る）
+  return {
+    ...card,
+    streamer: card.streamers,
+    count: ownershipCount,
+  };
+}
+
+/**
  * Get a specific user's card with details
  * Returns the card with count (how many the user owns) if the user owns it, null otherwise
  * 特定のユーザーのカード情報を詳細付きで取得
@@ -1503,6 +2233,11 @@ export const getUserCardDetail = cache(async (
   streamerId: string,
   cardId: string
 ): Promise<CardWithDetails | null> => {
+  // #571: pg 直結経路（フラグ未設定時は素通り。getStreamerDataPg 参照）
+  if (isPgReadEnabled()) {
+    return getUserCardDetailPg(twitchUserId, streamerId, cardId);
+  }
+
   const start = Date.now();
   const supabaseAdmin = getSupabaseAdmin();
 
@@ -1669,6 +2404,95 @@ export interface CollectionCompletionRecord {
 }
 
 /**
+ * getCollectionCompletions の Drizzle（pg 直結）実装 (#571)
+ *
+ * PostgREST 実装との対応:
+ * - select("total_cards, completed_at, collection_name") と同じ3列の列指定 select。
+ * - Issue #557 / migration 00064 のデプロイ窓（collection_name 列が未適用）では、
+ *   pg 直結は PostgreSQL の 42703 (undefined_column) を throw する。既存経路が
+ *   isMissingCollectionNameColumn（読み取りは 42703 を検知）で旧列リストへ
+ *   フォールバックするのと同じく、pg 版は isPgMissingColumnError (SQLSTATE 42703、
+ *   src/lib/db/errors.ts) でフォールバックする。このクエリで参照する列のうち
+ *   00064 で追加されたのは collection_name だけなので、42703 はデプロイ窓の
+ *   列欠落と一意に対応する。
+ * - フォールバック行は既存実装と同じく collection_name: null を補完して返す
+ *   （列が無い間はパック別レコード自体が存在し得ないため、これが唯一忠実な解釈）。
+ * - その他のエラーは既存実装と同じくログして []（ページ表示を壊さない）。
+ *
+ * LIMIT 1000 の根拠: 既存経路は max-rows=1000 で暗黙に打ち切られる。達成記録が
+ * 1000 行を超えることは実運用上まず無いが、上限の不変条件も無いため、既存挙動
+ * との完全一致を優先して明示 LIMIT 1000 を付ける（fetchActiveCardsForStreamerFromDBPg
+ * と同じ方針）。
+ */
+async function getCollectionCompletionsPg(
+  twitchUserId: string,
+  streamerId: string,
+): Promise<CollectionCompletionRecord[]> {
+  try {
+    return await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({
+            total_cards: collectionCompletionsTable.total_cards,
+            completed_at: collectionCompletionsTable.completed_at,
+            collection_name: collectionCompletionsTable.collection_name,
+          })
+          .from(collectionCompletionsTable)
+          .where(
+            and(
+              eq(collectionCompletionsTable.twitch_user_id, twitchUserId),
+              eq(collectionCompletionsTable.streamer_id, streamerId),
+            )
+          )
+          .orderBy(desc(collectionCompletionsTable.completed_at))
+          .limit(1000);
+      },
+      "dashboard:getCollectionCompletions",
+      { idempotent: true },
+    );
+  } catch (error) {
+    if (isPgMissingColumnError(error)) {
+      // Deploy window fallback: 未デプロイ列を除いた旧列リストで再取得し、
+      // 全行を全体コンプリート（collection_name: null）として返す
+      try {
+        const legacy = await withDbRetry(
+          async () => {
+            const { db } = await getDb();
+            return db
+              .select({
+                total_cards: collectionCompletionsTable.total_cards,
+                completed_at: collectionCompletionsTable.completed_at,
+              })
+              .from(collectionCompletionsTable)
+              .where(
+                and(
+                  eq(collectionCompletionsTable.twitch_user_id, twitchUserId),
+                  eq(collectionCompletionsTable.streamer_id, streamerId),
+                )
+              )
+              .orderBy(desc(collectionCompletionsTable.completed_at))
+              .limit(1000);
+          },
+          "dashboard:getCollectionCompletions:legacy",
+          { idempotent: true },
+        );
+        return legacy.map((row) => ({ ...row, collection_name: null }));
+      } catch (legacyError) {
+        logger.error(
+          `Failed to fetch collection completions (legacy): ${legacyError instanceof Error ? legacyError.message : String(legacyError)}`
+        );
+        return [];
+      }
+    }
+    logger.error(
+      `Failed to fetch collection completions: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return [];
+  }
+}
+
+/**
  * Get past collection completion records for a user and streamer
  * Returns records sorted by completed_at DESC (newest first)
  *
@@ -1686,6 +2510,12 @@ export const getCollectionCompletions = cache(async (
 ): Promise<CollectionCompletionRecord[]> => {
   const cachedFetch = unstable_cache(
     async (): Promise<CollectionCompletionRecord[]> => {
+      // #571: pg 直結経路。unstable_cache の内側で分岐することでキャッシュ
+      // キー・タグ・TTL の構造を変えない（フラグ未設定時は素通り）
+      if (isPgReadEnabled()) {
+        return getCollectionCompletionsPg(twitchUserId, streamerId);
+      }
+
       const supabaseAdmin = getSupabaseAdmin();
       const { data, error } = await withRetry(
         () => supabaseAdmin

--- a/src/lib/db/client.ts
+++ b/src/lib/db/client.ts
@@ -1,0 +1,189 @@
+/**
+ * postgres.js + Drizzle 接続管理 (#570, #568 Phase 1)
+ *
+ * Hyperdrive（Supabase 直結）経由で PostgreSQL に接続するクライアントの生成・
+ * ライフサイクル管理。PostgREST(supabase-js) 経路の置き換え先となる新経路。
+ * DB_DRIVER フラグが未設定の間は誰もこのモジュールの getDb() を呼ばないため、
+ * 存在するだけでは挙動に一切影響しない（src/lib/db/flags.ts 参照）。
+ *
+ * 接続ライフサイクルの設計根拠:
+ *
+ * - Workers 環境: 「リクエストスコープ」でクライアントを生成する。
+ *   Workers の TCP ソケットはそれを開いたリクエストに束縛され、リクエストを
+ *   跨いで再利用すると 'Cannot perform I/O on behalf of a different request' で
+ *   失敗する。そのためモジュールレベルのシングルトンは使えない。Cloudflare 公式も
+ *   per-request 生成を推奨しており、Hyperdrive が上流（Cloudflare エッジ側）で
+ *   実接続をプールするため、リクエストごとの接続確立は高速（プール済み接続への
+ *   ハンドシェイクのみ）。同一リクエスト内の複数クエリでクライアントを再生成
+ *   しないよう、リクエスト識別子（ExecutionContext）をキーにした WeakMap で再利用する。
+ *
+ * - 接続の後始末: 明示的な sql.end() は行わない。Workers ランタイムはリクエスト
+ *   コンテキスト終了時にそのリクエストが開いた I/O（TCP ソケット）を破棄し、
+ *   Hyperdrive 側は実接続をプールしたまま維持するため、リークは発生しない
+ *   （Cloudflare 公式の postgres.js / Drizzle 例、OpenNext の DB ガイドも
+ *   per-request 生成のみで明示クローズしない現行パターン）。
+ *   注意: 「作成直後に ctx.waitUntil(sql.end()) を登録する」方式は採用できない。
+ *   postgres.js の end() は呼び出した時点（1 マイクロタスク後）で ending フラグを
+ *   立て、以後の新規クエリをすべて CONNECTION_ENDED で拒否するため、リクエスト内の
+ *   後続クエリが全滅する（waitUntil は Promise の「完了を待つ」だけで、実行開始を
+ *   レスポンス後まで遅延させるものではない）。
+ *
+ * - Node 環境（next dev）フォールバック: getCloudflareContext() が throw した場合は
+ *   モジュールレベルのシングルトンにフォールバックする。Node では TCP ソケットの
+ *   リクエスト跨ぎ再利用が安全であり、毎回の接続確立（こちらは Hyperdrive を
+ *   経由しない実接続）を避けられる。idle_timeout で放置接続は自動クローズされる。
+ *
+ * - ビルド時評価の回避: 環境判定・接続文字列解決・クライアント生成はすべて
+ *   getDb() 呼び出し時に遅延実行する。モジュールトップで評価すると next build
+ *   （env 未注入・Cloudflare コンテキスト外）で壊れるため。
+ */
+
+import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
+import * as schema from './schema'
+
+/** getDb() が返すハンドル。db は Drizzle、sql は生 SQL 実行用の postgres.js クライアント */
+export interface DbHandle {
+  db: PostgresJsDatabase<typeof schema>
+  sql: postgres.Sql
+}
+
+/**
+ * Hyperdrive バインディングの最小インターフェース。
+ * r2-client.ts の R2BucketLike と同様、tsconfig に @cloudflare/workers-types を
+ * 要求しないためにここで最小限だけ定義する。
+ */
+interface HyperdriveBindingLike {
+  connectionString: string
+}
+
+/**
+ * Workers 環境: ExecutionContext（リクエストごとに一意）をキーにしたハンドルの
+ * キャッシュ。WeakMap なのでリクエスト終了とともに ctx ごと GC され、リークしない。
+ */
+const requestScopedHandles = new WeakMap<object, DbHandle>()
+
+/** Node 環境（next dev）用のシングルトン（supabase/admin.ts と同じパターン） */
+let nodeSingletonHandle: DbHandle | null = null
+
+/**
+ * postgres.js クライアントと Drizzle インスタンスを生成する。
+ *
+ * オプションの根拠:
+ * - max: 5
+ *   Workers の同時外部接続数制限とのバランス（Cloudflare 公式ガイドの推奨値）。
+ *   クライアントはリクエストスコープなので「1 リクエストあたり最大 5 接続」。
+ * - fetch_types: false
+ *   postgres.js は既定で接続時に pg_catalog から型情報（配列型 OID 等）を
+ *   フェッチする。この往復を省いてレイテンシを削る（公式ガイド推奨）。
+ *   ※制約: この設定では array 型（text[] 等）の列は postgres.js 側で
+ *   パースされない。array 列（users.twitch_scopes / twitch_bot_accounts.scopes）は
+ *   必ず Drizzle スキーマ経由（db.select 等）で読むこと。Drizzle が schema 定義に
+ *   基づいて配列をパースする。生 SQL（sql`...` / db.execute）で array 列を
+ *   SELECT すると '{a,b}' の生文字列が返り、値の形状が壊れる。
+ *   ※補足: drizzle() はこのクライアントの timestamp/timestamptz/date パーサを
+ *   透過（文字列パススルー）に上書きするため、日時列は Date ではなく PG テキスト
+ *   形式の文字列で返る（schema.ts の mode: 'string' が期待する入力）。プロセスの
+ *   タイムゾーンに依存する Date 変換は発生しない（drizzle-orm/postgres-js/driver の
+ *   construct() を実測確認済み）。
+ * - prepare は指定しない（デフォルト true）
+ *   Hyperdrive は prepared statements をサポートし、キャッシュもする。
+ *   false にすると Hyperdrive 側で追加の往復が発生する。
+ * - connect_timeout: 10（秒）
+ *   接続確立のハング防止。Hyperdrive 経由ではプール済みのため通常は瞬時。
+ * - idle_timeout: 20（秒）
+ *   アイドル接続の自動クローズ。主に Node シングルトン（next dev）で
+ *   放置接続が溜まらないようにするため。Workers ではリクエスト終了時に
+ *   ランタイムがソケットを破棄するため実質影響しない。
+ */
+function createHandle(connectionString: string): DbHandle {
+  const sql = postgres(connectionString, {
+    max: 5,
+    fetch_types: false,
+    connect_timeout: 10,
+    idle_timeout: 20,
+  })
+  const db = drizzle(sql, { schema })
+  return { db, sql }
+}
+
+/**
+ * 接続文字列の解決。優先順:
+ *   (1) Cloudflare env の HYPERDRIVE バインディング（wrangler.toml の [[hyperdrive]]）
+ *   (2) process.env.DATABASE_URL（next dev などローカル開発用）
+ *   (3) どちらも無ければ throw
+ * (3) は新経路（DB_DRIVER=pg-read/pg）を呼んだときにのみ到達する。フラグ未設定の
+ * postgrest 経路はこのモジュールを呼ばないため、Hyperdrive 未設定のままデプロイ
+ * しても既存機能には影響しない。
+ */
+function resolveConnectionString(cfEnv: Record<string, unknown> | null): string {
+  const hyperdrive = cfEnv?.HYPERDRIVE as HyperdriveBindingLike | undefined
+  if (hyperdrive?.connectionString) {
+    return hyperdrive.connectionString
+  }
+
+  const databaseUrl = process.env.DATABASE_URL?.trim()
+  if (databaseUrl) {
+    return databaseUrl
+  }
+
+  throw new Error(
+    '[db:pg] No database connection configured: bind HYPERDRIVE in wrangler.toml ' +
+      '(Workers) or set DATABASE_URL (local dev). This is only reached when ' +
+      'DB_DRIVER=pg-read/pg is set; unset DB_DRIVER to fall back to PostgREST.',
+  )
+}
+
+/**
+ * Drizzle クライアントを取得する。
+ * - Workers: リクエストごとに生成し、同一リクエスト内では WeakMap で再利用
+ * - Node（next dev）: モジュールシングルトン
+ *
+ * 使用側の規約: withDbRetry() でラップする場合は queryFn の中で getDb() を
+ * 呼ぶこと（リクエストスコープ破棄からの回復にはクライアント再取得が必要。
+ * src/lib/db/retry.ts 参照）。
+ */
+export async function getDb(): Promise<DbHandle> {
+  // Cloudflare コンテキストの取得を試みる。r2-client.ts と同じく動的 import に
+  // して、Workers 外（テスト・素の Node 実行）でのバンドル/評価問題を避ける。
+  // next dev では initOpenNextCloudflareForDev 未設定のため throw し、
+  // Node フォールバックに落ちる。
+  let cfCtx: object | null = null
+  let cfEnv: Record<string, unknown> | null = null
+  try {
+    const { getCloudflareContext } = await import('@opennextjs/cloudflare')
+    const { env, ctx } = await getCloudflareContext({ async: true })
+    cfCtx = ctx as unknown as object
+    cfEnv = env as unknown as Record<string, unknown>
+  } catch {
+    // Cloudflare Workers 環境ではない（next dev / Node）
+    cfCtx = null
+    cfEnv = null
+  }
+
+  if (cfCtx) {
+    // Workers: 同一リクエスト（= 同一 ExecutionContext）内はハンドルを再利用する。
+    // OpenNext は AsyncLocalStorage でリクエストごとに同一の ctx を返すため、
+    // ctx がそのままリクエスト識別子として機能する。
+    //
+    // 注意: 以下の get → create → set の間に await を挟まないこと。
+    // createHandle() は同期（postgres() は遅延接続でコンストラクトは同期）なので
+    // このブロックは原子的に実行され、同一リクエスト内で getDb() が並列に
+    // 呼ばれても（Promise.all 等）ハンドルが二重生成されることはない。
+    // ここに await を追加すると、その保証が壊れる。
+    const existing = requestScopedHandles.get(cfCtx)
+    if (existing) {
+      return existing
+    }
+    const handle = createHandle(resolveConnectionString(cfEnv))
+    requestScopedHandles.set(cfCtx, handle)
+    return handle
+  }
+
+  // Node（next dev）: シングルトンで TCP 接続を再利用
+  // （上と同じく判定〜代入は同期ブロックなので並列呼び出しでも二重生成されない）
+  if (!nodeSingletonHandle) {
+    nodeSingletonHandle = createHandle(resolveConnectionString(null))
+  }
+  return nodeSingletonHandle
+}

--- a/src/lib/db/errors.ts
+++ b/src/lib/db/errors.ts
@@ -1,0 +1,60 @@
+/**
+ * pg ドライバ用エラー判定ヘルパー (#570)
+ *
+ * 目的: 既存コードには PostgREST のエラーコード判定（PGRST204「列が見つからない」等を
+ * 検知して、コードとマイグレーションのデプロイ順ズレの間だけ旧クエリへフォールバック
+ * する「デプロイ窓フォールバック」）が各所にある。それに対応する pg ドライバ
+ * (postgres.js) 版の判定ヘルパー。移行済みモジュールが列/関数のデプロイ窓
+ * フォールバックを維持するために使う。
+ *
+ * postgres.js が throw するエラーは `code` プロパティに PostgreSQL の SQLSTATE
+ * （5文字の文字列）を持つ。呼び出し元が catch した値は unknown なので、
+ * ここでは型ガードで安全に判定する（null / undefined / 文字列などを食わせても
+ * 例外を出さず false を返す）。
+ */
+
+/**
+ * unknown なエラー値から SQLSTATE 文字列（err.code）を安全に取り出す。
+ * postgres.js の PostgresError は code に SQLSTATE を持つが、接続系エラーは
+ * 'CONNECTION_CLOSED' のような非 SQLSTATE 文字列を持つため、呼び出し側の
+ * 判定関数が期待値と厳密比較することで自然に除外される。
+ */
+function getSqlState(e: unknown): string | null {
+  if (typeof e !== 'object' || e === null) {
+    return null
+  }
+  const code = (e as { code?: unknown }).code
+  return typeof code === 'string' ? code : null
+}
+
+/**
+ * SQLSTATE 42703 undefined_column: 列が存在しない。
+ * PostgREST の PGRST204 に相当（列追加マイグレーション前のコードデプロイ窓で発生）。
+ */
+export function isPgMissingColumnError(e: unknown): boolean {
+  return getSqlState(e) === '42703'
+}
+
+/**
+ * SQLSTATE 42883 undefined_function: 関数が存在しない。
+ * RPC（DB 関数）追加マイグレーション前のデプロイ窓で発生。
+ */
+export function isPgFunctionNotFoundError(e: unknown): boolean {
+  return getSqlState(e) === '42883'
+}
+
+/**
+ * SQLSTATE 23505 unique_violation: 一意制約違反。
+ * 冪等性キー（event_id / request_id 等）の重複挿入検知に使う。
+ */
+export function isPgUniqueViolationError(e: unknown): boolean {
+  return getSqlState(e) === '23505'
+}
+
+/**
+ * SQLSTATE 42P01 undefined_table: テーブルが存在しない。
+ * テーブル追加マイグレーション前のデプロイ窓で発生。
+ */
+export function isPgMissingTableError(e: unknown): boolean {
+  return getSqlState(e) === '42P01'
+}

--- a/src/lib/db/flags.ts
+++ b/src/lib/db/flags.ts
@@ -1,0 +1,81 @@
+/**
+ * DB ドライバ切替フラグ (#570, #568 Phase 1)
+ *
+ * Supabase → PlanetScale 段階移行の Phase 1 として、データアクセス層を
+ * PostgREST (supabase-js) から postgres.js + Drizzle 直結へ「段階的に」切り替える。
+ * DB 本体は Supabase のまま・スキーマ変更なしで、経路だけを環境変数で切り替える。
+ *
+ * 運用意図（切替は必ずこの順で行い、問題があれば env を戻すだけでロールバック）:
+ *   1. DB_DRIVER 未設定 = 'postgrest' … 完全に従来どおり（マージ・デプロイしても挙動不変）
+ *   2. DB_DRIVER=pg-read            … 読み取りのみ pg 直結（書き込みは PostgREST のまま）
+ *   3. DB_DRIVER=pg                 … 読み書きとも pg 直結
+ * まず preview 環境で pg-read → pg を検証した後、prod で同順に切り替える。
+ * 詳細な手順は docs/db-driver-migration.md を参照。
+ */
+
+export type DbDriverMode = 'postgrest' | 'pg-read' | 'pg'
+
+/**
+ * 現在の DB ドライバモードを返す。
+ *
+ * 重要: process.env.DB_DRIVER は「呼び出しのたびに」読む。モジュールトップの
+ * const にキャッシュしてはならない。OpenNext (Cloudflare Workers) は環境変数を
+ * populateProcessEnv でランタイムに注入するため、モジュール評価時点では env が
+ * まだ確定していないことがある（評価時に読むと常に undefined = 'postgrest' に
+ * 固定されてしまい、フラグが効かなくなる）。
+ *
+ * 未設定・不正値は安全側の 'postgrest'（完全従来動作）に倒す。
+ *
+ * trim する理由: Cloudflare ダッシュボード / wrangler secret put 経由の設定は
+ * 改行・空白が混入しうる（supabase/admin.ts の getSupabaseCredentials と同じ
+ * 既知リスク）。trim しないと 'pg\n' が不正値扱いになり意図した切替が黙って
+ * 効かない。
+ */
+export function getDbDriverMode(): DbDriverMode {
+  const raw = process.env.DB_DRIVER?.trim()
+  if (raw === 'pg' || raw === 'pg-read') {
+    return raw
+  }
+  return 'postgrest'
+}
+
+/**
+ * pg 直結の「読み取り」経路が有効か。
+ * 'pg-read'（読み取りのみ）と 'pg'（読み書き）の両方で true。
+ */
+export function isPgReadEnabled(): boolean {
+  const mode = getDbDriverMode()
+  return mode === 'pg-read' || mode === 'pg'
+}
+
+/**
+ * pg 直結の「書き込み」経路が有効か。
+ * 'pg'（読み書き）のみ true。'pg-read' では書き込みは PostgREST 経路のまま。
+ */
+export function isPgWriteEnabled(): boolean {
+  return getDbDriverMode() === 'pg'
+}
+
+/**
+ * ガチャ経路（EventSub 由来の書き込みを含むクリティカルパス）専用のドライバ選択 (#573)。
+ *
+ * GACHA_DB_DRIVER はガチャ経路「だけ」を個別にロールバック/先行切替するための
+ * 緊急スイッチ。全体フラグ（DB_DRIVER）を触らずに、収益・ユーザー体験へ直結する
+ * ガチャ書き込みのみを即座に旧経路へ戻せるようにしておく（本番障害時の影響範囲を
+ * 最小化するための独立レバー）。
+ *
+ * 優先順位:
+ *   1. GACHA_DB_DRIVER が 'pg' / 'postgrest' ならそれを最優先
+ *   2. 未設定・不正値なら全体フラグに従う（isPgWriteEnabled() ? 'pg' : 'postgrest'）
+ *
+ * trim する理由: この値は「インシデント対応中に急いで設定される」性質のもの。
+ * 'postgrest\n'（末尾改行混入）が不正値扱いになると、DB_DRIVER=pg が生きている
+ * 限りフォールバックで 'pg' のまま動き続け、緊急ロールバックが黙って効かない。
+ */
+export function getGachaDbDriver(): 'postgrest' | 'pg' {
+  const raw = process.env.GACHA_DB_DRIVER?.trim()
+  if (raw === 'pg' || raw === 'postgrest') {
+    return raw
+  }
+  return isPgWriteEnabled() ? 'pg' : 'postgrest'
+}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,0 +1,13 @@
+/**
+ * db モジュールの barrel (#570)
+ *
+ * 新経路（postgres.js + Drizzle）関連の公開 API をまとめて re-export する。
+ * schema はテーブル名（errors 等）が他モジュールの識別子と衝突しやすいため
+ * フラット展開せず、名前空間付きで公開する。
+ */
+
+export * from './flags'
+export * from './client'
+export * from './retry'
+export * from './errors'
+export * as schema from './schema'

--- a/src/lib/db/retry.ts
+++ b/src/lib/db/retry.ts
@@ -1,0 +1,149 @@
+/**
+ * pg ドライバ (postgres.js + Drizzle) 用リトライユーティリティ (#570)
+ *
+ * 既存の src/lib/supabase/retry.ts（PostgREST の { data, error } 応答向け）の
+ * pg ドライバ版。postgres.js はエラーを throw するため、こちらは throw された
+ * エラーを分類してリトライする。バックオフ遅延は既存 retry.ts と同じ
+ * [100, 300, 1000] ms に揃える（両経路で障害時の挙動を比較しやすくするため）。
+ *
+ * 重要な規約: リトライ対象の queryFn は「中で getDb() を呼ぶ」こと。
+ * Cloudflare Workers ではクライアント（TCP ソケット）がリクエストスコープに
+ * 束縛されるため、スコープ破棄由来のエラー（下記 CROSS_REQUEST_IO_MESSAGE）から
+ * 回復するにはクライアントの再取得が必要になる。queryFn の外で getDb() した
+ * ハンドルを閉じ込めると、リトライしても壊れた同一クライアントを使い続けてしまう。
+ *
+ *   // OK: リトライごとに getDb() が評価される
+ *   await withDbRetry(async () => {
+ *     const { db } = await getDb()
+ *     return db.select()...
+ *   }, 'context', { idempotent: true })
+ */
+
+import { logger } from '@/lib/logger'
+
+interface DbRetryOptions {
+  /**
+   * この文が冪等（何度実行しても結果が同じ: 読み取り・ON CONFLICT DO NOTHING 等）
+   * であることの呼び出し元による明示宣言。既定は false。
+   */
+  idempotent?: boolean
+  maxRetries?: number
+  /** バックオフ遅延（ミリ秒）: 既定 [100, 300, 1000]（supabase/retry.ts と同一） */
+  delays?: number[]
+}
+
+const DEFAULT_DELAYS = [100, 300, 1000]
+
+// postgres.js の接続断系エラーコード（err.code）。
+// いずれも「クエリが PostgreSQL に到達したか不明」な接続レイヤの障害。
+const RETRYABLE_DRIVER_CODES = new Set([
+  'CONNECTION_CLOSED',
+  'CONNECTION_ENDED',
+  'CONNECTION_DESTROYED',
+  'CONNECT_TIMEOUT',
+])
+
+// Node.js のソケットレイヤのエラーコード（next dev ローカル実行時に発生しうる）。
+const RETRYABLE_NODE_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'EPIPE',
+])
+
+// PostgreSQL の一時障害系 SQLSTATE（サーバー側が返す。時間をおけば回復が見込める）。
+//   57P01 admin_shutdown / 57P02 crash_shutdown / 57P03 cannot_connect_now
+//   53300 too_many_connections
+//   08006 connection_failure / 08001 sqlclient_unable_to_establish_sqlconnection /
+//   08003 connection_does_not_exist
+const RETRYABLE_SQLSTATES = new Set([
+  '57P01',
+  '57P02',
+  '57P03',
+  '53300',
+  '08006',
+  '08001',
+  '08003',
+])
+
+// Cloudflare Workers のリクエストスコープ破棄エラー。
+// リクエスト A で作った TCP ソケットをリクエスト B で使うと runtime がこの
+// メッセージで throw する。エラーコードは無くメッセージ文字列でしか識別できない。
+// クライアント再取得（queryFn 内の getDb() 呼び直し）で回復するためリトライ対象。
+const CROSS_REQUEST_IO_MESSAGE = 'Cannot perform I/O on behalf of a different request'
+
+/**
+ * throw されたエラーがリトライに値する一時障害かを判定する。
+ * 制約違反（23505 等）や構文エラーなどの恒久的エラーは false（リトライ無意味）。
+ */
+export function isRetryableDbError(e: unknown): boolean {
+  if (typeof e !== 'object' || e === null) {
+    return false
+  }
+
+  const code = (e as { code?: unknown }).code
+  if (typeof code === 'string') {
+    if (
+      RETRYABLE_DRIVER_CODES.has(code) ||
+      RETRYABLE_NODE_CODES.has(code) ||
+      RETRYABLE_SQLSTATES.has(code)
+    ) {
+      return true
+    }
+  }
+
+  const message = (e as { message?: unknown }).message
+  if (typeof message === 'string' && message.includes(CROSS_REQUEST_IO_MESSAGE)) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * pg ドライバのクエリに対するリトライラッパー。
+ *
+ * 既定（idempotent: false）ではリトライせず即 throw する。
+ * 理由: 接続断は「クエリの結果不明」を意味する（サーバーに届いて COMMIT された後に
+ * 応答だけ失われた可能性がある）。非冪等な書き込みを自動リトライすると二重実行
+ * （ガチャ二重排出・ポイント二重加算等）のリスクがあるため、読み取り・
+ * ON CONFLICT 等で冪等であることを呼び出し元が保証できる文のみ opt-in で
+ * リトライする。
+ *
+ * @param queryFn - 実行するクエリ（規約: この関数の中で getDb() を呼ぶこと）
+ * @param context - ログ用コンテキスト文字列
+ * @param options - リトライオプション
+ */
+export async function withDbRetry<T>(
+  queryFn: () => Promise<T>,
+  context: string,
+  options?: DbRetryOptions,
+): Promise<T> {
+  const delays = options?.delays ?? DEFAULT_DELAYS
+  const maxRetries = options?.maxRetries ?? delays.length
+  const idempotent = options?.idempotent ?? false
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await queryFn()
+    } catch (error) {
+      // 非冪等（既定）は分類すらせず即 throw（上記の二重実行リスク回避）。
+      // 恒久的エラー・リトライ回数到達時もそのまま呼び出し元へ伝播する。
+      if (!idempotent || !isRetryableDbError(error) || attempt >= maxRetries) {
+        throw error
+      }
+
+      const delay = delays[Math.min(attempt, delays.length - 1)]
+      // ログ形式は supabase/retry.ts に合わせる。context の [db:pg] プレフィックスは
+      // 新経路（pg 直結）のログだけを wrangler tail 等で抽出するための観測用タグ。
+      logger.warn(
+        `[DB Retry] [db:pg] ${context} failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms`,
+        {
+          code: (error as { code?: unknown })?.code,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      )
+      await new Promise(resolve => setTimeout(resolve, delay))
+    }
+  }
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,0 +1,579 @@
+// =============================================================================
+// Drizzle ORM スキーマ定義（既存 Supabase PostgreSQL スキーマへの型付け）
+// =============================================================================
+//
+// このファイルは既存 Supabase スキーマ（supabase/migrations が正）への型付けであり、
+// drizzle-kit による migration 生成には使用しない。
+// スキーマ変更は従来どおり supabase/migrations で行う。
+//
+// 設計方針（実行時クエリの正確性 = 列名・PG 型・NULL 制約・デフォルト値 が唯一の品質基準）:
+// - 列プロパティ名は DB 列名そのまま（snake_case）。既存コードが PostgREST の
+//   snake_case 応答形状に依存しているため、select 結果をそのまま既存 JSON 形状として
+//   使えるようにする（camelCase 変換はしない）。
+// - timestamptz / timestamp 列は mode: 'string'。PostgREST が文字列を返す挙動と
+//   互換にするため（Date 変換はアプリ層で行わない）。
+// - numeric 列は mode: 'number'。PostgREST は JSON number を返すため。
+// - bigint 列は mode: 'number'。対象列（バイト数・ポイント合計）は
+//   Number.MAX_SAFE_INTEGER を実運用上超えないため。
+// - jsonb 列は .$type<...>() で src/types/database.ts の対応 TS 型を指定。
+// - NOT NULL / DEFAULT は migration の DDL に忠実（database.ts と食い違う場合は
+//   DDL を正とする。相違点はファイル末尾のコメントブロックに列挙）。
+// - 外部キー参照・インデックス・CHECK 制約は定義しない（実 DB 側が正であり、
+//   クエリの型付けには不要。ファイルの肥大を避ける）。
+// - GENERATED ALWAYS AS 列は .generatedAlwaysAs() で定義し、insert 対象外である
+//   ことが型で分かるようにする。
+// =============================================================================
+
+import { sql } from 'drizzle-orm'
+import {
+  bigint,
+  boolean,
+  integer,
+  jsonb,
+  numeric,
+  pgTable,
+  primaryKey,
+  smallint,
+  text,
+  timestamp,
+  uuid,
+  varchar,
+} from 'drizzle-orm/pg-core'
+import type { Json } from '@/types/database'
+
+// -----------------------------------------------------------------------------
+// streamers（配信者）
+// 根拠: 00001 初版, 00007 gacha_sound_*, 00009 chat_announcement_*,
+//       00025 rarity_weights, 00035 show_unowned_*, 00042 raid_gacha_active_until,
+//       00043 raid_gacha_draw_count, 00044 chat_announcement_multi_*,
+//       00049 custom_rarities, 00061 channel_point_collection_name,
+//       00062 card_pack_names, 00063 default_card_pack_name,
+//       00065 rarity_weights_scope / pack_rarity_weights, 00066 gacha_sound_rules
+// -----------------------------------------------------------------------------
+export const streamers = pgTable('streamers', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  twitch_user_id: text('twitch_user_id').notNull(),
+  twitch_username: text('twitch_username').notNull(),
+  twitch_display_name: text('twitch_display_name').notNull(),
+  twitch_profile_image_url: text('twitch_profile_image_url'),
+  channel_point_reward_id: text('channel_point_reward_id'),
+  channel_point_reward_name: text('channel_point_reward_name'),
+  // 00061: メイン報酬に紐付くカードパック名（NULL = 全カード対象）
+  channel_point_collection_name: text('channel_point_collection_name'),
+  // 00001: DDL に NOT NULL は無い（DEFAULT true のみ）
+  is_active: boolean('is_active').default(true),
+  // 00007
+  gacha_sound_url: text('gacha_sound_url'),
+  gacha_sound_enabled: boolean('gacha_sound_enabled').notNull().default(false),
+  // 00066: 複数ガチャ効果音ルール（全体・レアリティ別・報酬別）
+  gacha_sound_rules: jsonb('gacha_sound_rules').$type<Json>().notNull().default(sql`'[]'::jsonb`),
+  // 00009
+  chat_announcement_enabled: boolean('chat_announcement_enabled').notNull().default(false),
+  chat_announcement_template: text('chat_announcement_template'),
+  // 00044
+  chat_announcement_multi_template: text('chat_announcement_multi_template'),
+  chat_announcement_multi_show_cards: boolean('chat_announcement_multi_show_cards').notNull().default(true),
+  // 00025: レアリティ名をキーにした目標確率マップ（0-100）。NULL 許容
+  rarity_weights: jsonb('rarity_weights').$type<Record<string, number>>().default(sql`NULL`),
+  // 00065: 'global' | 'per_pack'（CHECK 制約は DB 側で担保）
+  rarity_weights_scope: text('rarity_weights_scope').notNull().default('global'),
+  // 00065: パック名（または __default__）をキーにしたレアリティ別確率マップの上書き
+  pack_rarity_weights: jsonb('pack_rarity_weights')
+    .$type<Record<string, Record<string, number>>>()
+    .default(sql`NULL`),
+  // 00049: DB 型は text[] ではなく JSONB の文字列配列（database.ts では string[]）
+  custom_rarities: jsonb('custom_rarities').$type<string[]>().notNull().default(sql`'[]'::jsonb`),
+  // 00062: 同上、JSONB の文字列配列
+  card_pack_names: jsonb('card_pack_names').$type<string[]>().notNull().default(sql`'[]'::jsonb`),
+  // 00063: デフォルト（未分類）パックの表示名オーバーライド
+  default_card_pack_name: text('default_card_pack_name'),
+  // 00035
+  show_unowned_cards: boolean('show_unowned_cards').notNull().default(false),
+  show_unowned_card_details: boolean('show_unowned_card_details').notNull().default(false),
+  // 00042: デフォルト無し・NULL 許容
+  raid_gacha_active_until: timestamp('raid_gacha_active_until', { withTimezone: true, mode: 'string' }),
+  // 00043
+  raid_gacha_draw_count: integer('raid_gacha_draw_count').notNull().default(0),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+  updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// cards（カード）
+// 根拠: 00001 初版, 00002 バトルステータス列追加, 00014 rarity_order（生成カラム）,
+//       00026 intra_rarity_weight, 00037 card_number, 00048 rarity の固定 CHECK 撤廃
+//       （列型は不変）, 00061 collection_name, 00067 max_issuance_count
+// -----------------------------------------------------------------------------
+export const cards = pgTable('cards', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  streamer_id: uuid('streamer_id').notNull(),
+  name: text('name').notNull(),
+  description: text('description'),
+  image_url: text('image_url'),
+  // 00001: NOT NULL DEFAULT 'common'（00048 以降は任意のカスタムレアリティ文字列を許容）
+  rarity: text('rarity').notNull().default('common'),
+  // 00014: GENERATED ALWAYS AS ... STORED（insert / update 不可の生成カラム）。
+  // PostgREST が CASE 式で ORDER BY できないため DB 側で階層順数値を持つ。
+  rarity_order: smallint('rarity_order').generatedAlwaysAs(
+    sql`CASE rarity WHEN 'legendary' THEN 1 WHEN 'epic' THEN 2 WHEN 'rare' THEN 3 WHEN 'common' THEN 4 ELSE 5 END`
+  ),
+  // 00001: DECIMAL(5,4) NOT NULL DEFAULT 0.25
+  drop_rate: numeric('drop_rate', { precision: 5, scale: 4, mode: 'number' }).notNull().default(0.25),
+  // 00026: NUMERIC NOT NULL DEFAULT 1.0（同レアリティ内の排出重み）
+  intra_rarity_weight: numeric('intra_rarity_weight', { mode: 'number' }).notNull().default(1.0),
+  // 00037: 図鑑番号の手動指定（NULL = アプリ側フォールバック採番）
+  card_number: integer('card_number'),
+  // 00067: 発行上限（NULL = 無制限）
+  max_issuance_count: integer('max_issuance_count'),
+  // 00061: 所属パック名（NULL = 未分類 = 全報酬の抽選対象）
+  collection_name: text('collection_name'),
+  // 00001: DDL に NOT NULL は無い（DEFAULT true のみ）
+  is_active: boolean('is_active').default(true),
+  // 00002: バトルステータス（いずれも DDL に NOT NULL は無い。DEFAULT のみ）
+  hp: integer('hp').default(100),
+  atk: integer('atk').default(30),
+  def: integer('def').default(15),
+  spd: integer('spd').default(5),
+  skill_type: text('skill_type').default('attack'),
+  skill_name: text('skill_name').default('通常攻撃'),
+  skill_power: integer('skill_power').default(10),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+  updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// users（視聴者）
+// 根拠: 00001 初版, 00004 Twitch トークン列, 00005 tos_accepted_at,
+//       00009 twitch_scopes, 00023 twitch_sub_verified_at / twitch_has_sub
+// -----------------------------------------------------------------------------
+export const users = pgTable('users', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  twitch_user_id: text('twitch_user_id').notNull(),
+  twitch_username: text('twitch_username').notNull(),
+  twitch_display_name: text('twitch_display_name').notNull(),
+  twitch_profile_image_url: text('twitch_profile_image_url'),
+  // 00004: DB には存在するが database.ts の Row 型には公開されていない
+  // （トークンを API 応答に露出させないアプリ層の判断。列自体は DROP されていない）
+  twitch_access_token: text('twitch_access_token'),
+  twitch_refresh_token: text('twitch_refresh_token'),
+  twitch_token_expires_at: timestamp('twitch_token_expires_at', { withTimezone: true, mode: 'string' }),
+  // 00005: 利用規約同意日時（NULL = 未同意）
+  tos_accepted_at: timestamp('tos_accepted_at', { withTimezone: true, mode: 'string' }),
+  // 00009: text[] DEFAULT '{}'（DDL に NOT NULL は無い）
+  twitch_scopes: text('twitch_scopes').array().default(sql`'{}'::text[]`),
+  // 00023
+  twitch_sub_verified_at: timestamp('twitch_sub_verified_at', { withTimezone: true, mode: 'string' }),
+  // 00023: DDL に NOT NULL は無い（DEFAULT FALSE のみ）
+  twitch_has_sub: boolean('twitch_has_sub').default(false),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+  updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// user_cards（ユーザーの所有カード）
+// 根拠: 00001 初版, 00010 で UNIQUE(user_id, card_id) を撤廃（複数枚所持を許可）
+// -----------------------------------------------------------------------------
+export const userCards = pgTable('user_cards', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  user_id: uuid('user_id').notNull(),
+  card_id: uuid('card_id').notNull(),
+  obtained_at: timestamp('obtained_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// gacha_history（ガチャ履歴）
+// 根拠: 00001 初版, 00033 reward_cost 追加, 00070 reward_id 追加
+// -----------------------------------------------------------------------------
+export const gachaHistory = pgTable('gacha_history', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  // Twitch EventSub メッセージ ID（冪等性キー、UNIQUE・NULL 許容）
+  event_id: text('event_id'),
+  user_twitch_id: text('user_twitch_id').notNull(),
+  user_twitch_username: text('user_twitch_username'),
+  card_id: uuid('card_id').notNull(),
+  streamer_id: uuid('streamer_id').notNull(),
+  // 00033: チャネルポイント消費量（EventSub 経由以外は NULL）
+  reward_cost: integer('reward_cost'),
+  // 00070: 起点になった Twitch チャネルポイント報酬 ID（EventSub 経由以外は NULL）
+  reward_id: text('reward_id'),
+  redeemed_at: timestamp('redeemed_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// battles（対戦履歴）
+// 根拠: 00002 初版, 00003 opponent_card_id の NOT NULL 撤廃 + opponent_card_data 追加
+// -----------------------------------------------------------------------------
+export const battles = pgTable('battles', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  user_id: uuid('user_id').notNull(),
+  user_card_id: uuid('user_card_id').notNull(),
+  // 00003: CPU 対戦（スナップショット保持）を許すため NULL 許容化
+  opponent_card_id: uuid('opponent_card_id'),
+  // 00003: 対戦時点の相手カードスナップショット
+  opponent_card_data: jsonb('opponent_card_data').$type<Json>(),
+  result: text('result').notNull(),
+  // 00002: DDL に NOT NULL は無い（DEFAULT 0 のみ）
+  turn_count: integer('turn_count').default(0),
+  battle_log: jsonb('battle_log').$type<Json>(),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// battle_stats（対戦統計）
+// 根拠: 00002 初版
+// -----------------------------------------------------------------------------
+export const battleStats = pgTable('battle_stats', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  user_id: uuid('user_id').notNull(),
+  // 以下は DDL に NOT NULL は無い（DEFAULT のみ。DB トリガーが常に値を入れる運用）
+  total_battles: integer('total_battles').default(0),
+  wins: integer('wins').default(0),
+  losses: integer('losses').default(0),
+  draws: integer('draws').default(0),
+  // DECIMAL(5,2) DEFAULT 0
+  win_rate: numeric('win_rate', { precision: 5, scale: 2, mode: 'number' }).default(0),
+  updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// storage_usage（ストレージ使用量。user_prefix = '_global_' はグローバル合計）
+// 根拠: 00006 初版
+// -----------------------------------------------------------------------------
+export const storageUsage = pgTable('storage_usage', {
+  user_prefix: varchar('user_prefix', { length: 8 }).primaryKey(),
+  bytes_used: bigint('bytes_used', { mode: 'number' }).notNull().default(0),
+  blob_count: integer('blob_count').notNull().default(0),
+  // 00006: TIMESTAMP WITH TIME ZONE DEFAULT NOW()（NOT NULL は無い）
+  updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// blob_files（個別ファイル情報。削除時のサイズ逆引き用）
+// 根拠: 00006 初版
+// -----------------------------------------------------------------------------
+export const blobFiles = pgTable('blob_files', {
+  // ファイルの公開 URL が主キー
+  url: text('url').primaryKey(),
+  user_prefix: varchar('user_prefix', { length: 8 }).notNull(),
+  file_size: bigint('file_size', { mode: 'number' }).notNull(),
+  // 'r2' | 'vercel'（CHECK 制約は DB 側で担保）
+  storage_type: varchar('storage_type', { length: 10 }).notNull().default('r2'),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// streamer_additional_gacha_rewards（追加のガチャ用チャネルポイント報酬）
+// 根拠: 00008 初版, 00041 draw_count / is_raid_limited 追加, 00061 collection_name 追加
+// -----------------------------------------------------------------------------
+export const streamerAdditionalGachaRewards = pgTable('streamer_additional_gacha_rewards', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  streamer_id: uuid('streamer_id').notNull(),
+  reward_id: text('reward_id').notNull(),
+  reward_name: text('reward_name'),
+  // 00041: N 連ガチャの排出数
+  draw_count: integer('draw_count').notNull().default(1),
+  // 00041: レイド限定報酬フラグ
+  is_raid_limited: boolean('is_raid_limited').notNull().default(false),
+  // 00061: この報酬に紐付くパック名（NULL = 全カード対象）
+  collection_name: text('collection_name'),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// errors（エラーログ。GitHub Issue 自動作成用）
+// 根拠: 00012 初版
+// -----------------------------------------------------------------------------
+export const errors = pgTable('errors', {
+  // このテーブルのみ初版から gen_random_uuid()（他の初期テーブルは uuid_generate_v4()）
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  error_type: varchar('error_type', { length: 50 }).notNull(),
+  message: text('message').notNull(),
+  stack_trace: text('stack_trace'),
+  context: jsonb('context').$type<Json>().default(sql`'{}'::jsonb`),
+  // 'production' | 'preview'
+  environment: varchar('environment', { length: 20 }).default('production'),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+  github_issue_created: boolean('github_issue_created').default(false),
+  github_issue_number: integer('github_issue_number'),
+  github_issue_url: text('github_issue_url'),
+})
+
+// -----------------------------------------------------------------------------
+// streamer_storage_bonus（ストレージ容量ボーナス）
+// 根拠: 00013 初版
+// -----------------------------------------------------------------------------
+export const streamerStorageBonus = pgTable('streamer_storage_bonus', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  streamer_id: uuid('streamer_id').notNull(),
+  amount_mb: integer('amount_mb').notNull(),
+  type: text('type').notNull(),
+  // UNIQUE 制約の NULL 問題回避のため NOT NULL DEFAULT ''
+  memo: text('memo').notNull().default(''),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// announcements（お知らせ）
+// 根拠: 00016 初版
+// -----------------------------------------------------------------------------
+export const announcements = pgTable('announcements', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  title: text('title').notNull(),
+  body: text('body').notNull(),
+  // 'info' | 'warning' | 'critical'（CHECK 制約は DB 側で担保）
+  severity: text('severity').notNull().default('info'),
+  is_published: boolean('is_published').notNull().default(false),
+  published_at: timestamp('published_at', { withTimezone: true, mode: 'string' }),
+  expires_at: timestamp('expires_at', { withTimezone: true, mode: 'string' }),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+  updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// announcement_reads（お知らせ既読管理）
+// 根拠: 00016 初版
+// -----------------------------------------------------------------------------
+export const announcementReads = pgTable('announcement_reads', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  announcement_id: uuid('announcement_id').notNull(),
+  // users テーブル未登録ユーザーも既読化できるよう FK なしの TEXT
+  twitch_user_id: text('twitch_user_id').notNull(),
+  read_at: timestamp('read_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// support_codes（支援プラン共有コードマスタ。コードは SHA-256 ハッシュで保存）
+// 根拠: 00017 初版
+// -----------------------------------------------------------------------------
+export const supportCodes = pgTable('support_codes', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  code_hash: text('code_hash').notNull(),
+  // 'support' | 'patron'
+  plan_type: text('plan_type').notNull(),
+  // 'active' | 'rotating' | 'revoked'
+  status: text('status').notNull().default('active'),
+  // 00017: DDL に NOT NULL は無い（DEFAULT '' のみ。database.ts は non-null 扱い）
+  memo: text('memo').default(''),
+  activation_count: integer('activation_count').notNull().default(0),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).notNull().default(sql`now()`),
+  updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).notNull().default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// user_licenses（ユーザーの支援プランライセンス）
+// 根拠: 00017 初版
+// -----------------------------------------------------------------------------
+export const userLicenses = pgTable('user_licenses', {
+  id: uuid('id').primaryKey().default(sql`gen_random_uuid()`),
+  twitch_user_id: text('twitch_user_id').notNull(),
+  code_id: uuid('code_id').notNull(),
+  // 'support' | 'patron'
+  plan_type: text('plan_type').notNull(),
+  // FANBOX ID の参考情報（不正検知用）
+  fanbox_id: text('fanbox_id'),
+  activated_at: timestamp('activated_at', { withTimezone: true, mode: 'string' }).notNull().default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// support_inquiries（支援者限定問い合わせ）
+// 根拠: 00019 初版
+// -----------------------------------------------------------------------------
+export const supportInquiries = pgTable('support_inquiries', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  twitch_user_id: text('twitch_user_id').notNull(),
+  // 投稿時点の表示名スナップショット
+  twitch_display_name: text('twitch_display_name').notNull(),
+  // 'bug' | 'feature' | 'other'
+  category: text('category').notNull(),
+  subject: text('subject').notNull(),
+  body: text('body').notNull(),
+  // 'open' | 'in_progress' | 'resolved' | 'closed'
+  status: text('status').notNull().default('open'),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+  updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// support_inquiry_messages（問い合わせへの後続メッセージ）
+// 根拠: 00019 初版
+// -----------------------------------------------------------------------------
+export const supportInquiryMessages = pgTable('support_inquiry_messages', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  inquiry_id: uuid('inquiry_id').notNull(),
+  // 'user' | 'admin'
+  sender_type: text('sender_type').notNull(),
+  // user: twitchUserId / admin: 'admin'
+  sender_id: text('sender_id').notNull(),
+  body: text('body').notNull(),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// collection_completions（コレクションコンプリート達成記録）
+// 根拠: 00030 初版, 00064 collection_name 追加（パック別コンプリート）
+// -----------------------------------------------------------------------------
+export const collectionCompletions = pgTable('collection_completions', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  twitch_user_id: text('twitch_user_id').notNull(),
+  streamer_id: uuid('streamer_id').notNull(),
+  // 達成時点のアクティブカード総数
+  total_cards: integer('total_cards').notNull(),
+  // 00064: NULL = 全体コンプリート（従来レコード）、'__default__' = デフォルトパック
+  collection_name: text('collection_name'),
+  completed_at: timestamp('completed_at', { withTimezone: true, mode: 'string' }).notNull().default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// channel_point_usage_stats（チャネルポイント使用量の累積集計。gacha_history の
+// トリガーで維持される）
+// 根拠: 00039 でテーブル化（00036 は同名 RPC のみで、テーブル定義は 00039 が初出）
+// -----------------------------------------------------------------------------
+export const channelPointUsageStats = pgTable(
+  'channel_point_usage_stats',
+  {
+    streamer_id: uuid('streamer_id').notNull(),
+    user_twitch_id: text('user_twitch_id').notNull(),
+    username: text('username'),
+    total_points: bigint('total_points', { mode: 'number' }).notNull().default(0),
+    redemption_count: integer('redemption_count').notNull().default(0),
+    last_redeemed_at: timestamp('last_redeemed_at', { withTimezone: true, mode: 'string' }),
+    created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).notNull().default(sql`now()`),
+    updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).notNull().default(sql`now()`),
+  },
+  (table) => [
+    // 00039: PRIMARY KEY (streamer_id, user_twitch_id)
+    primaryKey({ columns: [table.streamer_id, table.user_twitch_id] }),
+  ]
+)
+
+// -----------------------------------------------------------------------------
+// twitch_bot_accounts（チャット通知送信用 Twitch BOT アカウント）
+// 根拠: 00040 初版
+// -----------------------------------------------------------------------------
+export const twitchBotAccounts = pgTable('twitch_bot_accounts', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  // 'streamer' | 'system'
+  owner_type: text('owner_type').notNull(),
+  // owner_type = 'system' の場合は NULL（CHECK 制約は DB 側で担保）
+  streamer_id: uuid('streamer_id'),
+  twitch_user_id: text('twitch_user_id').notNull(),
+  twitch_username: text('twitch_username'),
+  twitch_display_name: text('twitch_display_name'),
+  twitch_access_token: text('twitch_access_token').notNull(),
+  twitch_refresh_token: text('twitch_refresh_token').notNull(),
+  twitch_token_expires_at: timestamp('twitch_token_expires_at', { withTimezone: true, mode: 'string' }).notNull(),
+  // text[] DEFAULT '{}'（NOT NULL は無い）
+  scopes: text('scopes').array().default(sql`'{}'::text[]`),
+  // 'active' | 'revoked' | 'error'
+  status: text('status').notNull().default('active'),
+  last_error: text('last_error'),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+  updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// streamer_chat_sender_settings（配信者ごとのチャット送信者設定）
+// 根拠: 00040 初版
+// -----------------------------------------------------------------------------
+export const streamerChatSenderSettings = pgTable('streamer_chat_sender_settings', {
+  // streamers.id がそのまま主キー（1 配信者 1 設定）
+  streamer_id: uuid('streamer_id').primaryKey(),
+  // 'streamer' | 'custom_bot' | 'official_bot'
+  sender_mode: text('sender_mode').notNull().default('streamer'),
+  custom_bot_account_id: uuid('custom_bot_account_id'),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+  updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// card_owner_stats（カード別所持ユーザーの累積集計。user_cards のトリガーで維持）
+// 根拠: 00051 初版
+// -----------------------------------------------------------------------------
+export const cardOwnerStats = pgTable(
+  'card_owner_stats',
+  {
+    streamer_id: uuid('streamer_id').notNull(),
+    card_id: uuid('card_id').notNull(),
+    user_twitch_id: text('user_twitch_id').notNull(),
+    username: text('username'),
+    display_name: text('display_name'),
+    owned_count: integer('owned_count').notNull().default(0),
+    last_obtained_at: timestamp('last_obtained_at', { withTimezone: true, mode: 'string' }),
+    created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).notNull().default(sql`now()`),
+    updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).notNull().default(sql`now()`),
+  },
+  (table) => [
+    // 00051: PRIMARY KEY (streamer_id, card_id, user_twitch_id)
+    primaryKey({ columns: [table.streamer_id, table.card_id, table.user_twitch_id] }),
+  ]
+)
+
+// -----------------------------------------------------------------------------
+// card_stone_balances（カードストーン残高。ユーザー × 配信者ごとに 1 行）
+// 根拠: 00059 初版
+// -----------------------------------------------------------------------------
+export const cardStoneBalances = pgTable('card_stone_balances', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  user_id: uuid('user_id').notNull(),
+  streamer_id: uuid('streamer_id').notNull(),
+  balance: integer('balance').notNull().default(0),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+  updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
+// card_stone_transactions（カードストーン取引履歴）
+// 根拠: 00059 初版, 00060 request_id（冪等性キー）追加
+// -----------------------------------------------------------------------------
+export const cardStoneTransactions = pgTable('card_stone_transactions', {
+  id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
+  user_id: uuid('user_id').notNull(),
+  streamer_id: uuid('streamer_id').notNull(),
+  // ON DELETE SET NULL のため NULL 許容
+  card_id: uuid('card_id'),
+  // 交換で削除された user_cards.id の記録（FK なし）
+  user_card_id: uuid('user_card_id'),
+  amount: integer('amount').notNull(),
+  // 現状 'duplicate_exchange' のみ（CHECK 制約は DB 側で担保）
+  type: text('type').notNull(),
+  // 00060: クライアント生成の冪等性キー（旧レコードは NULL）
+  request_id: uuid('request_id'),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+})
+
+// =============================================================================
+// database.ts（src/types/database.ts）と migrations（DDL）の食い違い一覧
+// いずれも migration の DDL を正としてこのファイルへ反映済み。
+//
+// 1. DB に存在するが database.ts の Row 型に無い列:
+//    - users.twitch_access_token / twitch_refresh_token / twitch_token_expires_at
+//      （00004 で追加、DROP する migration は無い。トークンをアプリ層の型に露出
+//      させない意図的な省略と思われるが、実 DB には存在するため定義した）
+//    - cards.rarity_order（00014、GENERATED ALWAYS AS ... STORED。生成カラムで
+//      insert / update 不可のため Row 型から省かれているが、select は可能）
+//    - gacha_history.reward_id（00070 で追加。database.ts が未更新）
+//
+// 2. DB 型の相違:
+//    - streamers.custom_rarities / card_pack_names は database.ts では string[] だが、
+//      DB 型は text[] ではなく JSONB の文字列配列（00049 / 00062）。
+//      jsonb().$type<string[]>() として実体に合わせた。
+//
+// 3. NULL 制約の相違（database.ts は non-null 扱いだが、DDL に NOT NULL が無く
+//    DEFAULT のみの列。insert 時に DB 側で値が入るため実運用上 NULL はほぼ
+//    発生しないが、DDL を正として .notNull() を付けていない）:
+//    - streamers.is_active / created_at / updated_at
+//    - users.twitch_scopes / twitch_has_sub / created_at / updated_at
+//    - cards.is_active / hp / atk / def / spd / skill_type / skill_name /
+//      skill_power / created_at / updated_at
+//    - user_cards.obtained_at
+//    - gacha_history.redeemed_at
+//    - battles.turn_count / created_at
+//    - battle_stats.total_battles / wins / losses / draws / win_rate / updated_at
+//    - streamer_additional_gacha_rewards.created_at
+//    - announcements.created_at / updated_at
+//    - announcement_reads.read_at
+//    - support_codes.memo
+//    - streamer_storage_bonus.created_at
+//    - twitch_bot_accounts.created_at / updated_at
+//    - streamer_chat_sender_settings.created_at / updated_at
+// =============================================================================

--- a/src/lib/overlay-version.ts
+++ b/src/lib/overlay-version.ts
@@ -1,0 +1,185 @@
+/**
+ * Issue #569: overlay ページ(src/app/overlay/[streamerId]/page.tsx)の
+ * 「バージョン不一致検出＋アイドル時自動リロード」に関する純粋関数群。
+ *
+ * sessionStorage や `Date.now()`・`setTimeout`・`location.reload()` などの
+ * 副作用を持つAPIには一切アクセスせず、必要な値(現在時刻・クールダウン記録・
+ * TTLなど)は全て引数として受け取る設計にしている。これにより overlay ページ
+ * 本体(ブラウザ環境・Reactのライフサイクル)を経由せずに、あらゆる分岐を
+ * ユニットテストできる。
+ *
+ * 呼び出し側(page.tsx)の責務:
+ * - sessionStorage の実際の読み書き(OBS等で無効な環境向けにtry/catchで包む)
+ * - setTimeout によるジッター/演出中の再試行のスケジューリング
+ * - location.reload() の実行
+ */
+
+/** sessionStorage に保存するクールダウン記録(直前にリロードしたバージョンと時刻)の型 */
+export interface ReloadCooldownRecord {
+  version: string;
+  reloadedAt: number;
+}
+
+/** sessionStorage に退避するポーリング状態のスナップショット */
+export interface OverlayPollStateSnapshot {
+  pollCursor: string;
+  seenHistoryIds: string[];
+  savedAt: number;
+}
+
+/**
+ * 同一バージョンへのリロードを許可する最短間隔(ミリ秒)。
+ *
+ * 「一度リロードしたら二度と自動リロードしない」という恒久的な一回限りガードに
+ * しない理由: 本番を旧バージョンへロールバックした場合、クライアントは
+ * 「(ロールバック後の)新しいバージョンへ戻る」ためにもう一度リロードする必要が
+ * あるが、恒久ガードだとロールバック後に復帰できなくなってしまう。
+ * クールダウン方式にすることで「同一バージョンへの往復リロード連発」だけを防ぎ
+ * つつ、一定時間が経てば何度でも追従できるようにする。
+ */
+export const RELOAD_COOLDOWN_MS = 60 * 60 * 1000; // 60分
+
+/**
+ * sessionStorage に退避したポーリング状態(pollCursor/seenHistoryIds)を
+ * 有効とみなす最長時間(ミリ秒)。これを超えて放置された古い状態は捨てて、
+ * 通常どおり「今」を起点にポーリングを再開する(古いカーソルを使い続けて
+ * 取りこぼし・重複判定の不整合を起こさないため)。
+ */
+export const POLLSTATE_TTL_MS = 15 * 60 * 1000; // 15分
+
+/**
+ * sessionStorage に退避する seenHistoryIds の最大件数。無制限に保存すると
+ * sessionStorage の容量やシリアライズ・復元コストが不必要に増えるため、
+ * 直近分(Set の挿入順で最新側)だけを残す。リロード窓をまたぐ重複表示防止が
+ * 目的であり、全履歴を保持する必要はない。
+ */
+export const MAX_PERSISTED_HISTORY_IDS = 50;
+
+/**
+ * 自身のビルドバージョン(current)とポーリング応答から受け取ったバージョン
+ * (received)を比較し、リロードをスケジュールすべきかを判定する。
+ *
+ * - current/received のいずれかが空文字列・undefined なら判定不能として false
+ * - どちらかが 'dev' なら false — ローカル開発環境やgit不在でのビルドは
+ *   常に 'dev' になり得る。'dev' を通常のバージョン文字列と同列に比較すると、
+ *   'dev' な自分 と 本番の実SHA が常に「不一致」判定されてリロードループの
+ *   原因になりかねないため、'dev' が絡む比較は意図的にスキップする。
+ * - 上記以外で文字列が異なれば true
+ */
+export function shouldScheduleReload(current: string, received: string | undefined): boolean {
+  if (!current || !received) return false;
+  if (current === "dev" || received === "dev") return false;
+  return current !== received;
+}
+
+/**
+ * targetVersion へのリロードが現在クールダウン中(＝直近 cooldownMs 以内に
+ * 同じバージョンへ既にリロード済み)かどうかを判定する。
+ *
+ * record が null(まだ一度もリロード記録が無い)、または記録されている
+ * バージョンが targetVersion と異なる(＝別バージョンへのリロードなので
+ * 独立してカウントする)場合は常に false を返す。
+ */
+export function isReloadCooldownActive(
+  record: ReloadCooldownRecord | null,
+  targetVersion: string,
+  now: number,
+  cooldownMs: number,
+): boolean {
+  if (!record) return false;
+  if (record.version !== targetVersion) return false;
+  return now - record.reloadedAt < cooldownMs;
+}
+
+/**
+ * sessionStorage に保存されたクールダウン記録(JSON文字列)をパースする。
+ * parsePollState と同様、以下のいずれかに該当する場合は例外を投げず null を
+ * 返す(呼び出し側は「クールダウン記録なし」として扱い、安全側に倒れる):
+ * - raw が null/undefined/空文字列
+ * - JSON として parse できない(壊れたデータ)
+ * - 期待する形状(version: string, reloadedAt: number)を満たさない
+ */
+export function parseReloadCooldownRecord(
+  raw: string | null | undefined,
+): ReloadCooldownRecord | null {
+  if (!raw) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== "object") return null;
+  const candidate = parsed as Record<string, unknown>;
+
+  if (typeof candidate.version !== "string") return null;
+  if (typeof candidate.reloadedAt !== "number") return null;
+
+  return { version: candidate.version, reloadedAt: candidate.reloadedAt };
+}
+
+/**
+ * ポーリング状態(pollCursor/seenHistoryIds)をリロード直前に sessionStorage へ
+ * 退避するため JSON 文字列にシリアライズする。
+ * seenHistoryIds は直近 MAX_PERSISTED_HISTORY_IDS 件(配列末尾側 = Set の
+ * 挿入順で最新側)だけを残す。
+ */
+export function serializePollState(state: {
+  pollCursor: string;
+  seenHistoryIds: string[];
+  savedAt: number;
+}): string {
+  const snapshot: OverlayPollStateSnapshot = {
+    pollCursor: state.pollCursor,
+    seenHistoryIds: state.seenHistoryIds.slice(-MAX_PERSISTED_HISTORY_IDS),
+    savedAt: state.savedAt,
+  };
+  return JSON.stringify(snapshot);
+}
+
+/**
+ * serializePollState の逆変換。以下のいずれかに該当する場合は null を返し、
+ * 呼び出し側は「復元しない(＝今を起点にポーリングを再開する)」ものとして
+ * 扱う:
+ * - raw が null/undefined/空文字列
+ * - JSON として parse できない(壊れたデータ)
+ * - 期待する形状(pollCursor: string, seenHistoryIds: string[], savedAt: number)
+ *   を満たさない
+ * - savedAt から now までの経過が ttlMs を超えている(TTL切れ)
+ *
+ * OBS ブラウザソース等 sessionStorage の内容が外部から書き換えられ得る前提を
+ * 置き、壊れた入力でも例外を投げず null を返すことを保証する
+ * (このモジュールを呼ぶ page.tsx 側の try/catch とは独立した防御)。
+ */
+export function parsePollState(
+  raw: string | null | undefined,
+  now: number,
+  ttlMs: number,
+): OverlayPollStateSnapshot | null {
+  if (!raw) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== "object") return null;
+  const candidate = parsed as Record<string, unknown>;
+
+  if (typeof candidate.pollCursor !== "string") return null;
+  if (typeof candidate.savedAt !== "number") return null;
+  if (!Array.isArray(candidate.seenHistoryIds)) return null;
+
+  if (now - candidate.savedAt > ttlMs) return null;
+
+  // 配列内に文字列以外が混じっていても(壊れたデータ)無視して安全側に倒す
+  const seenHistoryIds = candidate.seenHistoryIds.filter(
+    (id): id is string => typeof id === "string",
+  );
+
+  return { pollCursor: candidate.pollCursor, seenHistoryIds, savedAt: candidate.savedAt };
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -35,3 +35,17 @@ vi.mock('@/lib/supabase/admin', () => ({
   // logger.error → logErrorFromLogger → logErrorToSupabase で使用される
   getSupabaseAdmin: vi.fn(() => createMockSupabaseClient()),
 }))
+
+// #570: pg 直結経路（postgres.js + Drizzle）のグローバルモック。
+// 既存テストは DB_DRIVER 未設定（= 'postgrest' 経路）で動くため getDb は呼ばれない。
+// 万一呼ばれた場合はフラグ分岐漏れ（設計違反）を即検出できるよう throw するスタブにする。
+// pg 経路をテストしたいファイルでは vi.mocked(getDb).mockResolvedValue(...) で上書きする。
+// エクスポート形状は実モジュール（src/lib/db/client.ts）の実行時エクスポート（getDb のみ）と一致させること。
+vi.mock('@/lib/db/client', () => ({
+  getDb: vi.fn(() => {
+    throw new Error(
+      'getDb() must not be called in unit tests: DB_DRIVER defaults to postgrest. ' +
+        'Override with vi.mocked(getDb).mockResolvedValue(...) to test the pg path.'
+    )
+  }),
+}))

--- a/tests/unit/announcements-driver-parity.test.ts
+++ b/tests/unit/announcements-driver-parity.test.ts
@@ -1,0 +1,240 @@
+/**
+ * #570 パイロット: getUnreadAnnouncements の postgrest 経路 / pg 経路の形状互換テスト
+ *
+ * 同一 fixture を両経路のモックに与え、戻り値が deepEqual であることを検証する。
+ * pg 経路（Drizzle）は PostgREST 経路と「完全に同じ戻り値形状（snake_case キー、
+ * 日付は文字列）」を返すことが Phase 1 の要件（呼び出し側は経路を意識しない）。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { getUnreadAnnouncements } from '@/lib/announcements'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { getDb } from '@/lib/db/client'
+import {
+  announcementReads as announcementReadsTable,
+  announcements as announcementsTable,
+} from '@/lib/db/schema'
+
+// ---------------------------------------------------------------------------
+// 共通 fixture（両経路に同じ行データを与える）
+// 実時刻に依存しないよう、過去/未来の判定は十分に離れた日時を使う
+// ---------------------------------------------------------------------------
+
+/** announcements テーブルの行（SELECT 対象列のみ。日付は PostgREST が返す文字列形式） */
+const ANNOUNCEMENT_ROWS = [
+  {
+    // 表示対象: 公開中・期限内・未読
+    id: 'a1',
+    title: '新機能のお知らせ',
+    body: 'ガチャ演出を刷新しました',
+    severity: 'info',
+    published_at: '2020-01-01T00:00:00.000+00:00',
+    expires_at: '2999-01-01T00:00:00.000+00:00',
+    created_at: '2020-01-02T00:00:00.000+00:00',
+  },
+  {
+    // 既読のため除外される
+    id: 'a2',
+    title: 'メンテナンスのお知らせ',
+    body: '深夜にメンテナンスを行います',
+    severity: 'warning',
+    published_at: '2020-01-01T00:00:00.000+00:00',
+    expires_at: null,
+    created_at: '2020-01-01T00:00:00.000+00:00',
+  },
+  {
+    // 期限切れのため除外される
+    id: 'a3',
+    title: '過去のお知らせ',
+    body: '終了済みキャンペーン',
+    severity: 'info',
+    published_at: '2020-01-01T00:00:00.000+00:00',
+    expires_at: '2020-02-01T00:00:00.000+00:00',
+    created_at: '2019-12-31T00:00:00.000+00:00',
+  },
+  {
+    // 公開予定（未来）のため除外される
+    id: 'a4',
+    title: '未来のお知らせ',
+    body: 'まだ見えないはず',
+    severity: 'critical',
+    published_at: '2999-01-01T00:00:00.000+00:00',
+    expires_at: null,
+    created_at: '2019-12-30T00:00:00.000+00:00',
+  },
+  {
+    // published_at が NULL（即時公開扱い）: null がそのまま返ることの検証用
+    id: 'a5',
+    title: '公開日時なしのお知らせ',
+    body: 'published_at は null',
+    severity: 'info',
+    published_at: null,
+    expires_at: null,
+    created_at: '2019-12-29T00:00:00.000+00:00',
+  },
+]
+
+/** announcement_reads テーブルの行（a2 のみ既読） */
+const READ_ROWS = [{ announcement_id: 'a2' }]
+
+/** 両経路が返すべき期待値（a1 と a5 が未読・表示対象） */
+const EXPECTED = [
+  {
+    id: 'a1',
+    title: '新機能のお知らせ',
+    body: 'ガチャ演出を刷新しました',
+    severity: 'info',
+    published_at: '2020-01-01T00:00:00.000+00:00',
+    created_at: '2020-01-02T00:00:00.000+00:00',
+  },
+  {
+    id: 'a5',
+    title: '公開日時なしのお知らせ',
+    body: 'published_at は null',
+    severity: 'info',
+    published_at: null,
+    created_at: '2019-12-29T00:00:00.000+00:00',
+  },
+]
+
+// ---------------------------------------------------------------------------
+// postgrest 経路のモック: from().select().eq().order() を await できる thenable builder
+// ---------------------------------------------------------------------------
+
+function createThenableBuilder(result: { data: unknown; error: null }) {
+  const builder: any = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    order: vi.fn(() => builder),
+    then: (onFulfilled: any, onRejected: any) =>
+      Promise.resolve(result).then(onFulfilled, onRejected),
+  }
+  return builder
+}
+
+function createSupabaseClientMock() {
+  const from = vi.fn((table: string) => {
+    const data = table === 'announcements' ? ANNOUNCEMENT_ROWS : READ_ROWS
+    return createThenableBuilder({ data, error: null })
+  })
+  return { from }
+}
+
+// ---------------------------------------------------------------------------
+// pg 経路のモック: db.select(fields).from(table).where().orderBy() を await できる
+// thenable builder。実 Drizzle と同様に「select で指定された列だけ」を fixture 行から
+// 射影して返す（実装が列を選び忘れた場合に形状差としてテストが落ちるようにする。
+// 本実装は列キー = DB 列名なので、射影キー = fields のキーで良い）。
+// ---------------------------------------------------------------------------
+
+function createDrizzleDbMock() {
+  return {
+    select: vi.fn((fields: Record<string, unknown>) => ({
+      from: vi.fn((table: unknown) => {
+        const rows =
+          table === announcementsTable
+            ? ANNOUNCEMENT_ROWS
+            : table === announcementReadsTable
+              ? READ_ROWS
+              : []
+        const projected = rows.map((row) =>
+          Object.fromEntries(
+            Object.keys(fields).map((key) => [key, (row as Record<string, unknown>)[key]])
+          )
+        )
+        const builder: any = {
+          where: vi.fn(() => builder),
+          orderBy: vi.fn(() => builder),
+          then: (onFulfilled: any, onRejected: any) =>
+            Promise.resolve(projected).then(onFulfilled, onRejected),
+        }
+        return builder
+      }),
+    })),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// テスト本体
+// ---------------------------------------------------------------------------
+
+describe('getUnreadAnnouncements: postgrest / pg 経路の形状互換 (#570)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // 環境変数は vi.stubEnv で設定し vi.unstubAllEnvs で確実に復元する。
+  // process.env への直接 mutation は、テスト失敗時に復元されず同一プロセスで
+  // 実行される他テストへ漏れる構造的リスクがあるため使わない
+  // （db-flags.test.ts と同じ変数を扱うため特に重要）。
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  async function runPostgrestPath() {
+    // DB_DRIVER 未設定（= 既定の postgrest 経路）を再現
+    vi.stubEnv('DB_DRIVER', undefined)
+    const client = createSupabaseClientMock()
+    vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+    const result = await getUnreadAnnouncements('viewer-1')
+    return { result, client }
+  }
+
+  async function runPgPath() {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const db = createDrizzleDbMock()
+    vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any)
+    const result = await getUnreadAnnouncements('viewer-1')
+    return { result, db }
+  }
+
+  it('同一 fixture で両経路の戻り値が deepEqual になる', async () => {
+    const { result: postgrestResult, client } = await runPostgrestPath()
+    const { result: pgResult, db } = await runPgPath()
+
+    // 両経路が実際に実行されたこと（フラグ分岐の検証）
+    expect(client.from).toHaveBeenCalledWith('announcements')
+    expect(client.from).toHaveBeenCalledWith('announcement_reads')
+    expect(db.select).toHaveBeenCalledTimes(2)
+
+    // 形状互換の本体: キー・値とも完全一致
+    expect(pgResult).toEqual(postgrestResult)
+    expect(postgrestResult).toEqual(EXPECTED)
+  })
+
+  it('日付フィールドは両経路とも文字列（Date オブジェクトではない）で返る', async () => {
+    const { result: postgrestResult } = await runPostgrestPath()
+    const { result: pgResult } = await runPgPath()
+
+    for (const result of [postgrestResult, pgResult]) {
+      expect(result.length).toBeGreaterThan(0)
+      for (const announcement of result) {
+        // created_at は常に文字列
+        expect(typeof announcement.created_at).toBe('string')
+        // published_at は文字列または null（Date になっていないこと）
+        if (announcement.published_at !== null) {
+          expect(typeof announcement.published_at).toBe('string')
+        }
+        expect(announcement.published_at).not.toBeInstanceOf(Date)
+        expect(announcement.created_at).not.toBeInstanceOf(Date)
+      }
+    }
+  })
+
+  it('postgrest 経路（フラグ未設定）では getDb が一切呼ばれない（挙動不変の検証）', async () => {
+    await runPostgrestPath()
+    expect(getDb).not.toHaveBeenCalled()
+  })
+
+  it('pg 経路では supabase-js クライアントが一切呼ばれない', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const client = createSupabaseClientMock()
+    vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+    const db = createDrizzleDbMock()
+    vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any)
+
+    const result = await getUnreadAnnouncements('viewer-1')
+
+    expect(result).toEqual(EXPECTED)
+    expect(client.from).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -1,10 +1,11 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import type { GachaBroadcastPayload, RealtimeError, SubscribeOptions } from '@/lib/realtime'
 import type { GachaSoundRule } from '@/lib/gacha-sound-rules'
 import OverlayPage from '@/app/overlay/[streamerId]/page'
 import { pickSoundBearingCardIndex } from '@/lib/gacha-sound-rules'
 import { OVERLAY_EFFECT_PARTICLE_CONFIG } from '@/lib/overlay-effect'
+import { serializePollState } from '@/lib/overlay-version'
 
 const { subscribeMock } = vi.hoisted(() => ({
   subscribeMock: vi.fn(),
@@ -438,6 +439,271 @@ describe('OverlayPage', () => {
     })
     expect(screen.getByText('Gamma')).toBeInTheDocument()
     expect(playedSrcs).toEqual(['https://example.com/legendary.mp3'])
+  })
+
+  // Issue #569 厳格レビュー指摘(High): attemptReload / checkOverlayVersion /
+  // mount時pollstate復元は、テスト環境では page.tsx トップレベルの
+  // `CURRENT_OVERLAY_VERSION = process.env.NEXT_PUBLIC_OVERLAY_VERSION ?? "dev"`
+  // が常に 'dev' に評価される(tests/setup.tsで当該環境変数を設定していない)ため、
+  // shouldScheduleReloadが常にfalseを返し、通常のOverlayPageインポートでは
+  // この経路が一度も実行されない。
+  // vi.stubEnv + vi.resetModules + 動的importで「'dev'ではないビルド」を
+  // このdescribe専用に用意し、実際に不一致検出→ジッター待機→リロードの
+  // 経路を駆動して検証する。
+  describe('Issue #569: バージョン不一致検出とアイドル時自動リロード', () => {
+    // window.location を丸ごと差し替えるため、テストごとに元のLocationへ
+    // 復元する(そうしないと以降のテスト・describeでwindow.history.replaceState
+    // との整合が壊れる)
+    const originalLocation = window.location
+    let OverlayPageV: typeof OverlayPage
+
+    // page.tsx の RELOAD_COOLDOWN_STORAGE_KEY / POLLSTATE_STORAGE_KEY は
+    // overlay-version.tsの純粋関数群とは異なりpage.tsx内部の実装詳細のため
+    // 非exportになっている。ここでは実装と同じリテラル値を直接指定する
+    // (page.tsx側でキー名を変更した場合はこのテストも追随して更新が必要)。
+    const RELOAD_COOLDOWN_STORAGE_KEY = 'twica-overlay-reload'
+    const POLLSTATE_STORAGE_KEY = 'twica-overlay-pollstate'
+
+    // page.tsx内部の時間定数(非export)と同じ値をテスト側でも保持する。
+    // 実装側(VERSION_CHECK_INTERVAL_MS/RELOAD_JITTER_MAX_MS/RELOAD_DEFER_RETRY_MS)
+    // を変更した場合は、ここも追随して更新すること。
+    const RELOAD_JITTER_MAX_MS = 10 * 60 * 1000
+    const RELOAD_DEFER_RETRY_MS = 30 * 1000
+
+    beforeAll(async () => {
+      // CURRENT_OVERLAY_VERSION はモジュールのトップレベルで一度だけ評価される
+      // ため、'dev'以外の値にするには「環境変数スタブ→モジュールキャッシュ破棄→
+      // 再import」が必要になる。ファイル先頭で静的importした既存の OverlayPage
+      // はこの後も'dev'ビルドのまま維持される(他のテストへは影響しない)。
+      vi.stubEnv('NEXT_PUBLIC_OVERLAY_VERSION', 'v-a')
+      vi.resetModules()
+      const mod = await import('@/app/overlay/[streamerId]/page')
+      OverlayPageV = mod.default
+    })
+
+    afterAll(() => {
+      vi.unstubAllEnvs()
+    })
+
+    beforeEach(() => {
+      // cooldown/pollstateの仕込みがテスト間で残らないようにする
+      sessionStorage.clear()
+    })
+
+    afterEach(() => {
+      // Math.randomスパイ等をテストごとに元へ戻す
+      vi.restoreAllMocks()
+      // window.locationを元のLocationオブジェクトへ戻す
+      Object.defineProperty(window, 'location', { value: originalLocation, configurable: true })
+    })
+
+    /**
+     * location.reloadをスパイに差し替える(既存のLocationプロパティは維持する)。
+     * 注意: happy-domのLocationはhref/origin/search等をprototype上のgetterとして
+     * 実装しており、いずれもインスタンス自身のenumerableプロパティではない。
+     * そのため `{ ...window.location }` は何もフィールドをコピーできず
+     * (origin等がundefinedになり、page.tsx内の `new URL(path, location.origin)`
+     * がInvalid URLで例外を投げてしまう)、各プロパティをgetter経由で明示的に
+     * 読み出してコピーする必要がある。
+     */
+    const stubLocationReload = () => {
+      const reloadMock = vi.fn()
+      const current = window.location
+      Object.defineProperty(window, 'location', {
+        value: {
+          hash: current.hash,
+          host: current.host,
+          hostname: current.hostname,
+          href: current.href,
+          origin: current.origin,
+          pathname: current.pathname,
+          port: current.port,
+          protocol: current.protocol,
+          search: current.search,
+          reload: reloadMock,
+        },
+        configurable: true,
+      })
+      return reloadMock
+    }
+
+    /**
+     * overlay events ポーリング(かつsound-settings取得)の共通fetchレスポンスを
+     * 組み立てる。このテストファイルの既存の流儀(fetchはURLを区別せず単一の
+     * レスポンス形状を返す)に合わせ、events/overlayVersionとsoundUrl/soundEnabled
+     * を同居させる。
+     */
+    const stubEventsFetch = (overlayVersion: string) => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          soundUrl: null,
+          soundEnabled: false,
+          events: [],
+          overlayVersion,
+        }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      return fetchMock
+    }
+
+    it('フォールバックポーリングでoverlayVersion不一致を検出し、ジッター上限まで進めるとlocation.reloadが呼ばれる', async () => {
+      vi.useFakeTimers()
+      // ジッターを上限近くに固定し、「上限まで進めれば必ず発火する」ことを検証する
+      vi.spyOn(Math, 'random').mockReturnValue(0.999999)
+      const reloadMock = stubLocationReload()
+      stubEventsFetch('v-b')
+
+      render(<OverlayPageV />)
+
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      // 最初のフォールバックポーリング(3秒後)でoverlayVersion不一致を検出し、
+      // ジッター待機(setTimeout)をスケジュールする
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000)
+      })
+      expect(reloadMock).not.toHaveBeenCalled()
+
+      // ジッター上限まで進めると、スケジュールされたリロードが実行される
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(RELOAD_JITTER_MAX_MS)
+      })
+      expect(reloadMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('演出中(showCard)にジッターが発火した場合は即座にreloadされず、演出終了後に呼ばれる', async () => {
+      vi.useFakeTimers()
+      // ジッターをほぼ0にして、最初のポーリング直後に発火させる
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const reloadMock = stubLocationReload()
+      stubEventsFetch('v-b')
+
+      let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+      subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+        onGachaResult = callback as (payload: GachaBroadcastPayload) => void
+        options.onError?.(connectionError)
+        return vi.fn()
+      })
+
+      render(<OverlayPageV />)
+
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      // カードを表示させ、演出中(showCard=true)の状態を作る
+      act(() => {
+        onGachaResult?.({
+          type: 'gacha',
+          card: { id: 'card-1', name: 'Alpha', description: null, image_url: null, rarity: 'rare' },
+          userTwitchUsername: 'Viewer',
+        })
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(100)
+      })
+      expect(screen.getByText('Alpha')).toBeInTheDocument()
+
+      // 3秒後のポーリングでバージョン不一致を検出。ジッターはほぼ0のため直後に
+      // 発火するが、演出中(showCard=true)のため即座にはreloadされない
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000)
+      })
+      expect(reloadMock).not.toHaveBeenCalled()
+
+      // 演出のhide(6秒後)・クリア(その0.5秒後)を別々のactで個別にflushしてから
+      // 残りの再試行間隔を進める。ここを1回の巨大なadvanceTimersByTimeAsyncに
+      // まとめると、setShowCard(false)によるReact状態更新がshowCardRefへ
+      // ミラーされる(useEffect)前に再試行タイマーの判定が実行されてしまい、
+      // 「演出はとっくに終わっているのにshowCardRef.currentがstaleなtrueのまま」
+      // という誤検知でテストが不安定になることを確認済み(fake timers配下で
+      // 大量のタイマーを一度に進めた際のReactバッチング起因)。
+      // 演出終了の前後で明示的にactの区切りを入れ、Reactに反映の機会を与える。
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000) // 表示から6秒後: hideタイマー発火(showCard: true→false)
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000) // さらに0.5秒後: クリアタイマー発火(result: null、isDisplaying: false)
+      })
+      expect(reloadMock).not.toHaveBeenCalled()
+
+      // 演出(表示6秒+後片付け0.5秒)は既に終わっているはずなので、演出中の
+      // 再試行間隔(30秒)が経過すると今度はreloadが呼ばれる
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(RELOAD_DEFER_RETRY_MS - 4000)
+      })
+      expect(reloadMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('同一バージョンのクールダウン記録がsessionStorageにある場合、リロードはスキップされる', async () => {
+      vi.useFakeTimers()
+      vi.spyOn(Math, 'random').mockReturnValue(0.999999)
+      const reloadMock = stubLocationReload()
+
+      // mount前に、これから検出する予定のバージョン'v-b'に対する直近リロード
+      // 記録を仕込んでおく(60分クールダウン中なのでスキップされるはず)
+      sessionStorage.setItem(
+        RELOAD_COOLDOWN_STORAGE_KEY,
+        JSON.stringify({ version: 'v-b', reloadedAt: Date.now() }),
+      )
+      stubEventsFetch('v-b')
+
+      render(<OverlayPageV />)
+
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000)
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(RELOAD_JITTER_MAX_MS)
+      })
+
+      expect(reloadMock).not.toHaveBeenCalled()
+    })
+
+    it('mount時にsessionStorageのpollstateスナップショットを復元し、次のポーリングのsinceに反映する', async () => {
+      vi.useFakeTimers()
+
+      const restoredCursor = '2026-06-01T00:00:00.000Z'
+      sessionStorage.setItem(
+        POLLSTATE_STORAGE_KEY,
+        serializePollState({
+          pollCursor: restoredCursor,
+          seenHistoryIds: ['h-restored-1'],
+          savedAt: Date.now(),
+        }),
+      )
+      // このテストはpollstate復元のみに関心があるため、overlayVersionは現行
+      // ビルド('v-a')と一致させリロード関連の副作用を起こさないようにする
+      const fetchMock = stubEventsFetch('v-a')
+
+      render(<OverlayPageV />)
+
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000)
+      })
+
+      const eventsCall = fetchMock.mock.calls.find(([url]) =>
+        String(url).includes('/api/overlay/streamer-1/events'),
+      )
+      expect(eventsCall).toBeDefined()
+      const requestedUrl = new URL(String(eventsCall?.[0]))
+      expect(requestedUrl.searchParams.get('since')).toBe(restoredCursor)
+    })
   })
 })
 

--- a/tests/unit/dashboard-data-driver-parity.test.ts
+++ b/tests/unit/dashboard-data-driver-parity.test.ts
@@ -1,0 +1,959 @@
+/**
+ * #571: dashboard-data の RPC を含まない読み取り関数 10 本の
+ * postgrest 経路 / pg 経路 形状互換テスト
+ *
+ * tests/unit/announcements-driver-parity.test.ts（#570 パイロット）の形式を踏襲し、
+ * 同一 fixture を両経路のモックに与えて戻り値が deepEqual であることを検証する。
+ * 特に以下を明示的にアサートする:
+ *   - 埋め込み join の入れ子形状（cards は「単一オブジェクト」、
+ *     streamers(twitch_display_name) は 1 列だけのネストオブジェクト）
+ *   - 日付フィールドが文字列（Date オブジェクトではない）こと
+ *   - 0行時の挙動（maybeSingle 相当の null / 空配列 / total 0）
+ *   - 00064 デプロイ窓（collection_name 列欠落 42703）のフォールバック
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Column, SQL, Table, getTableColumns, is } from 'drizzle-orm'
+import {
+  getStreamerData,
+  getStreamerDataPaginated,
+  getRecentGachaHistory,
+  getGachaHistoryForStreamer,
+  getGachaHistoryForUser,
+  getActiveCardsForStreamer,
+  getActiveCardCountsForStreamers,
+  getStreamerById,
+  getUserCardDetail,
+  getCollectionCompletions,
+} from '@/lib/dashboard-data'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { getDb } from '@/lib/db/client'
+import {
+  cards as cardsTable,
+  collectionCompletions as collectionCompletionsTable,
+  gachaHistory as gachaHistoryTable,
+  streamers as streamersTable,
+  userCards as userCardsTable,
+  users as usersTable,
+} from '@/lib/db/schema'
+
+// logger.error は実装だと Supabase errors パイプラインへ fire-and-forget するため、
+// テストでは副作用のないモックに差し替える（既存 dashboard 系テストと同じ）
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('@/lib/sentry/error-handler', () => ({
+  reportError: vi.fn(),
+}))
+// unstable_cache / react cache はパススルーにしてキャッシュ層を素通しする
+// （キャッシュ「の中身」の両経路パリティを検証するため）
+vi.mock('next/cache', () => ({
+  unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+}))
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react')
+  return { ...actual, cache: (fn: unknown) => fn }
+})
+
+// ---------------------------------------------------------------------------
+// 共通 fixture（両経路に同じ行データを与える）
+// キーは DB 列名（= PostgREST の `*` 応答 = Drizzle スキーマの列プロパティ名）。
+// PostgREST の `*` は database.ts に無い実 DB 列（cards.rarity_order /
+// gacha_history.reward_id 等）も返すため、fixture も全列を持つ完全な行にする。
+// ---------------------------------------------------------------------------
+
+function makeStreamerRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'streamer-1',
+    twitch_user_id: 'twitch-user-1',
+    twitch_username: 'streamer_one',
+    twitch_display_name: 'Streamer One',
+    twitch_profile_image_url: null,
+    channel_point_reward_id: null,
+    channel_point_reward_name: null,
+    channel_point_collection_name: null,
+    is_active: true,
+    gacha_sound_url: null,
+    gacha_sound_enabled: false,
+    gacha_sound_rules: [],
+    chat_announcement_enabled: false,
+    chat_announcement_template: null,
+    chat_announcement_multi_template: null,
+    chat_announcement_multi_show_cards: true,
+    rarity_weights: null,
+    rarity_weights_scope: 'global',
+    pack_rarity_weights: null,
+    custom_rarities: [],
+    card_pack_names: [],
+    default_card_pack_name: null,
+    show_unowned_cards: false,
+    show_unowned_card_details: false,
+    raid_gacha_active_until: null,
+    raid_gacha_draw_count: 0,
+    created_at: '2025-12-01T00:00:00.000+00:00',
+    updated_at: '2025-12-01T00:00:00.000+00:00',
+    ...overrides,
+  }
+}
+
+function makeCardRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'card-1',
+    streamer_id: 'streamer-1',
+    name: 'Card One',
+    description: null,
+    image_url: 'https://example.com/card1.png',
+    rarity: 'common',
+    rarity_order: 4,
+    drop_rate: 0.25,
+    intra_rarity_weight: 1,
+    card_number: null,
+    max_issuance_count: null,
+    collection_name: null,
+    is_active: true,
+    hp: 100,
+    atk: 30,
+    def: 15,
+    spd: 5,
+    skill_type: 'attack',
+    skill_name: '通常攻撃',
+    skill_power: 10,
+    created_at: '2026-01-01T00:00:00.000+00:00',
+    updated_at: '2026-01-01T00:00:00.000+00:00',
+    ...overrides,
+  }
+}
+
+function makeGachaHistoryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'gh-1',
+    event_id: null,
+    user_twitch_id: 'viewer-1',
+    user_twitch_username: 'viewer_one',
+    card_id: 'card-old',
+    streamer_id: 'streamer-1',
+    reward_cost: 100,
+    reward_id: null,
+    redeemed_at: '2026-02-01T00:00:00.000+00:00',
+    ...overrides,
+  }
+}
+
+const STREAMER = makeStreamerRow()
+const CARD_OLD = makeCardRow({ id: 'card-old', created_at: '2026-01-01T00:00:00.000+00:00' })
+const CARD_NEW = makeCardRow({
+  id: 'card-new',
+  rarity: 'rare',
+  rarity_order: 3,
+  created_at: '2026-01-03T00:00:00.000+00:00',
+})
+const HISTORY_NEW = makeGachaHistoryRow({
+  id: 'gh-new',
+  card_id: 'card-new',
+  redeemed_at: '2026-02-02T00:00:00.000+00:00',
+})
+const HISTORY_OLD = makeGachaHistoryRow({
+  id: 'gh-old',
+  card_id: 'card-old',
+  redeemed_at: '2026-02-01T00:00:00.000+00:00',
+})
+
+// ---------------------------------------------------------------------------
+// postgrest 経路のモック: from(table) ごとに設定済み結果を順に返す thenable builder。
+// フィルタ・並び替え・range は評価しない（fixture を「クエリ結果そのもの」として
+// 与える。announcements-driver-parity.test.ts と同じ方針）。
+// ---------------------------------------------------------------------------
+
+interface PostgrestResult {
+  data: unknown
+  error: unknown
+  count?: number | null
+}
+
+function createSupabaseClientMock(resultsByTable: Record<string, PostgrestResult[]>) {
+  const queues = Object.fromEntries(
+    Object.entries(resultsByTable).map(([table, results]) => [table, [...results]])
+  )
+  const from = vi.fn((table: string) => {
+    const queue = queues[table]
+    if (!queue || queue.length === 0) {
+      throw new Error(`no mock result configured for table: ${table}`)
+    }
+    // 同一テーブルへの複数クエリ（count → rows 等）は先頭から順に消費し、
+    // 最後の1件はリトライ等の再実行に備えて残す
+    const result = queue.length > 1 ? (queue.shift() as PostgrestResult) : queue[0]
+    const builder: any = {
+      select: vi.fn(() => builder),
+      eq: vi.fn(() => builder),
+      in: vi.fn(() => builder),
+      ilike: vi.fn(() => builder),
+      gte: vi.fn(() => builder),
+      lt: vi.fn(() => builder),
+      order: vi.fn(() => builder),
+      range: vi.fn(() => builder),
+      limit: vi.fn(() => builder),
+      maybeSingle: vi.fn(() => Promise.resolve(result)),
+      then: (onFulfilled: any, onRejected: any) =>
+        Promise.resolve(result).then(onFulfilled, onRejected),
+    }
+    return builder
+  })
+  return { from }
+}
+
+// ---------------------------------------------------------------------------
+// pg 経路のモック: 実 Drizzle の挙動（選択フィールドの展開・等値結合・LEFT JOIN
+// 不一致時のネスト null 化 = mapResultRow の規則）を最小限エミュレートする。
+// WHERE / ORDER BY / LIMIT / OFFSET は postgrest モックと同様に評価しない。
+// テーブルは実 schema オブジェクトそのものをキーにするため、実装が select する
+// 列・結合するテーブルがそのまま射影結果に反映される（列の選び忘れ・結合誤りが
+// 形状差としてテストで検出される）。
+// ---------------------------------------------------------------------------
+
+interface DrizzleMockConfig {
+  /** テーブル（schema オブジェクト）ごとの fixture 行（キーは DB 列名） */
+  tables?: Map<Table, Array<Record<string, unknown>>>
+  /** count() 集計クエリが返す値（メインテーブルごと） */
+  counts?: Map<Table, number>
+  /** クエリ実行時に throw させるエラーのキュー（メインテーブルごと） */
+  errors?: Map<Table, unknown[]>
+}
+
+function createDrizzleDbMock(config: DrizzleMockConfig = {}) {
+  const db = {
+    select: vi.fn((fields?: Record<string, unknown>) => ({
+      from: vi.fn((mainTable: Table) => {
+        const joins: Array<{ table: Table; on: SQL }> = []
+
+        const evaluate = () => {
+          const errorQueue = config.errors?.get(mainTable)
+          if (errorQueue && errorQueue.length > 0) {
+            throw errorQueue.shift()
+          }
+
+          // 行コンテキスト: テーブル → その行（LEFT JOIN 不一致は null）
+          type Ctx = Map<Table, Record<string, unknown> | null>
+          let contexts: Ctx[] = (config.tables?.get(mainTable) ?? []).map(
+            (row) => new Map([[mainTable, row]]) as Ctx
+          )
+
+          // 等値結合の評価: ON 句（eq(colA, colB)）の SQL から Column を取り出す
+          for (const join of joins) {
+            const joinRows = config.tables?.get(join.table) ?? []
+            const onColumns = join.on.queryChunks.filter((chunk): chunk is Column =>
+              is(chunk, Column)
+            )
+            const joinCol = onColumns.find((c) => c.table === (join.table as unknown))
+            const otherCol = onColumns.find((c) => c.table !== (join.table as unknown))
+            if (!joinCol || !otherCol) throw new Error('unsupported join condition in mock')
+            const next: Ctx[] = []
+            for (const ctx of contexts) {
+              const otherRow = ctx.get(otherCol.table as unknown as Table)
+              const otherValue = otherRow ? otherRow[otherCol.name] : null
+              const matches =
+                otherValue == null
+                  ? []
+                  : joinRows.filter((r) => r[joinCol.name] === otherValue)
+              if (matches.length > 0) {
+                for (const match of matches) next.push(new Map(ctx).set(join.table, match))
+              } else {
+                // 対象実装の結合はすべて leftJoin（不一致は null 拡張）
+                next.push(new Map(ctx).set(join.table, null))
+              }
+            }
+            contexts = next
+          }
+
+          // 選択フィールドの射影（実 Drizzle の mapResultRow と同じ規則）:
+          //  - Column → その列の値（LEFT JOIN 不一致行は null）
+          //  - Table → 全列のネストオブジェクト（結合不一致は null）
+          //  - ネスト選択オブジェクト → 由来テーブルの行が無ければ全体が null
+          //  - SQL（count() 等の集計） → counts で設定した値
+          const project = (
+            sel: Record<string, unknown>,
+            ctx: Ctx
+          ): Record<string, unknown> =>
+            Object.fromEntries(
+              Object.entries(sel).map(([key, field]) => {
+                if (is(field, Column)) {
+                  const row = ctx.get(field.table as unknown as Table)
+                  return [key, row ? (row[field.name] ?? null) : null]
+                }
+                if (is(field, Table)) {
+                  const row = ctx.get(field)
+                  if (!row) return [key, null]
+                  return [key, project(getTableColumns(field) as Record<string, unknown>, ctx)]
+                }
+                if (is(field, SQL)) {
+                  return [key, config.counts?.get(mainTable) ?? 0]
+                }
+                const nested = field as Record<string, Column>
+                const first = Object.values(nested)[0]
+                const sourceRow = first ? ctx.get(first.table as unknown as Table) : null
+                return [key, sourceRow ? project(nested, ctx) : null]
+              })
+            )
+
+          const selection = fields ?? (getTableColumns(mainTable) as Record<string, unknown>)
+          // 集計（count() 等）を含む選択は、実 SQL の SELECT count(*) と同じく
+          // マッチ行数に関わらず常に 1 行を返す
+          const hasAggregate = Object.values(selection).some((f) => is(f, SQL))
+          if (hasAggregate) {
+            return [project(selection, new Map())]
+          }
+          return contexts.map((ctx) => project(selection, ctx))
+        }
+
+        const builder: any = {
+          leftJoin: vi.fn((table: Table, on: SQL) => {
+            joins.push({ table, on })
+            return builder
+          }),
+          innerJoin: vi.fn((table: Table, on: SQL) => {
+            joins.push({ table, on })
+            return builder
+          }),
+          where: vi.fn(() => builder),
+          orderBy: vi.fn(() => builder),
+          limit: vi.fn(() => builder),
+          offset: vi.fn(() => builder),
+          then: (onFulfilled: any, onRejected: any) =>
+            Promise.resolve().then(evaluate).then(onFulfilled, onRejected),
+        }
+        return builder
+      }),
+    })),
+  }
+  return db
+}
+
+// ---------------------------------------------------------------------------
+// 実行ヘルパー
+// 環境変数は vi.stubEnv + afterEach unstubAllEnvs（announcements テストと同じ理由:
+// process.env 直接変更はテスト失敗時に他テストへ漏れる）
+// ---------------------------------------------------------------------------
+
+async function runPostgrest<T>(
+  resultsByTable: Record<string, PostgrestResult[]>,
+  run: () => Promise<T>
+) {
+  vi.stubEnv('DB_DRIVER', undefined)
+  const client = createSupabaseClientMock(resultsByTable)
+  vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+  const result = await run()
+  return { result, client }
+}
+
+async function runPg<T>(config: DrizzleMockConfig, run: () => Promise<T>) {
+  vi.stubEnv('DB_DRIVER', 'pg-read')
+  const db = createDrizzleDbMock(config)
+  vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any)
+  const result = await run()
+  return { result, db }
+}
+
+// ---------------------------------------------------------------------------
+// テスト本体
+// ---------------------------------------------------------------------------
+
+describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('getStreamerData', () => {
+    it('同一 fixture で両経路の戻り値が deepEqual になる（cards は created_at 降順）', async () => {
+      const { result: postgrestResult, client } = await runPostgrest(
+        {
+          streamers: [
+            // PostgREST 埋め込み: streamer 行に cards 配列がネストされて返る
+            { data: { ...STREAMER, cards: [CARD_OLD, CARD_NEW] }, error: null },
+          ],
+        },
+        () => getStreamerData('twitch-user-1')
+      )
+      const { result: pgResult, db } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [streamersTable, [STREAMER]],
+            [cardsTable, [CARD_OLD, CARD_NEW]],
+          ]),
+        },
+        () => getStreamerData('twitch-user-1')
+      )
+
+      expect(client.from).toHaveBeenCalledWith('streamers')
+      expect(db.select).toHaveBeenCalledTimes(1)
+      expect(pgResult).toEqual(postgrestResult)
+
+      // JS ソート（created_at 降順）が両経路とも適用されている
+      expect((pgResult as any).cards.map((c: any) => c.id)).toEqual(['card-new', 'card-old'])
+      // streamer には埋め込みの cards キーが残らない（既存実装は分割代入で除去）
+      expect('cards' in (pgResult as any).streamer).toBe(false)
+      expect('cards' in (postgrestResult as any).streamer).toBe(false)
+    })
+
+    it('カード0枚でも両経路とも cards: [] を返す', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        { streamers: [{ data: { ...STREAMER, cards: [] }, error: null }] },
+        () => getStreamerData('twitch-user-1')
+      )
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [streamersTable, [STREAMER]],
+            [cardsTable, []],
+          ]),
+        },
+        () => getStreamerData('twitch-user-1')
+      )
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect((pgResult as any).cards).toEqual([])
+    })
+
+    it('0行（配信者なし）では両経路とも null を返す', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        { streamers: [{ data: null, error: null }] },
+        () => getStreamerData('missing-user')
+      )
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [streamersTable, []],
+            [cardsTable, []],
+          ]),
+        },
+        () => getStreamerData('missing-user')
+      )
+
+      expect(postgrestResult).toBeNull()
+      expect(pgResult).toBeNull()
+    })
+  })
+
+  describe('getStreamerDataPaginated', () => {
+    it('同一 fixture で両経路の戻り値（streamer / cards / pagination）が deepEqual になる', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        {
+          streamers: [{ data: STREAMER, error: null }],
+          // 1回目: count クエリ（head: true, data なし）、2回目: ページ行
+          cards: [
+            { data: null, error: null, count: 3 },
+            { data: [CARD_NEW, CARD_OLD], error: null },
+          ],
+        },
+        () => getStreamerDataPaginated('twitch-user-1', 2, 2)
+      )
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [streamersTable, [STREAMER]],
+            [cardsTable, [CARD_NEW, CARD_OLD]],
+          ]),
+          counts: new Map([[cardsTable, 3]]),
+        },
+        () => getStreamerDataPaginated('twitch-user-1', 2, 2)
+      )
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect((pgResult as any).pagination).toEqual({
+        page: 2,
+        perPage: 2,
+        total: 3,
+        totalPages: 2,
+      })
+    })
+
+    it('0行（配信者なし）では両経路とも null を返す', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        { streamers: [{ data: null, error: null }] },
+        () => getStreamerDataPaginated('missing-user')
+      )
+      const { result: pgResult } = await runPg(
+        { tables: new Map<Table, Array<Record<string, unknown>>>([[streamersTable, []]]) },
+        () => getStreamerDataPaginated('missing-user')
+      )
+
+      expect(postgrestResult).toBeNull()
+      expect(pgResult).toBeNull()
+    })
+  })
+
+  describe('getRecentGachaHistory', () => {
+    it('埋め込み cards が「単一オブジェクト」としてネストされ、両経路で deepEqual になる', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        {
+          gacha_history: [
+            {
+              data: [
+                { ...HISTORY_NEW, cards: CARD_NEW },
+                { ...HISTORY_OLD, cards: CARD_OLD },
+              ],
+              error: null,
+            },
+          ],
+        },
+        () => getRecentGachaHistory()
+      )
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [gachaHistoryTable, [HISTORY_NEW, HISTORY_OLD]],
+            [cardsTable, [CARD_OLD, CARD_NEW]],
+          ]),
+        },
+        () => getRecentGachaHistory()
+      )
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect(pgResult).toHaveLength(2)
+      for (const result of [postgrestResult, pgResult]) {
+        for (const entry of result as any[]) {
+          // cards は多対一 FK 埋め込みなので配列ではなく単一オブジェクト
+          expect(Array.isArray(entry.cards)).toBe(false)
+          expect(entry.cards).toMatchObject({ id: entry.card_id })
+          // 日付は文字列（Date オブジェクトではない）
+          expect(typeof entry.redeemed_at).toBe('string')
+          expect(entry.redeemed_at).not.toBeInstanceOf(Date)
+        }
+      }
+    })
+  })
+
+  describe('getGachaHistoryForStreamer', () => {
+    it('フィルタなし: 履歴 + count のページネーション結果が両経路で deepEqual になる', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        {
+          gacha_history: [
+            {
+              data: [
+                { ...HISTORY_NEW, cards: CARD_NEW },
+                { ...HISTORY_OLD, cards: CARD_OLD },
+              ],
+              error: null,
+              count: 42,
+            },
+          ],
+        },
+        () => getGachaHistoryForStreamer('streamer-1', { page: 2, perPage: 20 })
+      )
+      const { result: pgResult, db } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [gachaHistoryTable, [HISTORY_NEW, HISTORY_OLD]],
+            [cardsTable, [CARD_OLD, CARD_NEW]],
+          ]),
+          counts: new Map([[gachaHistoryTable, 42]]),
+        },
+        () => getGachaHistoryForStreamer('streamer-1', { page: 2, perPage: 20 })
+      )
+
+      // pg 経路は rows / count の2クエリ構成（PostgREST は1リクエストで両方返す）
+      expect(db.select).toHaveBeenCalledTimes(2)
+      expect(pgResult).toEqual(postgrestResult)
+      expect(pgResult.pagination).toEqual({
+        page: 2,
+        perPage: 20,
+        total: 42,
+        totalPages: 3,
+      })
+    })
+
+    it('rarity フィルタ指定時も両経路の戻り値が deepEqual になる', async () => {
+      // フィルタ自体の絞り込みはモックでは評価しない（両経路に同じ「絞り込み済み」
+      // fixture を与える）。pg 経路が cards 列を参照する WHERE を組み立てても
+      // クエリ構築が壊れないこと・形状が変わらないことを検証する。
+      const { result: postgrestResult } = await runPostgrest(
+        {
+          gacha_history: [
+            { data: [{ ...HISTORY_NEW, cards: CARD_NEW }], error: null, count: 1 },
+          ],
+        },
+        () => getGachaHistoryForStreamer('streamer-1', { rarity: 'rare' })
+      )
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [gachaHistoryTable, [HISTORY_NEW]],
+            [cardsTable, [CARD_NEW]],
+          ]),
+          counts: new Map([[gachaHistoryTable, 1]]),
+        },
+        () => getGachaHistoryForStreamer('streamer-1', { rarity: 'rare' })
+      )
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect(pgResult.history[0].cards.rarity).toBe('rare')
+    })
+
+    it('0行では両経路とも history: [] / total 0 / totalPages 0 を返す', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        { gacha_history: [{ data: [], error: null, count: 0 }] },
+        () => getGachaHistoryForStreamer('streamer-1')
+      )
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [gachaHistoryTable, []],
+            [cardsTable, []],
+          ]),
+          counts: new Map([[gachaHistoryTable, 0]]),
+        },
+        () => getGachaHistoryForStreamer('streamer-1')
+      )
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect(pgResult).toEqual({
+        history: [],
+        pagination: { page: 1, perPage: 20, total: 0, totalPages: 0 },
+      })
+    })
+  })
+
+  describe('getGachaHistoryForUser', () => {
+    it('cards（全列）と streamers（twitch_display_name のみ）の入れ子形状が両経路で一致する', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        {
+          gacha_history: [
+            {
+              data: [
+                {
+                  ...HISTORY_NEW,
+                  cards: CARD_NEW,
+                  // 列を絞った埋め込みは、その列だけを持つ単一オブジェクトになる
+                  streamers: { twitch_display_name: 'Streamer One' },
+                },
+              ],
+              error: null,
+              count: 1,
+            },
+          ],
+        },
+        () => getGachaHistoryForUser('viewer-1')
+      )
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [gachaHistoryTable, [HISTORY_NEW]],
+            [cardsTable, [CARD_NEW]],
+            [streamersTable, [STREAMER]],
+          ]),
+          counts: new Map([[gachaHistoryTable, 1]]),
+        },
+        () => getGachaHistoryForUser('viewer-1')
+      )
+
+      expect(pgResult).toEqual(postgrestResult)
+
+      const entry = (pgResult as any).history[0]
+      // streamers は twitch_display_name の 1 キーだけを持つ（全列が漏れて
+      // いないこと = 列を絞った埋め込みの厳密な再現）
+      expect(Object.keys(entry.streamers)).toEqual(['twitch_display_name'])
+      expect(entry.streamers).toEqual({ twitch_display_name: 'Streamer One' })
+      expect(Array.isArray(entry.cards)).toBe(false)
+      expect(typeof entry.redeemed_at).toBe('string')
+    })
+  })
+
+  describe('getActiveCardsForStreamer', () => {
+    it('同一 fixture で両経路の戻り値が deepEqual になる（drop_rate は数値に正規化）', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        { cards: [{ data: [CARD_NEW, CARD_OLD], error: null }] },
+        () => getActiveCardsForStreamer('streamer-1')
+      )
+      const { result: pgResult } = await runPg(
+        { tables: new Map<Table, Array<Record<string, unknown>>>([[cardsTable, [CARD_NEW, CARD_OLD]]]) },
+        () => getActiveCardsForStreamer('streamer-1')
+      )
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect(pgResult).toHaveLength(2)
+      for (const card of pgResult as any[]) {
+        expect(typeof card.drop_rate).toBe('number')
+        expect(typeof card.created_at).toBe('string')
+      }
+    })
+  })
+
+  describe('getActiveCardCountsForStreamers', () => {
+    it('複数配信者の集計 Map（totalActive / activeCardIds Set）が両経路で一致する', async () => {
+      const cardOther = makeCardRow({ id: 'card-other', streamer_id: 'streamer-2' })
+      const { result: postgrestResult } = await runPostgrest(
+        {
+          cards: [
+            {
+              // 既存経路の select("id, streamer_id") は 2 列だけの行を返す
+              data: [
+                { id: 'card-new', streamer_id: 'streamer-1' },
+                { id: 'card-old', streamer_id: 'streamer-1' },
+                { id: 'card-other', streamer_id: 'streamer-2' },
+              ],
+              error: null,
+            },
+          ],
+        },
+        // 重複と falsy はどちらの経路でも除外される
+        () => getActiveCardCountsForStreamers(['streamer-1', 'streamer-2', 'streamer-1', ''])
+      )
+      const { result: pgResult } = await runPg(
+        { tables: new Map<Table, Array<Record<string, unknown>>>([[cardsTable, [CARD_NEW, CARD_OLD, cardOther]]]) },
+        () => getActiveCardCountsForStreamers(['streamer-1', 'streamer-2', 'streamer-1', ''])
+      )
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect(pgResult.get('streamer-1')?.totalActive).toBe(2)
+      expect(pgResult.get('streamer-1')?.activeCardIds).toEqual(new Set(['card-new', 'card-old']))
+      expect(pgResult.get('streamer-2')?.totalActive).toBe(1)
+    })
+
+    it('空入力では両経路ともクエリを発行せず空 Map を返す', async () => {
+      const { result: postgrestResult, client } = await runPostgrest(
+        {},
+        () => getActiveCardCountsForStreamers([])
+      )
+      const { result: pgResult, db } = await runPg(
+        {},
+        () => getActiveCardCountsForStreamers([])
+      )
+
+      expect(postgrestResult.size).toBe(0)
+      expect(pgResult.size).toBe(0)
+      expect(client.from).not.toHaveBeenCalled()
+      expect(db.select).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getStreamerById', () => {
+    it('同一 fixture で両経路の戻り値が deepEqual になる', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        { streamers: [{ data: STREAMER, error: null }] },
+        () => getStreamerById('streamer-1')
+      )
+      const { result: pgResult } = await runPg(
+        { tables: new Map<Table, Array<Record<string, unknown>>>([[streamersTable, [STREAMER]]]) },
+        () => getStreamerById('streamer-1')
+      )
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect(pgResult).toEqual(STREAMER)
+    })
+
+    it('0行では両経路とも null を返す（maybeSingle 相当）', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        { streamers: [{ data: null, error: null }] },
+        () => getStreamerById('missing-id')
+      )
+      const { result: pgResult } = await runPg(
+        { tables: new Map<Table, Array<Record<string, unknown>>>([[streamersTable, []]]) },
+        () => getStreamerById('missing-id')
+      )
+
+      expect(postgrestResult).toBeNull()
+      expect(pgResult).toBeNull()
+    })
+  })
+
+  describe('getUserCardDetail', () => {
+    const USER_ROW = { id: 'user-uuid-1', twitch_user_id: 'viewer-1' }
+
+    it('所持カード: streamers（埋め込み）と streamer（別名）の両キーを含む形状が一致する', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        {
+          cards: [{ data: { ...CARD_NEW, streamers: STREAMER }, error: null }],
+          users: [{ data: { id: 'user-uuid-1' }, error: null }],
+          user_cards: [{ data: null, error: null, count: 2 }],
+        },
+        () => getUserCardDetail('viewer-1', 'streamer-1', 'card-new')
+      )
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [cardsTable, [CARD_NEW]],
+            [streamersTable, [STREAMER]],
+            [usersTable, [USER_ROW]],
+          ]),
+          counts: new Map([[userCardsTable, 2]]),
+        },
+        () => getUserCardDetail('viewer-1', 'streamer-1', 'card-new')
+      )
+
+      expect(pgResult).toEqual(postgrestResult)
+      // 既存実装は spread で埋め込みキー streamers を残したまま streamer を追加する
+      expect(pgResult).toEqual({
+        ...CARD_NEW,
+        streamers: STREAMER,
+        streamer: STREAMER,
+        count: 2,
+      })
+    })
+
+    it('未所持（count 0）では両経路とも null を返す', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        {
+          cards: [{ data: { ...CARD_NEW, streamers: STREAMER }, error: null }],
+          users: [{ data: { id: 'user-uuid-1' }, error: null }],
+          user_cards: [{ data: null, error: null, count: 0 }],
+        },
+        () => getUserCardDetail('viewer-1', 'streamer-1', 'card-new')
+      )
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [cardsTable, [CARD_NEW]],
+            [streamersTable, [STREAMER]],
+            [usersTable, [USER_ROW]],
+          ]),
+          counts: new Map([[userCardsTable, 0]]),
+        },
+        () => getUserCardDetail('viewer-1', 'streamer-1', 'card-new')
+      )
+
+      expect(postgrestResult).toBeNull()
+      expect(pgResult).toBeNull()
+    })
+
+    it('カードなし（0行）では両経路とも null を返す', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        { cards: [{ data: null, error: null }] },
+        () => getUserCardDetail('viewer-1', 'streamer-1', 'missing-card')
+      )
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [cardsTable, []],
+            [streamersTable, [STREAMER]],
+          ]),
+        },
+        () => getUserCardDetail('viewer-1', 'streamer-1', 'missing-card')
+      )
+
+      expect(postgrestResult).toBeNull()
+      expect(pgResult).toBeNull()
+    })
+  })
+
+  describe('getCollectionCompletions', () => {
+    const COMPLETION_ROWS = [
+      { total_cards: 8, completed_at: '2026-03-01T00:00:00.000+00:00', collection_name: null },
+      { total_cards: 5, completed_at: '2026-02-01T00:00:00.000+00:00', collection_name: 'weapons' },
+    ]
+
+    it('collection_name 付きの3列が両経路で deepEqual になる（completed_at は文字列）', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        { collection_completions: [{ data: COMPLETION_ROWS, error: null }] },
+        () => getCollectionCompletions('viewer-1', 'streamer-1')
+      )
+      const { result: pgResult } = await runPg(
+        { tables: new Map<Table, Array<Record<string, unknown>>>([[collectionCompletionsTable, COMPLETION_ROWS]]) },
+        () => getCollectionCompletions('viewer-1', 'streamer-1')
+      )
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect(pgResult).toEqual(COMPLETION_ROWS)
+      for (const record of pgResult) {
+        expect(typeof record.completed_at).toBe('string')
+        expect(record.completed_at).not.toBeInstanceOf(Date)
+      }
+    })
+
+    it('00064 デプロイ窓（collection_name 列欠落）では両経路とも旧列で再取得し null を補完する', async () => {
+      const legacyRows = [{ total_cards: 8, completed_at: '2026-03-01T00:00:00.000+00:00' }]
+      const { result: postgrestResult } = await runPostgrest(
+        {
+          collection_completions: [
+            // 読み取りパスの列欠落は PostgreSQL の 42703
+            {
+              data: null,
+              error: {
+                code: '42703',
+                message: 'column collection_completions.collection_name does not exist',
+              },
+            },
+            { data: legacyRows, error: null },
+          ],
+        },
+        () => getCollectionCompletions('viewer-1', 'streamer-1')
+      )
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([[collectionCompletionsTable, legacyRows]]),
+          errors: new Map([
+            [
+              collectionCompletionsTable,
+              [
+                // postgres.js は SQLSTATE を code に持つエラーを throw する
+                Object.assign(new Error('column "collection_name" does not exist'), {
+                  code: '42703',
+                }),
+              ],
+            ],
+          ]),
+        },
+        () => getCollectionCompletions('viewer-1', 'streamer-1')
+      )
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect(pgResult).toEqual([
+        { total_cards: 8, completed_at: '2026-03-01T00:00:00.000+00:00', collection_name: null },
+      ])
+    })
+
+    it('その他のエラーでは両経路とも空配列を返す', async () => {
+      const { result: postgrestResult } = await runPostgrest(
+        {
+          collection_completions: [
+            { data: null, error: { code: '42501', message: 'permission denied' } },
+          ],
+        },
+        () => getCollectionCompletions('viewer-1', 'streamer-1')
+      )
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([[collectionCompletionsTable, COMPLETION_ROWS]]),
+          errors: new Map([
+            [
+              collectionCompletionsTable,
+              [Object.assign(new Error('permission denied'), { code: '42501' })],
+            ],
+          ]),
+        },
+        () => getCollectionCompletions('viewer-1', 'streamer-1')
+      )
+
+      expect(postgrestResult).toEqual([])
+      expect(pgResult).toEqual([])
+    })
+  })
+
+  describe('フラグ分岐の分離（経路間の相互不可侵）', () => {
+    it('postgrest 経路（フラグ未設定）では getDb が一切呼ばれない', async () => {
+      await runPostgrest(
+        { streamers: [{ data: { ...STREAMER, cards: [] }, error: null }] },
+        () => getStreamerData('twitch-user-1')
+      )
+      expect(getDb).not.toHaveBeenCalled()
+    })
+
+    it('pg 経路では supabase-js クライアントが一切呼ばれない', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      const client = createSupabaseClientMock({})
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+      const db = createDrizzleDbMock({
+        tables: new Map<Table, Array<Record<string, unknown>>>([
+          [streamersTable, [STREAMER]],
+          [cardsTable, []],
+        ]),
+      })
+      vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any)
+
+      const result = await getStreamerData('twitch-user-1')
+
+      expect(result).not.toBeNull()
+      expect(client.from).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/db-client.test.ts
+++ b/tests/unit/db-client.test.ts
@@ -1,0 +1,102 @@
+/**
+ * #570: db/client.ts（接続文字列の解決順・スコープ管理）のテスト
+ *
+ * tests/setup.ts のグローバル throw スタブを unmock して実実装を検証する。
+ * postgres.js は遅延接続（初クエリまで TCP を張らない）のため、クライアント
+ * 生成のみのテストでは実接続は一切発生しない。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// setup.ts が登録する throw スタブを解除し、実装本体をテスト対象にする
+vi.unmock('@/lib/db/client')
+
+// Cloudflare コンテキストは環境依存のためモックで制御する。
+// client.ts は動的 import で解決するが、vi.mock は動的 import にも適用される。
+const mocks = vi.hoisted(() => ({
+  getCloudflareContext: vi.fn(),
+}))
+vi.mock('@opennextjs/cloudflare', () => ({
+  getCloudflareContext: mocks.getCloudflareContext,
+}))
+
+/** モジュール状態（Node シングルトン等）をテストごとにリセットして import する */
+async function importClient() {
+  return await import('@/lib/db/client')
+}
+
+describe('getDb (#570 client.ts)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mocks.getCloudflareContext.mockReset()
+  })
+
+  // 環境変数は vi.stubEnv で設定し vi.unstubAllEnvs で確実に復元する
+  // （直接 mutation はテスト失敗時に他テストへ漏れるため）
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('Workers: HYPERDRIVE バインディングの接続文字列を最優先で使う', async () => {
+    // DATABASE_URL も設定されている状態で HYPERDRIVE 側が勝つことを検証
+    vi.stubEnv('DATABASE_URL', 'postgres://user:pass@local-host:5432/localdb')
+    const ctx = { waitUntil: vi.fn() }
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: { HYPERDRIVE: { connectionString: 'postgres://user:pass@hyperdrive-host:5432/hyperdb' } },
+      ctx,
+    })
+
+    const { getDb } = await importClient()
+    const handle = await getDb()
+
+    expect((handle.sql as any).options.host).toEqual(['hyperdrive-host'])
+    expect((handle.sql as any).options.max).toBe(5)
+  })
+
+  it('Workers: 同一リクエスト（同一 ctx）ではハンドルを再利用し、別リクエストでは新規生成する', async () => {
+    vi.stubEnv('DATABASE_URL', 'postgres://user:pass@local-host:5432/localdb')
+    const ctxA = { waitUntil: vi.fn() }
+    const ctxB = { waitUntil: vi.fn() }
+    mocks.getCloudflareContext.mockResolvedValue({ env: {}, ctx: ctxA })
+
+    const { getDb } = await importClient()
+    const first = await getDb()
+    const second = await getDb()
+    expect(second).toBe(first)
+
+    // 別リクエスト（別の ExecutionContext）では新しいハンドル
+    mocks.getCloudflareContext.mockResolvedValue({ env: {}, ctx: ctxB })
+    const third = await getDb()
+    expect(third).not.toBe(first)
+  })
+
+  it('Node フォールバック: getCloudflareContext が throw したら DATABASE_URL のシングルトンを使う', async () => {
+    vi.stubEnv('DATABASE_URL', 'postgres://user:pass@dev-host:5432/devdb')
+    mocks.getCloudflareContext.mockRejectedValue(new Error('not in cloudflare context'))
+
+    const { getDb } = await importClient()
+    const first = await getDb()
+    const second = await getDb()
+
+    expect((first.sql as any).options.host).toEqual(['dev-host'])
+    // Node ではモジュールシングルトン（同一ハンドル再利用）
+    expect(second).toBe(first)
+  })
+
+  it('接続先が未設定（HYPERDRIVE なし・DATABASE_URL なし）なら文脈が分かるメッセージで throw する', async () => {
+    vi.stubEnv('DATABASE_URL', undefined)
+    mocks.getCloudflareContext.mockResolvedValue({ env: {}, ctx: { waitUntil: vi.fn() } })
+
+    const { getDb } = await importClient()
+    await expect(getDb()).rejects.toThrow(/HYPERDRIVE|DATABASE_URL/)
+    // postgrest へ戻す手段（DB_DRIVER を外す）がメッセージから分かること
+    await expect(getDb()).rejects.toThrow(/DB_DRIVER/)
+  })
+
+  it('Node フォールバックでも接続先未設定なら throw する', async () => {
+    vi.stubEnv('DATABASE_URL', undefined)
+    mocks.getCloudflareContext.mockRejectedValue(new Error('not in cloudflare context'))
+
+    const { getDb } = await importClient()
+    await expect(getDb()).rejects.toThrow(/DATABASE_URL/)
+  })
+})

--- a/tests/unit/db-errors.test.ts
+++ b/tests/unit/db-errors.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isPgFunctionNotFoundError,
+  isPgMissingColumnError,
+  isPgMissingTableError,
+  isPgUniqueViolationError,
+} from '@/lib/db/errors'
+
+/** postgres.js が throw するエラー（code = SQLSTATE）を模倣する */
+function pgError(code: string): Error & { code: string } {
+  return Object.assign(new Error(`SQLSTATE ${code}`), { code })
+}
+
+describe('db/errors SQLSTATE 判定', () => {
+  it('isPgMissingColumnError: 42703 のみ true', () => {
+    expect(isPgMissingColumnError(pgError('42703'))).toBe(true)
+    expect(isPgMissingColumnError(pgError('42P01'))).toBe(false)
+    expect(isPgMissingColumnError(pgError('23505'))).toBe(false)
+  })
+
+  it('isPgFunctionNotFoundError: 42883 のみ true', () => {
+    expect(isPgFunctionNotFoundError(pgError('42883'))).toBe(true)
+    expect(isPgFunctionNotFoundError(pgError('42703'))).toBe(false)
+  })
+
+  it('isPgUniqueViolationError: 23505 のみ true', () => {
+    expect(isPgUniqueViolationError(pgError('23505'))).toBe(true)
+    expect(isPgUniqueViolationError(pgError('23503'))).toBe(false)
+  })
+
+  it('isPgMissingTableError: 42P01 のみ true', () => {
+    expect(isPgMissingTableError(pgError('42P01'))).toBe(true)
+    expect(isPgMissingTableError(pgError('42703'))).toBe(false)
+  })
+})
+
+describe('db/errors unknown 安全性', () => {
+  const guards = [
+    isPgMissingColumnError,
+    isPgFunctionNotFoundError,
+    isPgUniqueViolationError,
+    isPgMissingTableError,
+  ]
+
+  it.each(guards.map((g) => [g.name, g] as const))(
+    '%s は null / undefined / 文字列 / code なしでも例外を出さず false',
+    (_name, guard) => {
+      expect(guard(null)).toBe(false)
+      expect(guard(undefined)).toBe(false)
+      expect(guard('42703')).toBe(false)
+      expect(guard(42703)).toBe(false)
+      expect(guard(new Error('no code'))).toBe(false)
+      // code が数値（SQLSTATE は文字列でなければならない）
+      expect(guard(Object.assign(new Error('x'), { code: 42703 }))).toBe(false)
+    }
+  )
+})

--- a/tests/unit/db-flags.test.ts
+++ b/tests/unit/db-flags.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  getDbDriverMode,
+  getGachaDbDriver,
+  isPgReadEnabled,
+  isPgWriteEnabled,
+} from '@/lib/db/flags'
+
+// 環境変数は vi.stubEnv で設定し afterEach の vi.unstubAllEnvs で確実に復元する。
+// process.env への直接 mutation は、テスト失敗時に復元されず他テストへ漏れる
+// 構造的リスクがある（vitest の推奨パターンに従う）。
+// vi.stubEnv(name, undefined) は「その変数が未設定」の状態を再現する。
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('getDbDriverMode', () => {
+  it('未設定なら postgrest（完全従来動作がデフォルト）', () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    expect(getDbDriverMode()).toBe('postgrest')
+  })
+
+  it('DB_DRIVER=pg-read を返す', () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    expect(getDbDriverMode()).toBe('pg-read')
+  })
+
+  it('DB_DRIVER=pg を返す', () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    expect(getDbDriverMode()).toBe('pg')
+  })
+
+  it('DB_DRIVER=postgrest を返す', () => {
+    vi.stubEnv('DB_DRIVER', 'postgrest')
+    expect(getDbDriverMode()).toBe('postgrest')
+  })
+
+  it('不正値は postgrest に倒す', () => {
+    vi.stubEnv('DB_DRIVER', 'mysql')
+    expect(getDbDriverMode()).toBe('postgrest')
+  })
+
+  it('空文字は postgrest に倒す', () => {
+    vi.stubEnv('DB_DRIVER', '')
+    expect(getDbDriverMode()).toBe('postgrest')
+  })
+
+  it('前後の空白・改行は無視される（wrangler secret put の混入対策）', () => {
+    vi.stubEnv('DB_DRIVER', ' pg\n')
+    expect(getDbDriverMode()).toBe('pg')
+    vi.stubEnv('DB_DRIVER', '\tpg-read ')
+    expect(getDbDriverMode()).toBe('pg-read')
+  })
+
+  it('呼び出しのたびに process.env を読む（モジュールキャッシュしない）', () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    expect(getDbDriverMode()).toBe('postgrest')
+    // OpenNext の populateProcessEnv のように「後から」env が注入されても反映される
+    vi.stubEnv('DB_DRIVER', 'pg')
+    expect(getDbDriverMode()).toBe('pg')
+  })
+})
+
+describe('isPgReadEnabled', () => {
+  it('未設定なら false', () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    expect(isPgReadEnabled()).toBe(false)
+  })
+
+  it('postgrest なら false', () => {
+    vi.stubEnv('DB_DRIVER', 'postgrest')
+    expect(isPgReadEnabled()).toBe(false)
+  })
+
+  it('pg-read なら true', () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    expect(isPgReadEnabled()).toBe(true)
+  })
+
+  it('pg なら true', () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    expect(isPgReadEnabled()).toBe(true)
+  })
+})
+
+describe('isPgWriteEnabled', () => {
+  it('未設定なら false', () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    expect(isPgWriteEnabled()).toBe(false)
+  })
+
+  it('pg-read では false（書き込みは PostgREST のまま）', () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    expect(isPgWriteEnabled()).toBe(false)
+  })
+
+  it('pg なら true', () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    expect(isPgWriteEnabled()).toBe(true)
+  })
+})
+
+describe('getGachaDbDriver', () => {
+  it('両方未設定なら postgrest', () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    vi.stubEnv('GACHA_DB_DRIVER', undefined)
+    expect(getGachaDbDriver()).toBe('postgrest')
+  })
+
+  it('GACHA_DB_DRIVER 未設定 + DB_DRIVER=pg なら pg（全体フラグに従う）', () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    vi.stubEnv('GACHA_DB_DRIVER', undefined)
+    expect(getGachaDbDriver()).toBe('pg')
+  })
+
+  it('GACHA_DB_DRIVER 未設定 + DB_DRIVER=pg-read なら postgrest（読み取り専用モードでは書き込みは旧経路）', () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    vi.stubEnv('GACHA_DB_DRIVER', undefined)
+    expect(getGachaDbDriver()).toBe('postgrest')
+  })
+
+  it('GACHA_DB_DRIVER=postgrest は DB_DRIVER=pg より優先される（緊急ロールバック）', () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    vi.stubEnv('GACHA_DB_DRIVER', 'postgrest')
+    expect(getGachaDbDriver()).toBe('postgrest')
+  })
+
+  it('GACHA_DB_DRIVER=pg は DB_DRIVER 未設定でも優先される（先行切替）', () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    vi.stubEnv('GACHA_DB_DRIVER', 'pg')
+    expect(getGachaDbDriver()).toBe('pg')
+  })
+
+  it('GACHA_DB_DRIVER が不正値なら全体フラグにフォールバックする', () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    vi.stubEnv('GACHA_DB_DRIVER', 'invalid')
+    expect(getGachaDbDriver()).toBe('pg')
+
+    vi.stubEnv('DB_DRIVER', undefined)
+    expect(getGachaDbDriver()).toBe('postgrest')
+  })
+
+  it('GACHA_DB_DRIVER の前後空白・改行は無視される（緊急ロールバック時の混入対策）', () => {
+    // インシデント対応中の 'postgrest\n' 混入でロールバックが無効化されないこと
+    vi.stubEnv('DB_DRIVER', 'pg')
+    vi.stubEnv('GACHA_DB_DRIVER', 'postgrest\n')
+    expect(getGachaDbDriver()).toBe('postgrest')
+  })
+})

--- a/tests/unit/db-retry.test.ts
+++ b/tests/unit/db-retry.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { isRetryableDbError, withDbRetry } from '@/lib/db/retry'
+import { logger } from '@/lib/logger'
+
+// loggerモック（supabase-retry.test.ts と同じスタイル）
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+
+/** postgres.js が throw するエラー（code プロパティ付き）を模倣する */
+function pgError(code: string, message = `error ${code}`): Error & { code: string } {
+  return Object.assign(new Error(message), { code })
+}
+
+describe('isRetryableDbError', () => {
+  it.each([
+    'CONNECTION_CLOSED',
+    'CONNECTION_ENDED',
+    'CONNECTION_DESTROYED',
+    'CONNECT_TIMEOUT',
+  ])('postgres.js の接続断系コード %s はリトライ対象', (code) => {
+    expect(isRetryableDbError(pgError(code))).toBe(true)
+  })
+
+  it.each(['ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'EPIPE'])(
+    'Node のソケット系コード %s はリトライ対象',
+    (code) => {
+      expect(isRetryableDbError(pgError(code))).toBe(true)
+    }
+  )
+
+  it.each(['57P01', '57P02', '57P03', '53300', '08006', '08001', '08003'])(
+    'PG 一時障害系 SQLSTATE %s はリトライ対象',
+    (code) => {
+      expect(isRetryableDbError(pgError(code))).toBe(true)
+    }
+  )
+
+  it('Workers のリクエストスコープ破棄エラー（メッセージで識別）はリトライ対象', () => {
+    expect(
+      isRetryableDbError(
+        new Error('Cannot perform I/O on behalf of a different request')
+      )
+    ).toBe(true)
+  })
+
+  it.each([
+    ['23505 unique_violation（恒久的エラー）', pgError('23505')],
+    ['42703 undefined_column（恒久的エラー）', pgError('42703')],
+    ['code なしの一般 Error', new Error('boom')],
+    ['数値 code', Object.assign(new Error('x'), { code: 57 })],
+  ])('%s はリトライ対象外', (_label, error) => {
+    expect(isRetryableDbError(error)).toBe(false)
+  })
+
+  it('unknown 安全性: null / undefined / 文字列を食わせても false', () => {
+    expect(isRetryableDbError(null)).toBe(false)
+    expect(isRetryableDbError(undefined)).toBe(false)
+    expect(isRetryableDbError('CONNECTION_CLOSED')).toBe(false)
+  })
+})
+
+describe('withDbRetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('成功時はリトライせずそのまま返す', async () => {
+    const queryFn = vi.fn().mockResolvedValue([{ id: '1' }])
+    const result = await withDbRetry(queryFn, 'test', { idempotent: true })
+    expect(result).toEqual([{ id: '1' }])
+    expect(queryFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('非冪等（既定）は接続断エラーでもリトライせず即 throw する', async () => {
+    const error = pgError('CONNECTION_CLOSED')
+    const queryFn = vi.fn().mockRejectedValue(error)
+    await expect(withDbRetry(queryFn, 'test')).rejects.toBe(error)
+    expect(queryFn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('idempotent: true なら接続断エラーでリトライし、回復したら値を返す', async () => {
+    const queryFn = vi
+      .fn()
+      .mockRejectedValueOnce(pgError('CONNECTION_CLOSED'))
+      .mockResolvedValueOnce([{ id: '1' }])
+    const result = await withDbRetry(queryFn, 'test', {
+      idempotent: true,
+      delays: [0, 0, 0],
+    })
+    expect(result).toEqual([{ id: '1' }])
+    expect(queryFn).toHaveBeenCalledTimes(2)
+    // ログに [db:pg] 観測タグが付くこと
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('[db:pg] test failed (attempt 1/4)'),
+      expect.objectContaining({ code: 'CONNECTION_CLOSED' })
+    )
+  })
+
+  it('idempotent: true でも恒久的エラー（23505）は即 throw する', async () => {
+    const error = pgError('23505')
+    const queryFn = vi.fn().mockRejectedValue(error)
+    await expect(
+      withDbRetry(queryFn, 'test', { idempotent: true, delays: [0, 0, 0] })
+    ).rejects.toBe(error)
+    expect(queryFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('cross-request I/O エラーは idempotent: true でリトライされる', async () => {
+    const queryFn = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error('Cannot perform I/O on behalf of a different request')
+      )
+      .mockResolvedValueOnce('ok')
+    const result = await withDbRetry(queryFn, 'test', {
+      idempotent: true,
+      delays: [0],
+    })
+    expect(result).toBe('ok')
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('maxRetries に到達したら最後のエラーを throw する（初回 + maxRetries 回）', async () => {
+    const error = pgError('ECONNRESET')
+    const queryFn = vi.fn().mockRejectedValue(error)
+    await expect(
+      withDbRetry(queryFn, 'test', {
+        idempotent: true,
+        maxRetries: 2,
+        delays: [0, 0],
+      })
+    ).rejects.toBe(error)
+    expect(queryFn).toHaveBeenCalledTimes(3)
+  })
+
+  it('既定の delays は [100, 300, 1000]（supabase/retry.ts と同一）で進行する', async () => {
+    vi.useFakeTimers()
+    const queryFn = vi.fn().mockRejectedValue(pgError('CONNECTION_CLOSED'))
+    const promise = withDbRetry(queryFn, 'test', { idempotent: true })
+    // rejection を先に捕捉しておく（unhandled rejection 防止）
+    const settled = promise.catch((e: unknown) => e)
+
+    // 初回失敗まで進める
+    await vi.advanceTimersByTimeAsync(0)
+    expect(queryFn).toHaveBeenCalledTimes(1)
+
+    // 100ms 後に 2 回目
+    await vi.advanceTimersByTimeAsync(100)
+    expect(queryFn).toHaveBeenCalledTimes(2)
+
+    // さらに 300ms 後に 3 回目
+    await vi.advanceTimersByTimeAsync(300)
+    expect(queryFn).toHaveBeenCalledTimes(3)
+
+    // さらに 1000ms 後に 4 回目（初回 + 3 リトライで打ち切り）
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(queryFn).toHaveBeenCalledTimes(4)
+
+    const result = await settled
+    expect(result).toMatchObject({ code: 'CONNECTION_CLOSED' })
+  })
+
+  it('delays より attempt が多い場合は最後の delay を使い続ける', async () => {
+    const queryFn = vi
+      .fn()
+      .mockRejectedValueOnce(pgError('CONNECTION_CLOSED'))
+      .mockRejectedValueOnce(pgError('CONNECTION_CLOSED'))
+      .mockResolvedValueOnce('ok')
+    // delays 1 要素 + maxRetries 2 → 2 回目のリトライも delays[0] を使う
+    const result = await withDbRetry(queryFn, 'test', {
+      idempotent: true,
+      maxRetries: 2,
+      delays: [0],
+    })
+    expect(result).toBe('ok')
+    expect(queryFn).toHaveBeenCalledTimes(3)
+  })
+})

--- a/tests/unit/overlay-events-api-pg.test.ts
+++ b/tests/unit/overlay-events-api-pg.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Issue #571 (#570 パイロット踏襲): overlay ポーリング API の pg 直結経路テスト。
+ *
+ * tests/unit/overlay-events-api.test.ts (既存 postgrest 経路のテスト、無変更) と
+ * tests/unit/announcements-driver-parity.test.ts (pg/postgrest 形状互換テストの
+ * 確立パターン) の両方を踏襲する。DB_DRIVER フラグで分岐する pg 経路について:
+ *   1. 応答形状が既存 postgrest 経路と deepEqual であること
+ *   2. reward_id 列欠落(42703, Issue #591 デプロイ窓)フォールバック
+ *   3. 0 イベント時
+ *   4. since カーソルの往復互換(pg のテキスト形式 redeemedAt がクライアント側
+ *      Date.parse 正規化を経て次回 since として問題なく受理されること)
+ * を検証する。フルスイートは実行せず、このファイル(と関連する変更分)のみを対象とする。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/overlay/[streamerId]/events/route";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { getDb } from "@/lib/db/client";
+import { createMockQueryBuilder } from "../utils/supabase-mock";
+
+vi.mock("@/lib/rate-limit");
+vi.mock("@/lib/supabase/admin", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/supabase/admin")>();
+  return { ...actual, getSupabaseAdmin: vi.fn() };
+});
+vi.mock("@/lib/sentry/error-handler", () => ({
+  reportError: vi.fn(),
+  reportApiError: vi.fn(),
+  logErrorFromLogger: vi.fn(),
+}));
+// @/lib/db/client の getDb は tests/setup.ts でグローバルに throw するスタブとして
+// モック済み(DB_DRIVER 既定=postgrestでは呼ばれないことを保証するため)。
+// pg 経路をテストする本ファイルでは vi.mocked(getDb).mockResolvedValue(...) で
+// 個別に上書きする(announcements-driver-parity.test.ts と同じ方式)。
+
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin);
+
+function createRequest(streamerId: string, params: Record<string, string> = {}): NextRequest {
+  const url = new URL(`http://localhost/api/overlay/${streamerId}/events`);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+  return new NextRequest(url);
+}
+
+function createRouteParams(streamerId: string) {
+  return { params: Promise.resolve({ streamerId }) };
+}
+
+/** postgrest(supabase-js) 経路の gacha_history クエリモック。既存テストと同形式。 */
+function createHistoryQuery(response: { data: unknown; error: unknown }) {
+  const q = createMockQueryBuilder();
+  (q as unknown as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
+    resolve(response);
+    return q;
+  };
+  return q;
+}
+
+/**
+ * pg 直結(Drizzle)経路のモック。
+ * db.select(fields).from(table).leftJoin(table2, cond).where(cond).orderBy(cond).limit(n)
+ * を await できる thenable にする。fixture 行(あらかじめ gacha_history + cards を
+ * 手動 join した flat 行)から fields のキーだけを射影して返すことで、実装が
+ * 列を選び忘れた場合にテストが落ちるようにする
+ * (announcements-driver-parity.test.ts の createDrizzleDbMock と同じ方針)。
+ * responses は呼び出し回数ごとの応答(行 or エラー)を並べた配列で、
+ * reward_id 列欠落フォールバックの「1回目失敗・2回目成功」を再現できる。
+ */
+function createDrizzleOverlayDbMock(
+  responses: Array<{ rows?: Record<string, unknown>[]; error?: unknown }>
+) {
+  let callCount = 0;
+  const select = vi.fn((fields: Record<string, unknown>) => {
+    const builder: any = {
+      from: vi.fn(() => builder),
+      leftJoin: vi.fn(() => builder),
+      where: vi.fn(() => builder),
+      orderBy: vi.fn(() => builder),
+      limit: vi.fn(() => {
+        const response = responses[Math.min(callCount, responses.length - 1)];
+        callCount += 1;
+        if (response.error) {
+          return Promise.reject(response.error);
+        }
+        const projected = (response.rows ?? []).map((row) =>
+          Object.fromEntries(Object.keys(fields).map((key) => [key, row[key]]))
+        );
+        return Promise.resolve(projected);
+      }),
+    };
+    return builder;
+  });
+  return { select };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCheckRateLimit.mockResolvedValue({
+    success: true,
+    limit: 120,
+    remaining: 119,
+    reset: Date.now() + 60000,
+  });
+});
+
+afterEach(() => {
+  // db-flags.test.ts 等と同じ変数を扱うため、他テストへ漏れないよう必ず復元する
+  vi.unstubAllEnvs();
+});
+
+// ---------------------------------------------------------------------------
+// 1. 応答形状: postgrest 経路と pg 経路で deepEqual
+// ---------------------------------------------------------------------------
+describe("GET /api/overlay/[streamerId]/events: pg 経路の応答形状互換 (#571)", () => {
+  // 同一の論理データを postgrest 用(nested cards)・pg 用(flat 列)それぞれの
+  // fixture として用意する。h3 は一致するカードが無い行(cards/card_id が null)で、
+  // 両経路とも resolveCard によりフィルタされ events に含まれないことも検証する。
+  const POSTGREST_ROWS = [
+    {
+      id: "h1",
+      event_id: "event-1",
+      redeemed_at: "2026-01-01T00:00:01.000Z",
+      user_twitch_username: "viewer1",
+      reward_id: "reward-abc",
+      cards: { id: "c1", name: "Card1", description: "desc1", image_url: "https://example.com/1.png", rarity: "rare" },
+    },
+    {
+      id: "h2",
+      event_id: null,
+      redeemed_at: "2026-01-01T00:00:02.000Z",
+      user_twitch_username: null,
+      reward_id: null,
+      cards: { id: "c2", name: "Card2", description: null, image_url: null, rarity: "common" },
+    },
+    {
+      id: "h3",
+      event_id: "event-3",
+      redeemed_at: "2026-01-01T00:00:03.000Z",
+      user_twitch_username: "viewer3",
+      reward_id: null,
+      cards: null,
+    },
+  ];
+
+  const PG_ROWS = [
+    {
+      id: "h1",
+      event_id: "event-1",
+      redeemed_at: "2026-01-01T00:00:01.000Z",
+      user_twitch_username: "viewer1",
+      reward_id: "reward-abc",
+      card_id: "c1",
+      card_name: "Card1",
+      card_description: "desc1",
+      card_image_url: "https://example.com/1.png",
+      card_rarity: "rare",
+    },
+    {
+      id: "h2",
+      event_id: null,
+      redeemed_at: "2026-01-01T00:00:02.000Z",
+      user_twitch_username: null,
+      reward_id: null,
+      card_id: "c2",
+      card_name: "Card2",
+      card_description: null,
+      card_image_url: null,
+      card_rarity: "common",
+    },
+    {
+      id: "h3",
+      event_id: "event-3",
+      redeemed_at: "2026-01-01T00:00:03.000Z",
+      user_twitch_username: "viewer3",
+      reward_id: null,
+      card_id: null,
+      card_name: null,
+      card_description: null,
+      card_image_url: null,
+      card_rarity: null,
+    },
+  ];
+
+  const EXPECTED_EVENTS = [
+    {
+      id: "h1",
+      eventId: "event-1",
+      redeemedAt: "2026-01-01T00:00:01.000Z",
+      userTwitchUsername: "viewer1",
+      rewardId: "reward-abc",
+      card: { id: "c1", name: "Card1", description: "desc1", image_url: "https://example.com/1.png", rarity: "rare" },
+    },
+    {
+      id: "h2",
+      eventId: null,
+      redeemedAt: "2026-01-01T00:00:02.000Z",
+      userTwitchUsername: "Unknown",
+      rewardId: null,
+      card: { id: "c2", name: "Card2", description: null, image_url: null, rarity: "common" },
+    },
+  ];
+
+  async function runPostgrestPath() {
+    vi.stubEnv("DB_DRIVER", undefined);
+    const historyQuery = createHistoryQuery({ data: POSTGREST_ROWS, error: null });
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn(() => historyQuery),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>);
+    const res = await GET(
+      createRequest("streamer-1", { since: "2026-01-01T00:00:00.000Z" }),
+      createRouteParams("streamer-1")
+    );
+    return { res, body: await res.json() };
+  }
+
+  async function runPgPath() {
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    const db = createDrizzleOverlayDbMock([{ rows: PG_ROWS }]);
+    vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any);
+    const res = await GET(
+      createRequest("streamer-1", { since: "2026-01-01T00:00:00.000Z" }),
+      createRouteParams("streamer-1")
+    );
+    return { res, body: await res.json(), db };
+  }
+
+  it("同一データで両経路の応答 JSON が deepEqual になる(card入れ子・キー名・日付文字列含む)", async () => {
+    const { res: postgrestRes, body: postgrestBody } = await runPostgrestPath();
+    const { res: pgRes, body: pgBody } = await runPgPath();
+
+    expect(postgrestRes.status).toBe(200);
+    expect(pgRes.status).toBe(200);
+    expect(pgBody.events).toEqual(postgrestBody.events);
+    expect(postgrestBody.events).toEqual(EXPECTED_EVENTS);
+
+    // redeemedAt は両経路とも文字列(Dateオブジェクトではない)
+    for (const body of [postgrestBody, pgBody]) {
+      for (const event of body.events) {
+        expect(typeof event.redeemedAt).toBe("string");
+      }
+    }
+  });
+
+  it("postgrest 経路(フラグ未設定)では getDb が一切呼ばれない(挙動不変の検証)", async () => {
+    await runPostgrestPath();
+    expect(getDb).not.toHaveBeenCalled();
+  });
+
+  it("pg 経路では supabase-js クライアントが一切呼ばれない", async () => {
+    const { db } = await runPgPath();
+    expect(mockGetSupabaseAdmin).not.toHaveBeenCalled();
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. reward_id 列欠落フォールバック (Issue #591 相当, pg版)
+// ---------------------------------------------------------------------------
+describe("GET /api/overlay/[streamerId]/events: pg経路のreward_id列欠落フォールバック (Issue #591)", () => {
+  it("42703(列欠落)時は列無しクエリへフォールバックしrewardId:nullを返す", async () => {
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    const db = createDrizzleOverlayDbMock([
+      { error: { code: "42703", message: 'column "reward_id" of relation "gacha_history" does not exist' } },
+      {
+        rows: [
+          {
+            id: "h4",
+            event_id: "event-4",
+            redeemed_at: "2026-01-01T00:00:04.000Z",
+            user_twitch_username: "viewer4",
+            card_id: "c4",
+            card_name: "Card4",
+            card_description: null,
+            card_image_url: null,
+            card_rarity: "epic",
+          },
+        ],
+      },
+    ]);
+    vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any);
+
+    const res = await GET(
+      createRequest("streamer-1", { since: "2026-01-01T00:00:00.000Z" }),
+      createRouteParams("streamer-1")
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].rewardId).toBeNull();
+    expect(db.select).toHaveBeenCalledTimes(2);
+  });
+
+  it("列欠落以外のエラーはフォールバックせずhandleDatabaseError経由で500を返す", async () => {
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    // 42601(syntax_error)は retry.ts の RETRYABLE_SQLSTATES に含まれない
+    // 恒久的エラーの例(08006 等の一時障害系コードだと withDbRetry が
+    // 正しくリトライしてしまい、このテストの意図(列欠落以外は即エラー)
+    // と噛み合わないため、恒久的エラーを選ぶ)。
+    const db = createDrizzleOverlayDbMock([
+      { error: { code: "42601", message: "syntax error" } },
+    ]);
+    vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any);
+
+    const res = await GET(
+      createRequest("streamer-1", { since: "2026-01-01T00:00:00.000Z" }),
+      createRouteParams("streamer-1")
+    );
+
+    expect(res.status).toBe(500);
+    // フォールバックは発生せず、withDbRetry も恒久的エラーとしてリトライせず
+    // 1回で即 throw する(isRetryableDbError が 42601 を非対象と判定するため)。
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it("接続断等の一時障害(08006)はmaxRetries:1の設定どおり1回だけ再試行して500を返す", async () => {
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    vi.useFakeTimers();
+    try {
+      // 08006(connection_failure)は retry.ts の RETRYABLE_SQLSTATES に含まれる
+      // 一時障害系コード。自己レビュー指摘への対応として、既存postgrest経路と
+      // 同じ maxRetries: 1(このエンドポイント固有のチューニング。3秒間隔の
+      // ポーリングで既定の3回リトライだと最大約1.4秒応答が遅延するため)を
+      // pg経路にも明示指定している。ここでは「1回だけ」再試行して打ち切る
+      // ことを検証する(fake timers で実時間の遅延を待たずに検証)。
+      const db = createDrizzleOverlayDbMock([
+        { error: { code: "08006", message: "connection reset" } },
+      ]);
+      vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any);
+
+      const resPromise = GET(
+        createRequest("streamer-1", { since: "2026-01-01T00:00:00.000Z" }),
+        createRouteParams("streamer-1")
+      );
+      await vi.runAllTimersAsync();
+      const res = await resPromise;
+
+      expect(res.status).toBe(500);
+      // 初回 + リトライ1回(maxRetries:1) = 2回
+      expect(db.select).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reward_id以外の列が欠落した42703(想定外のスキーマドリフト)はフォールバックしない", async () => {
+    // 自己レビュー指摘への対応: isPgMissingColumnError() だけで判定すると
+    // 列名を問わず true になり、reward_id とは無関係な列欠落まで
+    // 「reward_id フォールバック」だと誤認して無駄なフォールバッククエリを
+    // 発行してしまう。isMissingRewardIdColumnErrorPg はエラーメッセージに
+    // "reward_id" を含むかを追加で見るため、この誤発火が起きないことを検証する。
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    const db = createDrizzleOverlayDbMock([
+      { error: { code: "42703", message: 'column "user_twitch_username" of relation "gacha_history" does not exist' } },
+    ]);
+    vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any);
+
+    const res = await GET(
+      createRequest("streamer-1", { since: "2026-01-01T00:00:00.000Z" }),
+      createRouteParams("streamer-1")
+    );
+
+    expect(res.status).toBe(500);
+    // フォールバッククエリは発行されない(1回のみ)
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. 0 イベント時 (pg版)
+// ---------------------------------------------------------------------------
+describe("GET /api/overlay/[streamerId]/events: pg経路の0件応答", () => {
+  it("新着イベントが無い場合 events: [] を返す", async () => {
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    const db = createDrizzleOverlayDbMock([{ rows: [] }]);
+    vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any);
+
+    const res = await GET(
+      createRequest("streamer-1", { since: "2026-01-01T00:00:00.000Z" }),
+      createRouteParams("streamer-1")
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toEqual([]);
+    expect(body.overlayVersion).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. since カーソルの往復互換
+// ---------------------------------------------------------------------------
+describe("GET /api/overlay/[streamerId]/events: pg経路のredeemedAt/sinceカーソル往復互換", () => {
+  it("PGテキスト形式のredeemedAtがクライアント正規化(Date.parse→toISOString)を経て次回sinceとして受理される", async () => {
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    // pg 直結はスペース区切り・マイクロ秒精度の PG テキスト形式で timestamptz を返す
+    // (drizzle-orm/postgres-js がパーサをパススルーに上書きするため。
+    // src/lib/db/client.ts のコメント参照)。PostgREST の T区切りISO8601とは
+    // 表現が異なるが、overlay クライアント(page.tsx の pollOverlayEvents)は
+    // Date.parse() 経由でのみこの値を消費するため、ここでは同じ正規化ロジックを
+    // 再現して破綻しないことを検証する。
+    const db = createDrizzleOverlayDbMock([
+      {
+        rows: [
+          {
+            id: "h5",
+            event_id: "event-5",
+            redeemed_at: "2026-01-01 00:00:01.654321+00",
+            user_twitch_username: "viewer5",
+            reward_id: null,
+            card_id: "c5",
+            card_name: "Card5",
+            card_description: null,
+            card_image_url: null,
+            card_rarity: "legendary",
+          },
+        ],
+      },
+    ]);
+    vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any);
+
+    const res = await GET(
+      createRequest("streamer-1", { since: "2026-01-01T00:00:00.000Z" }),
+      createRouteParams("streamer-1")
+    );
+    const body = await res.json();
+    const redeemedAt: string = body.events[0].redeemedAt;
+
+    // overlay クライアントの pollOverlayEvents と同じ正規化: Date.parse が
+    // 有限値を返すこと(=パース破綻しないこと)、かつ toISOString() で
+    // 意図した瞬間に一致すること。
+    const ms = Date.parse(redeemedAt);
+    expect(Number.isFinite(ms)).toBe(true);
+    const nextSince = new Date(ms).toISOString();
+    expect(nextSince).toBe("2026-01-01T00:00:01.654Z");
+
+    // その nextSince を次回ポーリングの ?since= としてそのまま渡しても
+    // 400(Invalid since parameter)にならず正常に受理されること
+    // (normalizeDateParam との往復互換。既存の共有ロジックで無変更)。
+    const db2 = createDrizzleOverlayDbMock([{ rows: [] }]);
+    vi.mocked(getDb).mockResolvedValue({ db: db2, sql: {} } as any);
+    const res2 = await GET(
+      createRequest("streamer-1", { since: nextSince }),
+      createRouteParams("streamer-1")
+    );
+    expect(res2.status).toBe(200);
+  });
+});

--- a/tests/unit/overlay-events-api.test.ts
+++ b/tests/unit/overlay-events-api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NextRequest } from "next/server";
 import { GET } from "@/app/api/overlay/[streamerId]/events/route";
 import { checkRateLimit } from "@/lib/rate-limit";
@@ -180,5 +180,96 @@ describe("GET /api/overlay/[streamerId]/events", () => {
     );
 
     expect(res.status).toBe(500);
+  });
+});
+
+// Issue #569: overlay のバージョン不一致検出＋アイドル時自動リロード機構向けに、
+// ポーリング応答へ overlayVersion を追加したことを検証する。
+describe("GET /api/overlay/[streamerId]/events: overlayVersion (Issue #569)", () => {
+  const originalOverlayVersion = process.env.NEXT_PUBLIC_OVERLAY_VERSION;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 120,
+      remaining: 119,
+      reset: Date.now() + 60000,
+    });
+  });
+
+  afterEach(() => {
+    // 他のテストファイル/テストへ影響しないよう、テスト前の値へ必ず戻す
+    if (originalOverlayVersion !== undefined) {
+      process.env.NEXT_PUBLIC_OVERLAY_VERSION = originalOverlayVersion;
+    } else {
+      delete process.env.NEXT_PUBLIC_OVERLAY_VERSION;
+    }
+  });
+
+  it("NEXT_PUBLIC_OVERLAY_VERSION未設定時はoverlayVersion: 'dev'を返す", async () => {
+    delete process.env.NEXT_PUBLIC_OVERLAY_VERSION;
+
+    const historyQuery = createHistoryQuery({ data: [], error: null });
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn(() => historyQuery),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await GET(
+      createRequest("streamer-1", { since: "2026-01-01T00:00:00Z" }),
+      createRouteParams("streamer-1")
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.overlayVersion).toBe("dev");
+  });
+
+  it("NEXT_PUBLIC_OVERLAY_VERSION設定時はその値をoverlayVersionとして返す", async () => {
+    process.env.NEXT_PUBLIC_OVERLAY_VERSION = "abc123def456";
+
+    const historyQuery = createHistoryQuery({ data: [], error: null });
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn(() => historyQuery),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await GET(
+      createRequest("streamer-1", { since: "2026-01-01T00:00:00Z" }),
+      createRouteParams("streamer-1")
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.overlayVersion).toBe("abc123def456");
+  });
+
+  it("events配列を含む応答でもoverlayVersionが同居する(既存フィールドとの後方互換)", async () => {
+    process.env.NEXT_PUBLIC_OVERLAY_VERSION = "v-test";
+
+    const historyQuery = createHistoryQuery({
+      data: [
+        {
+          id: "h1",
+          event_id: "event-1",
+          redeemed_at: "2026-01-01T00:00:01Z",
+          user_twitch_username: "viewer1",
+          reward_id: null,
+          cards: { id: "c1", name: "Card1", description: null, image_url: null, rarity: "rare" },
+        },
+      ],
+      error: null,
+    });
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn(() => historyQuery),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>);
+
+    const res = await GET(
+      createRequest("streamer-1", { since: "2026-01-01T00:00:00Z" }),
+      createRouteParams("streamer-1")
+    );
+
+    const body = await res.json();
+    expect(body.overlayVersion).toBe("v-test");
+    expect(body.events).toHaveLength(1);
   });
 });

--- a/tests/unit/overlay-version.test.ts
+++ b/tests/unit/overlay-version.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldScheduleReload,
+  isReloadCooldownActive,
+  serializePollState,
+  parsePollState,
+  parseReloadCooldownRecord,
+  RELOAD_COOLDOWN_MS,
+  POLLSTATE_TTL_MS,
+  MAX_PERSISTED_HISTORY_IDS,
+} from "@/lib/overlay-version";
+
+// Issue #569: overlay のバージョン不一致検出＋アイドル時自動リロード機構の
+// 純粋関数群のユニットテスト。sessionStorageやタイマーには一切依存せず、
+// 全て引数として値を注入してテストする。
+
+describe("shouldScheduleReload", () => {
+  it("current/receivedが異なればtrueを返す", () => {
+    expect(shouldScheduleReload("abc123def456", "def456abc789")).toBe(true);
+  });
+
+  it("current/receivedが同じならfalseを返す(リロード不要)", () => {
+    expect(shouldScheduleReload("abc123def456", "abc123def456")).toBe(false);
+  });
+
+  it("receivedがundefinedならfalseを返す(判定不能)", () => {
+    expect(shouldScheduleReload("abc123def456", undefined)).toBe(false);
+  });
+
+  it("receivedが空文字列ならfalseを返す(判定不能)", () => {
+    expect(shouldScheduleReload("abc123def456", "")).toBe(false);
+  });
+
+  it("currentが空文字列ならfalseを返す(判定不能)", () => {
+    expect(shouldScheduleReload("", "abc123def456")).toBe(false);
+  });
+
+  it("currentが'dev'ならreceivedと異なっていてもfalseを返す(dev環境はスキップ)", () => {
+    expect(shouldScheduleReload("dev", "abc123def456")).toBe(false);
+  });
+
+  it("receivedが'dev'ならcurrentと異なっていてもfalseを返す(dev環境はスキップ)", () => {
+    expect(shouldScheduleReload("abc123def456", "dev")).toBe(false);
+  });
+
+  it("current/receivedが両方'dev'でもfalseを返す", () => {
+    expect(shouldScheduleReload("dev", "dev")).toBe(false);
+  });
+});
+
+describe("isReloadCooldownActive", () => {
+  it("recordがnull(未リロード)ならfalseを返す", () => {
+    expect(isReloadCooldownActive(null, "v2", 100000, RELOAD_COOLDOWN_MS)).toBe(false);
+  });
+
+  it("recordのバージョンがtargetVersionと異なればfalseを返す(別バージョンは独立してカウント)", () => {
+    const record = { version: "v1", reloadedAt: 100000 };
+    expect(isReloadCooldownActive(record, "v2", 100000 + 1000, RELOAD_COOLDOWN_MS)).toBe(false);
+  });
+
+  it("同一バージョンでcooldownMs未満ならtrueを返す(クールダウン中)", () => {
+    const record = { version: "v2", reloadedAt: 100000 };
+    const now = 100000 + RELOAD_COOLDOWN_MS - 1;
+    expect(isReloadCooldownActive(record, "v2", now, RELOAD_COOLDOWN_MS)).toBe(true);
+  });
+
+  it("同一バージョンでちょうどcooldownMs経過した境界ではfalseを返す(クールダウン明け)", () => {
+    const record = { version: "v2", reloadedAt: 100000 };
+    const now = 100000 + RELOAD_COOLDOWN_MS;
+    expect(isReloadCooldownActive(record, "v2", now, RELOAD_COOLDOWN_MS)).toBe(false);
+  });
+
+  it("同一バージョンでcooldownMsを超えて経過していればfalseを返す", () => {
+    const record = { version: "v2", reloadedAt: 100000 };
+    const now = 100000 + RELOAD_COOLDOWN_MS + 1;
+    expect(isReloadCooldownActive(record, "v2", now, RELOAD_COOLDOWN_MS)).toBe(false);
+  });
+
+  it("ロールバック相当のシナリオ: 旧バージョンへ戻る場合は直前の記録と別バージョン扱いになり即座にリロード可能", () => {
+    // v1(現行) -> v2(新版)へリロード済みの直後に、本番がv1へロールバックされたケース。
+    // v1向けのクールダウン記録はまだ無い(前回はv2への記録のみ)ため、
+    // v1への再リロードはクールダウンの影響を受けない。
+    const record = { version: "v2", reloadedAt: 100000 };
+    const now = 100000 + 1000; // v2へのクールダウン期間内
+    expect(isReloadCooldownActive(record, "v1", now, RELOAD_COOLDOWN_MS)).toBe(false);
+  });
+});
+
+describe("parseReloadCooldownRecord", () => {
+  it("正当なJSONを{version, reloadedAt}として復元する", () => {
+    const raw = JSON.stringify({ version: "v2", reloadedAt: 12345 });
+    expect(parseReloadCooldownRecord(raw)).toEqual({ version: "v2", reloadedAt: 12345 });
+  });
+
+  it("rawがnull/undefined/空文字列ならnullを返す", () => {
+    expect(parseReloadCooldownRecord(null)).toBeNull();
+    expect(parseReloadCooldownRecord(undefined)).toBeNull();
+    expect(parseReloadCooldownRecord("")).toBeNull();
+  });
+
+  it("JSONとしてparseできない壊れた文字列でも例外を投げずnullを返す", () => {
+    expect(() => parseReloadCooldownRecord("{broken")).not.toThrow();
+    expect(parseReloadCooldownRecord("{broken")).toBeNull();
+  });
+
+  it("JSONとして正当だがオブジェクトでない場合はnullを返す", () => {
+    expect(parseReloadCooldownRecord("42")).toBeNull();
+    expect(parseReloadCooldownRecord("null")).toBeNull();
+    expect(parseReloadCooldownRecord('"v2"')).toBeNull();
+  });
+
+  it("versionが欠けている/文字列でない場合はnullを返す", () => {
+    expect(parseReloadCooldownRecord(JSON.stringify({ reloadedAt: 1 }))).toBeNull();
+    expect(parseReloadCooldownRecord(JSON.stringify({ version: 123, reloadedAt: 1 }))).toBeNull();
+  });
+
+  it("reloadedAtが欠けている/数値でない場合はnullを返す", () => {
+    expect(parseReloadCooldownRecord(JSON.stringify({ version: "v2" }))).toBeNull();
+    expect(
+      parseReloadCooldownRecord(JSON.stringify({ version: "v2", reloadedAt: "not-a-number" })),
+    ).toBeNull();
+  });
+});
+
+describe("serializePollState / parsePollState (round-trip)", () => {
+  it("シリアライズしたものをそのままパースすると同じ内容が復元される", () => {
+    const state = {
+      pollCursor: "2026-07-04T00:00:00.000Z",
+      seenHistoryIds: ["h1", "h2", "h3"],
+      savedAt: 1_700_000_000_000,
+    };
+    const serialized = serializePollState(state);
+    const parsed = parsePollState(serialized, state.savedAt, POLLSTATE_TTL_MS);
+    expect(parsed).toEqual(state);
+  });
+
+  it("seenHistoryIdsがMAX_PERSISTED_HISTORY_IDSを超える場合は直近(末尾)側だけが残る", () => {
+    const ids = Array.from({ length: MAX_PERSISTED_HISTORY_IDS + 10 }, (_, i) => `h${i}`);
+    const serialized = serializePollState({
+      pollCursor: "2026-07-04T00:00:00.000Z",
+      seenHistoryIds: ids,
+      savedAt: 0,
+    });
+    const parsed = parsePollState(serialized, 0, POLLSTATE_TTL_MS);
+    expect(parsed?.seenHistoryIds).toHaveLength(MAX_PERSISTED_HISTORY_IDS);
+    // 末尾側(最新側)が残ることを確認
+    expect(parsed?.seenHistoryIds[0]).toBe(`h${10}`);
+    expect(parsed?.seenHistoryIds.at(-1)).toBe(`h${ids.length - 1}`);
+  });
+
+  it("savedAtからちょうどttlMs経過した境界ではまだ有効(復元される)", () => {
+    const state = { pollCursor: "cursor", seenHistoryIds: [], savedAt: 1000 };
+    const serialized = serializePollState(state);
+    const now = 1000 + POLLSTATE_TTL_MS;
+    expect(parsePollState(serialized, now, POLLSTATE_TTL_MS)).toEqual(state);
+  });
+
+  it("savedAtからttlMsを1msでも超えるとTTL切れでnullを返す", () => {
+    const state = { pollCursor: "cursor", seenHistoryIds: [], savedAt: 1000 };
+    const serialized = serializePollState(state);
+    const now = 1000 + POLLSTATE_TTL_MS + 1;
+    expect(parsePollState(serialized, now, POLLSTATE_TTL_MS)).toBeNull();
+  });
+});
+
+describe("parsePollState: 壊れた入力への耐性", () => {
+  it("rawがnullならnullを返す", () => {
+    expect(parsePollState(null, Date.now(), POLLSTATE_TTL_MS)).toBeNull();
+  });
+
+  it("rawがundefinedならnullを返す", () => {
+    expect(parsePollState(undefined, Date.now(), POLLSTATE_TTL_MS)).toBeNull();
+  });
+
+  it("rawが空文字列ならnullを返す", () => {
+    expect(parsePollState("", Date.now(), POLLSTATE_TTL_MS)).toBeNull();
+  });
+
+  it("JSONとしてparseできない壊れた文字列でも例外を投げずnullを返す", () => {
+    expect(() => parsePollState("{not valid json", Date.now(), POLLSTATE_TTL_MS)).not.toThrow();
+    expect(parsePollState("{not valid json", Date.now(), POLLSTATE_TTL_MS)).toBeNull();
+  });
+
+  it("JSONとして正当だがオブジェクトでない場合(数値)はnullを返す", () => {
+    expect(parsePollState("42", Date.now(), POLLSTATE_TTL_MS)).toBeNull();
+  });
+
+  it("JSONとして正当だがオブジェクトでない場合(文字列)はnullを返す", () => {
+    expect(parsePollState('"hello"', Date.now(), POLLSTATE_TTL_MS)).toBeNull();
+  });
+
+  it("JSONとして正当だがnullの場合はnullを返す", () => {
+    expect(parsePollState("null", Date.now(), POLLSTATE_TTL_MS)).toBeNull();
+  });
+
+  it("pollCursorが欠けている場合はnullを返す", () => {
+    const raw = JSON.stringify({ seenHistoryIds: [], savedAt: 0 });
+    expect(parsePollState(raw, 0, POLLSTATE_TTL_MS)).toBeNull();
+  });
+
+  it("savedAtが欠けている/数値でない場合はnullを返す", () => {
+    const raw = JSON.stringify({ pollCursor: "c", seenHistoryIds: [], savedAt: "not-a-number" });
+    expect(parsePollState(raw, 0, POLLSTATE_TTL_MS)).toBeNull();
+  });
+
+  it("seenHistoryIdsが配列でない場合はnullを返す", () => {
+    const raw = JSON.stringify({ pollCursor: "c", seenHistoryIds: "not-an-array", savedAt: 0 });
+    expect(parsePollState(raw, 0, POLLSTATE_TTL_MS)).toBeNull();
+  });
+
+  it("seenHistoryIds配列内に文字列以外が混じっていても、文字列要素だけを残して復元する", () => {
+    const raw = JSON.stringify({
+      pollCursor: "c",
+      seenHistoryIds: ["h1", 123, null, "h2", { bad: true }],
+      savedAt: 0,
+    });
+    const parsed = parsePollState(raw, 0, POLLSTATE_TTL_MS);
+    expect(parsed?.seenHistoryIds).toEqual(["h1", "h2"]);
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -72,6 +72,36 @@ binding = "R2_SOUNDS"
 bucket_name = "twica-sound-prod"
 preview_bucket_name = "twica-sound-dev"
 
+# ============================================================
+# Hyperdrive binding for direct Postgres access (#570, #568 Phase 1)
+# Postgres 直結アクセス用 Hyperdrive バインディング (#570, #568 Phase 1)
+# ============================================================
+#
+# DB_DRIVER=pg-read/pg で有効になる新データアクセス経路（postgres.js + Drizzle）が
+# 使用する。フラグ未設定の間はコードから参照されないため、このバインディングが
+# 無くてもデプロイ・動作に影響はない（安全にコメントアウトのまま置ける）。
+#
+# 作成手順（リポジトリオーナーが実行）:
+#   wrangler hyperdrive create twica-hyperdrive-prod \
+#     --connection-string="<本番 Supabase の Direct connection 文字列>" \
+#     --caching-disabled
+#
+# --caching-disabled が必須である理由:
+#   Hyperdrive のクエリキャッシュはデフォルト有効（max_age 60s）。Phase 1 は
+#   PostgREST（毎回実クエリ）との完全パリティが目的であり、キャッシュが有効だと
+#   overlay ポーリングの新着イベントが最大 60 秒遅延する等の挙動差が出るため。
+#
+# 実 id は上記コマンドの出力をユーザーが作成後に記入すること。
+# プレースホルダ id のまま有効化（コメント解除）してはならない（デプロイが壊れる）。
+#
+# localConnectionString は `wrangler dev` 実行時のみ使われるローカル接続先
+# （next dev は process.env.DATABASE_URL を使う。docs/db-driver-migration.md 参照）。
+#
+# [[hyperdrive]]
+# binding = "HYPERDRIVE"
+# id = "<wrangler hyperdrive create twica-hyperdrive-prod の出力 id を記入>"
+# localConnectionString = "postgres://user:password@localhost:5432/postgres"
+
 # Environment variables that must survive deploys (Dashboard-only vars get overwritten)
 # デプロイ時に上書きされないよう、Dashboard のみで設定していた変数をここに明示する
 [vars]
@@ -162,3 +192,19 @@ bucket_name = "twica-dev"
 [[env.preview.r2_buckets]]
 binding = "R2_SOUNDS"
 bucket_name = "twica-sound-dev"
+
+# Hyperdrive binding for preview environment (#570)
+# プレビュー環境用 Hyperdrive バインディング (#570)
+#
+# [env.preview] はトップレベルのバインディングをマージではなく上書きするため、
+# （KV・R2 と同様）Hyperdrive も preview 側に明示的な再宣言が必要。
+# preview 用は別の Hyperdrive config（preview プロジェクトの Supabase に接続）を作る:
+#   wrangler hyperdrive create twica-hyperdrive-preview \
+#     --connection-string="<preview Supabase の Direct connection 文字列>" \
+#     --caching-disabled
+# --caching-disabled 必須の理由・id 記入ルールはトップレベルの [[hyperdrive]] コメント参照。
+#
+# [[env.preview.hyperdrive]]
+# binding = "HYPERDRIVE"
+# id = "<wrangler hyperdrive create twica-hyperdrive-preview の出力 id を記入>"
+# localConnectionString = "postgres://user:password@localhost:5432/postgres"


### PR DESCRIPTION
## 概要

既存 Supabase PostgreSQL スキーマへの型付けを行う Drizzle ORM スキーマ定義を追加し、同時に overlay ページの「バージョン不一致検出＋アイドル時自動リロード」機構を実装しました。

## 主な変更

### 1. Drizzle ORM スキーマ定義 (`src/lib/db/schema.ts`)
- 既存 Supabase マイグレーション(00001～00067)に対応する 16 テーブルの型付けスキーマを追加
- **設計方針**:
  - 列プロパティ名は DB 列名そのまま(snake_case)で、PostgREST の応答形状と直接互換
  - `timestamptz`/`timestamp` は `mode: 'string'` で PostgREST の文字列応答に対応
  - `numeric`/`bigint` は `mode: 'number'` で JSON number 型に対応
  - `GENERATED ALWAYS AS` 列は `.generatedAlwaysAs()` で insert 対象外を型で表現
  - 外部キー・インデックス・CHECK 制約は定義しない(実 DB が正、クエリ型付けには不要)
  - `jsonb` 列は `.$type<...>()` で `src/types/database.ts` の TS 型を指定
- migration 生成には使用しない(既存 supabase/migrations が正)

### 2. Overlay バージョン不一致検出＋自動リロード機構

#### `src/lib/overlay-version.ts` (新規)
- sessionStorage や副作用 API に依存しない純粋関数群
- **主要関数**:
  - `shouldScheduleReload()`: 現在バージョンと受信バージョンを比較、リロード要否を判定
  - `isReloadCooldownActive()`: 同一バージョンへの連続リロードを防ぐクールダウン判定(60分)
  - `serializePollState()` / `parsePollState()`: ポーリング状態(pollCursor/seenHistoryIds)をリロード前後で sessionStorage で引き継ぎ(TTL: 15分)
  - `parseReloadCooldownRecord()`: クールダウン記録の安全なパース(壊れたデータでも例外を投げない)

#### `src/app/overlay/[streamerId]/page.tsx` (修正)
- **バージョン確認・リロード機構の統合**:
  - `CURRENT_OVERLAY_VERSION` を `process.env.NEXT_PUBLIC_OVERLAY_VERSION` から取得(ビルド時にインライン化)
  - Realtime 接続中に 10 分ごとにバージョン確認を実施
  - 不一致検出時、0～10 分のランダムジッターを経てリロード実行(サンダリングハード回避)
  - 演出中(キュー処理・カード表示)は 30 秒後に再試行(演出を壊さない)
  - sessionStorage でクールダウン記録とポーリング状態を退避・復元
- **ref 群の追加**:
  - `showCardRef`: 演出中判定を最新値で参照(クロージャ生成時点の古い値を避ける)
  - `lastVersionCheckAtRef`: 10 分ごとのバージョン確認を絞る
  - `reloadScheduled

https://claude.ai/code/session_01CUaLcBzVWuDqFexAnrBQCn