### PR TITLE
feat(worker): 新規問い合わせをGitHub Issueで自動通知する (#633)

### DIFF
--- a/docs/cloudflare-workers-builds.md
+++ b/docs/cloudflare-workers-builds.md
@@ -4,7 +4,7 @@ TwiCa deploys the Next.js Worker through Cloudflare Workers Builds. GitHub
 Actions remains responsible for Supabase migrations from the existing GitHub
 Environment secrets, remains available as a fallback until the Cloudflare
 connection is confirmed, and continues to deploy the auxiliary error-reporter
-Worker after the cutover.
+Cron Worker after the cutover.
 
 ## Build Targets
 
@@ -69,6 +69,31 @@ feature branch to the preview deployment.
    it skips the legacy app deploy while still applying Supabase migrations from
    GitHub Environment secrets, and deploys `workers/error-reporter` for
    production.
+
+## Auxiliary Cron Worker
+
+`workers/error-reporter` (`twica-error-reporter`) is a single Cron Worker
+(`*/5 * * * *`) that files GitHub Issues from two Supabase tables using the same
+Transactional Outbox pattern (poll unprocessed rows, create an Issue, mark
+processed). Both jobs run sequentially in one invocation and are isolated, so a
+failure in one does not block the other:
+
+- `errors` → Issues for unprocessed application errors (see issue #239).
+- `support_inquiries` → Issues that notify the maintainer of new support
+  inquiries (see issue #633).
+
+Both jobs are consolidated into one Worker on purpose: they share the same
+secrets, cron schedule, and deploy step, so keeping them separate would only
+duplicate operational setup. The Worker needs these Cloudflare secrets (set via
+`wrangler secret put` or the Cloudflare Dashboard). Until they are set, the
+Worker validates env and returns early on each run, so it is harmless:
+
+- `SUPABASE_URL`
+- `SUPABASE_SECRET_KEY` (or legacy `SUPABASE_SERVICE_ROLE_KEY`)
+- `GITHUB_TOKEN` (Fine-grained PAT, scopes: Issues read/write)
+
+`GITHUB_REPO_OWNER` / `GITHUB_REPO_NAME` are non-secret and set in the Worker's
+`wrangler.toml` `[vars]`.
 
 ## Safety Rules
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -376,7 +376,7 @@ export const userLicenses = pgTable('user_licenses', {
 
 // -----------------------------------------------------------------------------
 // support_inquiries（支援者限定問い合わせ）
-// 根拠: 00019 初版
+// 根拠: 00019 初版, 00072 GitHub Issue 追跡カラム追加（Issue #633）
 // -----------------------------------------------------------------------------
 export const supportInquiries = pgTable('support_inquiries', {
   id: uuid('id').primaryKey().default(sql`uuid_generate_v4()`),
@@ -391,6 +391,12 @@ export const supportInquiries = pgTable('support_inquiries', {
   status: text('status').notNull().default('open'),
   created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
   updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
+  // Cron Worker (twica-error-reporter) による GitHub Issue 発行状況（00072）。
+  // errors テーブルは DDL が単なる DEFAULT FALSE だが、support_inquiries の DDL は
+  // NOT NULL DEFAULT FALSE のため notNull を付与する（eq.false ポーリングで NULL 漏れ防止）。
+  github_issue_created: boolean('github_issue_created').notNull().default(false),
+  github_issue_number: integer('github_issue_number'),
+  github_issue_url: text('github_issue_url'),
 })
 
 // -----------------------------------------------------------------------------

--- a/supabase/migrations/00072_add_inquiry_github_issue_tracking.sql
+++ b/supabase/migrations/00072_add_inquiry_github_issue_tracking.sql
@@ -25,9 +25,9 @@
 --   PostgreSQL 11+ では定数 DEFAULT 付きの列追加・DEFAULT 変更いずれも
 --   メタデータのみの操作で、テーブル全体の書き換えや長時間ロックは発生しない。
 ALTER TABLE support_inquiries
-  ADD COLUMN github_issue_created BOOLEAN NOT NULL DEFAULT TRUE,
-  ADD COLUMN github_issue_number INTEGER,
-  ADD COLUMN github_issue_url TEXT;
+  ADD COLUMN IF NOT EXISTS github_issue_created BOOLEAN NOT NULL DEFAULT TRUE,
+  ADD COLUMN IF NOT EXISTS github_issue_number INTEGER,
+  ADD COLUMN IF NOT EXISTS github_issue_url TEXT;
 
 -- 以後の新規問い合わせは未処理(FALSE)で始まり、Cron Worker が拾って Issue 化する。
 ALTER TABLE support_inquiries
@@ -38,7 +38,7 @@ ALTER TABLE support_inquiries
 -- created_at 昇順（FIFO）で取得するため created_at をキーにする（errors 版の
 -- idx_errors_pending は先頭列に定数の github_issue_created を含めていたが、
 -- 部分述語で既に FALSE 固定のため created_at 単独で十分）。
-CREATE INDEX idx_support_inquiries_pending
+CREATE INDEX IF NOT EXISTS idx_support_inquiries_pending
   ON support_inquiries(created_at)
   WHERE github_issue_created = FALSE;
 

--- a/supabase/migrations/00072_add_inquiry_github_issue_tracking.sql
+++ b/supabase/migrations/00072_add_inquiry_github_issue_tracking.sql
@@ -1,0 +1,47 @@
+-- Migration: Add GitHub Issue tracking to support_inquiries
+-- 問い合わせの GitHub Issue 自動発行のための追跡カラムを追加
+--
+-- 支援者が投稿した新規問い合わせ (support_inquiries) を、Cron Worker
+-- (twica-error-reporter) が定期的に読み出して GitHub Issue を自動作成し、
+-- メンテナへ通知する。errors テーブル (00012) と同じ Transactional Outbox
+-- パターンを踏襲する（同一 Worker がエラーと問い合わせの両方を処理）。
+--
+-- See: https://github.com/azumag/twica/issues/633
+
+-- Cron Worker による GitHub Issue 発行状況の追跡カラム。
+-- github_issue_created: 発行済みフラグ。未処理ポーリングの対象判定に使う。
+--   NOT NULL とすることで、PostgREST の eq.false フィルタから NULL 行が漏れる
+--   事故を防ぐ（errors は DEFAULT のみだが、こちらはより厳密に）。
+-- github_issue_number / github_issue_url: 作成された Issue の参照情報（監査用）。
+--
+-- 【重要】既存行のバックフィル方針:
+--   本機能は「新規問い合わせ」の通知が目的なので、マイグレーション適用時点で
+--   既に存在する問い合わせ（解決済み・クローズ済みを含む過去分）を遡って
+--   大量に Issue 化してはならない。そこで DEFAULT TRUE で列を追加して既存行を
+--   すべて「発行済み(TRUE)」にし、その後 DEFAULT を FALSE に切り替えることで、
+--   以後にアプリが INSERT する新規行だけが未処理(FALSE)＝処理対象になるようにする。
+--   ADD COLUMN ... DEFAULT による既存行の充填は UPDATE トリガを発火させないため、
+--   既存行の updated_at は書き換わらない（UPDATE 文でのバックフィルは不可）。
+--   PostgreSQL 11+ では定数 DEFAULT 付きの列追加・DEFAULT 変更いずれも
+--   メタデータのみの操作で、テーブル全体の書き換えや長時間ロックは発生しない。
+ALTER TABLE support_inquiries
+  ADD COLUMN github_issue_created BOOLEAN NOT NULL DEFAULT TRUE,
+  ADD COLUMN github_issue_number INTEGER,
+  ADD COLUMN github_issue_url TEXT;
+
+-- 以後の新規問い合わせは未処理(FALSE)で始まり、Cron Worker が拾って Issue 化する。
+ALTER TABLE support_inquiries
+  ALTER COLUMN github_issue_created SET DEFAULT FALSE;
+
+-- 未処理問い合わせの検索を高速化（Cron Worker が定期的にクエリする対象）。
+-- 部分インデックスで github_issue_created = FALSE のみを対象にしてサイズを最小化。
+-- created_at 昇順（FIFO）で取得するため created_at をキーにする（errors 版の
+-- idx_errors_pending は先頭列に定数の github_issue_created を含めていたが、
+-- 部分述語で既に FALSE 固定のため created_at 単独で十分）。
+CREATE INDEX idx_support_inquiries_pending
+  ON support_inquiries(created_at)
+  WHERE github_issue_created = FALSE;
+
+COMMENT ON COLUMN support_inquiries.github_issue_created IS 'GitHub Issue 発行済みフラグ（Cron Worker が更新）- Issue #633';
+COMMENT ON COLUMN support_inquiries.github_issue_number IS '発行された GitHub Issue 番号';
+COMMENT ON COLUMN support_inquiries.github_issue_url IS '発行された GitHub Issue の URL';

--- a/tests/unit/error-reporter-worker.test.ts
+++ b/tests/unit/error-reporter-worker.test.ts
@@ -579,5 +579,86 @@ describe('reporter worker', () => {
       expect(createBody.body).toContain('`line1 # fake heading`');
       expect(createBody.body).not.toContain('\nline1\n# fake heading');
     });
+
+    it('未知カテゴリに改行/見出し注入を含んでいても inlineCode で無害化される', async () => {
+      // category は DB の CHECK 制約 + API 側バリデーションで bug/feature/other に
+      // 限定されるが、Worker 自身もこの不変条件に依存せず防御的であるべき。
+      // label（フォールバック時は category そのもの）が本文にそのまま展開されず、
+      // inlineCode を通ることを検証する。
+      const inquiry = makeInquiry({ category: 'weird\n# injected heading' });
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([inquiry]) });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ total_count: 0, items: [] }),
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ number: 1, html_url: 'https://github.com/test/1' }),
+      });
+      fetchMock.mockResolvedValueOnce({ ok: true });
+
+      await processInquiries(mockEnv);
+
+      const createBody = JSON.parse(fetchMock.mock.calls[2][1].body);
+      expect(createBody.body).toContain('`weird # injected heading`');
+      expect(createBody.body).not.toContain('\nweird\n# injected heading');
+    });
+  });
+
+  describe('processInquiries: 冪等性の保険', () => {
+    it('新規作成に成功しても処理済みマーク(PATCH)が失敗した場合は例外が伝播する', async () => {
+      // フラグが false のまま残るため、次回実行時に search で拾われて重複作成が
+      // 防がれる想定（本命の冪等性）。ここでは PATCH 失敗時に例外が正しく
+      // 伝播し、個別 try/catch で処理が打ち切られることのみ検証する。
+      const inquiry = makeInquiry();
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([inquiry]) });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ total_count: 0, items: [] }),
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ number: 5, html_url: 'https://github.com/test/5' }),
+      });
+      // PATCH 失敗
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('db error'),
+      });
+
+      await processInquiries(mockEnv);
+
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to process inquiry inq-1'),
+        expect.any(Error)
+      );
+    });
+
+    it('GitHub Search API 自体が失敗した場合は既存なし扱いで新規作成に進む', async () => {
+      // searchIssue は API 失敗時に例外を投げず null を返す設計（本命の冪等性は
+      // github_issue_created フラグであり、search はあくまで補助のため）。
+      const inquiry = makeInquiry();
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([inquiry]) });
+      // search 失敗（403 = レート制限等）
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 403 });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ number: 8, html_url: 'https://github.com/test/8' }),
+      });
+      fetchMock.mockResolvedValueOnce({ ok: true });
+
+      await processInquiries(mockEnv);
+
+      // search 失敗後も create → patch まで進む
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      const createCall = fetchMock.mock.calls[2];
+      expect(createCall[0]).toContain('/repos/testowner/testrepo/issues');
+      expect(createCall[1].method).toBe('POST');
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('GitHub search API failed')
+      );
+    });
   });
 });

