### PR TITLE
fix(sound): レガシーミラー列を新クライアントの効果音ゲートに使わない (#638)

### DIFF
--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -4,6 +4,7 @@ import { getStreamerData } from "@/lib/dashboard-data";
 import { getCustomBotAccountDisplayForStreamer } from "@/lib/twitch/token-manager";
 import { shouldShowVoteCampaign } from "@/lib/storage-db";
 import { getUserPlan } from "@/lib/plan";
+import { normalizeGachaSoundRules } from "@/lib/gacha-sound-rules";
 import SettingsLayout from "@/components/SettingsLayout";
 
 // Note: Page is automatically dynamic due to cookies() usage in getSession()
@@ -38,8 +39,17 @@ export default async function SettingsPage() {
 
   const botAccount = await getCustomBotAccountDisplayForStreamer(streamerData.streamer.id);
 
+  // Issue #638(回帰): gacha_sound_enabled は PR #595 F1 で「有効なcatch-all
+  // ルールがある場合のみtrue」を返す互換ミラーに変更されたため、レアリティ別・
+  // 報酬別ルールしか設定していない配信者はこの条件だけでは検知できず、
+  // 既に効果音を使っているのに初期モードが simple に戻ってしまう。
+  // 実際に有効なルールが1件でもあれば「詳細設定を使用中」とみなす条件を追加する。
+  const hasEnabledGachaSoundRule = normalizeGachaSoundRules(streamerData.streamer.gacha_sound_rules)
+    .some((rule) => rule.enabled);
+
   const hasAdvancedSettingsInUse =
     Boolean(streamerData.streamer.gacha_sound_enabled) ||
+    hasEnabledGachaSoundRule ||
     Boolean(streamerData.streamer.chat_announcement_enabled) ||
     Boolean(streamerData.streamer.show_unowned_cards) ||
     Boolean(streamerData.streamer.show_unowned_card_details);

--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -19,8 +19,8 @@ import {
 import { getRarityGlowClass, getRarityGradientClass, getRarityDisplayInfo } from "@/lib/rarity";
 import {
   normalizeGachaSoundRules,
-  pickGachaSoundRule,
   pickSoundBearingCardIndex,
+  resolvePlayableGachaSound,
   type GachaSoundRule,
 } from "@/lib/gacha-sound-rules";
 import {
@@ -320,40 +320,48 @@ export default function OverlayPage() {
             soundRules,
           });
 
-          if (soundEnabled) {
-            // 再生され得る全URL（ルールごと + レガシー単一URL）を収集して
-            // それぞれHTMLAudioElementを作成しプリロードする。
-            // HTMLAudioElementはCORS不要で外部URLから読み込める（fetchとは異なる）。
-            // key: ruleId、レガシーURLは固定キー "__legacy__" を使う。
-            const cache = audioCacheRef.current;
-            const entries: { key: string; url: string }[] = [];
-            for (const rule of soundRules) {
-              if (rule.enabled && rule.url) {
-                entries.push({ key: rule.id, url: rule.url });
-              }
+          // Issue #638(回帰): 以前はここを `if (soundEnabled)` で丸ごと
+          // ゲートしていたが、soundEnabled はレガシー互換ミラー
+          // (catch-allルールの有無に連動、PR #595 F1)であり、レアリティ別・
+          // 報酬別ルールしか設定していない配信ではこれが false になり得る。
+          // その結果、実際には有効なルールがあるのにプリロードが一切
+          // 行われず、初回再生が遅延・無音になっていた。
+          // 再生され得る全URL（ルールごと + レガシー単一URL）を収集して
+          // それぞれHTMLAudioElementを作成しプリロードする。
+          // HTMLAudioElementはCORS不要で外部URLから読み込める（fetchとは異なる）。
+          // key: ruleId、レガシーURLは固定キー "__legacy__" を使う。
+          const cache = audioCacheRef.current;
+          const entries: { key: string; url: string }[] = [];
+          // (a) 有効なルールのURLは soundEnabled(ミラー)に関係なく常に対象にする
+          for (const rule of soundRules) {
+            if (rule.enabled && rule.url) {
+              entries.push({ key: rule.id, url: rule.url });
             }
-            if (data.soundUrl) {
-              entries.push({ key: "__legacy__", url: data.soundUrl });
-            }
+          }
+          // (b) レガシー単一URLは、再生ロジック(resolvePlayableGachaSound)と
+          // 同じ条件(ルールが空 かつ soundEnabled)の場合のみ対象にする。
+          // ルールが非空ならレガシーURLは再生され得ないためプリロード不要。
+          if (soundRules.length === 0 && soundEnabled && data.soundUrl) {
+            entries.push({ key: "__legacy__", url: data.soundUrl });
+          }
 
-            for (const { key, url } of entries) {
-              if (cache.has(key)) continue;
-              const audio = new Audio(url);
-              audio.preload = "auto";
-              cache.set(key, audio);
+          for (const { key, url } of entries) {
+            if (cache.has(key)) continue;
+            const audio = new Audio(url);
+            audio.preload = "auto";
+            cache.set(key, audio);
 
-              // 自動再生可能かテスト（ブロックされていればUI表示用フラグを立てる）
-              audio.play().then(() => {
-                // 再生成功 → 即座に停止（プリロード目的）
-                audio.pause();
-                audio.currentTime = 0;
-                audioUnlockedRef.current = true;
-              }).catch(() => {
-                // NotAllowedError: 自動再生ポリシーによりブロック
-                // ユーザー操作後にアンロックされる
-                setAudioBlocked(true);
-              });
-            }
+            // 自動再生可能かテスト（ブロックされていればUI表示用フラグを立てる）
+            audio.play().then(() => {
+              // 再生成功 → 即座に停止（プリロード目的）
+              audio.pause();
+              audio.currentTime = 0;
+              audioUnlockedRef.current = true;
+            }).catch(() => {
+              // NotAllowedError: 自動再生ポリシーによりブロック
+              // ユーザー操作後にアンロックされる
+              setAudioBlocked(true);
+            });
           }
         }
       } catch (error) {
@@ -485,24 +493,23 @@ export default function OverlayPage() {
    * 未アンロック時は再生失敗するがエラーは無視する
    */
   const playGachaSound = useCallback((data: GachaResult) => {
-    // 効果音が無効または未設定の場合はスキップ
-    const selectedRule = pickGachaSoundRule(soundSettings.soundRules, {
-      rarity: data.card.rarity,
-      rewardId: data.rewardId,
-    });
-    // PR #451 レビュー指摘(F1b): soundRules が1件以上ある(=このクライアントは
-    // ルールベースの音を理解している)のにどのルールにも一致しなかった場合、
-    // 「何も鳴らさない」が正しい挙動。以前はここで soundSettings.soundUrl
-    // (サーバー側がミラーしていた「有効な最初のルール」のURL)にフォール
-    // バックしていたため、例えば'legendary'限定ルールしか設定していない
-    // 配信でも、それ以外の全レアリティでレジェンダリー音が鳴ってしまって
-    // いた(サーバー側 F1 のミラー修正とセットで直る問題)。
-    // レガシー設定(soundRulesが空=ルール未対応の単一URL設定)の場合のみ、
-    // 従来どおり soundUrl にフォールバックする。
-    const soundUrl = soundSettings.soundRules.length > 0
-      ? (selectedRule?.url ?? null)
-      : soundSettings.soundUrl;
-    if (!soundSettings.soundEnabled || !soundUrl) {
+    // Issue #638(回帰): PR #595 F1でサーバー側ミラー(soundEnabled/soundUrl)は
+    // 「有効なcatch-all(targetType==='all')ルールがある場合のみtrue/URL」を
+    // 返すよう修正された。しかしここで soundEnabled を再生可否のゲートに
+    // 使い続けていたため、レアリティ別・報酬別ルールしか設定していない
+    // 配信では常にミラーがfalseになり、効果音が一切鳴らなくなっていた。
+    // resolvePlayableGachaSound はルール対応クライアント向けに「ミラーを
+    // 見ない」判定(ルール自身のenabledで再生可否を決める)を行うため、
+    // これに委譲する(レガシー設定=ルール空の場合のみミラーを見る)。
+    const playable = resolvePlayableGachaSound(
+      {
+        soundUrl: soundSettings.soundUrl,
+        soundEnabled: soundSettings.soundEnabled,
+        soundRules: soundSettings.soundRules,
+      },
+      { rarity: data.card.rarity, rewardId: data.rewardId },
+    );
+    if (!playable) {
       return;
     }
 
@@ -537,10 +544,10 @@ export default function OverlayPage() {
       };
 
       // ルールに対応するプリロード済みAudio要素を優先的に使用する。
-      // ルールが選択された場合は rule.id、レガシー単一URLの場合は固定キー。
-      const cacheKey = selectedRule?.id ?? "__legacy__";
-      const cached = audioCacheRef.current.get(cacheKey);
-      if (cached && cached.src === soundUrl) {
+      // ルールが選択された場合は rule.id、レガシー単一URLの場合は固定キー
+      // ("__legacy__")。いずれも resolvePlayableGachaSound の戻り値に含まれる。
+      const cached = audioCacheRef.current.get(playable.cacheKey);
+      if (cached && cached.src === playable.url) {
         // プリロード済みのAudio要素を使用して再生
         cached.currentTime = 0;
         const clearGuard = markSoundPlaying(cached);
@@ -552,7 +559,7 @@ export default function OverlayPage() {
         });
       } else {
         // キャッシュ未生成（取得タイミング差など）のフォールバック
-        const audio = new Audio(soundUrl);
+        const audio = new Audio(playable.url);
         const clearGuard = markSoundPlaying(audio);
         audio.play().catch(() => {
           clearGuard();
@@ -984,12 +991,23 @@ export default function OverlayPage() {
     }
   }, [triggerDemo]);
 
+  // Issue #638(回帰): レガシーミラー(soundEnabled && soundUrl)を「効果音が
+  // 設定されているか」の判定に使うと、レアリティ別・報酬別ルールしか
+  // 設定していない配信では常にfalseになり、自動再生ブロック時の案内
+  // (Click to enable sound)が表示されなくなる。resolvePlayableGachaSound は
+  // rarity/rewardIdのコンテキストを要求し表示判定には使えないため、ここでは
+  // 「有効なルールが1件でもあるか」（ルール非空時）または従来どおりの
+  // レガシーミラー判定（ルール空＝純レガシー設定時）で代用する。
+  const hasPlayableSound = soundSettings.soundRules.length > 0
+    ? soundSettings.soundRules.some((rule) => rule.enabled)
+    : soundSettings.soundEnabled && !!soundSettings.soundUrl;
+
   if (!result) {
     return (
       <div className="flex h-screen w-screen items-center justify-center bg-transparent">
         {/* 音声がブラウザの自動再生ポリシーでブロックされている場合の表示 */}
         {/* 通常の配信オーバーレイには運用メッセージを出さず、debug=true の調査時のみ表示する */}
-        {options.debug && audioBlocked && soundSettings.soundEnabled && soundSettings.soundUrl && (
+        {options.debug && audioBlocked && hasPlayableSound && (
           <div className="fixed top-4 left-4 rounded bg-yellow-600/90 px-3 py-2 text-xs text-white cursor-pointer"
             onClick={() => {
               // クリックイベントはdocumentのunlockAudioハンドラーでも処理される

--- a/src/components/SettingsLayout.tsx
+++ b/src/components/SettingsLayout.tsx
@@ -13,6 +13,7 @@ import {
 import CopyButton from "@/components/CopyButton";
 import VoteCampaignButton from "@/components/VoteCampaignButton";
 import { VOTE_CAMPAIGN_CONFIG } from "@/lib/constants";
+import { legacySoundToRules, normalizeGachaSoundRules } from "@/lib/gacha-sound-rules";
 import type { Card, Json } from "@/types/database";
 import type { PlanType } from "@/lib/plan-constants";
 
@@ -222,9 +223,22 @@ function AdvancedLayout({ data }: { data: SettingsLayoutData }) {
   const collectionUrl = `${data.baseUrl}/collection/${data.streamerId}`;
 
   const rewardStatus: SettingsSection["status"] = data.channelPoint.rewardId ? "active" : "empty";
-  const soundStatus: SettingsSection["status"] = data.gachaSound.soundEnabled
+  // Issue #638(回帰): gacha_sound_enabled は PR #595 F1 で「有効なcatch-all
+  // ルールがある場合のみtrue」を返す互換ミラーに変更された。これをそのまま
+  // ステータスドット判定に使うと、レアリティ別・報酬別ルールしか設定して
+  // いない配信者でも常に「無効」(灰色)表示になってしまう。GachaSoundSettings
+  // (initialRules)と同じ「ルールがあればそれを、無ければレガシー値をルール化
+  // したもの」にフォールバックする方式で実効ルールを求め、その中に有効な
+  // ルールが1件でもあるかで判定する。これは GachaSoundSettings 内のバッジ
+  // (enabledRule = rules.find((rule) => rule.enabled))と同じ判定基準であり、
+  // セクション一覧のドットとセクション内バッジの表示が食い違わないようにする。
+  const effectiveSoundRules = (() => {
+    const rules = normalizeGachaSoundRules(data.gachaSound.soundRules);
+    return rules.length > 0 ? rules : legacySoundToRules(data.gachaSound.soundUrl, data.gachaSound.soundEnabled);
+  })();
+  const soundStatus: SettingsSection["status"] = effectiveSoundRules.some((rule) => rule.enabled)
     ? "active"
-    : data.gachaSound.soundUrl
+    : effectiveSoundRules.length > 0
       ? "configured"
       : "empty";
   const announcementStatus: SettingsSection["status"] = data.chatAnnouncement.enabled

--- a/src/lib/gacha-sound-rules.ts
+++ b/src/lib/gacha-sound-rules.ts
@@ -181,6 +181,43 @@ export function pickGachaSoundRule(
   return enabled.find((rule) => rule.targetType === "all") ?? null;
 }
 
+/**
+ * 実際に再生してよい効果音(URL + プリロードキャッシュキー)を1つ解決する
+ * (Issue #638 の回帰修正)。
+ *
+ * PR #595 (F1) でサーバー側は互換ミラー列 gacha_sound_enabled /
+ * gacha_sound_url を「有効な catch-all(targetType === "all")ルールが
+ * ある場合のみ true/URL」に変更した。このミラーは、レアリティ／報酬別
+ * ルールを理解しない“旧オーバーレイクライアント(キャッシュ済み・未更新の
+ * ブラウザソース)”との後方互換のためだけに存在する値であり、ルール対応
+ * クライアントの再生可否を左右する値ではない。
+ * ところが新クライアント側の一部(オーバーレイの再生ゲート・設定画面の
+ * ステータスドット)がこのミラーを「効果音機能全体の有効フラグ」として
+ * 参照し続けていたため、レアリティ別・報酬別ルールしか設定していない
+ * 配信者はミラーが常に false になり、実際には有効なルールがあるのに
+ * 効果音が一切鳴らない/未設定に見える、という回帰が起きていた。
+ *
+ * そのため soundRules が1件でもある(=ルール対応データ)場合は
+ * soundEnabled(ミラー)を一切参照せず、ルール自身の enabled のみで
+ * 再生可否を決める。soundRules が空(純レガシー・ルール未対応データ)の
+ * 場合のみ、従来どおり soundEnabled + soundUrl のペアで判定する。
+ */
+export function resolvePlayableGachaSound(
+  settings: { soundUrl: string | null; soundEnabled: boolean; soundRules: GachaSoundRule[] },
+  context: PickSoundContext,
+): { url: string; cacheKey: string } | null {
+  if (settings.soundRules.length > 0) {
+    const rule = pickGachaSoundRule(settings.soundRules, context);
+    return rule ? { url: rule.url, cacheKey: rule.id } : null;
+  }
+
+  if (settings.soundEnabled && settings.soundUrl) {
+    return { url: settings.soundUrl, cacheKey: "__legacy__" };
+  }
+
+  return null;
+}
+
 export function legacySoundToRules(soundUrl: string | null, soundEnabled: boolean): GachaSoundRule[] {
   if (!soundUrl) return [];
   return [{

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -296,8 +296,11 @@ describe('OverlayPage', () => {
     await waitFor(() => {
       expect(createdUrls).toContain('https://example.com/rare.mp3')
       expect(createdUrls).toContain('https://example.com/legendary.mp3')
-      expect(createdUrls).toContain('https://example.com/legacy.mp3')
     })
+    // Issue #638: soundRulesが非空の場合、レガシー単一URLは再生ロジック
+    // (resolvePlayableGachaSound)上そもそも使われないため、プリロードもしない
+    // (無駄なリクエストを避ける)。
+    expect(createdUrls).not.toContain('https://example.com/legacy.mp3')
   })
 
   it('ルールが設定されているのにどれも一致しない場合、レガシーURLへフォールバックせず無音になる（F1b）', async () => {
@@ -439,6 +442,66 @@ describe('OverlayPage', () => {
     })
     expect(screen.getByText('Gamma')).toBeInTheDocument()
     expect(playedSrcs).toEqual(['https://example.com/legendary.mp3'])
+  })
+
+  it('Issue #638の再現・修正確認: レアリティ限定ルールのみ設定(soundEnabledミラーはfalse)でも一致すれば効果音が鳴る', async () => {
+    vi.useFakeTimers()
+
+    const playedSrcs: string[] = []
+    class MockAudio {
+      currentTime = 0
+      preload = ''
+      src: string
+      constructor(src?: string) { this.src = src ?? '' }
+      play() {
+        playedSrcs.push(this.src)
+        return Promise.resolve()
+      }
+      pause() {}
+    }
+    vi.stubGlobal('Audio', MockAudio as unknown as typeof Audio)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        // PR #595 F1により、catch-allルールが無い設定ではサーバーはミラーを
+        // soundUrl: null / soundEnabled: false で返す。ここで soundEnabled を
+        // 再生ゲートに使うと(#638の回帰)、rarity限定ルールがあっても無音になる。
+        soundUrl: null,
+        soundEnabled: false,
+        soundRules: [
+          { id: 'rare-rule', url: 'https://example.com/rare.mp3', enabled: true, targetType: 'rarity', rarity: 'rare' },
+        ],
+      }),
+    }))
+
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
+      options.onSuccess?.()
+      return vi.fn()
+    })
+
+    render(<OverlayPage />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    playedSrcs.length = 0
+
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        card: { id: 'card-1', name: 'Alpha', description: null, image_url: null, rarity: 'rare' },
+        userTwitchUsername: 'Viewer',
+      })
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+    expect(playedSrcs).toEqual(['https://example.com/rare.mp3'])
   })
 
   // Issue #569 厳格レビュー指摘(High): attemptReload / checkOverlayVersion /

--- a/tests/unit/gacha-sound-rules.test.ts
+++ b/tests/unit/gacha-sound-rules.test.ts
@@ -4,6 +4,8 @@ import {
   legacySoundToRules,
   normalizeGachaSoundRules,
   pickGachaSoundRule,
+  resolvePlayableGachaSound,
+  type GachaSoundRule,
 } from "@/lib/gacha-sound-rules";
 
 describe("gacha sound rules", () => {
@@ -142,5 +144,83 @@ describe("gacha sound rules", () => {
     const rules = normalizeGachaSoundRules(input);
     expect(rules).toHaveLength(MAX_GACHA_SOUND_RULES);
     expect(rules[0].id).toBe("rule-0");
+  });
+
+  describe("resolvePlayableGachaSound (Issue #638)", () => {
+    const rule = (overrides: Partial<GachaSoundRule>): GachaSoundRule => ({
+      id: "id",
+      url: "https://example.com/s.mp3",
+      enabled: true,
+      label: "L",
+      targetType: "all",
+      rarity: null,
+      rewardId: null,
+      rewardName: null,
+      ...overrides,
+    });
+
+    it("#638の再現ケース: rarity限定の有効ルールのみ設定されている配信は、レガシーミラー(soundEnabled)がfalseでも一致すれば再生できる", () => {
+      const rules = [rule({ id: "legendary-rule", targetType: "rarity", rarity: "legendary" })];
+      // PR #595 F1により、catch-allルールが無いためサーバー側ミラーは
+      // soundEnabled=falseで届く。これに引きずられず一致すれば再生できることを確認する。
+      const result = resolvePlayableGachaSound(
+        { soundUrl: null, soundEnabled: false, soundRules: rules },
+        { rarity: "legendary", rewardId: null },
+      );
+      expect(result).toEqual({ url: "https://example.com/s.mp3", cacheKey: "legendary-rule" });
+    });
+
+    it("報酬限定ルールも同様に、ミラーがfalseでもrewardId一致で再生できる", () => {
+      const rules = [
+        rule({ id: "reward-rule", url: "https://example.com/reward.mp3", targetType: "reward", rewardId: "reward-1" }),
+      ];
+      const result = resolvePlayableGachaSound(
+        { soundUrl: null, soundEnabled: false, soundRules: rules },
+        { rarity: "common", rewardId: "reward-1" },
+      );
+      expect(result).toEqual({ url: "https://example.com/reward.mp3", cacheKey: "reward-rule" });
+    });
+
+    it("ルールが非空でもどれにも一致しなければnull(レガシーurlがあってもフォールバックしない、F1bの維持)", () => {
+      const rules = [rule({ id: "legendary-rule", targetType: "rarity", rarity: "legendary" })];
+      const result = resolvePlayableGachaSound(
+        { soundUrl: "https://example.com/legacy.mp3", soundEnabled: true, soundRules: rules },
+        { rarity: "common", rewardId: null },
+      );
+      expect(result).toBeNull();
+    });
+
+    it("ルールが空 + レガシーurl + soundEnabled: trueなら、レガシーurlを__legacy__キーで返す", () => {
+      const result = resolvePlayableGachaSound(
+        { soundUrl: "https://example.com/legacy.mp3", soundEnabled: true, soundRules: [] },
+        { rarity: "common", rewardId: null },
+      );
+      expect(result).toEqual({ url: "https://example.com/legacy.mp3", cacheKey: "__legacy__" });
+    });
+
+    it("ルールが空 + レガシーurl + soundEnabled: falseならnull", () => {
+      const result = resolvePlayableGachaSound(
+        { soundUrl: "https://example.com/legacy.mp3", soundEnabled: false, soundRules: [] },
+        { rarity: "common", rewardId: null },
+      );
+      expect(result).toBeNull();
+    });
+
+    it("ルールが空 + url: nullならnull", () => {
+      const result = resolvePlayableGachaSound(
+        { soundUrl: null, soundEnabled: true, soundRules: [] },
+        { rarity: "common", rewardId: null },
+      );
+      expect(result).toBeNull();
+    });
+
+    it("無効化(enabled: false)されたルールのみの場合はnull", () => {
+      const rules = [rule({ id: "disabled-rule", enabled: false, targetType: "all" })];
+      const result = resolvePlayableGachaSound(
+        { soundUrl: null, soundEnabled: true, soundRules: rules },
+        { rarity: "common", rewardId: null },
+      );
+      expect(result).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
Closes #638

## 問題
PR #595 (F1) で `gacha_sound_enabled`/`gacha_sound_url` は「有効な catch-all ルールがある場合のみ true/URL」の旧クライアント互換ミラーに変更されたが、新クライアント側がこれを「効果音機能全体の有効フラグ」として参照し続けていた。そのため**レアリティ別・報酬別ルールしか設定していない配信者**は:

- 設定画面左タブのステータスドットが灰色のまま（セクション内バッジは緑「有効」で矛盾）
- オーバーレイで効果音が一切鳴らない（マッチするルールがあっても `!soundEnabled` で早期 return）

7/5 のえるりゅ氏の報告と症状・タイムライン（#451 7/3 10:46 → #595 7/3 12:46 で回帰 → 7/5 報告）が一致。

## 修正
- **lib**: `resolvePlayableGachaSound` を追加。ルール非空ならミラーを見ずルール自身の `enabled` で再生可否を決定、空なら従来のレガシー判定（`soundEnabled && soundUrl`）
- **overlay**: 再生ゲート・プリロード・debug バナー（Click to enable sound）をミラー直読みから上記判定へ置換。#630 のリロード延期ガード (`markSoundPlaying`) は維持
- **settings**: 左タブ `soundStatus` と `hasAdvancedSettingsInUse` を実効ルール（有効ルールの有無）から判定
- サーバー側ミラー (#595 F1) は旧キャッシュ済みオーバーレイ互換のため**変更しない**

## テスト
- `resolvePlayableGachaSound` の単体テスト 7 件（#638 再現ケース含む）
- オーバーレイのコンポーネント統合回帰テスト（`soundEnabled: false` ミラー下で rarity ルール一致 → 再生される）
- 既存プリロードテストを新仕様（ルール非空時はレガシー URL をプリロードしない）に更新

## 検証（実測）
- red/green 実証: 修正前ソースに対し新規テスト 9 件が失敗することを確認
- `npx vitest run`: **1669/1669 全通過**（origin/main rebase 後）
- `npx eslint`（変更 6 ファイル）: 指摘 0
- `next build`: 成功（overlay page の named export 制約 #596 も遵守）
- `tsc --noEmit`: 変更ファイル起因の新規エラーなし（既知の #588 のみ）

## 未実施
- 本番/実ブラウザでのライブ再現・修正確認は未実施（デプロイ後にえるりゅ氏の設定で確認するのが確実）

🤖 Generated with [Claude Code](https://claude.com/claude-code)