### PR TITLE
fix(types): tsc型エラーを解消しCIにtypecheckゲートを追加 (#588)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Typecheck
+        # #588: 型エラーの検出漏れ防止のため tsc --noEmit をゲート化する。
+        # 既に依存インストール済みの test job に同居させ、新規 job による
+        # 追加の npm ci / セットアップコストを避ける。
+        run: npm run typecheck
+
       - name: Unit tests
         run: npm run test:unit
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",
     "test:all": "vitest run",

--- a/tests/unit/additional-rewards-api.test.ts
+++ b/tests/unit/additional-rewards-api.test.ts
@@ -42,7 +42,10 @@ describe('/api/streamer/additional-rewards raid options', () => {
       twitchUserId: 'streamer-twitch-1',
       twitchUsername: 'streamer',
       twitchDisplayName: 'Streamer',
-      twitchProfileImageUrl: null,
+      // SessionPayload.twitchProfileImageUrl は string 必須（null 非許容）。
+      // 実際のセッション生成元(callback route)でも Twitch API の profile_image_url を
+      // そのまま格納するため、他のテストと同様にプレースホルダURL文字列を使う。
+      twitchProfileImageUrl: 'https://example.com/avatar.png',
       broadcasterType: 'affiliate',
       expiresAt: Date.now() + 60_000,
       version: 1,

--- a/tests/unit/auth-scope-preservation.test.ts
+++ b/tests/unit/auth-scope-preservation.test.ts
@@ -67,14 +67,18 @@ vi.mock('@/lib/supabase/admin', () => ({
 }))
 
 // twitch auth
-const mockIsInvalidAuthorizationCodeError = vi.fn(() => false)
+// 実関数 isInvalidAuthorizationCodeError(error: unknown) と同じ引数個数で宣言する。
+// vi.fn の型はコールバック引数から推論されるため、0引数のままだと
+// モックするモジュールの型 (error: unknown) => boolean と合わずコンパイルエラーになる。
+const mockIsInvalidAuthorizationCodeError = vi.fn((_error: unknown) => false)
 vi.mock('@/lib/twitch/auth', () => ({
   getTwitchAuthUrl: vi.fn((_redirectUri: string, _state: string, additionalScopes?: string[]) =>
     `https://twitch.tv/authorize?scopes=${(additionalScopes ?? []).join(',')}`
   ),
   exchangeCodeForTokens: vi.fn(),
   getTwitchUser: vi.fn(),
-  isInvalidAuthorizationCodeError: (...args: unknown[]) => mockIsInvalidAuthorizationCodeError(...args),
+  // mock自体の引数型が実関数と一致しているため、spreadラッパーを介さず直接割り当てる
+  isInvalidAuthorizationCodeError: mockIsInvalidAuthorizationCodeError,
 }))
 
 // token-manager
@@ -91,7 +95,9 @@ vi.mock('@/lib/rate-limit', () => ({
 }))
 
 // error handlers and sentry
-const mockHandleAuthError = vi.fn((_err: unknown, code: string) => ({
+// 実関数 handleAuthError(error, errorType, context?, options?) と同じ引数個数で宣言する。
+// 2引数のままだとモックするモジュールの型(4引数)と合わずコンパイルエラーになる。
+const mockHandleAuthError = vi.fn((_err: unknown, code: string, _context?: Record<string, unknown>, _options?: { returnJson?: boolean; baseUrl?: string }) => ({
   type: 'error',
   code,
   cookies: {
@@ -103,7 +109,8 @@ const mockHandleAuthError = vi.fn((_err: unknown, code: string) => ({
   },
 }))
 vi.mock('@/lib/auth-error-handler', () => ({
-  handleAuthError: (...args: unknown[]) => mockHandleAuthError(...args),
+  // 同上: mock自体の引数型が実関数と一致しているため直接割り当てる
+  handleAuthError: mockHandleAuthError,
 }))
 vi.mock('@/lib/sentry/error-handler', () => ({
   reportAuthError: vi.fn(),

--- a/tests/unit/battle.test.ts
+++ b/tests/unit/battle.test.ts
@@ -109,6 +109,8 @@ describe('toBattleCard', () => {
       image_url: 'https://example.com/image.jpg',
       rarity: 'rare',
       card_number: null,
+      // Card.max_issuance_count は `number | null` 必須フィールド。
+      max_issuance_count: null,
       collection_name: null,
       drop_rate: 0.1,
       intra_rarity_weight: 1.0,
@@ -390,6 +392,10 @@ describe('generateCPUOpponent', () => {
     image_url: 'https://example.com/image.jpg',
     rarity: 'common',
     card_number: null,
+    // Card.max_issuance_count は `number | null`(undefined 非許容)。overrides のみに
+    // 委ねると Partial<Card> 由来で `undefined` を許容してしまい型不一致になるため、
+    // ベースオブジェクト側で明示的にデフォルト値を持たせる。
+    max_issuance_count: null,
     collection_name: null,
     drop_rate: 0.1,
     intra_rarity_weight: 1.0,

--- a/tests/unit/cards-get-api.test.ts
+++ b/tests/unit/cards-get-api.test.ts
@@ -69,7 +69,7 @@ function setupCardsMock(options: {
   }
   // PostgREST returns result via implicit await (thenable)
   // PostgRESTは暗黙のawait（thenable）で結果を返す
-  ;(cardsQuery as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
+  ;(cardsQuery as unknown as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
     resolve(cardsResponse)
     return cardsQuery
   }
@@ -77,10 +77,8 @@ function setupCardsMock(options: {
   // Issue #542: 発行済み枚数集計用のuser_cardsクエリビルダー（暗黙のawaitに対応）
   // user_cards query builder for the issued_count aggregation (implicit await)
   const userCardsQuery = createMockQueryBuilder()
-  // Note: 既存の cardsQuery 等は `as Record<string, unknown>` で直接キャストしているが、
-  // MockQueryBuilder<unknown> と Record<string, unknown> は型として十分重ならず
-  // TS2352になる（tsc baseline比較のため、新規コードではここだけ `as unknown` を
-  // 経由してこのエラーパターンを増やさないようにする）。
+  // MockQueryBuilder<unknown> と Record<string, unknown> は型として十分重ならないため
+  // 直接キャストは TS2352 になる。`unknown` を経由して安全にキャストする。
   ;(userCardsQuery as unknown as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
     resolve({ data: options.userCards ?? [], error: options.userCardsError ?? null })
     return userCardsQuery
@@ -97,7 +95,9 @@ function setupCardsMock(options: {
     return createMockQueryBuilder()
   })
 
-  mockGetSupabaseAdmin.mockReturnValue({ from } as ReturnType<typeof getSupabaseAdmin>)
+  // モックの `{ from }` は SupabaseClient の一部プロパティしか持たないため、
+  // `unknown` を経由してキャストする(既存テストで確立されたパターンに合わせる)。
+  mockGetSupabaseAdmin.mockReturnValue({ from } as unknown as ReturnType<typeof getSupabaseAdmin>)
 
   return { streamerQuery, cardsQuery, userCardsQuery, from }
 }
@@ -113,13 +113,13 @@ function setupCardsMockWithRetry(options: {
   )
 
   const firstCardsQuery = createMockQueryBuilder()
-  ;(firstCardsQuery as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
+  ;(firstCardsQuery as unknown as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
     resolve({ data: null, error: options.firstCardsError, count: null })
     return firstCardsQuery
   }
 
   const retryCardsQuery = createMockQueryBuilder()
-  ;(retryCardsQuery as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
+  ;(retryCardsQuery as unknown as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
     resolve({
       data: options.retryCards ?? [],
       error: null,
@@ -140,7 +140,7 @@ function setupCardsMockWithRetry(options: {
 
   mockGetSupabaseAdmin.mockReturnValue({
     from,
-  } as ReturnType<typeof getSupabaseAdmin>)
+  } as unknown as ReturnType<typeof getSupabaseAdmin>)
 
   return { firstCardsQuery, retryCardsQuery }
 }
@@ -154,12 +154,16 @@ function createRequest(params: Record<string, string> = {}): NextRequest {
 describe('GET /api/cards', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // `issuedAt` は SessionPayload に存在しないフィールド(本番コードでも未参照)のため削除し、
+    // 他のテストと同じ形で必須フィールドを揃える。
     mockGetSession.mockResolvedValue({
       twitchUserId: 'user123',
       twitchUsername: 'testuser',
       twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/avatar.png',
       broadcasterType: 'affiliate',
-      issuedAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+      version: 1,
     })
     mockCheckRateLimit.mockResolvedValue({
       success: true,

--- a/tests/unit/components/collection-pack-filter.test.tsx
+++ b/tests/unit/components/collection-pack-filter.test.tsx
@@ -20,6 +20,10 @@ const baseCard = (overrides: Partial<StreamerCollectionCard>): StreamerCollectio
   image_url: null,
   rarity: 'common',
   card_number: null,
+  // StreamerCollectionCard.max_issuance_count は `number | null`(undefined 非許容)。
+  // overrides のみに委ねると Partial<> 由来で `undefined` を許容してしまい型不一致に
+  // なるため、ベースオブジェクト側で明示的にデフォルト値を持たせる。
+  max_issuance_count: null,
   collection_name: null,
   drop_rate: 25,
   intra_rarity_weight: 1,

--- a/tests/unit/components/sorted-card-grid.test.tsx
+++ b/tests/unit/components/sorted-card-grid.test.tsx
@@ -18,6 +18,10 @@ const baseCard = (overrides: Partial<Card>): Card => ({
   image_url: 'https://example.com/card-a.png',
   rarity: 'common',
   card_number: null,
+  // Card.max_issuance_count は `number | null`(undefined 非許容)。overrides のみに
+  // 委ねると Partial<Card> 由来で `undefined` を許容してしまい型不一致になるため、
+  // ベースオブジェクト側で明示的にデフォルト値を持たせる。
+  max_issuance_count: null,
   collection_name: null,
   drop_rate: 25,
   intra_rarity_weight: 1,

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -334,9 +334,9 @@ describe('GachaService.executeGacha', () => {
 
   it('発行上限に達したカードを抽選候補から除外する', async () => {
     const cardsQuery = createCardsQuery([
-      { id: 'sold-out-card', name: 'Sold Out', description: null, image_url: null, rarity: 'legendary', drop_rate: 100, max_issuance_count: 1 },
-      { id: 'available-card', name: 'Available', description: null, image_url: null, rarity: 'common', drop_rate: 1, max_issuance_count: null },
-    ] as typeof testCards)
+      { id: 'sold-out-card', name: 'Sold Out', description: 'desc', image_url: null, rarity: 'legendary', collection_name: 'standard', drop_rate: 100, max_issuance_count: 1 },
+      { id: 'available-card', name: 'Available', description: 'desc', image_url: null, rarity: 'common', collection_name: 'standard', drop_rate: 1, max_issuance_count: null },
+    ])
     const mockRpc = createRpcMock({
       issuedCounts: { 'sold-out-card': 1 },
       transactionResponses: [{ data: { is_duplicate: false, limit_reached: false, history_id: 'h-1' }, error: null }],
@@ -358,9 +358,9 @@ describe('GachaService.executeGacha', () => {
 
   it('発行枚数チェックRPCは limitedCards のIDのみに絞り込む（無制限カードIDを含まない）', async () => {
     const cardsQuery = createCardsQuery([
-      { id: 'unlimited-card', name: 'Unlimited', description: null, image_url: null, rarity: 'common', drop_rate: 1, max_issuance_count: null },
-      { id: 'limited-card', name: 'Limited', description: null, image_url: null, rarity: 'rare', drop_rate: 1, max_issuance_count: 5 },
-    ] as typeof testCards)
+      { id: 'unlimited-card', name: 'Unlimited', description: 'desc', image_url: null, rarity: 'common', collection_name: 'standard', drop_rate: 1, max_issuance_count: null },
+      { id: 'limited-card', name: 'Limited', description: 'desc', image_url: null, rarity: 'rare', collection_name: 'standard', drop_rate: 1, max_issuance_count: 5 },
+    ])
     const mockRpc = createRpcMock({
       transactionResponses: [{ data: { is_duplicate: false, history_id: 'h-1' }, error: null }],
     })
@@ -378,8 +378,8 @@ describe('GachaService.executeGacha', () => {
 
   it('全カードが発行上限に達している場合はエラーを返す', async () => {
     const cardsQuery = createCardsQuery([
-      { id: 'sold-out-card', name: 'Sold Out', description: null, image_url: null, rarity: 'legendary', drop_rate: 100, max_issuance_count: 1 },
-    ] as typeof testCards)
+      { id: 'sold-out-card', name: 'Sold Out', description: 'desc', image_url: null, rarity: 'legendary', collection_name: 'standard', drop_rate: 100, max_issuance_count: 1 },
+    ])
     const mockRpc = createRpcMock({
       issuedCounts: { 'sold-out-card': 1 },
       transactionResponses: [],

--- a/tests/unit/open-next-config.test.ts
+++ b/tests/unit/open-next-config.test.ts
@@ -4,17 +4,32 @@ import config from "../../open-next.config";
 
 describe("open-next.config", () => {
   it("uses the Cloudflare config helper while preserving existing runtime overrides", () => {
-    expect(config.default.override.wrapper).toBe("cloudflare-node");
-    expect(config.default.override.converter).toBe("edge");
-    expect(config.default.override.proxyExternalRequest).toBe("fetch");
-    expect(config.default.override.incrementalCache).toBe("dummy");
-    expect(config.default.override.tagCache).toBe("dummy");
-    expect(config.default.override.queue).toBe("direct");
+    // `FunctionOptions.override` は optional なため `config.default.override` は
+    // `OverrideOptions | undefined` 型になる。non-null assertion(!)ではなく、
+    // 未定義なら即座にテスト失敗として扱う型ガードで安全に絞り込む。
+    const defaultOverride = config.default.override;
+    if (!defaultOverride) {
+      throw new Error("config.default.override should be defined by defineCloudflareConfig");
+    }
+    expect(defaultOverride.wrapper).toBe("cloudflare-node");
+    expect(defaultOverride.converter).toBe("edge");
+    expect(defaultOverride.proxyExternalRequest).toBe("fetch");
+    expect(defaultOverride.incrementalCache).toBe("dummy");
+    expect(defaultOverride.tagCache).toBe("dummy");
+    expect(defaultOverride.queue).toBe("direct");
 
     expect(config.edgeExternals).toContain("node:crypto");
-    expect(config.middleware?.external).toBe(true);
-    expect(config.middleware?.override?.wrapper).toBe("cloudflare-edge");
-    expect(config.middleware?.override?.queue).toBe("direct");
+
+    // `config.middleware` は `ExternalMiddlewareConfig | InternalMiddlewareConfig` の
+    // 判別共用体で、`override` は `external: true` 側(ExternalMiddlewareConfig)にしか
+    // 存在しない。`external` の真偽値で絞り込むことで `override` へ安全にアクセスする。
+    const middleware = config.middleware;
+    if (!middleware || !middleware.external) {
+      throw new Error("config.middleware should be configured as external middleware");
+    }
+    expect(middleware.external).toBe(true);
+    expect(middleware.override?.wrapper).toBe("cloudflare-edge");
+    expect(middleware.override?.queue).toBe("direct");
     expect(config.cloudflare?.useWorkerdCondition).toBe(true);
   });
 });


### PR DESCRIPTION
## 概要

Fixes #588

`npx tsc --noEmit` のエラーが24件 (17→24へ増加、#450-453マージ起因) 発生していた問題を修正し、0件にした。あわせて CI に typecheck ゲートを追加し、今後の型エラー増加をPRでブロックする。

## #628 (battle機能廃止) との関係について

issue #628「battle機能の廃止判断と実施」は `state_reason: completed` で **close 済み**でしたが、実装内容を確認したところ `tests/unit/battle.test.ts` は `origin/main` / `origin/preview` の両方に**まだ存在しており**、#628 に紐づくマージ済みPRも見つかりませんでした(closeされたが実装は行われていない状態)。

本issueの実装プランでは battle.test.ts の2件を「#628で削除される想定」としてスコープ外にしていましたが、上記の理由により削除が実施されていないため、**本PRで battle.test.ts の2件も含めて修正しました**(#628が実際に削除を実施する場合、当該ファイルごと削除されるため本PRの変更は無害に上書きされます)。

## 修正内容(ファイル別、22→24件すべて対応)

- **additional-rewards-api.test.ts / cards-get-api.test.ts**: `SessionPayload.twitchProfileImageUrl` は `null` 非許容の `string` 必須フィールドのため、テストデータを他のテストと同じプレースホルダURL文字列に修正。`cards-get-api.test.ts` の `issuedAt` は `SessionPayload` に存在しない(本番コードでも未参照の)テスト側のtypoと判断し削除、代わりに欠けていた必須フィールド(`twitchProfileImageUrl`, `expiresAt`, `version`)を補完。
- **auth-scope-preservation.test.ts**: モック関数(`vi.fn(...)`)の宣言引数がモック対象の実関数(`isInvalidAuthorizationCodeError`, `handleAuthError`)と引数個数が一致しておらず spread 時に型エラーになっていたため、モック宣言側の引数を実関数のシグネチャに合わせた。
- **cards-get-api.test.ts**: `MockQueryBuilder<unknown>` → `Record<string, unknown>` への直接キャストが型として重ならず失敗していた箇所を、同ファイル内の既存パターンと同じ `as unknown as ...` 経由のキャストに統一。
- **collection-pack-filter.test.tsx / sorted-card-grid.test.tsx / battle.test.ts**: `Card` / `StreamerCollectionCard` 型の `max_issuance_count` (`number | null`、undefined非許容)が overrides 経由でのみ供給されており `undefined` を許容してしまっていたため、ベースのカードファクトリに明示的なデフォルト値 (`null`) を追加。
- **gacha-service.test.ts**: `testCards` と異なる形のテストデータに不要な `as typeof testCards` キャストが付与されており、型不一致(`collection_name` 欠如、単一要素配列でのリテラル型不一致)を起こしていた。キャストは `createCardsQuery` の型推論に不要だったため削除し、データも `testCards` と一貫した形に補完。
- **open-next-config.test.ts**: non-null assertion の代わりに、`config.default.override` の undefined チェックと、`config.middleware` の判別共用体(`ExternalMiddlewareConfig | InternalMiddlewareConfig`、`external: true/false` で判別)に対する型ガードを追加。実装コード(`open-next.config.ts`)や `@opennextjs` の型定義を確認し、`override` は `external: true` 側にのみ存在することを確認した上で対応。

いずれもキャスト逃げ (`as unknown as` / `any`) は最小限にとどめ、可能な限りテストデータ・型ガードを実際の型定義に合わせる方針で修正。

## CI変更

- `package.json` に `"typecheck": "tsc --noEmit"` を追加
- `.github/workflows/ci.yml` の既存 `test` job に typecheck ステップを追加(依存インストール済みの同一jobに同居させ、新規job追加による `npm ci` の重複コストを避けた)

### オーナーコメント(2026-07-03)への対応について

issueに付いていたオーナーコメントで、CIの `test` job が `next build` / `workers:build` を実行しないため build 固有のエラーが素通りした事故(#595→#596)への言及がありました。確認したところ、CIには既に `build` job (`npm run build` = `next build --webpack`) が存在しますが、`if: vars.CLOUDFLARE_WORKERS_BUILDS_ENABLED != 'true'` の条件がついており、**このリポジトリ変数の値次第では現在スキップされている可能性があります**。

このゲート条件の見直しはデプロイパイプラインの構成に関わる変更であり、型エラー修正のみを目的とする本PRでの実施はスコープ超過・リスクが大きいと判断し、**本PRでは対応していません**。別issueとしての切り出しを推奨します(具体的には: `vars.CLOUDFLARE_WORKERS_BUILDS_ENABLED` の現在値の確認と、trueの場合にCloudflare側のビルドチェックが同等の安全性を担保できているかの検証)。

## テスト結果(実測)

- `npx tsc --noEmit`: **24件 → 0件**
- `npm run test:unit`: 134 files / **1670 tests 全成功**
- `npm run test:integration`: 1 file / **13 tests 全成功**
- `npm run lint`: **0 errors**(warning 22件は本PR起因のもの含め全て pre-existing の underscore-prefixed unused-vars 等、既存パターンと同一)

## セルフレビュー

CLAUDE.mdの運用ルールに従い、subagentによる厳しい自己レビュー(correctness / cleanup / altitude / conventions の観点)を実施。correctness面での指摘はゼロ。cleanup面で1件(`auth-scope-preservation.test.ts` の spread ラッパーが不要な複雑化になっていた)を検出・修正済み。残り3件(既存の個別テストファイルごとのカードファクトリ重複、他ファイルの既存 `as unknown as` キャストパターンとの不整合、コメント密度)は本PRのスコープ外の既存パターンであり、YAGNI原則に基づき本PRでは対応せず据え置いた。

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WEjTKExHEP2HxBECRUTyyB)_