--- a/tests/unit/error-reporter-worker.test.ts
+++ b/tests/unit/error-reporter-worker.test.ts
@@ -492,4 +492,92 @@ describe('reporter worker', () => {
       expect(lastCall[1].method).toBe('PATCH');
     });
   });
+
+  // 共通ヘルパへ集約したヘッダの契約を固定する（githubHeaders / supabase 認証ヘッダ改変時の回帰検知）
+  describe('リクエストヘッダ契約', () => {
+    it('GitHub POST と Supabase PATCH が期待するヘッダを送る', async () => {
+      const inquiry = makeInquiry();
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([inquiry]) });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ total_count: 0, items: [] }),
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ number: 7, html_url: 'https://github.com/test/7' }),
+      });
+      fetchMock.mockResolvedValueOnce({ ok: true });
+
+      await processInquiries(mockEnv);
+
+      const createHeaders = fetchMock.mock.calls[2][1].headers;
+      expect(createHeaders['Authorization']).toBe('Bearer gh-token');
+      expect(createHeaders['Accept']).toBe('application/vnd.github+json');
+      expect(createHeaders['X-GitHub-Api-Version']).toBe('2022-11-28');
+      expect(createHeaders['User-Agent']).toBe('twica-error-reporter');
+      expect(createHeaders['Content-Type']).toBe('application/json');
+
+      const patchHeaders = fetchMock.mock.calls[3][1].headers;
+      expect(patchHeaders['apikey']).toBe('test-key');
+      expect(patchHeaders['Authorization']).toBe('Bearer test-key');
+      expect(patchHeaders['Content-Type']).toBe('application/json');
+      expect(patchHeaders['Prefer']).toBe('return=minimal');
+    });
+
+    it('SUPABASE_SECRET_KEY が SERVICE_ROLE_KEY より優先される', async () => {
+      const env = { ...mockEnv, SUPABASE_SECRET_KEY: 'secret-key' };
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) });
+
+      await processInquiries(env);
+
+      expect(fetchMock.mock.calls[0][1].headers['apikey']).toBe('secret-key');
+    });
+  });
+
+  describe('processInquiries: 入力の無害化とカテゴリ', () => {
+    it('未知のカテゴリはそのまま表示される', async () => {
+      const inquiry = makeInquiry({ category: 'weird' });
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([inquiry]) });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ total_count: 0, items: [] }),
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ number: 1, html_url: 'https://github.com/test/1' }),
+      });
+      fetchMock.mockResolvedValueOnce({ ok: true });
+
+      await processInquiries(mockEnv);
+
+      const createBody = JSON.parse(fetchMock.mock.calls[2][1].body);
+      expect(createBody.title).toContain('[問い合わせ/weird]');
+    });
+
+    it('件名・表示名は inlineCode で無害化され、改行や markdown 注入を防ぐ', async () => {
+      const inquiry = makeInquiry({
+        twitch_display_name: '@everyone',
+        subject: 'line1\n# fake heading',
+      });
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([inquiry]) });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ total_count: 0, items: [] }),
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ number: 1, html_url: 'https://github.com/test/1' }),
+      });
+      fetchMock.mockResolvedValueOnce({ ok: true });
+
+      await processInquiries(mockEnv);
+
+      const createBody = JSON.parse(fetchMock.mock.calls[2][1].body);
+      // 表示名はインラインコード化され、@everyone は生メンションとして展開されない
+      expect(createBody.body).toContain('`@everyone`');
+      // 件名の改行は空白へ畳まれ、行頭 '# ' の見出し注入は無効化される
+      expect(createBody.body).toContain('`line1 # fake heading`');
+      expect(createBody.body).not.toContain('\nline1\n# fake heading');
+    });
+  });
 });

--- a/tests/unit/error-reporter-worker.test.ts
+++ b/tests/unit/error-reporter-worker.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import worker from '../../workers/error-reporter/src/index';
+import worker, { processErrors, processInquiries } from '../../workers/error-reporter/src/index';
 
-// Worker の scheduled ハンドラをテストする
-// 内部関数は export されていないため、scheduled 経由で統合的にテスト
+// Reporter Worker（twica-error-reporter）は errors と support_inquiries の両方を
+// GitHub Issue 化する。内部関数は export されていないため、
+//   - scheduled: env 検証と「エラー/問い合わせの独立実行」を統合的にテスト
+//   - processErrors / processInquiries: 各処理フローを個別にテスト
+// global.fetch をモックして「どの外部 API を何回・どんな内容で叩いたか」を検証する。
 
 const mockEnv = {
   SUPABASE_URL: 'https://test.supabase.co',
@@ -23,10 +26,22 @@ const makeErrorRecord = (overrides = {}) => ({
   ...overrides,
 });
 
+const makeInquiry = (overrides = {}) => ({
+  id: 'inq-1',
+  twitch_user_id: 'user-123',
+  twitch_display_name: 'TestUser',
+  category: 'bug',
+  subject: 'Test subject',
+  body: 'Test body',
+  status: 'open',
+  created_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
 const mockEvent = {} as ScheduledController;
 const mockCtx = { waitUntil: vi.fn() } as unknown as ExecutionContext;
 
-describe('error-reporter worker', () => {
+describe('reporter worker', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
@@ -64,17 +79,47 @@ describe('error-reporter worker', () => {
     });
   });
 
-  describe('未処理エラーがない場合', () => {
-    it('Supabase から空配列が返った場合は GitHub API を呼ばない', async () => {
-      // fetchPendingErrors → 空配列
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve([]),
-      });
+  describe('scheduled: エラー処理と問い合わせ処理の独立実行', () => {
+    it('両処理とも未処理なしなら fetch は2回（errors + support_inquiries のポーリング）', async () => {
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) }); // errors
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) }); // inquiries
 
       await worker.scheduled(mockEvent, mockEnv, mockCtx);
 
-      // Supabase への fetch のみ（GitHub API は呼ばれない）
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[0][0]).toContain('/rest/v1/errors');
+      expect(fetchMock.mock.calls[1][0]).toContain('/rest/v1/support_inquiries');
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('No pending errors'));
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('No pending inquiries'));
+    });
+
+    it('エラー処理が失敗しても問い合わせ処理は実行される', async () => {
+      // processErrors: fetchPendingErrors が 500 で失敗
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 500, text: () => Promise.resolve('err') });
+      // processInquiries: 未処理なし
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) });
+
+      await expect(worker.scheduled(mockEvent, mockEnv, mockCtx)).resolves.toBeUndefined();
+
+      // エラー側は 'Cron job failed' を記録し、問い合わせ側は最後まで実行される
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('[Error Reporter] Cron job failed'),
+        expect.any(Error)
+      );
+      expect(fetchMock.mock.calls[1][0]).toContain('/rest/v1/support_inquiries');
+      expect(console.log).toHaveBeenCalledWith(expect.stringContaining('No pending inquiries'));
+    });
+  });
+
+  // ===========================================================================
+  // processErrors（errors テーブル → GitHub Issue）
+  // ===========================================================================
+  describe('processErrors: 未処理エラーがない場合', () => {
+    it('Supabase から空配列が返った場合は GitHub API を呼ばない', async () => {
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) });
+
+      await processErrors(mockEnv);
+
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(console.log).toHaveBeenCalledWith(
         expect.stringContaining('No pending errors')
@@ -82,35 +127,25 @@ describe('error-reporter worker', () => {
     });
   });
 
-  describe('新規 Issue 作成フロー', () => {
+  describe('processErrors: 新規 Issue 作成フロー', () => {
     it('未処理エラーがあり既存 Issue がない場合、新規 Issue を作成して処理済みマークする', async () => {
       const errorRecord = makeErrorRecord();
 
-      // 1. fetchPendingErrors → エラー1件
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve([errorRecord]),
-      });
-      // 2. findExistingIssue (GitHub search) → 該当なし
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([errorRecord]) });
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ total_count: 0, items: [] }),
       });
-      // 3. createGitHubIssue → 成功
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ number: 42, html_url: 'https://github.com/test/42' }),
       });
-      // 4. markErrorsAsProcessed (Supabase PATCH) → 成功
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-      });
+      fetchMock.mockResolvedValueOnce({ ok: true });
 
-      await worker.scheduled(mockEvent, mockEnv, mockCtx);
+      await processErrors(mockEnv);
 
       expect(fetchMock).toHaveBeenCalledTimes(4);
 
-      // GitHub Issue 作成 API の呼び出しを検証
       const createIssueCall = fetchMock.mock.calls[2];
       expect(createIssueCall[0]).toContain('/repos/testowner/testrepo/issues');
       const createBody = JSON.parse(createIssueCall[1].body);
@@ -118,10 +153,8 @@ describe('error-reporter worker', () => {
       expect(createBody.body).toContain('Signature:');
       expect(createBody.labels).toContain('bug');
       expect(createBody.labels).toContain('auto-generated');
-      // preview 環境のラベルが追加される
       expect(createBody.labels).toContain('preview');
 
-      // Supabase PATCH の呼び出しを検証
       const patchCall = fetchMock.mock.calls[3];
       expect(patchCall[0]).toContain('/rest/v1/errors');
       const patchBody = JSON.parse(patchCall[1].body);
@@ -130,16 +163,11 @@ describe('error-reporter worker', () => {
     });
   });
 
-  describe('既存 Issue へのコメント追加フロー', () => {
+  describe('processErrors: 既存 Issue へのコメント追加フロー', () => {
     it('既存 Issue がある場合はコメントを追加する', async () => {
       const errorRecord = makeErrorRecord();
 
-      // 1. fetchPendingErrors
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve([errorRecord]),
-      });
-      // 2. findExistingIssue → 既存 Issue あり
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([errorRecord]) });
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({
@@ -147,30 +175,22 @@ describe('error-reporter worker', () => {
           items: [{ number: 10, html_url: 'https://github.com/test/10' }],
         }),
       });
-      // 3. addCommentToIssue → 成功
       fetchMock.mockResolvedValueOnce({ ok: true });
-      // 4. markErrorsAsProcessed → 成功
       fetchMock.mockResolvedValueOnce({ ok: true });
 
-      await worker.scheduled(mockEvent, mockEnv, mockCtx);
+      await processErrors(mockEnv);
 
-      // コメント追加 API の呼び出しを検証
       const commentCall = fetchMock.mock.calls[2];
       expect(commentCall[0]).toContain('/issues/10/comments');
       expect(commentCall[1].method).toBe('POST');
     });
   });
 
-  describe('addCommentToIssue 失敗時', () => {
+  describe('processErrors: addCommentToIssue 失敗時', () => {
     it('コメント追加失敗時は markErrorsAsProcessed がスキップされる', async () => {
       const errorRecord = makeErrorRecord();
 
-      // 1. fetchPendingErrors
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve([errorRecord]),
-      });
-      // 2. findExistingIssue → 既存 Issue あり
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([errorRecord]) });
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({
@@ -178,10 +198,9 @@ describe('error-reporter worker', () => {
           items: [{ number: 10, html_url: 'https://github.com/test/10' }],
         }),
       });
-      // 3. addCommentToIssue → 失敗（403）
       fetchMock.mockResolvedValueOnce({ ok: false, status: 403 });
 
-      await worker.scheduled(mockEvent, mockEnv, mockCtx);
+      await processErrors(mockEnv);
 
       // markErrorsAsProcessed (PATCH) は呼ばれない（fetch は3回のみ）
       expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -192,35 +211,27 @@ describe('error-reporter worker', () => {
     });
   });
 
-  describe('エラーグループ化（シグネチャ重複排除）', () => {
+  describe('processErrors: エラーグループ化（シグネチャ重複排除）', () => {
     it('同一メッセージのエラーは1つの Issue にまとめられる', async () => {
       const error1 = makeErrorRecord({ id: 'uuid-1', created_at: '2026-01-01T00:00:00Z' });
       const error2 = makeErrorRecord({ id: 'uuid-2', created_at: '2026-01-01T01:00:00Z' });
 
-      // 1. fetchPendingErrors → 同一シグネチャのエラー2件
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve([error1, error2]),
-      });
-      // 2. findExistingIssue → 該当なし
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([error1, error2]) });
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ total_count: 0, items: [] }),
       });
-      // 3. createGitHubIssue → 成功
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ number: 50, html_url: 'https://github.com/test/50' }),
       });
-      // 4. markErrorsAsProcessed → 成功
       fetchMock.mockResolvedValueOnce({ ok: true });
 
-      await worker.scheduled(mockEvent, mockEnv, mockCtx);
+      await processErrors(mockEnv);
 
       // Issue は1つだけ作成される（search 1回 + create 1回 + patch 1回）
       expect(fetchMock).toHaveBeenCalledTimes(4);
 
-      // PATCH に両方の ID が含まれる
       const patchCall = fetchMock.mock.calls[3];
       expect(patchCall[0]).toContain('uuid-1');
       expect(patchCall[0]).toContain('uuid-2');
@@ -230,109 +241,79 @@ describe('error-reporter worker', () => {
       const error1 = makeErrorRecord({ id: 'uuid-1', message: 'Error A' });
       const error2 = makeErrorRecord({ id: 'uuid-2', message: 'Error B' });
 
-      // 1. fetchPendingErrors → 異なるシグネチャのエラー2件
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve([error1, error2]),
-      });
-      // 2. findExistingIssue(group1) → なし
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([error1, error2]) });
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ total_count: 0, items: [] }),
       });
-      // 3. createGitHubIssue(group1)
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ number: 51, html_url: 'https://github.com/test/51' }),
       });
-      // 4. markErrorsAsProcessed(group1)
       fetchMock.mockResolvedValueOnce({ ok: true });
-      // 5. findExistingIssue(group2) → なし
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ total_count: 0, items: [] }),
       });
-      // 6. createGitHubIssue(group2)
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ number: 52, html_url: 'https://github.com/test/52' }),
       });
-      // 7. markErrorsAsProcessed(group2)
       fetchMock.mockResolvedValueOnce({ ok: true });
 
-      await worker.scheduled(mockEvent, mockEnv, mockCtx);
+      await processErrors(mockEnv);
 
-      // 2つの Issue が作成される
       expect(fetchMock).toHaveBeenCalledTimes(7);
     });
   });
 
-  describe('MAX_NEW_ISSUES_PER_RUN 制限', () => {
+  describe('processErrors: MAX_NEW_ISSUES_PER_RUN 制限', () => {
     it('1回の実行で最大5件の新規 Issue しか作成しない', async () => {
-      // 6つの異なるエラーを生成
       const errors = Array.from({ length: 6 }, (_, i) =>
         makeErrorRecord({ id: `uuid-${i}`, message: `Error ${i}` })
       );
 
-      // 1. fetchPendingErrors
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(errors),
-      });
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(errors) });
 
-      // 各グループに対して search → create → patch を繰り返す
       for (let i = 0; i < 6; i++) {
-        // findExistingIssue → なし
         fetchMock.mockResolvedValueOnce({
           ok: true,
           json: () => Promise.resolve({ total_count: 0, items: [] }),
         });
         if (i < 5) {
-          // createGitHubIssue
           fetchMock.mockResolvedValueOnce({
             ok: true,
             json: () => Promise.resolve({ number: 100 + i, html_url: `https://github.com/test/${100 + i}` }),
           });
-          // markErrorsAsProcessed
           fetchMock.mockResolvedValueOnce({ ok: true });
         }
       }
 
-      await worker.scheduled(mockEvent, mockEnv, mockCtx);
+      await processErrors(mockEnv);
 
-      // 6番目のグループは search のみで create されない
-      // fetch: 1 (pendingErrors) + 5 * 3 (search+create+patch) + 1 (search for 6th) = 17
       expect(console.log).toHaveBeenCalledWith(
         expect.stringContaining('Max new issues limit')
       );
     });
   });
 
-  describe('Supabase API エラー', () => {
-    it('fetchPendingErrors が失敗しても例外を外に漏らさない', async () => {
+  describe('processErrors: Supabase API エラー', () => {
+    it('fetchPendingErrors が失敗した場合は例外を投げる（scheduled 側で捕捉される）', async () => {
       fetchMock.mockResolvedValueOnce({
         ok: false,
         status: 500,
         text: () => Promise.resolve('Internal Server Error'),
       });
 
-      // 例外が投げられないことを確認（scheduled 内の try-catch で捕捉される）
-      await expect(worker.scheduled(mockEvent, mockEnv, mockCtx)).resolves.toBeUndefined();
-      expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('Cron job failed'),
-        expect.any(Error)
-      );
+      await expect(processErrors(mockEnv)).rejects.toThrow(/Supabase fetch error/);
     });
   });
 
-  describe('production 環境のラベル', () => {
+  describe('processErrors: production 環境のラベル', () => {
     it('production 環境のエラーには環境ラベルが付かない', async () => {
       const errorRecord = makeErrorRecord({ environment: 'production' });
 
-      fetchMock.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve([errorRecord]),
-      });
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([errorRecord]) });
       fetchMock.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({ total_count: 0, items: [] }),
@@ -343,11 +324,172 @@ describe('error-reporter worker', () => {
       });
       fetchMock.mockResolvedValueOnce({ ok: true });
 
-      await worker.scheduled(mockEvent, mockEnv, mockCtx);
+      await processErrors(mockEnv);
 
       const createBody = JSON.parse(fetchMock.mock.calls[2][1].body);
       expect(createBody.labels).toEqual(['bug', 'auto-generated']);
       expect(createBody.labels).not.toContain('production');
+    });
+  });
+
+  // ===========================================================================
+  // processInquiries（support_inquiries テーブル → GitHub Issue）
+  // ===========================================================================
+  describe('processInquiries: 未処理問い合わせがない場合', () => {
+    it('空配列なら GitHub API を呼ばず、FIFO・limit=10 でポーリングする', async () => {
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([]) });
+
+      await processInquiries(mockEnv);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const fetchUrl = fetchMock.mock.calls[0][0];
+      expect(fetchUrl).toContain('/rest/v1/support_inquiries');
+      expect(fetchUrl).toContain('github_issue_created=eq.false');
+      expect(fetchUrl).toContain('order=created_at.asc');
+      expect(fetchUrl).toContain('limit=10');
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('No pending inquiries')
+      );
+    });
+  });
+
+  describe('processInquiries: 新規 Issue 作成フロー', () => {
+    it('既存 Issue がない場合、新規 Issue を作成して処理済みマークする', async () => {
+      const inquiry = makeInquiry();
+
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([inquiry]) });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ total_count: 0, items: [] }),
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ number: 42, html_url: 'https://github.com/test/42' }),
+      });
+      fetchMock.mockResolvedValueOnce({ ok: true });
+
+      await processInquiries(mockEnv);
+
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+
+      const createCall = fetchMock.mock.calls[2];
+      expect(createCall[0]).toContain('/repos/testowner/testrepo/issues');
+      expect(createCall[1].method).toBe('POST');
+      const createBody = JSON.parse(createCall[1].body);
+      expect(createBody.title).toContain('[問い合わせ/バグ報告]');
+      expect(createBody.title).toContain('Test subject');
+      expect(createBody.body).toContain('Inquiry-ID: inq-1');
+      expect(createBody.body).toContain('TestUser');
+      expect(createBody.labels).toContain('support-inquiry');
+      expect(createBody.labels).toContain('auto-generated');
+
+      const patchCall = fetchMock.mock.calls[3];
+      expect(patchCall[0]).toContain('/rest/v1/support_inquiries');
+      expect(patchCall[0]).toContain('id=eq.inq-1');
+      expect(patchCall[1].method).toBe('PATCH');
+      const patchBody = JSON.parse(patchCall[1].body);
+      expect(patchBody.github_issue_created).toBe(true);
+      expect(patchBody.github_issue_number).toBe(42);
+      expect(patchBody.github_issue_url).toBe('https://github.com/test/42');
+    });
+
+    it('本文中のバッククォート連より長いフェンスで囲む（フェンス脱出防止）', async () => {
+      const inquiry = makeInquiry({ body: 'contains ``` triple backticks' });
+
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([inquiry]) });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ total_count: 0, items: [] }),
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ number: 1, html_url: 'https://github.com/test/1' }),
+      });
+      fetchMock.mockResolvedValueOnce({ ok: true });
+
+      await processInquiries(mockEnv);
+
+      const createBody = JSON.parse(fetchMock.mock.calls[2][1].body);
+      // 本文の最長 ``` (3連) より長い ```` (4連) フェンスで囲まれる
+      expect(createBody.body).toContain('````\ncontains ``` triple backticks\n````');
+    });
+  });
+
+  describe('processInquiries: 既存 Issue が見つかった場合（冪等性）', () => {
+    it('既存 Issue があれば新規作成せず、それでも処理済みマークする', async () => {
+      const inquiry = makeInquiry();
+
+      fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([inquiry]) });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          total_count: 1,
+          items: [{ number: 10, html_url: 'https://github.com/test/10' }],
+        }),
+      });
+      fetchMock.mockResolvedValueOnce({ ok: true });
+
+      await processInquiries(mockEnv);
+
+      // create を挟まないので fetch は3回（GET + search + PATCH）
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+
+      const patchCall = fetchMock.mock.calls[2];
+      expect(patchCall[0]).toContain('/rest/v1/support_inquiries');
+      expect(patchCall[1].method).toBe('PATCH');
+      const patchBody = JSON.parse(patchCall[1].body);
+      expect(patchBody.github_issue_created).toBe(true);
+      expect(patchBody.github_issue_number).toBe(10);
+
+      const postedToIssues = fetchMock.mock.calls.some(
+        (c) => typeof c[0] === 'string' && c[0].endsWith('/issues') && c[1]?.method === 'POST'
+      );
+      expect(postedToIssues).toBe(false);
+    });
+  });
+
+  describe('processInquiries: 個別エラーの分離', () => {
+    it('1件の作成が失敗しても他の問い合わせは処理される', async () => {
+      const inquiry1 = makeInquiry({ id: 'inq-1' });
+      const inquiry2 = makeInquiry({ id: 'inq-2' });
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve([inquiry1, inquiry2]),
+      });
+      // inq-1: search なし → create 失敗（500）
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ total_count: 0, items: [] }),
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('server error'),
+      });
+      // inq-2: search なし → create 成功 → PATCH 成功
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ total_count: 0, items: [] }),
+      });
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ number: 99, html_url: 'https://github.com/test/99' }),
+      });
+      fetchMock.mockResolvedValueOnce({ ok: true });
+
+      await processInquiries(mockEnv);
+
+      // GET(1) + inq-1[search, create-fail](2) + inq-2[search, create, patch](3) = 6
+      expect(fetchMock).toHaveBeenCalledTimes(6);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to process inquiry inq-1'),
+        expect.any(Error)
+      );
+
+      const lastCall = fetchMock.mock.calls[5];
+      expect(lastCall[0]).toContain('id=eq.inq-2');
+      expect(lastCall[1].method).toBe('PATCH');
     });
   });
 });

--- a/workers/error-reporter/src/index.ts
+++ b/workers/error-reporter/src/index.ts
@@ -501,7 +501,7 @@ function buildInquiryIssue(inquiry: InquiryRecord): { title: string; body: strin
   // （投稿者による @メンション通知スパム・リンク/画像・偽の見出し行注入を防ぐ）。
   const body = `## 新規問い合わせ
 
-**カテゴリ**: ${label} (${inlineCode(inquiry.category)})
+**カテゴリ**: ${inlineCode(label)} (${inlineCode(inquiry.category)})
 **投稿者**: ${inlineCode(inquiry.twitch_display_name)} (${inlineCode(inquiry.twitch_user_id)})
 **件名**: ${inlineCode(inquiry.subject)}
 **投稿日時**: ${inquiry.created_at}
@@ -531,7 +531,8 @@ async function markInquiryProcessed(
   issueUrl: string,
   env: Env
 ): Promise<void> {
-  await supabasePatch(env, `support_inquiries?id=eq.${id}`, {
+  // id はサーバ生成 UUID だが、将来の型変更に対する防御として encode しておく
+  await supabasePatch(env, `support_inquiries?id=eq.${encodeURIComponent(id)}`, {
     github_issue_created: true,
     github_issue_number: issueNumber,
     github_issue_url: issueUrl,
@@ -561,7 +562,9 @@ export async function processInquiries(env: Env): Promise<void> {
       // 冪等性の保険: 直前の実行で「作成成功 → 処理済みマーク失敗」となった場合に
       // 二重作成しないよう既存 Issue を検索する。本命の冪等性は github_issue_created
       // フラグ + create→mark の順序であり、検索は非同期インデックス依存の補助。
-      const query = `repo:${env.GITHUB_REPO_OWNER}/${env.GITHUB_REPO_NAME} is:issue "Inquiry-ID: ${inquiry.id}"`
+      // label:support-inquiry も条件に含め、無関係 Issue の本文に同じ文字列が
+      // 偶然/意図的に含まれていた場合の誤マッチ面を減らす。
+      const query = `repo:${env.GITHUB_REPO_OWNER}/${env.GITHUB_REPO_NAME} is:issue label:support-inquiry "Inquiry-ID: ${inquiry.id}"`
       const existing = await searchIssue(env, query)
 
       let issueNumber: number

--- a/workers/error-reporter/src/index.ts
+++ b/workers/error-reporter/src/index.ts
@@ -1,16 +1,25 @@
 /**
- * Error Reporter Cron Worker
- * エラーレポーター定期実行Worker
+ * Reporter Cron Worker (twica-error-reporter)
+ * レポーター定期実行Worker
  *
- * 5分ごとに Supabase errors テーブルから未処理エラーを取得し、
- * エラーをシグネチャでグループ化（重複排除）してから
- * GitHub Issue を自動作成する。
+ * 5分ごとに Supabase をポーリングし、2種類の未処理レコードを GitHub Issue 化する:
+ *   1. errors           … アプリで捕捉した未処理エラー（シグネチャで重複排除）
+ *   2. support_inquiries … 支援者からの新規問い合わせ（メンテナへの通知）
+ *
+ * いずれも同じ Transactional Outbox パターン（Supabase をアウトボックスとして
+ * 使い、処理済みフラグでリトライ・重複を制御）。GitHub / Supabase REST の薄い
+ * ラッパを共通ヘルパとして両処理で共有する。単一 Worker に集約することで、
+ * secrets・cron・デプロイを1組で済ませ運用を単純化する。
  *
  * Tail Workers (有料プラン必須) の無料代替として実装。
  * Cloudflare Workers Free プランの Cron Triggers を使用。
  *
- * See: https://github.com/azumag/twica/issues/239
+ * See: https://github.com/azumag/twica/issues/239 (errors)
+ *      https://github.com/azumag/twica/issues/633 (inquiries)
  */
+
+/** GitHub API 呼び出し時の User-Agent（GitHub は User-Agent 必須） */
+const USER_AGENT = 'twica-error-reporter'
 
 interface Env {
   SUPABASE_URL: string
@@ -21,9 +30,164 @@ interface Env {
   GITHUB_REPO_NAME: string
 }
 
+// =============================================================================
+// 共通ヘルパ: Supabase REST (PostgREST)
+// Supabase JS クライアントは使わず fetch で直接叩く（バンドルサイズ最小化）。
+// service_role 相当のキーで RLS を越えてサーバーサイド専用アクセスする。
+// =============================================================================
+
+/** secret キーを解決する（新キー優先、無ければ旧 service role キー） */
 function getSupabaseApiKey(env: Env): string | undefined {
   return env.SUPABASE_SECRET_KEY || env.SUPABASE_SERVICE_ROLE_KEY
 }
+
+/**
+ * PostgREST の GET でレコードを取得する。
+ * @param pathAndQuery /rest/v1/ 以降のパス + クエリ
+ */
+async function supabaseSelect<T>(env: Env, pathAndQuery: string): Promise<T> {
+  const key = getSupabaseApiKey(env)
+  const res = await fetch(`${env.SUPABASE_URL}/rest/v1/${pathAndQuery}`, {
+    headers: {
+      'apikey': key!,
+      'Authorization': `Bearer ${key}`,
+      'Accept': 'application/json',
+    },
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`Supabase fetch error: ${res.status} ${text}`)
+  }
+
+  return (await res.json()) as T
+}
+
+/**
+ * PostgREST の PATCH でレコードを更新する（Prefer: return=minimal）。
+ * @param pathAndQuery /rest/v1/ 以降のパス + フィルタ
+ * @param body 更新する列の値
+ */
+async function supabasePatch(
+  env: Env,
+  pathAndQuery: string,
+  body: Record<string, unknown>
+): Promise<void> {
+  const key = getSupabaseApiKey(env)
+  const res = await fetch(`${env.SUPABASE_URL}/rest/v1/${pathAndQuery}`, {
+    method: 'PATCH',
+    headers: {
+      'apikey': key!,
+      'Authorization': `Bearer ${key}`,
+      'Content-Type': 'application/json',
+      'Prefer': 'return=minimal',
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`Supabase PATCH error: ${res.status} ${text}`)
+  }
+}
+
+// =============================================================================
+// 共通ヘルパ: GitHub Issues API
+// @octokit は使わず raw fetch（バンドルサイズ最小化）。
+// =============================================================================
+
+/** GitHub API 共通ヘッダ。json=true で Content-Type を付与。 */
+function githubHeaders(env: Env, json = false): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Authorization': `Bearer ${env.GITHUB_TOKEN}`,
+    'Accept': 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': USER_AGENT,
+  }
+  if (json) {
+    headers['Content-Type'] = 'application/json'
+  }
+  return headers
+}
+
+/**
+ * GitHub Issues Search API で既存 Issue を検索する。
+ * Issue 本文に埋め込んだマーカー（Signature / Inquiry-ID 等）で照合し、
+ * 重複作成を防止する。API 失敗時は例外を投げず null を返す。
+ *
+ * 検索は best-effort（GitHub の検索インデックスは非同期更新のため、作成直後の
+ * Issue はヒットしないことがある）。冪等性の本命は呼び出し元の処理済みフラグ。
+ */
+async function searchIssue(
+  env: Env,
+  query: string
+): Promise<{ number: number; url: string } | null> {
+  const url = `https://api.github.com/search/issues?q=${encodeURIComponent(query)}`
+  const res = await fetch(url, { headers: githubHeaders(env) })
+
+  if (!res.ok) {
+    console.warn(`[Reporter] GitHub search API failed: ${res.status}`)
+    return null
+  }
+
+  const data = (await res.json()) as {
+    total_count: number
+    items: Array<{ number: number; html_url: string }>
+  }
+  if (data.total_count > 0) {
+    return { number: data.items[0].number, url: data.items[0].html_url }
+  }
+  return null
+}
+
+/**
+ * GitHub Issue を新規作成する。
+ * @throws API がエラーを返した場合（呼び出し元で処理済みマークをスキップさせる）
+ */
+async function postGitHubIssue(
+  env: Env,
+  payload: { title: string; body: string; labels: string[] }
+): Promise<{ number: number; url: string }> {
+  const res = await fetch(
+    `https://api.github.com/repos/${env.GITHUB_REPO_OWNER}/${env.GITHUB_REPO_NAME}/issues`,
+    {
+      method: 'POST',
+      headers: githubHeaders(env, true),
+      body: JSON.stringify(payload),
+    }
+  )
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`GitHub API error: ${res.status} ${text}`)
+  }
+
+  const issue = (await res.json()) as { number: number; html_url: string }
+  return { number: issue.number, url: issue.html_url }
+}
+
+/**
+ * 既存 Issue にコメントを追加する。
+ * @throws API がエラーを返した場合
+ */
+async function postIssueComment(env: Env, issueNumber: number, body: string): Promise<void> {
+  const res = await fetch(
+    `https://api.github.com/repos/${env.GITHUB_REPO_OWNER}/${env.GITHUB_REPO_NAME}/issues/${issueNumber}/comments`,
+    {
+      method: 'POST',
+      headers: githubHeaders(env, true),
+      body: JSON.stringify({ body }),
+    }
+  )
+
+  if (!res.ok) {
+    throw new Error(`Failed to add comment to issue #${issueNumber}: ${res.status}`)
+  }
+}
+
+// =============================================================================
+// エラー処理（errors テーブル → GitHub Issue）
+// =============================================================================
 
 /** Supabase errors テーブルのレコード型 */
 interface ErrorRecord {
@@ -49,9 +213,7 @@ interface ErrorGroup {
  * エラーシグネチャを生成する。
  * error_type + message の先頭行 + スタックトレースの先頭行 を組み合わせ、
  * 同一のエラーを1つの GitHub Issue にまとめるために使用。
- *
- * SHA-256 を使って固定長のハッシュにすることで、
- * Issue 本文内での検索・照合を容易にする。
+ * SHA-256 で固定長ハッシュにし、Issue 本文内での検索・照合を容易にする。
  */
 async function generateSignature(error: ErrorRecord): Promise<string> {
   const messageLine = error.message.split('\n')[0].slice(0, 200)
@@ -66,10 +228,7 @@ async function generateSignature(error: ErrorRecord): Promise<string> {
   return hashArray.map(b => b.toString(16).padStart(2, '0')).join('').slice(0, 16)
 }
 
-/**
- * エラーをシグネチャでグループ化する。
- * 同一シグネチャのエラーは1つの GitHub Issue にまとめる。
- */
+/** エラーをシグネチャでグループ化する（同一シグネチャは1つの Issue にまとめる）。 */
 async function groupErrors(errors: ErrorRecord[]): Promise<ErrorGroup[]> {
   const groups = new Map<string, ErrorRecord[]>()
 
@@ -91,45 +250,20 @@ async function groupErrors(errors: ErrorRecord[]): Promise<ErrorGroup[]> {
   }))
 }
 
-/**
- * GitHub Issues API で既存 Issue を検索する。
- * Issue 本文に埋め込んだ Signature ハッシュで照合。
- * 既に同じエラーの Issue が存在する場合は重複作成を防止する。
- */
-async function findExistingIssue(
+/** 既存 Issue を Signature ハッシュで検索する（重複作成防止）。 */
+async function findExistingErrorIssue(
   signature: string,
   env: Env
 ): Promise<{ number: number; url: string } | null> {
   const query = `repo:${env.GITHUB_REPO_OWNER}/${env.GITHUB_REPO_NAME} is:issue "Signature: ${signature}"`
-  const url = `https://api.github.com/search/issues?q=${encodeURIComponent(query)}`
-
-  const res = await fetch(url, {
-    headers: {
-      'Authorization': `Bearer ${env.GITHUB_TOKEN}`,
-      'Accept': 'application/vnd.github+json',
-      'X-GitHub-Api-Version': '2022-11-28',
-      'User-Agent': 'twica-error-reporter',
-    },
-  })
-
-  if (!res.ok) {
-    console.warn(`[Error Reporter] GitHub search API failed: ${res.status}`)
-    return null
-  }
-
-  const data = await res.json() as { total_count: number; items: Array<{ number: number; html_url: string }> }
-  if (data.total_count > 0) {
-    return { number: data.items[0].number, url: data.items[0].html_url }
-  }
-  return null
+  return searchIssue(env, query)
 }
 
 /**
- * GitHub Issue を新規作成する。
- * Issue 本文にエラー詳細、発生回数、シグネチャを記載。
- * シグネチャは重複検索に使用されるため、フォーマットを変更しないこと。
+ * GitHub Issue を新規作成する（エラー用）。
+ * Signature は重複検索に使用されるため、フォーマットを変更しないこと。
  */
-async function createGitHubIssue(
+async function createErrorIssue(
   group: ErrorGroup,
   env: Env
 ): Promise<{ number: number; url: string }> {
@@ -138,8 +272,6 @@ async function createGitHubIssue(
   // タイトル: 環境 + エラー種別 + メッセージ先頭（最大80文字）
   const title = `[${first.environment}] ${first.error_type} ${first.message.split('\n')[0]}`.slice(0, 80)
 
-  // 本文: エラー詳細を構造化して記載
-  // Signature は重複検索に使用するため、フォーマットを変更しないこと
   const body = `## Auto-generated Error Report
 
 **Type**: \`${first.error_type}\`
@@ -167,40 +299,15 @@ ${JSON.stringify(first.context, null, 2).slice(0, 2000)}
 Signature: ${group.signature}
 *Auto-generated by [twica-error-reporter](https://github.com/azumag/twica/issues/239)*`
 
-  // ラベル: 自動生成であることを明示 + 環境名
   const labels = ['bug', 'auto-generated']
   if (first.environment !== 'production') {
     labels.push(first.environment)
   }
 
-  const res = await fetch(
-    `https://api.github.com/repos/${env.GITHUB_REPO_OWNER}/${env.GITHUB_REPO_NAME}/issues`,
-    {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${env.GITHUB_TOKEN}`,
-        'Accept': 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-        'Content-Type': 'application/json',
-        'User-Agent': 'twica-error-reporter',
-      },
-      body: JSON.stringify({ title, body, labels }),
-    }
-  )
-
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(`GitHub API error: ${res.status} ${text}`)
-  }
-
-  const issue = await res.json() as { number: number; html_url: string }
-  return { number: issue.number, url: issue.html_url }
+  return postGitHubIssue(env, { title, body, labels })
 }
 
-/**
- * 既存 Issue にコメントを追加する（再発通知）。
- * 同じエラーが再発した場合、新規 Issue を作成せずに既存 Issue にコメントする。
- */
+/** 既存 Issue にコメントを追加する（再発通知）。 */
 async function addCommentToIssue(
   issueNumber: number,
   group: ErrorGroup,
@@ -213,183 +320,287 @@ async function addCommentToIssue(
 
 This error has reoccurred. Please investigate if still unresolved.`
 
-  const res = await fetch(
-    `https://api.github.com/repos/${env.GITHUB_REPO_OWNER}/${env.GITHUB_REPO_NAME}/issues/${issueNumber}/comments`,
-    {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${env.GITHUB_TOKEN}`,
-        'Accept': 'application/vnd.github+json',
-        'X-GitHub-Api-Version': '2022-11-28',
-        'Content-Type': 'application/json',
-        'User-Agent': 'twica-error-reporter',
-      },
-      body: JSON.stringify({ body }),
-    }
-  )
-
-  if (!res.ok) {
-    // コメント追加失敗時は throw して markErrorsAsProcessed をスキップする
-    // throw しないとエラーが「処理済み」マークされ、GitHub Issue への追記が永久に失われる
-    throw new Error(`Failed to add comment to issue #${issueNumber}: ${res.status}`)
-  }
+  // コメント追加失敗時は throw して markErrorsAsProcessed をスキップさせる
+  // （throw しないと「処理済み」マークされ、GitHub Issue への追記が永久に失われる）。
+  await postIssueComment(env, issueNumber, body)
 }
 
-/**
- * Supabase REST API でエラーレコードを処理済みに更新する。
- * Supabase JS クライアントは使わず、fetch で直接 REST API を叩く
- * （Cron Worker のバンドルサイズを最小化するため）。
- */
+/** errors テーブルのレコードを処理済みに更新する。 */
 async function markErrorsAsProcessed(
   errorIds: string[],
   issueNumber: number,
   issueUrl: string,
   env: Env
 ): Promise<void> {
-  // Supabase REST API の IN フィルタ: id=in.(uuid1,uuid2,...)
-  const idFilter = `in.(${errorIds.join(',')})`
-  const url = `${env.SUPABASE_URL}/rest/v1/errors?id=${idFilter}`
-  const supabaseKey = getSupabaseApiKey(env)
-
-  const res = await fetch(url, {
-    method: 'PATCH',
-    headers: {
-      'apikey': supabaseKey!,
-      'Authorization': `Bearer ${supabaseKey}`,
-      'Content-Type': 'application/json',
-      'Prefer': 'return=minimal',
-    },
-    body: JSON.stringify({
-      github_issue_created: true,
-      github_issue_number: issueNumber,
-      github_issue_url: issueUrl,
-    }),
+  await supabasePatch(env, `errors?id=in.(${errorIds.join(',')})`, {
+    github_issue_created: true,
+    github_issue_number: issueNumber,
+    github_issue_url: issueUrl,
   })
-
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(`Supabase PATCH error: ${res.status} ${text}`)
-  }
 }
 
 /**
- * Supabase REST API から未処理エラーを取得する。
- * github_issue_created = false のエラーを古い順（FIFO）で最大100件取得。
- * 古い順にすることで、MAX_NEW_ISSUES_PER_RUN に達した場合でも
- * 新しいエラーが優先されて古いエラーが永久に未処理になる「飢餓状態」を防止する。
+ * 未処理エラーを取得する。
+ * github_issue_created = false を古い順（FIFO）で最大100件。
+ * 古い順にすることで、上限到達時も古いエラーが飢餓状態にならない。
  */
 async function fetchPendingErrors(env: Env): Promise<ErrorRecord[]> {
-  const url = `${env.SUPABASE_URL}/rest/v1/errors?github_issue_created=eq.false&order=created_at.asc&limit=100`
-  const supabaseKey = getSupabaseApiKey(env)
+  return supabaseSelect<ErrorRecord[]>(
+    env,
+    'errors?github_issue_created=eq.false&order=created_at.asc&limit=100'
+  )
+}
 
-  const res = await fetch(url, {
-    headers: {
-      'apikey': supabaseKey!,
-      'Authorization': `Bearer ${supabaseKey}`,
-      'Accept': 'application/json',
-    },
-  })
+/**
+ * エラー処理本体。
+ * 1. 未処理エラーを取得 → 2. シグネチャでグループ化 → 3. 既存 Issue 検索
+ *    （あり=コメント / なし=新規作成）→ 4. 処理済みマーク。
+ */
+export async function processErrors(env: Env): Promise<void> {
+  console.log('[Error Reporter] Started')
 
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(`Supabase fetch error: ${res.status} ${text}`)
+  const errors = await fetchPendingErrors(env)
+  if (errors.length === 0) {
+    console.log('[Error Reporter] No pending errors')
+    return
   }
 
-  return await res.json() as ErrorRecord[]
+  console.log(`[Error Reporter] Processing ${errors.length} errors`)
+
+  const groups = await groupErrors(errors)
+  console.log(`[Error Reporter] ${groups.length} unique error groups`)
+
+  // 1回の実行で新規作成する Issue 数の上限（バースト時の Issue 乱立を防止）
+  const MAX_NEW_ISSUES_PER_RUN = 5
+  let newIssuesCreated = 0
+
+  for (const group of groups) {
+    try {
+      const existing = await findExistingErrorIssue(group.signature, env)
+
+      let issueNumber: number
+      let issueUrl: string
+
+      if (existing) {
+        issueNumber = existing.number
+        issueUrl = existing.url
+        await addCommentToIssue(issueNumber, group, env)
+        console.log(`[Error Reporter] Added comment to existing issue #${issueNumber}`)
+      } else {
+        if (newIssuesCreated >= MAX_NEW_ISSUES_PER_RUN) {
+          console.log(`[Error Reporter] Max new issues limit (${MAX_NEW_ISSUES_PER_RUN}) reached. Deferring group: ${group.signature}`)
+          continue
+        }
+        const issue = await createErrorIssue(group, env)
+        issueNumber = issue.number
+        issueUrl = issue.url
+        newIssuesCreated++
+        console.log(`[Error Reporter] Created issue #${issueNumber}: ${issueUrl}`)
+      }
+
+      const errorIds = group.errors.map(e => e.id)
+      await markErrorsAsProcessed(errorIds, issueNumber, issueUrl, env)
+    } catch (err) {
+      // 個別グループのエラーは他のグループの処理を阻害しない
+      console.error(`[Error Reporter] Failed to process group ${group.signature}:`, err)
+    }
+  }
+
+  console.log(`[Error Reporter] Completed (${newIssuesCreated} new issues created)`)
 }
+
+// =============================================================================
+// 問い合わせ処理（support_inquiries テーブル → GitHub Issue）
+// error 処理との違い: 問い合わせは1件ずつ一意なのでグループ化・再発コメント不要。
+// =============================================================================
+
+/** Supabase support_inquiries テーブルのレコード型（必要な列のみ） */
+interface InquiryRecord {
+  id: string
+  twitch_user_id: string
+  twitch_display_name: string
+  // 'bug' | 'feature' | 'other'
+  category: string
+  subject: string
+  body: string
+  status: string
+  created_at: string
+}
+
+/**
+ * 1回の実行で処理する問い合わせの最大件数。
+ * Supabase fetch の limit にも使い、1件ごとに走る GitHub Search の回数を抑える。
+ * 問い合わせは低頻度なので通常はほぼ 0 件。
+ */
+const MAX_INQUIRIES_PER_RUN = 10
+
+/** カテゴリコード → 日本語表示名 */
+const INQUIRY_CATEGORY_LABELS: Record<string, string> = {
+  bug: 'バグ報告',
+  feature: '機能要望',
+  other: 'その他',
+}
+
+/** カテゴリの日本語表示名を返す（未知の値はそのままフォールバック） */
+function inquiryCategoryLabel(category: string): string {
+  return INQUIRY_CATEGORY_LABELS[category] ?? category
+}
+
+/**
+ * 本文を安全にコードフェンスで囲む。
+ * 本文中のバッククォート連の最大長 + 1 のフェンスを使うことで、本文から
+ * フェンスを脱出して偽の `Inquiry-ID:` 行などを混入させる余地をなくす。
+ */
+function fenceInquiryBody(body: string): string {
+  const runs = body.match(/`+/g)
+  const longest = runs ? Math.max(...runs.map(r => r.length)) : 0
+  const fence = '`'.repeat(Math.max(3, longest + 1))
+  return `${fence}\n${body}\n${fence}`
+}
+
+/** 未処理問い合わせを取得する（FIFO・上限つき）。 */
+async function fetchPendingInquiries(env: Env): Promise<InquiryRecord[]> {
+  return supabaseSelect<InquiryRecord[]>(
+    env,
+    `support_inquiries?github_issue_created=eq.false&order=created_at.asc&limit=${MAX_INQUIRIES_PER_RUN}`
+  )
+}
+
+/**
+ * 問い合わせから GitHub Issue のペイロードを組み立てる。
+ * リポジトリは private のためメンテナが対応に必要な投稿者情報も含める。
+ * 末尾の `Inquiry-ID:` 行は重複検索のマーカーなのでフォーマットを変更しないこと。
+ */
+function buildInquiryIssue(inquiry: InquiryRecord): { title: string; body: string; labels: string[] } {
+  const label = inquiryCategoryLabel(inquiry.category)
+  // タイトル: 一覧で判別しやすい接頭辞 + 件名。改行を除去し120字上限に丸める。
+  const singleLineSubject = inquiry.subject.replace(/\s+/g, ' ').trim()
+  const title = `[問い合わせ/${label}] ${singleLineSubject}`.slice(0, 120)
+
+  const body = `## 新規問い合わせ
+
+**カテゴリ**: ${label} (\`${inquiry.category}\`)
+**投稿者**: ${inquiry.twitch_display_name} (\`${inquiry.twitch_user_id}\`)
+**件名**: ${inquiry.subject}
+**投稿日時**: ${inquiry.created_at}
+
+### 本文
+${fenceInquiryBody(inquiry.body)}
+
+---
+返信はダッシュボードの問い合わせ管理画面から行ってください。
+Inquiry-ID: ${inquiry.id}
+*Auto-generated by twica-error-reporter — https://github.com/azumag/twica/issues/633*`
+
+  // 自動生成であることを明示するラベル（存在しなければ GitHub が自動作成する）。
+  return { title, body, labels: ['support-inquiry', 'auto-generated'] }
+}
+
+/** 問い合わせを処理済みに更新する（発行した Issue の番号・URL を記録）。 */
+async function markInquiryProcessed(
+  id: string,
+  issueNumber: number,
+  issueUrl: string,
+  env: Env
+): Promise<void> {
+  await supabasePatch(env, `support_inquiries?id=eq.${id}`, {
+    github_issue_created: true,
+    github_issue_number: issueNumber,
+    github_issue_url: issueUrl,
+  })
+}
+
+/**
+ * 問い合わせ処理本体。
+ * 各件について既存 Issue を検索（冪等性の保険）→ 無ければ新規作成 →
+ * 既存/新規いずれでも必ず処理済みマーク。
+ */
+export async function processInquiries(env: Env): Promise<void> {
+  console.log('[Inquiry Reporter] Started')
+
+  const inquiries = await fetchPendingInquiries(env)
+  if (inquiries.length === 0) {
+    console.log('[Inquiry Reporter] No pending inquiries')
+    return
+  }
+
+  console.log(`[Inquiry Reporter] Processing ${inquiries.length} inquiries`)
+
+  let created = 0
+
+  for (const inquiry of inquiries) {
+    try {
+      // 冪等性の保険: 直前の実行で「作成成功 → 処理済みマーク失敗」となった場合に
+      // 二重作成しないよう既存 Issue を検索する。本命の冪等性は github_issue_created
+      // フラグ + create→mark の順序であり、検索は非同期インデックス依存の補助。
+      const query = `repo:${env.GITHUB_REPO_OWNER}/${env.GITHUB_REPO_NAME} is:issue "Inquiry-ID: ${inquiry.id}"`
+      const existing = await searchIssue(env, query)
+
+      let issueNumber: number
+      let issueUrl: string
+
+      if (existing) {
+        issueNumber = existing.number
+        issueUrl = existing.url
+        console.log(`[Inquiry Reporter] Existing issue #${issueNumber} found for inquiry ${inquiry.id}, skipping create`)
+      } else {
+        const issue = await postGitHubIssue(env, buildInquiryIssue(inquiry))
+        issueNumber = issue.number
+        issueUrl = issue.url
+        created++
+        console.log(`[Inquiry Reporter] Created issue #${issueNumber} for inquiry ${inquiry.id}: ${issueUrl}`)
+      }
+
+      // 既存・新規いずれの場合でも必ず処理済みマークする。
+      // これを怠ると、既存 Issue があるのに github_issue_created=false のまま残り、
+      // 毎回 GitHub Search を無駄に叩き続ける「飢餓 + 無限 search」状態に陥る。
+      await markInquiryProcessed(inquiry.id, issueNumber, issueUrl, env)
+    } catch (err) {
+      // 個別問い合わせのエラーは他の問い合わせの処理を阻害しない
+      console.error(`[Inquiry Reporter] Failed to process inquiry ${inquiry.id}:`, err)
+    }
+  }
+
+  console.log(`[Inquiry Reporter] Completed (${created} new issues created)`)
+}
+
+// =============================================================================
+// Cron Trigger エントリポイント
+// =============================================================================
 
 export default {
   /**
    * Cron Trigger ハンドラ: 5分ごとに実行される。
-   * 1. Supabase から未処理エラーを取得
-   * 2. エラーをシグネチャでグループ化（重複排除）
-   * 3. 各グループについて既存 Issue を検索
-   *    - 既存あり → コメント追加（再発通知）
-   *    - 既存なし → 新規 Issue 作成
-   * 4. Supabase でエラーを処理済みマーク
+   * 環境変数を検証したうえで、エラー処理と問い合わせ処理を順に実行する。
+   * 2つの処理は独立しており、片方が失敗しても他方は実行される。
    */
   async scheduled(
     _event: ScheduledController,
     env: Env,
     _ctx: ExecutionContext
   ): Promise<void> {
+    // 環境変数バリデーション（両処理共通）: 未設定の場合は早期リターン。
+    // secret 未設定でも無害に空振りする。
+    if (!env.SUPABASE_URL || !getSupabaseApiKey(env) || !env.GITHUB_TOKEN) {
+      console.error('[Reporter] Missing required secrets. Set SUPABASE_URL, SUPABASE_SECRET_KEY (or legacy SUPABASE_SERVICE_ROLE_KEY), GITHUB_TOKEN via wrangler secret put')
+      return
+    }
+    if (!env.GITHUB_REPO_OWNER || !env.GITHUB_REPO_NAME) {
+      console.error('[Reporter] Missing GITHUB_REPO_OWNER or GITHUB_REPO_NAME in wrangler.toml [vars]')
+      return
+    }
+
+    // エラー処理と問い合わせ処理は独立。片方の失敗が他方を止めないよう個別に捕捉。
     try {
-      // 環境変数バリデーション: 未設定の場合は早期リターン
-      if (!env.SUPABASE_URL || !getSupabaseApiKey(env) || !env.GITHUB_TOKEN) {
-        console.error('[Error Reporter] Missing required secrets. Set SUPABASE_URL, SUPABASE_SECRET_KEY (or legacy SUPABASE_SERVICE_ROLE_KEY), GITHUB_TOKEN via wrangler secret put')
-        return
-      }
-      // GITHUB_REPO_OWNER / GITHUB_REPO_NAME は wrangler.toml の [vars] で定義
-      // 未定義の場合 GitHub API の URL に undefined が含まれて予期しないエラーになる
-      if (!env.GITHUB_REPO_OWNER || !env.GITHUB_REPO_NAME) {
-        console.error('[Error Reporter] Missing GITHUB_REPO_OWNER or GITHUB_REPO_NAME in wrangler.toml [vars]')
-        return
-      }
-
-      console.log('[Error Reporter] Cron job started')
-
-      // 1. 未処理エラーを取得
-      const errors = await fetchPendingErrors(env)
-
-      if (errors.length === 0) {
-        console.log('[Error Reporter] No pending errors')
-        return
-      }
-
-      console.log(`[Error Reporter] Processing ${errors.length} errors`)
-
-      // 2. エラーをシグネチャでグループ化
-      const groups = await groupErrors(errors)
-      console.log(`[Error Reporter] ${groups.length} unique error groups`)
-
-      // 1回の Cron 実行で新規作成する Issue 数の上限
-      // GitHub API レート制限（認証済み: 5,000 req/hour）を考慮し、
-      // エラーバースト時の Issue 乱立を防止
-      const MAX_NEW_ISSUES_PER_RUN = 5
-      let newIssuesCreated = 0
-
-      // 3. 各グループを処理
-      for (const group of groups) {
-        try {
-          // 既存 Issue を検索（重複防止）
-          const existing = await findExistingIssue(group.signature, env)
-
-          let issueNumber: number
-          let issueUrl: string
-
-          if (existing) {
-            // 既存 Issue にコメント追加（再発通知）
-            issueNumber = existing.number
-            issueUrl = existing.url
-            await addCommentToIssue(issueNumber, group, env)
-            console.log(`[Error Reporter] Added comment to existing issue #${issueNumber}`)
-          } else {
-            // 新規 Issue 作成数の上限チェック
-            if (newIssuesCreated >= MAX_NEW_ISSUES_PER_RUN) {
-              console.log(`[Error Reporter] Max new issues limit (${MAX_NEW_ISSUES_PER_RUN}) reached. Deferring group: ${group.signature}`)
-              continue
-            }
-            // 新規 Issue 作成
-            const issue = await createGitHubIssue(group, env)
-            issueNumber = issue.number
-            issueUrl = issue.url
-            newIssuesCreated++
-            console.log(`[Error Reporter] Created issue #${issueNumber}: ${issueUrl}`)
-          }
-
-          // 4. Supabase で処理済みマーク
-          const errorIds = group.errors.map(e => e.id)
-          await markErrorsAsProcessed(errorIds, issueNumber, issueUrl, env)
-        } catch (err) {
-          // 個別グループのエラーは他のグループの処理を阻害しない
-          console.error(`[Error Reporter] Failed to process group ${group.signature}:`, err)
-        }
-      }
-
-      console.log(`[Error Reporter] Cron job completed (${newIssuesCreated} new issues created)`)
+      await processErrors(env)
     } catch (err) {
-      // Cron job 全体のエラーは Cloudflare Workers Observability で確認可能
       console.error('[Error Reporter] Cron job failed:', err)
+    }
+
+    try {
+      await processInquiries(env)
+    } catch (err) {
+      console.error('[Inquiry Reporter] Cron job failed:', err)
     }
   },
 }

--- a/workers/error-reporter/src/index.ts
+++ b/workers/error-reporter/src/index.ts
@@ -414,7 +414,7 @@ export async function processErrors(env: Env): Promise<void> {
 // error 処理との違い: 問い合わせは1件ずつ一意なのでグループ化・再発コメント不要。
 // =============================================================================
 
-/** Supabase support_inquiries テーブルのレコード型（必要な列のみ） */
+/** Supabase support_inquiries テーブルのレコード型（Issue 化に必要な列のみ） */
 interface InquiryRecord {
   id: string
   twitch_user_id: string
@@ -423,9 +423,11 @@ interface InquiryRecord {
   category: string
   subject: string
   body: string
-  status: string
   created_at: string
 }
+
+/** fetchPendingInquiries で取得する列（InquiryRecord に対応。body 以外の余計な列は引かない） */
+const INQUIRY_SELECT_COLUMNS = 'id,twitch_user_id,twitch_display_name,category,subject,body,created_at'
 
 /**
  * 1回の実行で処理する問い合わせの最大件数。
@@ -458,11 +460,29 @@ function fenceInquiryBody(body: string): string {
   return `${fence}\n${body}\n${fence}`
 }
 
-/** 未処理問い合わせを取得する（FIFO・上限つき）。 */
+/**
+ * ユーザー入力を安全なインラインコードスパンとして描画する。
+ * 改行を空白へ畳んで1行に収め、markdown 描画（@メンションによる他ユーザーへの
+ * 通知スパム・画像/リンク・整形崩し）や偽の見出し行の注入を無効化する。
+ * 値に含まれるバッククォート連より1つ長いデリミタを使い、必要なら CommonMark に
+ * 従いスペースパディングしてエスケープする。件名・表示名など fenced ブロック外に
+ * 展開する自由入力フィールドに使う（本文は fenceInquiryBody で保護済み）。
+ */
+function inlineCode(value: string): string {
+  const collapsed = value.replace(/\s+/g, ' ').trim()
+  const runs = collapsed.match(/`+/g)
+  const ticks = '`'.repeat((runs ? Math.max(...runs.map(r => r.length)) : 0) + 1)
+  // 先頭/末尾がバッククォートだとデリミタと隣接して壊れるためスペースパディング
+  const needsPad = collapsed.startsWith('`') || collapsed.endsWith('`')
+  const inner = needsPad ? ` ${collapsed} ` : collapsed
+  return `${ticks}${inner}${ticks}`
+}
+
+/** 未処理問い合わせを取得する（FIFO・上限つき・必要列のみ）。 */
 async function fetchPendingInquiries(env: Env): Promise<InquiryRecord[]> {
   return supabaseSelect<InquiryRecord[]>(
     env,
-    `support_inquiries?github_issue_created=eq.false&order=created_at.asc&limit=${MAX_INQUIRIES_PER_RUN}`
+    `support_inquiries?select=${INQUIRY_SELECT_COLUMNS}&github_issue_created=eq.false&order=created_at.asc&limit=${MAX_INQUIRIES_PER_RUN}`
   )
 }
 
@@ -477,11 +497,13 @@ function buildInquiryIssue(inquiry: InquiryRecord): { title: string; body: strin
   const singleLineSubject = inquiry.subject.replace(/\s+/g, ' ').trim()
   const title = `[問い合わせ/${label}] ${singleLineSubject}`.slice(0, 120)
 
+  // fenced ブロック外に出す自由入力フィールドは inlineCode で無害化する
+  // （投稿者による @メンション通知スパム・リンク/画像・偽の見出し行注入を防ぐ）。
   const body = `## 新規問い合わせ
 
-**カテゴリ**: ${label} (\`${inquiry.category}\`)
-**投稿者**: ${inquiry.twitch_display_name} (\`${inquiry.twitch_user_id}\`)
-**件名**: ${inquiry.subject}
+**カテゴリ**: ${label} (${inlineCode(inquiry.category)})
+**投稿者**: ${inlineCode(inquiry.twitch_display_name)} (${inlineCode(inquiry.twitch_user_id)})
+**件名**: ${inlineCode(inquiry.subject)}
 **投稿日時**: ${inquiry.created_at}
 
 ### 本文
@@ -496,7 +518,13 @@ Inquiry-ID: ${inquiry.id}
   return { title, body, labels: ['support-inquiry', 'auto-generated'] }
 }
 
-/** 問い合わせを処理済みに更新する（発行した Issue の番号・URL を記録）。 */
+/**
+ * 問い合わせを処理済みに更新する（発行した Issue の番号・URL を記録）。
+ * この PATCH は support_inquiries の update_support_inquiries_updated_at トリガ
+ * (00019) を発火させ、対象行の updated_at を発行時刻に1度だけ書き換える。
+ * ユーザー向け一覧・詳細は created_at ソートで updated_at に依存しないため実害は
+ * 無いが、将来 updated_at を「最終更新」として表示する場合は考慮すること。
+ */
 async function markInquiryProcessed(
   id: string,
   issueNumber: number,

--- a/workers/error-reporter/wrangler.toml
+++ b/workers/error-reporter/wrangler.toml
@@ -1,10 +1,13 @@
-# Error Reporter Cron Worker
-# エラーレポーター定期実行Worker
+# Reporter Cron Worker
+# レポーター定期実行Worker
 #
-# Supabase errors テーブルから未処理エラーを取得し、
-# GitHub Issue を自動作成する。Tail Workers (有料) の無料代替。
+# Supabase から未処理レコードを取得し GitHub Issue を自動作成する。
+#   - errors テーブル: 未処理エラー（Tail Workers 有料の無料代替）
+#   - support_inquiries テーブル: 新規問い合わせの通知（Issue #633）
+# 同一の secrets・cron・デプロイを共有するため単一 Worker に集約している。
 #
-# See: https://github.com/azumag/twica/issues/239
+# See: https://github.com/azumag/twica/issues/239 (errors)
+#      https://github.com/azumag/twica/issues/633 (inquiries)
 
 name = "twica-error-reporter"
 main = "src/index.ts"


### PR DESCRIPTION
support_inquiries の未処理問い合わせを error-reporter Cron Worker が
定期ポーリングし、GitHub Issue を自動発行してメンテナへ通知する。
error-reporter (#239) と同じ Transactional Outbox パターンを、運用を
単純化するため同一 Worker に集約する形で追加（secrets・cron・デプロイを共有）。

- migration 00072: support_inquiries に github_issue_created / number / url と
  未処理ポーリング用の部分インデックスを追加。既存行は ADD COLUMN DEFAULT TRUE で
  「発行済み」にバックフィルしてから DEFAULT を FALSE に切替え、過去分を遡って
  Issue 化せず今後の新規行のみ処理対象にする（UPDATE 文を使わないため updated_at
  トリガも発火しない）。
- schema.ts: supportInquiries に対応する3カラムを追加。
- error-reporter worker: processErrors と processInquiries を scheduled から
  独立実行（片方の失敗が他方を止めない）。GitHub/Supabase の fetch ヘルパを
  両処理で共有。冪等性は github_issue_created フラグ + create→mark 順序で担保し、
  GitHub Search は再試行時重複防止の保険。private リポジトリのため Issue 本文に
  投稿者情報も含める。
- tests: 集約後の worker テスト（エラー処理 / 問い合わせ処理 / 独立実行）。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xj9Xbq2xFiTBa22s3DssHo