### PR TITLE
db: 低頻度APIルート群のpg直結移行 + cardsバグ修正 (#663)

### DIFF
--- a/src/app/api/announcements/read/route.ts
+++ b/src/app/api/announcements/read/route.ts
@@ -6,6 +6,58 @@ import { checkRateLimit, rateLimits, getRateLimitIdentifier } from '@/lib/rate-l
 import { ERROR_MESSAGES } from '@/lib/constants'
 import { logger } from '@/lib/logger'
 import type { ApiRateLimitResponse } from '@/types/api'
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgWriteEnabled() が false を返すため getDb() は一切呼ばれず、既存の
+// supabase-js 経路が従来どおり実行される。
+// ---------------------------------------------------------------------------
+import { getDb } from '@/lib/db/client'
+import { isPgWriteEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import { announcementReads as announcementReadsTable } from '@/lib/db/schema'
+
+/**
+ * announcement_reads への UPSERT の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応: onConflict('announcement_id,twitch_user_id') は
+ * この複合カラムに対する UNIQUE 制約を conflict target とした
+ * INSERT ... ON CONFLICT DO UPDATE と等価。payload に含まれる列は conflict
+ * target 自身（announcement_id / twitch_user_id）のみで、それ以外の列
+ * （read_at 等）を更新しないため、DO UPDATE で書き戻しても値は変化しない
+ * ＝ DO NOTHING と実質的に同じ最終状態になる。ここでは意図をそのまま表せる
+ * onConflictDoNothing を使う。read_at の DB 側 DEFAULT now() は INSERT 時のみ
+ * 適用されるため、重複呼び出しで既読日時が上書きされることもない（既存の
+ * postgrest 経路と同じ挙動）。
+ *
+ * 書き込む値は固定（announcementId / twitchUserId）のため、接続断リトライしても
+ * 同じ内容を書く UPSERT ＝冪等。
+ */
+async function upsertAnnouncementReadPg(
+  announcementId: string,
+  twitchUserId: string
+): Promise<{ error: { message: string } | null }> {
+  try {
+    await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .insert(announcementReadsTable)
+          .values({ announcement_id: announcementId, twitch_user_id: twitchUserId })
+          .onConflictDoNothing({
+            target: [announcementReadsTable.announcement_id, announcementReadsTable.twitch_user_id],
+          })
+      },
+      'announcements/read(upsert)',
+      { idempotent: true },
+    )
+    return { error: null }
+  } catch (error) {
+    return {
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }
+  }
+}
 
 // UUID v4形式のバリデーション
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -57,18 +109,19 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const supabase = getSupabaseAdmin()
-
     // UNIQUE制約により重複INSERTはエラーになるため、upsertで冪等性を確保
-    const { error } = await supabase
-      .from('announcement_reads')
-      .upsert(
-        {
-          announcement_id: announcementId,
-          twitch_user_id: session.twitchUserId,
-        },
-        { onConflict: 'announcement_id,twitch_user_id' }
-      )
+    // #663: 書き込みのため isPgWriteEnabled() で分岐。
+    const { error } = isPgWriteEnabled()
+      ? await upsertAnnouncementReadPg(announcementId, session.twitchUserId)
+      : await getSupabaseAdmin()
+          .from('announcement_reads')
+          .upsert(
+            {
+              announcement_id: announcementId,
+              twitch_user_id: session.twitchUserId,
+            },
+            { onConflict: 'announcement_id,twitch_user_id' }
+          )
 
     if (error) {
       logger.error('Failed to mark announcement as read', {

--- a/src/app/api/auth/bot/connect/route.ts
+++ b/src/app/api/auth/bot/connect/route.ts
@@ -10,6 +10,47 @@ import { randomBytesHex } from '@/lib/crypto-utils'
 import { getBaseUrl } from '@/lib/url-utils'
 import { checkRateLimit, getRateLimitIdentifier, rateLimits } from '@/lib/rate-limit'
 import { handleApiError } from '@/lib/error-handler'
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgReadEnabled() が false を返すため getDb() は一切呼ばれず、既存の
+// supabase-js 経路が従来どおり実行される。
+// ---------------------------------------------------------------------------
+import { eq } from 'drizzle-orm'
+import { getDb } from '@/lib/db/client'
+import { isPgReadEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import { streamers as streamersTable } from '@/lib/db/schema'
+
+/**
+ * streamer 存在確認の pg 直結実装 (#663)
+ * PostgREST 実装との対応: .maybeSingle() は twitch_user_id の UNIQUE 制約
+ * （migration 00001）により最大 1 行のため、LIMIT 1 + rows[0] ?? null で同じ
+ * 外部挙動。既存コードは error を確認しない（data のみ利用）ため、pg 版も
+ * エラー時は null（配信者なし = 403）に落として throw しない。
+ */
+async function fetchStreamerIdPg(twitchUserId: string): Promise<{ id: string } | null> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({ id: streamersTable.id })
+          .from(streamersTable)
+          .where(eq(streamersTable.twitch_user_id, twitchUserId))
+          .limit(1)
+      },
+      'bot/connect(streamer)',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    )
+    return rows[0] ?? null
+  } catch {
+    // 既存 postgrest 経路は error を確認しない（data のみ利用）ため、pg 版も
+    // 取得失敗時は null（=配信者なし扱い）に揃える。
+    return null
+  }
+}
 
 export async function POST(request: NextRequest) {
   try {
@@ -29,12 +70,16 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: ERROR_MESSAGES.UNAUTHORIZED }, { status: 401 })
     }
 
-    const supabaseAdmin = getSupabaseAdmin()
-    const { data: streamer } = await supabaseAdmin
-      .from('streamers')
-      .select('id')
-      .eq('twitch_user_id', session.twitchUserId)
-      .maybeSingle()
+    // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+    const streamer = isPgReadEnabled()
+      ? await fetchStreamerIdPg(session.twitchUserId)
+      : (
+          await getSupabaseAdmin()
+            .from('streamers')
+            .select('id')
+            .eq('twitch_user_id', session.twitchUserId)
+            .maybeSingle()
+        ).data
 
     if (!streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 })

--- a/src/app/api/auth/reauth/route.ts
+++ b/src/app/api/auth/reauth/route.ts
@@ -12,10 +12,61 @@ import { checkRateLimit, rateLimits, getRateLimitIdentifier } from '@/lib/rate-l
 import { randomBytesHex } from '@/lib/crypto-utils'
 import { getBaseUrl } from '@/lib/url-utils'
 import { validateCSRFToken } from '@/lib/csrf'
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgReadEnabled() が false を返すため getDb() は一切呼ばれず、既存の
+// supabase-js 経路が従来どおり実行される。
+// ---------------------------------------------------------------------------
+import { eq } from 'drizzle-orm'
+import { getDb } from '@/lib/db/client'
+import { isPgReadEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import { isPgMissingColumnError } from '@/lib/db/errors'
+import { users as usersTable } from '@/lib/db/schema'
 
 // 有効な追加スコープのリスト（セキュリティ: 許可されたスコープのみ受け付ける）
 // List of valid additional scopes (security: only accept allowed scopes)
 const VALID_ADDITIONAL_SCOPES: string[] = Object.values(ADDITIONAL_SCOPES)
+
+/**
+ * 既存の追加スコープ取得の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応: .maybeSingle() は twitch_user_id の UNIQUE 制約
+ * （migration 00001、token-manager.ts 等と同じ根拠）により最大 1 行のため、
+ * LIMIT 1 + rows[0] ?? null で同じ外部挙動。既存コードは PGRST204（列未デプロイ）
+ * のみ許容してそれ以外のエラーは 503 にするため、pg 版も 42703
+ * (isPgMissingColumnError) だけを「スコープなし」として許容し、それ以外は
+ * 呼び出し元へ throw で伝播する。
+ */
+async function fetchPreservedScopesPg(
+  twitchUserId: string
+): Promise<{ data: { twitch_scopes: string[] | null } | null; error: { code?: string; message: string } | null }> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({ twitch_scopes: usersTable.twitch_scopes })
+          .from(usersTable)
+          .where(eq(usersTable.twitch_user_id, twitchUserId))
+          .limit(1)
+      },
+      'reauth(scope fetch)',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    )
+    return { data: rows[0] ?? null, error: null }
+  } catch (error) {
+    if (isPgMissingColumnError(error)) {
+      return { data: null, error: { code: '42703', message: 'twitch_scopes column not found' } }
+    }
+    return {
+      data: null,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }
+  }
+}
 
 export async function POST(request: Request) {
   try {
@@ -56,14 +107,19 @@ export async function POST(request: Request) {
 
     // 既存の追加スコープも再認証要求に含める（user:write:chat などの消失防止）
     // Include already granted additional scopes so re-auth does not drop existing permissions.
-    const supabaseAdmin = getSupabaseAdmin()
-    const { data: user, error: scopeFetchError } = await supabaseAdmin
-      .from('users')
-      .select('twitch_scopes')
-      .eq('twitch_user_id', session.twitchUserId)
-      .maybeSingle()
+    // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+    const { data: user, error: scopeFetchError } = isPgReadEnabled()
+      ? await fetchPreservedScopesPg(session.twitchUserId)
+      : await getSupabaseAdmin()
+          .from('users')
+          .select('twitch_scopes')
+          .eq('twitch_user_id', session.twitchUserId)
+          .maybeSingle()
 
-    if (scopeFetchError && scopeFetchError.code !== 'PGRST204') {
+    // PGRST204（postgrest 経路）/ 42703（pg 経路、isPgMissingColumnError 相当）は
+    // どちらも「twitch_scopes 列未デプロイのデプロイ窓」を表す同じ意味のコードで、
+    // 既存コードはこれだけ許容してスコープなしとして処理を続ける。
+    if (scopeFetchError && scopeFetchError.code !== 'PGRST204' && scopeFetchError.code !== '42703') {
       logger.error('Re-auth scope fetch failed', {
         twitchUserId: session.twitchUserId,
         error: scopeFetchError.message,

--- a/src/app/api/auth/twitch/callback/route.ts
+++ b/src/app/api/auth/twitch/callback/route.ts
@@ -11,6 +11,191 @@ import { logger } from '@/lib/logger'
 import { getBaseUrl } from '@/lib/url-utils'
 import { signSession } from '@/lib/session'
 import { handleLinkedAccountCallback } from '@/lib/twitch/linked-account-auth'
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgReadEnabled() / isPgWriteEnabled() が false を返すため getDb() は一切
+// 呼ばれず、既存の supabase-js 経路が従来どおり実行される。読み取り専用のクエリは
+// isPgReadEnabled()、書き込みは isPgWriteEnabled() で分岐する（token-manager.ts
+// 冒頭のフラグ使い分け方針と同じ）。
+// ---------------------------------------------------------------------------
+import { eq } from 'drizzle-orm'
+import { getDb } from '@/lib/db/client'
+import { isPgReadEnabled, isPgWriteEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import { streamers as streamersTable, users as usersTable } from '@/lib/db/schema'
+
+interface AuthCallbackDriverError {
+  code?: string
+  message: string
+}
+
+/**
+ * スコープ乖離チェック用の既存ユーザー読み取りの pg 直結実装 (#663)
+ * PostgREST 実装との対応: .maybeSingle() は twitch_user_id の UNIQUE 制約
+ * （migration 00001）により最大 1 行のため、LIMIT 1 + rows[0] ?? null で同じ
+ * 外部挙動。
+ */
+async function fetchExistingUserScopesPg(
+  twitchUserId: string
+): Promise<{ data: { twitch_scopes: string[] | null } | null; error: AuthCallbackDriverError | null }> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({ twitch_scopes: usersTable.twitch_scopes })
+          .from(usersTable)
+          .where(eq(usersTable.twitch_user_id, twitchUserId))
+          .limit(1)
+      },
+      'auth callback(existing scopes)',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    )
+    return { data: rows[0] ?? null, error: null }
+  } catch (error) {
+    return {
+      data: null,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }
+  }
+}
+
+/**
+ * users への UPSERT（トークン・プロフィール保存）の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応: onConflict('twitch_user_id') の UPSERT は users の
+ * twitch_user_id UNIQUE 制約（migration 00001）を conflict target とした
+ * INSERT ... ON CONFLICT DO UPDATE と等価。既存経路は upsertError を検知次第
+ * ログ出力後に throw し、直後の外側 catch で 'database_error' へ変換する。
+ * pg 版もエラー時はここで一度ログしてから throw することで、同じ2段ログ
+ * （個別ログ + 外側 catch の "Database error details" ログ）を再現する。
+ *
+ * 書き込む値は呼び出し元で計算済みの固定値のため、接続断リトライしても同じ
+ * 内容を書く UPSERT ＝冪等。
+ */
+async function upsertAuthUserPg(payload: {
+  twitchUserId: string
+  twitchUsername: string
+  twitchDisplayName: string
+  twitchProfileImageUrl: string | null
+  accessToken: string
+  refreshToken: string
+  expiresAtIso: string
+}): Promise<void> {
+  try {
+    await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        const values = {
+          twitch_user_id: payload.twitchUserId,
+          twitch_username: payload.twitchUsername,
+          twitch_display_name: payload.twitchDisplayName,
+          twitch_profile_image_url: payload.twitchProfileImageUrl,
+          twitch_access_token: payload.accessToken,
+          twitch_refresh_token: payload.refreshToken,
+          twitch_token_expires_at: payload.expiresAtIso,
+        }
+        return db
+          .insert(usersTable)
+          .values(values)
+          .onConflictDoUpdate({ target: usersTable.twitch_user_id, set: values })
+      },
+      'auth callback(upsert user)',
+      { idempotent: true },
+    )
+  } catch (error) {
+    logger.error('Auth callback: User upsert failed', {
+      twitchUserId: payload.twitchUserId,
+      error,
+      code: (error as { code?: unknown } | null)?.code,
+      message: error instanceof Error ? error.message : String(error),
+    })
+    throw error
+  }
+}
+
+/**
+ * streamers への UPSERT（アフィリエイト/パートナー時のみ）の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応が重要な差異: 既存経路は
+ * `await supabaseAdmin.from('streamers').upsert(...)` の戻り値を分割代入せず
+ * 破棄しているため、外側の try/catch は「クエリ結果の error フィールド」は
+ * 一切見ておらず、fetch() 自体が reject した場合（実質的にほぼ発生しない）だけを
+ * 捕捉する ＝ クエリレベルのエラー（例: 制約違反）は事実上黙って握りつぶされる
+ * 既存動作になっている。postgres.js は全クエリエラーを throw するため、pg 版で
+ * 何もしなければ「今まで無視されていたエラー」が新たに 'database_error' で
+ * コールバック全体を失敗させてしまい、外部挙動が変わってしまう。
+ * token-manager.ts の getBotAccountForChatPg と同じ判断で、ここでも意図的に
+ * エラーを catch して握りつぶし（warn ログのみ）、既存の「結果を確認しない
+ * best-effort UPSERT」という外部挙動を再現する。
+ */
+async function upsertAuthStreamerPg(payload: {
+  twitchUserId: string
+  twitchUsername: string
+  twitchDisplayName: string
+  twitchProfileImageUrl: string | null
+}): Promise<void> {
+  try {
+    await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        const values = {
+          twitch_user_id: payload.twitchUserId,
+          twitch_username: payload.twitchUsername,
+          twitch_display_name: payload.twitchDisplayName,
+          twitch_profile_image_url: payload.twitchProfileImageUrl,
+        }
+        return db
+          .insert(streamersTable)
+          .values(values)
+          .onConflictDoUpdate({ target: streamersTable.twitch_user_id, set: values })
+      },
+      'auth callback(upsert streamer)',
+      { idempotent: true },
+    )
+  } catch (error) {
+    // 既存 postgrest 経路はこの upsert の結果（error）を確認せず無視する
+    // （best-effort）。pg 直結では失敗が throw になるため catch で握りつぶし、
+    // 同じ外部挙動（コールバック全体は失敗させない）に合わせる。
+    logger.warn('Auth callback: Streamer upsert failed (ignored, best-effort)', {
+      twitchUserId: payload.twitchUserId,
+      error,
+    })
+  }
+}
+
+/**
+ * TOS 同意確認読み取りの pg 直結実装 (#663)
+ * PostgREST 実装との対応: .maybeSingle() は twitch_user_id の UNIQUE 制約により
+ * 最大 1 行のため LIMIT 1 + rows[0] ?? null で同じ外部挙動。
+ * 既知の差異: 既存経路は destructure で error を確認しないため、クエリレベルの
+ * エラー時は data=null → `null?.tos_accepted_at !== null` が true と評価され
+ * 「TOS 同意済み扱い」に落ちる（意図せぬ既存の副作用）。pg 版は全エラーが throw
+ * になり外側 catch で hasTosAccepted=false（TOS 未同意扱い＝より安全側）のまま
+ * 継続するため、この極めて稀なケース（クエリは成功するが行取得だけ失敗する状況）
+ * でのみ挙動が異なる。安全側にしか倒れないため許容する。
+ */
+async function fetchTosAcceptedPg(twitchUserId: string): Promise<{ tos_accepted_at: string | null } | null> {
+  const rows = await withDbRetry(
+    async () => {
+      // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+      const { db } = await getDb()
+      return db
+        .select({ tos_accepted_at: usersTable.tos_accepted_at })
+        .from(usersTable)
+        .where(eq(usersTable.twitch_user_id, twitchUserId))
+        .limit(1)
+    },
+    'auth callback(tos check)',
+    // 読み取り専用クエリのため冪等（リトライ可）
+    { idempotent: true },
+  )
+  return rows[0] ?? null
+}
 
 export async function GET(request: NextRequest) {
   // 開発環境ではリクエストのホストから動的にベースURLを取得
@@ -142,11 +327,14 @@ export async function GET(request: NextRequest) {
     let skipScopeSave = false
     if (!isReauthFlow && !scopeRestoreFailed && !isScopeRecovery) {
       try {
-        const { data: existingUser, error: existingScopeError } = await supabaseAdmin
-          .from('users')
-          .select('twitch_scopes')
-          .eq('twitch_user_id', twitchUser.id)
-          .maybeSingle()
+        // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+        const { data: existingUser, error: existingScopeError } = isPgReadEnabled()
+          ? await fetchExistingUserScopesPg(twitchUser.id)
+          : await supabaseAdmin
+              .from('users')
+              .select('twitch_scopes')
+              .eq('twitch_user_id', twitchUser.id)
+              .maybeSingle()
 
         if (existingScopeError) {
           // DB読み取り失敗: fail-safe(スキップ)で保護。リダイレクトできない（スコープ不明）
@@ -206,32 +394,47 @@ export async function GET(request: NextRequest) {
     }
 
     try {
-      // upsertのエラーを明示的にチェック（Supabase JSはエラー時にthrowせずerrorオブジェクトを返す）
-      // Explicitly check upsert error (Supabase JS returns error object instead of throwing)
-      const { error: upsertError } = await supabaseAdmin
-        .from('users')
-        .upsert({
-          twitch_user_id: twitchUser.id,
-          twitch_username: twitchUser.login,
-          twitch_display_name: twitchUser.display_name,
-          twitch_profile_image_url: twitchUser.profile_image_url,
-          twitch_access_token: tokens.access_token,
-          twitch_refresh_token: tokens.refresh_token,
-          twitch_token_expires_at: new Date(Date.now() + tokens.expires_in * 1000).toISOString(),
-        }, {
-          onConflict: 'twitch_user_id',
-        })
-
-      if (upsertError) {
-        logger.error('Auth callback: User upsert failed', {
+      // #663: 書き込みのため isPgWriteEnabled() で分岐。pg 版（upsertAuthUserPg）は
+      // 内部でログ出力後に throw するため、既存の「エラー時ログ＋throw」と同じ
+      // 外部挙動になる。
+      if (isPgWriteEnabled()) {
+        await upsertAuthUserPg({
           twitchUserId: twitchUser.id,
-          error: upsertError,
-          code: upsertError.code,
-          message: upsertError.message,
-          details: upsertError.details,
-          hint: upsertError.hint,
+          twitchUsername: twitchUser.login,
+          twitchDisplayName: twitchUser.display_name,
+          twitchProfileImageUrl: twitchUser.profile_image_url,
+          accessToken: tokens.access_token,
+          refreshToken: tokens.refresh_token,
+          expiresAtIso: new Date(Date.now() + tokens.expires_in * 1000).toISOString(),
         })
-        throw upsertError
+      } else {
+        // upsertのエラーを明示的にチェック（Supabase JSはエラー時にthrowせずerrorオブジェクトを返す）
+        // Explicitly check upsert error (Supabase JS returns error object instead of throwing)
+        const { error: upsertError } = await supabaseAdmin
+          .from('users')
+          .upsert({
+            twitch_user_id: twitchUser.id,
+            twitch_username: twitchUser.login,
+            twitch_display_name: twitchUser.display_name,
+            twitch_profile_image_url: twitchUser.profile_image_url,
+            twitch_access_token: tokens.access_token,
+            twitch_refresh_token: tokens.refresh_token,
+            twitch_token_expires_at: new Date(Date.now() + tokens.expires_in * 1000).toISOString(),
+          }, {
+            onConflict: 'twitch_user_id',
+          })
+
+        if (upsertError) {
+          logger.error('Auth callback: User upsert failed', {
+            twitchUserId: twitchUser.id,
+            error: upsertError,
+            code: upsertError.code,
+            message: upsertError.message,
+            details: upsertError.details,
+            hint: upsertError.hint,
+          })
+          throw upsertError
+        }
       }
 
       // トークン交換時に付与されたスコープをDBに全置換で保存する。
@@ -292,16 +495,29 @@ export async function GET(request: NextRequest) {
 
     if (canBeStreamer) {
       try {
-        await supabaseAdmin
-          .from('streamers')
-          .upsert({
-            twitch_user_id: twitchUser.id,
-            twitch_username: twitchUser.login,
-            twitch_display_name: twitchUser.display_name,
-            twitch_profile_image_url: twitchUser.profile_image_url,
-          }, {
-            onConflict: 'twitch_user_id',
+        // #663: 書き込みのため isPgWriteEnabled() で分岐。pg 版
+        // （upsertAuthStreamerPg）は既存経路と同じく結果を確認しない
+        // best-effort UPSERT として内部でエラーを握りつぶすため、この catch は
+        // 両経路とも実質的に発火しない（postgrest 経路のコメント参照）。
+        if (isPgWriteEnabled()) {
+          await upsertAuthStreamerPg({
+            twitchUserId: twitchUser.id,
+            twitchUsername: twitchUser.login,
+            twitchDisplayName: twitchUser.display_name,
+            twitchProfileImageUrl: twitchUser.profile_image_url,
           })
+        } else {
+          await supabaseAdmin
+            .from('streamers')
+            .upsert({
+              twitch_user_id: twitchUser.id,
+              twitch_username: twitchUser.login,
+              twitch_display_name: twitchUser.display_name,
+              twitch_profile_image_url: twitchUser.profile_image_url,
+            }, {
+              onConflict: 'twitch_user_id',
+            })
+        }
       } catch (error) {
         return handleAuthError(
           error,
@@ -334,11 +550,17 @@ export async function GET(request: NextRequest) {
     // Check if user has accepted Terms of Service
     let hasTosAccepted = false
     try {
-      const { data: userData } = await supabaseAdmin
-        .from('users')
-        .select('tos_accepted_at')
-        .eq('twitch_user_id', twitchUser.id)
-        .maybeSingle()
+      // #663: 読み取り専用のため isPgReadEnabled() で分岐。既知の挙動差は
+      // fetchTosAcceptedPg の doc コメント参照（pg 版はより安全側に倒れるのみ）。
+      const userData = isPgReadEnabled()
+        ? await fetchTosAcceptedPg(twitchUser.id)
+        : (
+            await supabaseAdmin
+              .from('users')
+              .select('tos_accepted_at')
+              .eq('twitch_user_id', twitchUser.id)
+              .maybeSingle()
+          ).data
 
       hasTosAccepted = userData?.tos_accepted_at !== null
 

--- a/src/app/api/auth/twitch/check-subscription/route.ts
+++ b/src/app/api/auth/twitch/check-subscription/route.ts
@@ -8,6 +8,116 @@ import { ADDITIONAL_SCOPES } from '@/lib/twitch/scopes'
 import { ERROR_MESSAGES } from '@/lib/constants'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { logger } from '@/lib/logger'
+// ---------------------------------------------------------------------------
+// #663 (#572 sub-check.ts の hasTwitchSub 踏襲): pg 直結経路。フラグ未設定時
+// （既定 'postgrest'）は isPgWriteEnabled() が false を返すため getDb() は
+// 一切呼ばれず、既存の supabase-js 経路が従来どおり実行される。
+// このルートは読み取り（読み戻し検証）と書き込み（キャッシュ保存）が混在するため
+// isPgWriteEnabled() で分岐する（token-manager.ts 冒頭のフラグ使い分け方針）。
+// ---------------------------------------------------------------------------
+import { eq } from 'drizzle-orm'
+import { getDb } from '@/lib/db/client'
+import { isPgWriteEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import { isPgMissingColumnError } from '@/lib/db/errors'
+import { users as usersTable } from '@/lib/db/schema'
+
+interface PersistDriverError {
+  code?: string
+  message: string
+}
+
+/**
+ * サブスク確認結果の保存（UPSERT）の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応: onConflict('twitch_user_id') の UPSERT は、users の
+ * twitch_user_id UNIQUE 制約（migration 00001、token-manager.ts 等と同じ根拠）を
+ * conflict target とした INSERT ... ON CONFLICT DO UPDATE と等価。
+ * .select('twitch_user_id').maybeSingle() は .returning({twitch_user_id}) の
+ * rows[0] ?? null で同じ外部挙動（0 行 = 環境依存でレスポンス行が空のケース）。
+ * 42703（列未デプロイ）は既存の PGRST204 分岐と同じ「保存はスキップし手動確認の
+ * 結果自体は返す」安全側フォールバックに揃える。
+ *
+ * 保存する値（twitchUsername 等）は呼び出し元で計算済みの固定値のため、
+ * 接続断リトライしても同じ内容を書く UPSERT ＝冪等。
+ */
+async function persistSubscriptionResultPg(payload: {
+  twitchUserId: string
+  twitchUsername: string
+  twitchDisplayName: string
+  twitchProfileImageUrl: string | null | undefined
+  verifiedAt: string
+  hasSub: boolean
+}): Promise<{ data: { twitch_user_id: string } | null; error: PersistDriverError | null }> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        const values = {
+          twitch_user_id: payload.twitchUserId,
+          twitch_username: payload.twitchUsername,
+          twitch_display_name: payload.twitchDisplayName,
+          twitch_profile_image_url: payload.twitchProfileImageUrl ?? null,
+          twitch_sub_verified_at: payload.verifiedAt,
+          twitch_has_sub: payload.hasSub,
+        }
+        return db
+          .insert(usersTable)
+          .values(values)
+          .onConflictDoUpdate({ target: usersTable.twitch_user_id, set: values })
+          .returning({ twitch_user_id: usersTable.twitch_user_id })
+      },
+      'check-subscription(persist)',
+      { idempotent: true },
+    )
+    return { data: rows[0] ?? null, error: null }
+  } catch (error) {
+    if (isPgMissingColumnError(error)) {
+      return { data: null, error: { code: '42703', message: 'schema mismatch' } }
+    }
+    return {
+      data: null,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }
+  }
+}
+
+/**
+ * 保存確認の読み戻し（persistedUser が空だった場合の検証読み取り）の pg 直結実装 (#663)
+ * PostgREST 実装との対応: .maybeSingle() は twitch_user_id の UNIQUE 制約により
+ * 最大 1 行のため LIMIT 1 + rows[0] ?? null で同じ外部挙動。
+ */
+async function verifySubscriptionPersistPg(
+  twitchUserId: string
+): Promise<{
+  data: { twitch_has_sub: boolean | null; twitch_sub_verified_at: string | null } | null
+  error: PersistDriverError | null
+}> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        const { db } = await getDb()
+        return db
+          .select({
+            twitch_has_sub: usersTable.twitch_has_sub,
+            twitch_sub_verified_at: usersTable.twitch_sub_verified_at,
+          })
+          .from(usersTable)
+          .where(eq(usersTable.twitch_user_id, twitchUserId))
+          .limit(1)
+      },
+      'check-subscription(verify)',
+      { idempotent: true },
+    )
+    return { data: rows[0] ?? null, error: null }
+  } catch (error) {
+    return {
+      data: null,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }
+  }
+}
 
 /**
  * Twitch サブスク状態を手動確認する POST API
@@ -93,27 +203,38 @@ export async function POST(request: Request) {
     // users 行が欠けている環境でも保存できるよう upsert を使用する。
     const supabaseAdmin = getSupabaseAdmin()
     const verifiedAt = new Date().toISOString()
-    const { data: persistedUser, error: persistError } = await supabaseAdmin
-      .from('users')
-      .upsert({
-        twitch_user_id: session.twitchUserId,
-        twitch_username: session.twitchUsername,
-        twitch_display_name: session.twitchDisplayName,
-        twitch_profile_image_url: session.twitchProfileImageUrl,
-        twitch_sub_verified_at: verifiedAt,
-        twitch_has_sub: hasSub,
-      }, {
-        onConflict: 'twitch_user_id',
-      })
-      .select('twitch_user_id')
-      .maybeSingle()
+    // #663: 書き込み（読み戻し検証を含む）のため isPgWriteEnabled() で分岐。
+    const { data: persistedUser, error: persistError } = isPgWriteEnabled()
+      ? await persistSubscriptionResultPg({
+          twitchUserId: session.twitchUserId,
+          twitchUsername: session.twitchUsername,
+          twitchDisplayName: session.twitchDisplayName,
+          twitchProfileImageUrl: session.twitchProfileImageUrl,
+          verifiedAt,
+          hasSub,
+        })
+      : await supabaseAdmin
+          .from('users')
+          .upsert({
+            twitch_user_id: session.twitchUserId,
+            twitch_username: session.twitchUsername,
+            twitch_display_name: session.twitchDisplayName,
+            twitch_profile_image_url: session.twitchProfileImageUrl,
+            twitch_sub_verified_at: verifiedAt,
+            twitch_has_sub: hasSub,
+          }, {
+            onConflict: 'twitch_user_id',
+          })
+          .select('twitch_user_id')
+          .maybeSingle()
 
     let saved = true
     let saveFailureCode: string | undefined
     if (persistError) {
-      // PGRST204: スキーマ差分（カラム未適用等）で保存だけ失敗するケース。
+      // PGRST204（postgrest 経路）/ 42703（pg 経路、isPgMissingColumnError 相当）は
+      // どちらも「スキーマ差分（カラム未適用等）で保存だけ失敗するケース」を表す。
       // 手動確認結果は返せるため、API全体は成功として扱う。
-      if (persistError.code === 'PGRST204') {
+      if (persistError.code === 'PGRST204' || persistError.code === '42703') {
         saved = false
         saveFailureCode = persistError.code
         logger.warn('[TwitchSub] Persist skipped due to schema mismatch:', {
@@ -136,11 +257,13 @@ export async function POST(request: Request) {
     } else if (!persistedUser) {
       // 環境/レスポンス設定により、更新成功でも返却行が空になるケースがある。
       // その場合は再読込して実際に保存できたかを検証する。
-      const { data: latestUser, error: verifyError } = await supabaseAdmin
-        .from('users')
-        .select('twitch_has_sub, twitch_sub_verified_at')
-        .eq('twitch_user_id', session.twitchUserId)
-        .maybeSingle()
+      const { data: latestUser, error: verifyError } = isPgWriteEnabled()
+        ? await verifySubscriptionPersistPg(session.twitchUserId)
+        : await supabaseAdmin
+            .from('users')
+            .select('twitch_has_sub, twitch_sub_verified_at')
+            .eq('twitch_user_id', session.twitchUserId)
+            .maybeSingle()
 
       const verifiedAtMs = latestUser?.twitch_sub_verified_at
         ? new Date(latestUser.twitch_sub_verified_at).getTime()

--- a/src/app/api/auth/twitch/disable-subscription/route.ts
+++ b/src/app/api/auth/twitch/disable-subscription/route.ts
@@ -5,8 +5,54 @@ import { checkRateLimit, rateLimits, getRateLimitIdentifier } from '@/lib/rate-l
 import { ERROR_MESSAGES } from '@/lib/constants'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { logger } from '@/lib/logger'
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgWriteEnabled() が false を返すため getDb() は一切呼ばれず、既存の
+// supabase-js 経路が従来どおり実行される。
+// ---------------------------------------------------------------------------
+import { eq } from 'drizzle-orm'
+import { getDb } from '@/lib/db/client'
+import { isPgWriteEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import { users as usersTable } from '@/lib/db/schema'
 
 const DISABLED_SUB_VERIFIED_AT = '9999-12-31T00:00:00.000Z'
+
+/**
+ * サブスク状態の手動無効化 UPDATE の pg 直結実装 (#663)
+ * PostgREST 実装との対応: .select('twitch_user_id').maybeSingle() は
+ * .returning({twitch_user_id}) の rows[0] ?? null と同じ外部挙動。書き込む値は
+ * 固定値（DISABLED_SUB_VERIFIED_AT）のため、接続断リトライしても同じ内容を
+ * 書く UPDATE ＝冪等。
+ */
+async function disableSubscriptionPg(
+  twitchUserId: string
+): Promise<{ data: { twitch_user_id: string } | null; error: { message: string } | null }> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .update(usersTable)
+          .set({
+            twitch_has_sub: false,
+            twitch_sub_verified_at: DISABLED_SUB_VERIFIED_AT,
+          })
+          .where(eq(usersTable.twitch_user_id, twitchUserId))
+          .returning({ twitch_user_id: usersTable.twitch_user_id })
+      },
+      'disable-subscription',
+      { idempotent: true },
+    )
+    return { data: rows[0] ?? null, error: null }
+  } catch (error) {
+    return {
+      data: null,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }
+  }
+}
 
 /**
  * Twitch サブスク状態を手動で無効化する POST API
@@ -46,16 +92,18 @@ export async function POST(request: Request) {
       )
     }
 
-    const supabaseAdmin = getSupabaseAdmin()
-    const { data: updatedUser, error: updateError } = await supabaseAdmin
-      .from('users')
-      .update({
-        twitch_has_sub: false,
-        twitch_sub_verified_at: DISABLED_SUB_VERIFIED_AT,
-      })
-      .eq('twitch_user_id', session.twitchUserId)
-      .select('twitch_user_id')
-      .maybeSingle()
+    // #663: 書き込みのみのため isPgWriteEnabled() で分岐。
+    const { data: updatedUser, error: updateError } = isPgWriteEnabled()
+      ? await disableSubscriptionPg(session.twitchUserId)
+      : await getSupabaseAdmin()
+          .from('users')
+          .update({
+            twitch_has_sub: false,
+            twitch_sub_verified_at: DISABLED_SUB_VERIFIED_AT,
+          })
+          .eq('twitch_user_id', session.twitchUserId)
+          .select('twitch_user_id')
+          .maybeSingle()
 
     if (updateError || !updatedUser) {
       logger.error('[TwitchSub] Failed to disable subscription status:', {

--- a/src/app/api/auth/twitch/login/route.ts
+++ b/src/app/api/auth/twitch/login/route.ts
@@ -11,6 +11,53 @@ import { getBaseUrl } from '@/lib/url-utils'
 import { getSession, parseSession, verifySession } from '@/lib/session'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { logger } from '@/lib/logger'
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgReadEnabled() が false を返すため getDb() は一切呼ばれず、既存の
+// supabase-js 経路が従来どおり実行される。
+// ---------------------------------------------------------------------------
+import { eq } from 'drizzle-orm'
+import { getDb } from '@/lib/db/client'
+import { isPgReadEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import { users as usersTable } from '@/lib/db/schema'
+
+/**
+ * ログイン時のスコープ復元読み取りの pg 直結実装 (#663)
+ * PostgREST 実装との対応: .maybeSingle() は twitch_user_id の UNIQUE 制約
+ * （migration 00001）により最大 1 行のため、LIMIT 1 + rows[0] ?? null で同じ
+ * 外部挙動。
+ */
+async function fetchScopeRestorationUserPg(
+  twitchUserId: string
+): Promise<{ data: { twitch_scopes: string[] | null } | null; error: { code?: string; message: string } | null }> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({ twitch_scopes: usersTable.twitch_scopes })
+          .from(usersTable)
+          .where(eq(usersTable.twitch_user_id, twitchUserId))
+          .limit(1)
+      },
+      'login(scope restore)',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    )
+    return { data: rows[0] ?? null, error: null }
+  } catch (error) {
+    const code = (error as { code?: unknown } | null)?.code
+    return {
+      data: null,
+      error: {
+        code: typeof code === 'string' ? code : undefined,
+        message: error instanceof Error ? error.message : String(error),
+      },
+    }
+  }
+}
 
 // Web Crypto APIのcrypto.randomUUID()を使用（Cloudflare Workers互換）
 // Using Web Crypto API crypto.randomUUID() for Cloudflare Workers compatibility
@@ -122,12 +169,14 @@ export async function GET(request: Request) {
       }
 
       if (twitchUserId) {
-        const supabaseAdmin = getSupabaseAdmin()
-        const { data: user, error: dbError } = await supabaseAdmin
-          .from('users')
-          .select('twitch_scopes')
-          .eq('twitch_user_id', twitchUserId)
-          .maybeSingle()
+        // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+        const { data: user, error: dbError } = isPgReadEnabled()
+          ? await fetchScopeRestorationUserPg(twitchUserId)
+          : await getSupabaseAdmin()
+              .from('users')
+              .select('twitch_scopes')
+              .eq('twitch_user_id', twitchUserId)
+              .maybeSingle()
 
         if (dbError) {
           // DB障害時: スコープ復元に失敗したことをcallbackに伝達する

--- a/src/app/api/cards/[id]/route.ts
+++ b/src/app/api/cards/[id]/route.ts
@@ -21,7 +21,27 @@ import { CARD_NUMBER_MESSAGES, isCardNumberConflictError, isMissingCardNumberCol
 import { CARD_ISSUANCE_MESSAGES, isMissingCardIssuanceColumnError, parseCardIssuanceLimit } from "@/lib/card-issuance";
 import { resolveCollectionNameField, isRegisteredOrUnchanged } from "@/lib/validation/collection-name";
 import { isMissingCollectionNameColumn, isMissingCardPackNamesColumnError } from "@/lib/collections/collection-existence";
+// -----------------------------------------------------------------------------
+// #663 (#570/#572 パイロット踏襲): pg 直結経路。PUT/DELETE とも読み取り
+// （所有権確認）と書き込み（UPDATE/DELETE）が混在するため、関数全体を
+// isPgWriteEnabled() で分岐する（token-manager.ts の getBotAccountForChat と
+// 同じ方針）。既存 supabase-js 実装は 1 文字も変えず、フラグ未設定時
+// （既定 'postgrest'）は完全に従来どおり動く。pg 実装は各所の xxxPg 関数に
+// 置き、getDb() は withDbRetry の queryFn 内で呼ぶ規約(src/lib/db/retry.ts 参照)。
+// -----------------------------------------------------------------------------
+import { eq } from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
+import { isPgWriteEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+import { cards as cardsTable, streamers as streamersTable } from "@/lib/db/schema";
+import { CARDS_SAFE_COLUMNS, isMissingCardsBattleColumnError } from "@/lib/db/cards-safe-columns";
 import type { ApiRateLimitResponse } from "@/types/api";
+
+// pg (postgres.js) が throw するエラーの汎用形状。card-number-errors.ts /
+// card-issuance.ts / collection-existence.ts の判定ヘルパーは postgrest/pg
+// 両対応の汎用判定（error.code の SQLSTATE、error.message のテキスト一致）のため、
+// この形にキャストするだけで pg のエラーも判定できる（新規ヘルパーは作らない）。
+type CardsSchemaError = { message?: string; code?: string; details?: string; hint?: string } | null | undefined;
 
 function extractRarityWeights(streamers: unknown): Record<string, number> | null {
   if (!streamers) return null;
@@ -67,6 +87,265 @@ function withEmptyCardPackNames(streamers: unknown): unknown {
   return streamers;
 }
 
+// PUT のオーナーシップ確認 SELECT（cards INNER JOIN streamers）が返す行の pg 直結形状。
+// デプロイ窓フォールバックで card_pack_names / collection_name を落とした場合も
+// 同じ形状（該当フィールドはフォールバック値）で返すことで、呼び出し側の再構成
+// ロジックを1本化する。
+interface CardOwnershipRowPg {
+  streamer_id: string;
+  image_url: string | null;
+  rarity: string;
+  is_active: boolean | null;
+  intra_rarity_weight: number;
+  collection_name: string | null;
+  twitch_user_id: string;
+  rarity_weights: Record<string, number> | null;
+  card_pack_names: string[];
+}
+
+async function selectCardOwnershipFull(id: string): Promise<CardOwnershipRowPg | null> {
+  const rows = await withDbRetry(
+    async () => {
+      // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+      const { db } = await getDb();
+      return db
+        .select({
+          streamer_id: cardsTable.streamer_id,
+          image_url: cardsTable.image_url,
+          rarity: cardsTable.rarity,
+          is_active: cardsTable.is_active,
+          intra_rarity_weight: cardsTable.intra_rarity_weight,
+          collection_name: cardsTable.collection_name,
+          twitch_user_id: streamersTable.twitch_user_id,
+          rarity_weights: streamersTable.rarity_weights,
+          card_pack_names: streamersTable.card_pack_names,
+        })
+        .from(cardsTable)
+        .innerJoin(streamersTable, eq(streamersTable.id, cardsTable.streamer_id))
+        .where(eq(cardsTable.id, id))
+        .limit(1);
+    },
+    "Cards API PUT: ownership check",
+    { idempotent: true }
+  );
+  return rows[0] ?? null;
+}
+
+async function selectCardOwnershipWithoutCardPackNames(id: string): Promise<CardOwnershipRowPg | null> {
+  const rows = await withDbRetry(
+    async () => {
+      const { db } = await getDb();
+      return db
+        .select({
+          streamer_id: cardsTable.streamer_id,
+          image_url: cardsTable.image_url,
+          rarity: cardsTable.rarity,
+          is_active: cardsTable.is_active,
+          intra_rarity_weight: cardsTable.intra_rarity_weight,
+          collection_name: cardsTable.collection_name,
+          twitch_user_id: streamersTable.twitch_user_id,
+          rarity_weights: streamersTable.rarity_weights,
+        })
+        .from(cardsTable)
+        .innerJoin(streamersTable, eq(streamersTable.id, cardsTable.streamer_id))
+        .where(eq(cardsTable.id, id))
+        .limit(1);
+    },
+    "Cards API PUT: ownership check (retry without card_pack_names)",
+    { idempotent: true }
+  );
+  const row = rows[0];
+  return row ? { ...row, card_pack_names: [] } : null;
+}
+
+async function selectCardOwnershipWithoutCollectionAndPackNames(id: string): Promise<CardOwnershipRowPg | null> {
+  const rows = await withDbRetry(
+    async () => {
+      const { db } = await getDb();
+      return db
+        .select({
+          streamer_id: cardsTable.streamer_id,
+          image_url: cardsTable.image_url,
+          rarity: cardsTable.rarity,
+          is_active: cardsTable.is_active,
+          intra_rarity_weight: cardsTable.intra_rarity_weight,
+          twitch_user_id: streamersTable.twitch_user_id,
+          rarity_weights: streamersTable.rarity_weights,
+        })
+        .from(cardsTable)
+        .innerJoin(streamersTable, eq(streamersTable.id, cardsTable.streamer_id))
+        .where(eq(cardsTable.id, id))
+        .limit(1);
+    },
+    "Cards API PUT: ownership check (retry without card_pack_names/collection_name)",
+    { idempotent: true }
+  );
+  const row = rows[0];
+  return row ? { ...row, collection_name: null, card_pack_names: [] } : null;
+}
+
+/**
+ * PUT /api/cards/[id] のオーナーシップ確認 SELECT（cards INNER JOIN streamers、
+ * card_pack_names → collection_name の2段階デプロイ窓フォールバック付き）の
+ * pg 直結実装 (#663)。
+ *
+ * PostgREST 実装との対応:
+ * - `streamers!cards_streamer_id_fkey!inner(...)` は
+ *   `.innerJoin(streamersTable, eq(streamersTable.id, cardsTable.streamer_id))`
+ *   が等価（FK: streamers.id = cards.streamer_id 上の INNER JOIN）。
+ * - 取得した行は既存の extractTwitchUserId/extractRarityWeights/
+ *   extractCardPackNames ヘルパーがそのまま使えるよう、
+ *   `{ ...cardFields, streamers: { twitch_user_id, rarity_weights, card_pack_names } }`
+ *   の同じネスト形状に再構成する。
+ * - 想定外のエラーを含め、いずれの取得も最終的に失敗した場合は throw せず
+ *   `card: null` を返す。postgrest 経路もこの SELECT のエラーを明示チェックせず
+ *   `!card` だけで 403 に倒しており（cardSelectError は「フォールバック判定」
+ *   にのみ使われる）、同じ外部挙動に合わせるため。
+ */
+async function fetchCardForUpdatePg(id: string): Promise<{
+  card: {
+    streamer_id: string;
+    image_url: string | null;
+    rarity: string;
+    is_active: boolean | null;
+    intra_rarity_weight: number;
+    collection_name: string | null;
+    streamers: { twitch_user_id: string; rarity_weights: Record<string, number> | null; card_pack_names: string[] };
+  } | null;
+  cardPackNamesUnavailable: boolean;
+}> {
+  let cardPackNamesUnavailable = false;
+  let row: CardOwnershipRowPg | null = null;
+  let currentError: unknown = null;
+
+  try {
+    row = await selectCardOwnershipFull(id);
+  } catch (error) {
+    currentError = error;
+  }
+
+  // Issue #393再設計: card_pack_names(事前登録パック一覧、streamers埋め込み内)
+  // がデプロイ窓で未検出の場合、それだけ外して再試行する。
+  if (currentError && isMissingCardPackNamesColumnError(currentError as CardsSchemaError)) {
+    cardPackNamesUnavailable = true;
+    currentError = null;
+    try {
+      row = await selectCardOwnershipWithoutCardPackNames(id);
+    } catch (error) {
+      currentError = error;
+    }
+  }
+
+  // Issue #269 (self-review fix): collection_name 列がデプロイ窓で未検出の場合、
+  // それを落として再試行する。card_pack_names も併せて落とす(両方同時に
+  // 未デプロイという稀なケースの安全側対応。postgrest 経路と同じ)。
+  if (currentError && isMissingCollectionNameColumn(currentError as CardsSchemaError)) {
+    cardPackNamesUnavailable = true;
+    currentError = null;
+    try {
+      row = await selectCardOwnershipWithoutCollectionAndPackNames(id);
+    } catch (error) {
+      currentError = error;
+    }
+  }
+
+  if (currentError || !row) {
+    return { card: null, cardPackNamesUnavailable };
+  }
+
+  return {
+    card: {
+      streamer_id: row.streamer_id,
+      image_url: row.image_url,
+      rarity: row.rarity,
+      is_active: row.is_active,
+      intra_rarity_weight: row.intra_rarity_weight,
+      collection_name: row.collection_name,
+      streamers: {
+        twitch_user_id: row.twitch_user_id,
+        rarity_weights: row.rarity_weights,
+        card_pack_names: row.card_pack_names,
+      },
+    },
+    cardPackNamesUnavailable,
+  };
+}
+
+/**
+ * PUT /api/cards/[id] のカード UPDATE（card_number → max_issuance_count →
+ * collection_name の3段階デプロイ窓フォールバック付き、さらに RETURNING 列の
+ * フォールバックを末尾に追加）の pg 直結実装 (#663 self-review fix)。
+ *
+ * PostgREST 実装との対応:
+ * - `.update(...).eq("id", id).select().maybeSingle()` は
+ *   `.update(...).set(...).where(eq(id, ...)).returning()` が等価。
+ * - 各フォールバックは同じ判定ヘルパー(isMissingCardNumberColumnError 等)を
+ *   そのまま再利用する。
+ * - リクエストボディの明示的な最終値を書き込む UPDATE のため冪等（リトライ可）。
+ * - unique_violation (23505) は呼び出し元(PUT)で isCardNumberConflictError
+ *   により 409 に変換される（postgrest 経路と共通）。
+ *
+ * self-review fix: 無指定 `.returning()` は schema.ts の静的列リストを生成する
+ * ため、本番に実在しない8列(card_number/hp/atk/def/spd/skill_*、
+ * cards-safe-columns.ts参照)を含む RETURNING は必ず失敗する。updateData に
+ * card_number 等が一切含まれていない（=リクエストで変更していない）場合でも
+ * RETURNING は無関係に全列を要求するため、常にこの失敗が起こりうる。
+ * 上記3段階フォールバックを終えてもなお失敗する場合、最後に RETURNING を
+ * CARDS_SAFE_COLUMNS（8列除外）へ切り替えて再試行する。
+ */
+async function updateCardPg(
+  id: string,
+  updateDataInitial: Record<string, unknown>
+): Promise<{ updatedCard: Record<string, unknown> | null; error: unknown }> {
+  const updateData = { ...updateDataInitial };
+
+  async function attemptUpdate(
+    useSafeReturning = false
+  ): Promise<{ updatedCard: Record<string, unknown> | null; error: unknown }> {
+    try {
+      const rows = await withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          const query = db
+            .update(cardsTable)
+            .set(updateData as Partial<typeof cardsTable.$inferInsert>)
+            .where(eq(cardsTable.id, id));
+          return useSafeReturning ? query.returning(CARDS_SAFE_COLUMNS) : query.returning();
+        },
+        "Cards API PUT: update card",
+        // 明示的な最終値を書く UPDATE のため冪等（リトライ可）
+        { idempotent: true }
+      );
+      return { updatedCard: rows[0] ?? null, error: null };
+    } catch (error) {
+      return { updatedCard: null, error };
+    }
+  }
+
+  let { updatedCard, error } = await attemptUpdate();
+
+  if (error && isMissingCardNumberColumnError(error) && "card_number" in updateData) {
+    delete updateData.card_number;
+    ({ updatedCard, error } = await attemptUpdate());
+  }
+  if (error && isMissingCardIssuanceColumnError(error) && "max_issuance_count" in updateData) {
+    delete updateData.max_issuance_count;
+    ({ updatedCard, error } = await attemptUpdate());
+  }
+  if (error && isMissingCollectionNameColumn(error as CardsSchemaError) && "collection_name" in updateData) {
+    delete updateData.collection_name;
+    ({ updatedCard, error } = await attemptUpdate());
+  }
+  // self-review fix: 上記までの入力値フォールバックを尽くしてもなお、無指定
+  // RETURNING が本番未デプロイ列(hp/atk/...等)を要求して失敗している場合、
+  // 明示列リストで最後にもう一度だけ試す。
+  if (error && isMissingCardsBattleColumnError(error)) {
+    ({ updatedCard, error } = await attemptUpdate(true));
+  }
+
+  return { updatedCard, error };
+}
+
 export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -86,7 +365,7 @@ export async function PUT(
 
   if (!rateLimitResult.success) {
     return NextResponse.json<ApiRateLimitResponse>(
-      { 
+      {
         error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
         retryAfter: (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000)
       },
@@ -198,57 +477,77 @@ export async function PUT(
 
     // Verify ownership and get current image_url for cleanup
     // 所有権を確認し、クリーンアップ用に現在のimage_urlを取得
-    let { data: card, error: cardSelectError } = await supabaseAdmin
-      .from("cards")
-      // streamers の埋め込みは FK 制約名で一意化する: migration 00051 の
-      // card_owner_stats が cards↔streamers を m2m にも見せ、ヒントなしの
-      // streamers(...) は PGRST201 で失敗するため。
-      .select("streamer_id, image_url, rarity, is_active, intra_rarity_weight, collection_name, streamers!cards_streamer_id_fkey!inner(twitch_user_id, rarity_weights, card_pack_names)")
-      .eq("id", id)
-      .maybeSingle();
-
-    // Issue #393再設計: card_pack_names(事前登録パック一覧、streamers埋め込み内)
-    // がデプロイ窓で未検出の場合、それだけ外して再試行する(collection_nameは
-    // 既に本番稼働済みの列のため、通常この組み合わせのみが発生する)。
+    let card:
+      | {
+          streamer_id: string;
+          image_url: string | null;
+          rarity: string;
+          is_active: boolean | null;
+          intra_rarity_weight: number;
+          collection_name: string | null;
+          streamers: unknown;
+        }
+      | null;
     let cardPackNamesUnavailable = false;
-    if (cardSelectError && isMissingCardPackNamesColumnError(cardSelectError)) {
-      const retryResult = await supabaseAdmin
-        .from("cards")
-        .select("streamer_id, image_url, rarity, is_active, intra_rarity_weight, collection_name, streamers!cards_streamer_id_fkey!inner(twitch_user_id, rarity_weights)")
-        .eq("id", id)
-        .maybeSingle();
-      card = retryResult.data
-        ? ({ ...retryResult.data, streamers: withEmptyCardPackNames(retryResult.data.streamers) } as typeof card)
-        : null;
-      cardSelectError = retryResult.error;
-      cardPackNamesUnavailable = true;
-    }
 
-    // Issue #269 (self-review fix): collection_name was added to this
-    // ownership-check SELECT to read the current pack value for the gate
-    // below. During the deploy window (migration 00061 not applied yet) that
-    // turns the SELECT itself into a 42703 "column does not exist" error,
-    // which would 403 EVERY card edit — not just pack-related ones — because
-    // this branch only checked `!card`, not `error`. Retry without the
-    // column so unrelated edits keep working; the gate then just sees no
-    // current pack value (treated as null), matching every other #393
-    // deploy-window fallback in this codebase. card_pack_names も併せて落とす
-    // (両方同時に未デプロイという稀なケースの安全側対応)。
-    if (cardSelectError && isMissingCollectionNameColumn(cardSelectError)) {
-      const retryResult = await supabaseAdmin
+    if (isPgWriteEnabled()) {
+      const result = await fetchCardForUpdatePg(id);
+      card = result.card;
+      cardPackNamesUnavailable = result.cardPackNamesUnavailable;
+    } else {
+      let { data: cardData, error: cardSelectError } = await supabaseAdmin
         .from("cards")
-        .select("streamer_id, image_url, rarity, is_active, intra_rarity_weight, streamers!cards_streamer_id_fkey!inner(twitch_user_id, rarity_weights)")
+        // streamers の埋め込みは FK 制約名で一意化する: migration 00051 の
+        // card_owner_stats が cards↔streamers を m2m にも見せ、ヒントなしの
+        // streamers(...) は PGRST201 で失敗するため。
+        .select("streamer_id, image_url, rarity, is_active, intra_rarity_weight, collection_name, streamers!cards_streamer_id_fkey!inner(twitch_user_id, rarity_weights, card_pack_names)")
         .eq("id", id)
         .maybeSingle();
-      card = retryResult.data
-        ? ({
-            ...retryResult.data,
-            collection_name: null,
-            streamers: withEmptyCardPackNames(retryResult.data.streamers),
-          } as typeof card)
-        : null;
-      cardSelectError = retryResult.error;
-      cardPackNamesUnavailable = true;
+
+      // Issue #393再設計: card_pack_names(事前登録パック一覧、streamers埋め込み内)
+      // がデプロイ窓で未検出の場合、それだけ外して再試行する(collection_nameは
+      // 既に本番稼働済みの列のため、通常この組み合わせのみが発生する)。
+      if (cardSelectError && isMissingCardPackNamesColumnError(cardSelectError)) {
+        const retryResult = await supabaseAdmin
+          .from("cards")
+          .select("streamer_id, image_url, rarity, is_active, intra_rarity_weight, collection_name, streamers!cards_streamer_id_fkey!inner(twitch_user_id, rarity_weights)")
+          .eq("id", id)
+          .maybeSingle();
+        cardData = retryResult.data
+          ? ({ ...retryResult.data, streamers: withEmptyCardPackNames(retryResult.data.streamers) } as typeof cardData)
+          : null;
+        cardSelectError = retryResult.error;
+        cardPackNamesUnavailable = true;
+      }
+
+      // Issue #269 (self-review fix): collection_name was added to this
+      // ownership-check SELECT to read the current pack value for the gate
+      // below. During the deploy window (migration 00061 not applied yet) that
+      // turns the SELECT itself into a 42703 "column does not exist" error,
+      // which would 403 EVERY card edit — not just pack-related ones — because
+      // this branch only checked `!card`, not `error`. Retry without the
+      // column so unrelated edits keep working; the gate then just sees no
+      // current pack value (treated as null), matching every other #393
+      // deploy-window fallback in this codebase. card_pack_names も併せて落とす
+      // (両方同時に未デプロイという稀なケースの安全側対応)。
+      if (cardSelectError && isMissingCollectionNameColumn(cardSelectError)) {
+        const retryResult = await supabaseAdmin
+          .from("cards")
+          .select("streamer_id, image_url, rarity, is_active, intra_rarity_weight, streamers!cards_streamer_id_fkey!inner(twitch_user_id, rarity_weights)")
+          .eq("id", id)
+          .maybeSingle();
+        cardData = retryResult.data
+          ? ({
+              ...retryResult.data,
+              collection_name: null,
+              streamers: withEmptyCardPackNames(retryResult.data.streamers),
+            } as typeof cardData)
+          : null;
+        cardSelectError = retryResult.error;
+        cardPackNamesUnavailable = true;
+      }
+
+      card = cardData;
     }
 
     const twitchUserId = extractTwitchUserId(card?.streamers);
@@ -339,49 +638,61 @@ export async function PUT(
       }
     }
 
-    let { data: updatedCard, error } = await supabaseAdmin
-      .from("cards")
-      .update(updateData)
-      .eq("id", id)
-      .select()
-      .maybeSingle();
+    let updatedCard: Record<string, unknown> | null;
+    let error: unknown;
 
-    if (error && isMissingCardNumberColumnError(error) && "card_number" in updateData) {
-      delete updateData.card_number;
-      const retryResult = await supabaseAdmin
+    if (isPgWriteEnabled()) {
+      const result = await updateCardPg(id, updateData);
+      updatedCard = result.updatedCard;
+      error = result.error;
+    } else {
+      let { data: updatedCardData, error: updateError } = await supabaseAdmin
         .from("cards")
         .update(updateData)
         .eq("id", id)
         .select()
         .maybeSingle();
-      updatedCard = retryResult.data;
-      error = retryResult.error;
-    }
-    if (error && isMissingCardIssuanceColumnError(error) && "max_issuance_count" in updateData) {
-      delete updateData.max_issuance_count;
-      const retryResult = await supabaseAdmin
-        .from("cards")
-        .update(updateData)
-        .eq("id", id)
-        .select()
-        .maybeSingle();
-      updatedCard = retryResult.data;
-      error = retryResult.error;
-    }
 
-    // Issue #393: deploy-window safety — retry without collection_name if the
-    // column is not migrated yet so other field edits still persist. Mirrors the
-    // card_number retry above.
-    if (error && isMissingCollectionNameColumn(error) && "collection_name" in updateData) {
-      delete updateData.collection_name;
-      const retryResult = await supabaseAdmin
-        .from("cards")
-        .update(updateData)
-        .eq("id", id)
-        .select()
-        .maybeSingle();
-      updatedCard = retryResult.data;
-      error = retryResult.error;
+      if (updateError && isMissingCardNumberColumnError(updateError) && "card_number" in updateData) {
+        delete updateData.card_number;
+        const retryResult = await supabaseAdmin
+          .from("cards")
+          .update(updateData)
+          .eq("id", id)
+          .select()
+          .maybeSingle();
+        updatedCardData = retryResult.data;
+        updateError = retryResult.error;
+      }
+      if (updateError && isMissingCardIssuanceColumnError(updateError) && "max_issuance_count" in updateData) {
+        delete updateData.max_issuance_count;
+        const retryResult = await supabaseAdmin
+          .from("cards")
+          .update(updateData)
+          .eq("id", id)
+          .select()
+          .maybeSingle();
+        updatedCardData = retryResult.data;
+        updateError = retryResult.error;
+      }
+
+      // Issue #393: deploy-window safety — retry without collection_name if the
+      // column is not migrated yet so other field edits still persist. Mirrors the
+      // card_number retry above.
+      if (updateError && isMissingCollectionNameColumn(updateError) && "collection_name" in updateData) {
+        delete updateData.collection_name;
+        const retryResult = await supabaseAdmin
+          .from("cards")
+          .update(updateData)
+          .eq("id", id)
+          .select()
+          .maybeSingle();
+        updatedCardData = retryResult.data;
+        updateError = retryResult.error;
+      }
+
+      updatedCard = updatedCardData;
+      error = updateError;
     }
 
     if (error) {
@@ -419,6 +730,71 @@ export async function PUT(
   }
 }
 
+/**
+ * DELETE /api/cards/[id] のオーナーシップ確認 SELECT（cards INNER JOIN
+ * streamers、フォールバックチェーン無し）の pg 直結実装 (#663)。
+ *
+ * PostgREST 実装との対応:
+ * - postgrest 経路は `data` のみ分割代入し error を確認しない
+ *   （`const { data: card } = await ...`）ため、いかなるエラーも `!card` の
+ *   403 分岐に落ちる。pg 版も同じ外部挙動に合わせ、throw せず null を返す。
+ */
+async function selectCardOwnershipForDeletePg(
+  id: string
+): Promise<{ streamer_id: string; image_url: string | null; streamers: { twitch_user_id: string; rarity_weights: Record<string, number> | null } } | null> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select({
+            streamer_id: cardsTable.streamer_id,
+            image_url: cardsTable.image_url,
+            twitch_user_id: streamersTable.twitch_user_id,
+            rarity_weights: streamersTable.rarity_weights,
+          })
+          .from(cardsTable)
+          .innerJoin(streamersTable, eq(streamersTable.id, cardsTable.streamer_id))
+          .where(eq(cardsTable.id, id))
+          .limit(1);
+      },
+      "Cards API DELETE: ownership check",
+      { idempotent: true }
+    );
+    const row = rows[0];
+    if (!row) return null;
+    return {
+      streamer_id: row.streamer_id,
+      image_url: row.image_url,
+      streamers: { twitch_user_id: row.twitch_user_id, rarity_weights: row.rarity_weights },
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * DELETE /api/cards/[id] の DELETE 文の pg 直結実装 (#663)。
+ * PK（id）指定の DELETE は再実行しても最終状態が同じため冪等（リトライ可）。
+ * removeBlobFilePg の DELETE と同じ方針（src/lib/storage-db.ts 参照）。
+ */
+async function deleteCardPg(id: string): Promise<{ error: unknown }> {
+  try {
+    await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db.delete(cardsTable).where(eq(cardsTable.id, id));
+      },
+      "Cards API DELETE: delete card",
+      { idempotent: true }
+    );
+    return { error: null };
+  } catch (error) {
+    return { error };
+  }
+}
+
 export async function DELETE(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -438,7 +814,7 @@ export async function DELETE(
 
   if (!rateLimitResult.success) {
     return NextResponse.json<ApiRateLimitResponse>(
-      { 
+      {
         error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
         retryAfter: (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000)
       },
@@ -464,14 +840,21 @@ export async function DELETE(
 
     // Get card with image_url for deletion
     // 削除用にimage_url付きでカードを取得
-    const { data: card } = await supabaseAdmin
-      .from("cards")
-      // streamers の埋め込みは FK 制約名で一意化する(PUT と同じ理由: migration
-      // 00051 の card_owner_stats が cards↔streamers を m2m にも見せ、ヒント
-      // なしの streamers(...) は PGRST201 で失敗するため)。
-      .select("streamer_id, image_url, streamers!cards_streamer_id_fkey!inner(twitch_user_id, rarity_weights)")
-      .eq("id", id)
-      .maybeSingle();
+    let card: { streamer_id: string; image_url: string | null; streamers: unknown } | null;
+
+    if (isPgWriteEnabled()) {
+      card = await selectCardOwnershipForDeletePg(id);
+    } else {
+      const { data } = await supabaseAdmin
+        .from("cards")
+        // streamers の埋め込みは FK 制約名で一意化する(PUT と同じ理由: migration
+        // 00051 の card_owner_stats が cards↔streamers を m2m にも見せ、ヒント
+        // なしの streamers(...) は PGRST201 で失敗するため)。
+        .select("streamer_id, image_url, streamers!cards_streamer_id_fkey!inner(twitch_user_id, rarity_weights)")
+        .eq("id", id)
+        .maybeSingle();
+      card = data;
+    }
 
     const twitchUserId = extractTwitchUserId(card?.streamers);
 
@@ -511,10 +894,18 @@ export async function DELETE(
       }
     }
 
-    const { error } = await supabaseAdmin
-      .from("cards")
-      .delete()
-      .eq("id", id);
+    let error: unknown;
+
+    if (isPgWriteEnabled()) {
+      const result = await deleteCardPg(id);
+      error = result.error;
+    } else {
+      const result = await supabaseAdmin
+        .from("cards")
+        .delete()
+        .eq("id", id);
+      error = result.error;
+    }
 
     if (error) {
       return handleDatabaseError(error, "Failed to delete card");

--- a/src/app/api/cards/batch/route.ts
+++ b/src/app/api/cards/batch/route.ts
@@ -13,6 +13,19 @@ import { ERROR_MESSAGES } from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
 import { recalculateIfAutoMode } from "@/lib/recalculate-drop-rates";
+// -----------------------------------------------------------------------------
+// #663 (#570/#572 パイロット踏襲): pg 直結経路。POST は読み取り（所有権確認）と
+// 書き込み（一括 INSERT）が混在するため、DB アクセス部分は isPgWriteEnabled()
+// で分岐する（token-manager.ts の getBotAccountForChat と同じ方針）。既存
+// supabase-js 実装は 1 文字も変えず、フラグ未設定時（既定 'postgrest'）は
+// 完全に従来どおり動く。フォールバックチェーンは無い（postgrest 経路も無い）。
+// -----------------------------------------------------------------------------
+import { and, eq } from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
+import { isPgWriteEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+import { cards as cardsTable, streamers as streamersTable } from "@/lib/db/schema";
+import { CARDS_SAFE_COLUMNS, isMissingCardsBattleColumnError } from "@/lib/db/cards-safe-columns";
 import type { ApiRateLimitResponse } from "@/types/api";
 import type { Rarity } from "@/types/database";
 
@@ -27,6 +40,87 @@ interface BatchCardInput {
   dropRate: number;
   description?: string;
   intraRarityWeight?: number;
+}
+
+/**
+ * POST /api/cards/batch の streamer 所有権確認 (id, rarity_weights) の
+ * pg 直結実装 (#663)。フォールバックチェーンは無い(postgrest 経路にも無い)。
+ *
+ * PostgREST 実装との対応:
+ * - postgrest 経路は `data` のみ分割代入し error を確認しない
+ *   （`const { data: streamer } = await ...`）ため、いかなるエラーも `!streamer`
+ *   の 403 分岐に落ちる。pg 版も同じ外部挙動に合わせ、throw せず null を返す。
+ */
+async function selectStreamerForBatchCreatePg(
+  streamerId: string,
+  twitchUserId: string
+): Promise<{ id: string; rarity_weights: Record<string, number> | null } | null> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select({ id: streamersTable.id, rarity_weights: streamersTable.rarity_weights })
+          .from(streamersTable)
+          .where(and(eq(streamersTable.id, streamerId), eq(streamersTable.twitch_user_id, twitchUserId)))
+          .limit(1);
+      },
+      "Cards Batch API: streamer ownership check",
+      { idempotent: true }
+    );
+    return rows[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * POST /api/cards/batch の一括 INSERT の pg 直結実装 (#663)。
+ * 入力値のデプロイ窓フォールバックチェーンは無い(postgrest 経路にも無い。
+ * cardsToInsert は card_number/hp/atk 等の本番未デプロイ列を最初から
+ * 含めない)。
+ *
+ * PostgREST 実装との対応:
+ * - `.insert(cardsToInsert).select()` は `.insert(...).values(...).returning()`
+ *   が等価（RETURNING で挿入行を1回の往復で取得）。
+ * - ON CONFLICT の無い一括 INSERT のため非冪等（withDbRetry にオプションを
+ *   渡さない = リトライなし。二重作成を避けるため）。
+ *
+ * self-review fix: 無指定 `.returning()` は schema.ts の静的列リストを生成する
+ * ため、本番に実在しない8列(card_number/hp/atk/def/spd/skill_*、
+ * cards-safe-columns.ts参照)を含む RETURNING は必ず失敗する。cardsToInsert
+ * 自体はこれらの列を含まないため INSERT の VALUES 自体は成功しうるが、
+ * RETURNING が無関係にそれらを要求するため失敗する。検知したら RETURNING を
+ * CARDS_SAFE_COLUMNS（8列除外）へ切り替えて一度だけ再試行する。
+ */
+async function insertCardsBatchPg(
+  cardsToInsert: Record<string, unknown>[]
+): Promise<{ createdCards: Record<string, unknown>[] | null; error: unknown }> {
+  async function attemptInsert(
+    useSafeReturning = false
+  ): Promise<{ createdCards: Record<string, unknown>[] | null; error: unknown }> {
+    try {
+      const rows = await withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          const query = db.insert(cardsTable).values(cardsToInsert as (typeof cardsTable.$inferInsert)[]);
+          return useSafeReturning ? query.returning(CARDS_SAFE_COLUMNS) : query.returning();
+        },
+        "Cards Batch API: bulk insert cards"
+        // ON CONFLICT の無い INSERT は再実行で二重作成になりうるため非冪等（既定 = リトライなし）
+      );
+      return { createdCards: rows, error: null };
+    } catch (error) {
+      return { createdCards: null, error };
+    }
+  }
+
+  let { createdCards, error } = await attemptInsert();
+  if (error && isMissingCardsBattleColumnError(error)) {
+    ({ createdCards, error } = await attemptInsert(true));
+  }
+  return { createdCards, error };
 }
 
 /**
@@ -108,12 +202,19 @@ export async function POST(request: NextRequest) {
 
     // Verify streamer owns this streamer profile
     // 配信者がこのstreamerプロフィールを所有しているか確認
-    const { data: streamer } = await supabaseAdmin
-      .from("streamers")
-      .select("id, rarity_weights")
-      .eq("id", streamerId)
-      .eq("twitch_user_id", session.twitchUserId)
-      .maybeSingle();
+    let streamer: { id: string; rarity_weights: Record<string, number> | null } | null;
+
+    if (isPgWriteEnabled()) {
+      streamer = await selectStreamerForBatchCreatePg(streamerId, session.twitchUserId);
+    } else {
+      const { data } = await supabaseAdmin
+        .from("streamers")
+        .select("id, rarity_weights")
+        .eq("id", streamerId)
+        .eq("twitch_user_id", session.twitchUserId)
+        .maybeSingle();
+      streamer = data;
+    }
 
     if (!streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
@@ -174,10 +275,21 @@ export async function POST(request: NextRequest) {
 
     // Insert all cards at once
     // 全カードを一度に挿入
-    const { data: createdCards, error } = await supabaseAdmin
-      .from("cards")
-      .insert(cardsToInsert)
-      .select();
+    let createdCards: Record<string, unknown>[] | null;
+    let error: unknown;
+
+    if (isPgWriteEnabled()) {
+      const result = await insertCardsBatchPg(cardsToInsert);
+      createdCards = result.createdCards;
+      error = result.error;
+    } else {
+      const result = await supabaseAdmin
+        .from("cards")
+        .insert(cardsToInsert)
+        .select();
+      createdCards = result.data;
+      error = result.error;
+    }
 
     if (error) {
       return handleDatabaseError(error, "Cards Batch API: Failed to create cards");

--- a/src/app/api/cards/route.ts
+++ b/src/app/api/cards/route.ts
@@ -22,11 +22,163 @@ import { CARD_NUMBER_MESSAGES, isCardNumberConflictError, isMissingCardNumberCol
 import { CARD_ISSUANCE_MESSAGES, isMissingCardIssuanceColumnError, parseCardIssuanceLimit } from "@/lib/card-issuance";
 import { resolveCollectionNameField, isRegisteredOrUnchanged } from "@/lib/validation/collection-name";
 import { isMissingCollectionNameColumn, isMissingCardPackNamesColumnError } from "@/lib/collections/collection-existence";
+// -----------------------------------------------------------------------------
+// #663 (#570/#572 パイロット踏襲): pg 直結経路。POST/GET とも読み取り・書き込みが
+// 混在しうるため、DB アクセス部分は isPgWriteEnabled()（POST）/ isPgReadEnabled()
+// （GET は読み取り専用）で分岐する。既存 supabase-js 実装は 1 文字も変えず、
+// フラグ未設定時（既定 'postgrest'）は完全に従来どおり動く。pg 実装は各所の
+// xxxPg 関数に置き、getDb() は withDbRetry の queryFn 内で呼ぶ規約
+// (src/lib/db/retry.ts 参照)。
+// -----------------------------------------------------------------------------
+import { and, count as countAggregate, eq, inArray, sql, type AnyColumn } from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
+import { isPgReadEnabled, isPgWriteEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+import { cards as cardsTable, streamers as streamersTable, userCards as userCardsTable } from "@/lib/db/schema";
+import { CARDS_SAFE_COLUMNS, isMissingCardsBattleColumnError } from "@/lib/db/cards-safe-columns";
 import type { ApiRateLimitResponse } from "@/types/api";
+
+// pg (postgres.js) が throw するエラーの汎用形状。card-number-errors.ts /
+// card-issuance.ts / collection-existence.ts の判定ヘルパーは postgrest/pg
+// 両対応の汎用判定（error.code の SQLSTATE、error.message のテキスト一致）のため、
+// この形にキャストするだけで pg のエラーも判定できる（新規ヘルパーは作らない）。
+type CardsSchemaError = { message?: string; code?: string; details?: string; hint?: string } | null | undefined;
 
 // Cache TTL for cards list (30 seconds to balance freshness and CPU usage)
 // カード一覧のキャッシュTTL（新鮮さとCPU使用量のバランスで30秒）
 const CARDS_CACHE_TTL = 30;
+
+/**
+ * POST /api/cards の streamer 所有権確認 (id, rarity_weights, card_pack_names) の
+ * pg 直結実装 (#663)。card_pack_names 列未デプロイ時のフォールバックを含む。
+ *
+ * PostgREST 実装との対応:
+ * - `.eq("id", ...).eq("twitch_user_id", ...).maybeSingle()` は id が PK のため
+ *   LIMIT 1 + rows[0] ?? null で同じ外部挙動。
+ * - card_pack_names 列未デプロイ(42703)を検知したら列を落として再試行し、
+ *   card_pack_names: [] を注入する（postgrest 経路と同じフォールバック）。
+ * - 想定外のエラーは throw して呼び出し元(POST)の外側 catch で 500 にする。
+ */
+async function fetchStreamerForCardCreatePg(
+  streamerId: string,
+  twitchUserId: string
+): Promise<{
+  streamer: { id: string; rarity_weights: Record<string, number> | null; card_pack_names: string[] } | null;
+  cardPackNamesUnavailable: boolean;
+}> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select({
+            id: streamersTable.id,
+            rarity_weights: streamersTable.rarity_weights,
+            card_pack_names: streamersTable.card_pack_names,
+          })
+          .from(streamersTable)
+          .where(and(eq(streamersTable.id, streamerId), eq(streamersTable.twitch_user_id, twitchUserId)))
+          .limit(1);
+      },
+      "Cards API POST: streamer ownership check",
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true }
+    );
+    return { streamer: rows[0] ?? null, cardPackNamesUnavailable: false };
+  } catch (error) {
+    if (isMissingCardPackNamesColumnError(error as CardsSchemaError)) {
+      const rows = await withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          return db
+            .select({ id: streamersTable.id, rarity_weights: streamersTable.rarity_weights })
+            .from(streamersTable)
+            .where(and(eq(streamersTable.id, streamerId), eq(streamersTable.twitch_user_id, twitchUserId)))
+            .limit(1);
+        },
+        "Cards API POST: streamer ownership check (retry without card_pack_names)",
+        { idempotent: true }
+      );
+      const row = rows[0];
+      return {
+        streamer: row ? { ...row, card_pack_names: [] } : null,
+        cardPackNamesUnavailable: true,
+      };
+    }
+    throw error;
+  }
+}
+
+/**
+ * POST /api/cards のカード INSERT（card_number → max_issuance_count →
+ * collection_name の3段階デプロイ窓フォールバック付き、さらに RETURNING 列の
+ * フォールバックを末尾に追加）の pg 直結実装 (#663 self-review fix)。
+ *
+ * PostgREST 実装との対応:
+ * - `.insert(...).select().maybeSingle()` は `.insert(...).values(...).returning()`
+ *   が等価（RETURNING で挿入行を1回の往復で取得）。
+ * - 各フォールバックは同じ判定ヘルパー(isMissingCardNumberColumnError 等)を
+ *   そのまま再利用する。ON CONFLICT の無い INSERT のため各試行は非冪等
+ *   （withDbRetry にオプションを渡さない = リトライなし）。
+ * - unique_violation (23505) は呼び出し元(POST)で isCardNumberConflictError
+ *   により 409 に変換される（postgrest 経路と共通）。
+ *
+ * self-review fix: 無指定 `.returning()` は schema.ts の静的列リストを生成する
+ * ため、本番に実在しない8列(card_number/hp/atk/def/spd/skill_*、
+ * cards-safe-columns.ts参照)を含む RETURNING は必ず失敗する。card_number を
+ * insertData から削除しても RETURNING 自体は無指定のままなので直らない
+ * （RETURNING は values() の内容とは無関係にスキーマ全列を要求するため）。
+ * 上記3段階フォールバックを終えてもなお失敗する場合、最後に RETURNING を
+ * CARDS_SAFE_COLUMNS（8列除外）へ切り替えて再試行する。
+ */
+async function insertCardPg(
+  insertDataInitial: Record<string, unknown>
+): Promise<{ card: Record<string, unknown> | null; error: unknown }> {
+  const insertData = { ...insertDataInitial };
+
+  async function attemptInsert(
+    useSafeReturning = false
+  ): Promise<{ card: Record<string, unknown> | null; error: unknown }> {
+    try {
+      const rows = await withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          const query = db.insert(cardsTable).values(insertData as typeof cardsTable.$inferInsert);
+          return useSafeReturning ? query.returning(CARDS_SAFE_COLUMNS) : query.returning();
+        },
+        "Cards API POST: insert card"
+        // ON CONFLICT の無い INSERT は再実行で二重作成になりうるため非冪等（既定 = リトライなし）
+      );
+      return { card: rows[0] ?? null, error: null };
+    } catch (error) {
+      return { card: null, error };
+    }
+  }
+
+  let { card, error } = await attemptInsert();
+
+  if (error && isMissingCardNumberColumnError(error)) {
+    delete insertData.card_number;
+    ({ card, error } = await attemptInsert());
+  }
+  if (error && isMissingCardIssuanceColumnError(error)) {
+    delete insertData.max_issuance_count;
+    ({ card, error } = await attemptInsert());
+  }
+  if (error && isMissingCollectionNameColumn(error as CardsSchemaError) && "collection_name" in insertData) {
+    delete insertData.collection_name;
+    ({ card, error } = await attemptInsert());
+  }
+  // self-review fix: 上記までの入力値フォールバックを尽くしてもなお、無指定
+  // RETURNING が本番未デプロイ列(hp/atk/...等)を要求して失敗している場合、
+  // 明示列リストで最後にもう一度だけ試す。
+  if (error && isMissingCardsBattleColumnError(error)) {
+    ({ card, error } = await attemptInsert(true));
+  }
+
+  return { card, error };
+}
 
 export async function POST(request: NextRequest) {
   // Content-Type validation - must be the first check
@@ -50,7 +202,7 @@ export async function POST(request: NextRequest) {
 
   if (!rateLimitResult.success) {
     return NextResponse.json<ApiRateLimitResponse>(
-      { 
+      {
         error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
         retryAfter: (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000)
       },
@@ -161,27 +313,36 @@ export async function POST(request: NextRequest) {
     }
 
     // Verify streamer owns this streamer profile
-    let { data: streamer, error: streamerSelectError } = await supabaseAdmin
-      .from("streamers")
-      .select("id, rarity_weights, card_pack_names")
-      .eq("id", streamerId)
-      .eq("twitch_user_id", session.twitchUserId)
-      .maybeSingle();
-
-    // Issue #393再設計: card_pack_names(事前登録パック一覧)列がデプロイ窓で
-    // まだ無い場合、membership検証ができない。ownership確認自体は
-    // rarity_weightsのみで継続できるようフォールバックする。
+    let streamer: { id: string; rarity_weights: Record<string, number> | null; card_pack_names: string[] } | null;
     let cardPackNamesUnavailable = false;
-    if (streamerSelectError && isMissingCardPackNamesColumnError(streamerSelectError)) {
-      const retryResult = await supabaseAdmin
+
+    if (isPgWriteEnabled()) {
+      const result = await fetchStreamerForCardCreatePg(streamerId, session.twitchUserId);
+      streamer = result.streamer;
+      cardPackNamesUnavailable = result.cardPackNamesUnavailable;
+    } else {
+      let { data: streamerData, error: streamerSelectError } = await supabaseAdmin
         .from("streamers")
-        .select("id, rarity_weights")
+        .select("id, rarity_weights, card_pack_names")
         .eq("id", streamerId)
         .eq("twitch_user_id", session.twitchUserId)
         .maybeSingle();
-      streamer = retryResult.data ? { ...retryResult.data, card_pack_names: [] as string[] } : null;
-      streamerSelectError = retryResult.error;
-      cardPackNamesUnavailable = true;
+
+      // Issue #393再設計: card_pack_names(事前登録パック一覧)列がデプロイ窓で
+      // まだ無い場合、membership検証ができない。ownership確認自体は
+      // rarity_weightsのみで継続できるようフォールバックする。
+      if (streamerSelectError && isMissingCardPackNamesColumnError(streamerSelectError)) {
+        const retryResult = await supabaseAdmin
+          .from("streamers")
+          .select("id, rarity_weights")
+          .eq("id", streamerId)
+          .eq("twitch_user_id", session.twitchUserId)
+          .maybeSingle();
+        streamerData = retryResult.data ? { ...retryResult.data, card_pack_names: [] as string[] } : null;
+        streamerSelectError = retryResult.error;
+        cardPackNamesUnavailable = true;
+      }
+      streamer = streamerData;
     }
 
     if (!streamer) {
@@ -237,46 +398,58 @@ export async function POST(request: NextRequest) {
       insertData.intra_rarity_weight = intraRarityWeight;
     }
 
-    let { data: card, error } = await supabaseAdmin
-      .from("cards")
-      .insert(insertData)
-      .select()
-      .maybeSingle();
+    let card: Record<string, unknown> | null;
+    let error: unknown;
 
-    if (error && isMissingCardNumberColumnError(error)) {
-      delete insertData.card_number;
-      const retryResult = await supabaseAdmin
+    if (isPgWriteEnabled()) {
+      const result = await insertCardPg(insertData);
+      card = result.card;
+      error = result.error;
+    } else {
+      let { data: cardData, error: insertError } = await supabaseAdmin
         .from("cards")
         .insert(insertData)
         .select()
         .maybeSingle();
-      card = retryResult.data;
-      error = retryResult.error;
-    }
-    if (error && isMissingCardIssuanceColumnError(error)) {
-      delete insertData.max_issuance_count;
-      const retryResult = await supabaseAdmin
-        .from("cards")
-        .insert(insertData)
-        .select()
-        .maybeSingle();
-      card = retryResult.data;
-      error = retryResult.error;
-    }
 
-    // Issue #393: deploy-window safety. If collection_name is not migrated yet,
-    // retry without it so card creation still succeeds (the pack is dropped for
-    // this card; the streamer can re-assign it once the column is live). Mirrors
-    // the card_number missing-column retry above.
-    if (error && isMissingCollectionNameColumn(error) && "collection_name" in insertData) {
-      delete insertData.collection_name;
-      const retryResult = await supabaseAdmin
-        .from("cards")
-        .insert(insertData)
-        .select()
-        .maybeSingle();
-      card = retryResult.data;
-      error = retryResult.error;
+      if (insertError && isMissingCardNumberColumnError(insertError)) {
+        delete insertData.card_number;
+        const retryResult = await supabaseAdmin
+          .from("cards")
+          .insert(insertData)
+          .select()
+          .maybeSingle();
+        cardData = retryResult.data;
+        insertError = retryResult.error;
+      }
+      if (insertError && isMissingCardIssuanceColumnError(insertError)) {
+        delete insertData.max_issuance_count;
+        const retryResult = await supabaseAdmin
+          .from("cards")
+          .insert(insertData)
+          .select()
+          .maybeSingle();
+        cardData = retryResult.data;
+        insertError = retryResult.error;
+      }
+
+      // Issue #393: deploy-window safety. If collection_name is not migrated yet,
+      // retry without it so card creation still succeeds (the pack is dropped for
+      // this card; the streamer can re-assign it once the column is live). Mirrors
+      // the card_number missing-column retry above.
+      if (insertError && isMissingCollectionNameColumn(insertError) && "collection_name" in insertData) {
+        delete insertData.collection_name;
+        const retryResult = await supabaseAdmin
+          .from("cards")
+          .insert(insertData)
+          .select()
+          .maybeSingle();
+        cardData = retryResult.data;
+        insertError = retryResult.error;
+      }
+
+      card = cardData;
+      error = insertError;
     }
 
     if (error) {
@@ -337,6 +510,50 @@ type StatusFilter = typeof VALID_STATUS_FILTERS[number];
 type CardWithIssuanceLimit = { id: string; max_issuance_count?: number | null };
 
 /**
+ * attachIssuedCounts の pg 直結実装 (#663)。limitedCardIds は呼び出し元
+ * (attachIssuedCounts) 側で「1件も無ければ問い合わせをスキップする」判定済みの
+ * ため、ここでは常に inArray で絞り込む。
+ *
+ * PostgREST 実装との対応:
+ * - `.in("card_id", limitedCardIds)` は inArray() が等価。
+ * - 取得失敗はログのみでカード一覧自体は返す（ベストエフォート、既存と同じ）。
+ */
+async function attachIssuedCountsPg<T extends CardWithIssuanceLimit>(
+  cards: T[],
+  limitedCardIds: string[]
+): Promise<Array<T & { issued_count?: number }>> {
+  try {
+    const issuedRows = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({ card_id: userCardsTable.card_id })
+          .from(userCardsTable)
+          .where(inArray(userCardsTable.card_id, limitedCardIds));
+      },
+      "Cards API: fetch issued counts (Issue #542, pg)",
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true }
+    );
+
+    const issuedCounts = new Map<string, number>();
+    for (const row of issuedRows) {
+      issuedCounts.set(row.card_id, (issuedCounts.get(row.card_id) || 0) + 1);
+    }
+
+    return cards.map((card) => {
+      if (card.max_issuance_count === null || card.max_issuance_count === undefined) {
+        return card;
+      }
+      return { ...card, issued_count: issuedCounts.get(card.id) ?? 0 };
+    });
+  } catch (error) {
+    logger.error("Cards API: Failed to fetch issued counts (Issue #542)", error);
+    return cards;
+  }
+}
+
+/**
  * Issue #542 (CardManagerで発行済み枚数・残余枚数を表示する):
  * max_issuance_count が設定された「限定カード」のみ、user_cards から発行済み
  * 枚数を取得して issued_count として付与する。
@@ -371,6 +588,11 @@ async function attachIssuedCounts<T extends CardWithIssuanceLimit>(
     return cards;
   }
 
+  // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+  if (isPgReadEnabled()) {
+    return attachIssuedCountsPg(cards, limitedCardIds);
+  }
+
   const { data: issuedRows, error } = await supabaseAdmin
     .from("user_cards")
     .select("card_id")
@@ -395,6 +617,146 @@ async function attachIssuedCounts<T extends CardWithIssuanceLimit>(
 }
 
 /**
+ * NULLS LAST を明示した ORDER BY 式を組み立てる。PostgREST の
+ * `.order(col, { ascending, nullsFirst: false })` は昇順・降順どちらでも
+ * NULL を末尾に置くが、PostgreSQL の素の ASC/DESC のデフォルトは
+ * 「ASC=NULLS LAST」「DESC=NULLS FIRST」なので、DESC側は明示指定しないと
+ * 挙動が変わってしまう。drizzle-orm の asc()/desc() は本バージョンでは
+ * nulls 制御のチェーンを持たないため、sql テンプレートで直接組み立てる。
+ */
+function orderByNullsLast(column: AnyColumn, ascending: boolean) {
+  return ascending ? sql`${column} ASC NULLS LAST` : sql`${column} DESC NULLS LAST`;
+}
+
+function resolveSortColumn(sortField: SortField): AnyColumn {
+  switch (sortField) {
+    case "rarity":
+      return cardsTable.rarity_order;
+    case "display_order":
+      return cardsTable.card_number;
+    case "drop_rate":
+      return cardsTable.drop_rate;
+    case "card_number":
+      return cardsTable.card_number;
+    case "created_at":
+    default:
+      return cardsTable.created_at;
+  }
+}
+
+/**
+ * fetchCardsFromDB の pg 直結実装 (#663)。
+ *
+ * PostgREST 実装は `{ count: "exact" }` （Content-Range トリック）で行取得と
+ * 件数取得を1往復にまとめるが、Drizzle に同等機能は無いため、(1) COUNT(*) の
+ * クエリと (2) ページネーション済みの行取得クエリの2クエリに分ける。往復数の
+ * 完全一致ではなく、最終的な count の値と rows の内容が一致することを機能的
+ * パリティの基準とする（Issue #663 の指示どおり）。
+ *
+ * card_number/display_order ソート時の列未デプロイフォールバックは、COUNT側
+ * クエリはソート列を使わないため対象外（元々失敗しない）。行取得クエリのみ
+ * created_at 降順へのフォールバックを行う。
+ *
+ * self-review fix: 行取得クエリの無指定 `.select()` は schema.ts の静的列リスト
+ * を生成するため、本番に実在しない8列(card_number/hp/atk/...、
+ * cards-safe-columns.ts参照)を含む SELECT は必ず失敗する。ORDER BY 列の
+ * フォールバック（card_number→created_at）を終えてもなお失敗する場合、
+ * SELECT 列リストを CARDS_SAFE_COLUMNS（8列除外）へ切り替えて再試行する。
+ */
+async function fetchCardsFromDBPg(
+  streamerId: string,
+  limit: number,
+  offset: number,
+  sortField: SortField,
+  sortDirection: SortDirection,
+  statusFilter: StatusFilter
+): Promise<{ cards: unknown[]; count: number | null }> {
+  const conditions = [eq(cardsTable.streamer_id, streamerId)];
+  if (statusFilter === "active") {
+    conditions.push(eq(cardsTable.is_active, true));
+  } else if (statusFilter === "inactive") {
+    conditions.push(eq(cardsTable.is_active, false));
+  }
+  const whereCondition = and(...conditions);
+
+  const countRows = await withDbRetry(
+    async () => {
+      const { db } = await getDb();
+      return db.select({ count: countAggregate() }).from(cardsTable).where(whereCondition);
+    },
+    "fetchCardsFromDB(pg): count",
+    { idempotent: true }
+  );
+  const total = countRows[0]?.count ?? 0;
+
+  const ascending = sortDirection === "asc";
+  const primarySortColumn = resolveSortColumn(sortField);
+  const primaryOrderExprs = [orderByNullsLast(primarySortColumn, ascending)];
+  if (sortField === "display_order") {
+    // display_order は card_number の後に作成日昇順で安定ソートする（postgrest 経路と同じ）
+    primaryOrderExprs.push(orderByNullsLast(cardsTable.created_at, true));
+  }
+
+  async function selectRows(orderExprs: ReturnType<typeof orderByNullsLast>[], useSafeColumns = false) {
+    return withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        const query = useSafeColumns ? db.select(CARDS_SAFE_COLUMNS) : db.select();
+        return query
+          .from(cardsTable)
+          .where(whereCondition)
+          .orderBy(...orderExprs)
+          .limit(limit)
+          .offset(offset);
+      },
+      "fetchCardsFromDB(pg): rows",
+      { idempotent: true }
+    );
+  }
+
+  let orderExprs = primaryOrderExprs;
+  let useSafeColumns = false;
+  let rows: unknown[];
+  let rowsError: unknown = null;
+
+  try {
+    rows = await selectRows(orderExprs);
+  } catch (error) {
+    rows = [];
+    rowsError = error;
+  }
+
+  if (
+    rowsError &&
+    (sortField === "card_number" || sortField === "display_order") &&
+    isMissingCardNumberColumnError(rowsError)
+  ) {
+    orderExprs = [orderByNullsLast(cardsTable.created_at, ascending)];
+    try {
+      rows = await selectRows(orderExprs);
+      rowsError = null;
+    } catch (error) {
+      rowsError = error;
+    }
+  }
+
+  // self-review fix: card_number は「本番未デプロイ8列」にも含まれるため、
+  // 上記 ORDER BY フォールバック後もなお無指定 SELECT が hp/atk 等の欠落で
+  // 失敗し続けることがある。最後に明示列リストへ切り替えて再試行する。
+  if (rowsError && isMissingCardsBattleColumnError(rowsError)) {
+    useSafeColumns = true;
+    rows = await selectRows(orderExprs, useSafeColumns);
+    rowsError = null;
+  }
+
+  if (rowsError) {
+    throw rowsError;
+  }
+
+  return { cards: rows, count: total };
+}
+
+/**
  * Internal function to fetch cards from database (used for caching)
  * データベースからカードを取得する内部関数（キャッシュ用）
  */
@@ -409,6 +771,24 @@ async function fetchCardsFromDB(
 ): Promise<{ cards: unknown[]; count: number | null }> {
   const start = Date.now();
   const supabaseAdmin = getSupabaseAdmin();
+
+  // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+  if (isPgReadEnabled()) {
+    const { cards: pgCards, count: pgCount } = await fetchCardsFromDBPg(
+      streamerId,
+      limit,
+      offset,
+      sortField,
+      sortDirection,
+      statusFilter
+    );
+    const cardsWithIssuedCounts = await attachIssuedCounts(
+      supabaseAdmin,
+      normalizeDropRate(pgCards as Array<{ drop_rate: unknown } & CardWithIssuanceLimit>)
+    );
+    logger.info(`[Perf] fetchCardsFromDB: ${Date.now() - start}ms (${pgCards.length} cards)`);
+    return { cards: cardsWithIssuedCounts, count: pgCount };
+  }
 
   let query = supabaseAdmin
     .from("cards")
@@ -479,6 +859,38 @@ async function fetchCardsFromDB(
   return { cards: cardsWithIssuedCounts, count };
 }
 
+/**
+ * GET /api/cards の streamer 所有権確認 (id のみ) の pg 直結実装 (#663)。
+ * 読み取り専用のため isPgReadEnabled() で分岐する。twitchUserId が undefined
+ * （未ログイン）の場合は空文字列で照合し、常に不一致（403）にする —
+ * postgrest 経路が `.eq("twitch_user_id", undefined)` で実質どのユーザーとも
+ * 一致しないのと同じ「認証なしは常に forbidden」という外部挙動を保つ。
+ */
+async function checkStreamerOwnershipForCardsListPg(
+  streamerId: string,
+  twitchUserId: string | undefined
+): Promise<boolean> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({ id: streamersTable.id })
+          .from(streamersTable)
+          .where(and(eq(streamersTable.id, streamerId), eq(streamersTable.twitch_user_id, twitchUserId ?? "")))
+          .limit(1);
+      },
+      "Cards API GET: streamer ownership check",
+      { idempotent: true }
+    );
+    return rows.length > 0;
+  } catch {
+    // postgrest 経路もこの SELECT のエラーで即 500 化はせず、`!streamer` と同じ
+    // 分岐（403）に倒れる。pg 版も同じ外部挙動に合わせる。
+    return false;
+  }
+}
+
 export async function GET(request: NextRequest) {
   const session = await getSession();
   const { searchParams } = new URL(request.url);
@@ -538,14 +950,22 @@ export async function GET(request: NextRequest) {
 
   try {
     const supabaseAdmin = getSupabaseAdmin();
-    const { data: streamer, error: streamerError } = await supabaseAdmin
-      .from("streamers")
-      .select("id")
-      .eq("id", streamerId)
-      .eq("twitch_user_id", session?.twitchUserId)
-      .maybeSingle();
+    let streamerFound: boolean;
 
-    if (streamerError || !streamer) {
+    if (isPgReadEnabled()) {
+      streamerFound = await checkStreamerOwnershipForCardsListPg(streamerId, session?.twitchUserId);
+    } else {
+      const { data: streamer, error: streamerError } = await supabaseAdmin
+        .from("streamers")
+        .select("id")
+        .eq("id", streamerId)
+        .eq("twitch_user_id", session?.twitchUserId)
+        .maybeSingle();
+
+      streamerFound = !streamerError && !!streamer;
+    }
+
+    if (!streamerFound) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
     }
 

--- a/src/app/api/gacha-history/[id]/route.ts
+++ b/src/app/api/gacha-history/[id]/route.ts
@@ -5,9 +5,79 @@ import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
 import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgReadEnabled() / isPgWriteEnabled() が false を返すため getDb() は一切
+// 呼ばれず、既存の supabase-js 経路が従来どおり実行される。
+// ---------------------------------------------------------------------------
+import { eq } from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
+import { isPgReadEnabled, isPgWriteEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+import { gachaHistory as gachaHistoryTable } from "@/lib/db/schema";
 
 interface DeleteRequestBody {
   userId: string;
+}
+
+interface GachaHistoryDriverError {
+  message: string;
+}
+
+/**
+ * gacha_history 所有者確認の pg 直結実装 (#663)
+ * PostgREST 実装との対応: .maybeSingle() は id が PK のため最大 1 行、
+ * LIMIT 1 + rows[0] ?? null で同じ外部挙動。
+ */
+async function fetchGachaHistoryOwnerPg(
+  id: string
+): Promise<{ data: { user_twitch_id: string | null } | null; error: GachaHistoryDriverError | null }> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select({ user_twitch_id: gachaHistoryTable.user_twitch_id })
+          .from(gachaHistoryTable)
+          .where(eq(gachaHistoryTable.id, id))
+          .limit(1);
+      },
+      "gacha-history/[id](fetch owner)",
+      { idempotent: true },
+    );
+    return { data: rows[0] ?? null, error: null };
+  } catch (error) {
+    return {
+      data: null,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    };
+  }
+}
+
+/**
+ * gacha_history の DELETE の pg 直結実装 (#663)
+ *
+ * PK（id）指定の DELETE は再実行しても最終状態（対象行が存在しない）が同じ
+ * ため冪等（storage-db.ts removeBlobFilePg と同じ判断）。接続断リトライを許可する。
+ */
+async function deleteGachaHistoryPg(id: string): Promise<{ error: GachaHistoryDriverError | null }> {
+  try {
+    await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db.delete(gachaHistoryTable).where(eq(gachaHistoryTable.id, id));
+      },
+      "gacha-history/[id](delete)",
+      { idempotent: true },
+    );
+    return { error: null };
+  } catch (error) {
+    return {
+      error: { message: error instanceof Error ? error.message : String(error) },
+    };
+  }
 }
 
 export async function DELETE(
@@ -53,14 +123,15 @@ export async function DELETE(
       return NextResponse.json({ error: "userId is required" }, { status: 400 });
     }
 
-    const supabaseAdmin = getSupabaseAdmin();
-
     // Verify the gacha history belongs to the user
-    const { data: history, error: fetchError } = await supabaseAdmin
-      .from("gacha_history")
-      .select("user_twitch_id")
-      .eq("id", id)
-      .maybeSingle();
+    // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+    const { data: history, error: fetchError } = isPgReadEnabled()
+      ? await fetchGachaHistoryOwnerPg(id)
+      : await getSupabaseAdmin()
+          .from("gacha_history")
+          .select("user_twitch_id")
+          .eq("id", id)
+          .maybeSingle();
 
     if (fetchError || !history) {
       return handleDatabaseError(fetchError, "Fetching gacha history for deletion");
@@ -70,10 +141,13 @@ export async function DELETE(
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
     }
 
-    const { error } = await supabaseAdmin
-      .from("gacha_history")
-      .delete()
-      .eq("id", id);
+    // #663: 書き込みのため isPgWriteEnabled() で分岐。
+    const { error } = isPgWriteEnabled()
+      ? await deleteGachaHistoryPg(id)
+      : await getSupabaseAdmin()
+          .from("gacha_history")
+          .delete()
+          .eq("id", id);
 
     if (error) {
       return handleDatabaseError(error, "Deleting gacha history");

--- a/src/app/api/gacha-history/route.ts
+++ b/src/app/api/gacha-history/route.ts
@@ -13,6 +13,46 @@ import {
   getGachaHistoryForUser,
   getGachaUsersForStreamer,
 } from "@/lib/dashboard-data";
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgReadEnabled() が false を返すため getDb() は一切呼ばれず、既存の
+// supabase-js 経路が従来どおり実行される。dashboard-data.ts 側の各関数
+// （getGachaHistoryForStreamer 等）は #571 で既に pg 直結対応済みのため、この
+// route に残る唯一の supabase-js 呼び出し（streamer 取得）のみを対応する。
+// ---------------------------------------------------------------------------
+import { eq } from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
+import { isPgReadEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+import { streamers as streamersTable } from "@/lib/db/schema";
+
+/**
+ * streamer 取得の pg 直結実装 (#663)
+ * PostgREST 実装との対応: .maybeSingle() は twitch_user_id の UNIQUE 制約
+ * （migration 00001）により最大 1 行のため LIMIT 1 + rows[0] ?? null で同じ
+ * 外部挙動。既存コードは error を確認しない（data のみ利用）ため、pg 版も
+ * 取得失敗時は null（=配信者なし=404 扱い）に揃える。
+ */
+async function fetchStreamerIdPg(twitchUserId: string): Promise<{ id: string } | null> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select({ id: streamersTable.id })
+          .from(streamersTable)
+          .where(eq(streamersTable.twitch_user_id, twitchUserId))
+          .limit(1);
+      },
+      "gacha-history(streamer)",
+      { idempotent: true },
+    );
+    return rows[0] ?? null;
+  } catch {
+    return null;
+  }
+}
 
 const VALID_RARITIES = ["common", "rare", "epic", "legendary"];
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
@@ -86,12 +126,16 @@ export async function GET(request: NextRequest) {
     if (isStreamer && view !== "personal") {
       // Streamer: get their streamer_id
       // 配信者: streamer_idを取得
-      const supabaseAdmin = getSupabaseAdmin();
-      const { data: streamer } = await supabaseAdmin
-        .from("streamers")
-        .select("id")
-        .eq("twitch_user_id", session.twitchUserId)
-        .maybeSingle();
+      // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+      const streamer = isPgReadEnabled()
+        ? await fetchStreamerIdPg(session.twitchUserId)
+        : (
+            await getSupabaseAdmin()
+              .from("streamers")
+              .select("id")
+              .eq("twitch_user_id", session.twitchUserId)
+              .maybeSingle()
+          ).data;
 
       if (!streamer) {
         return NextResponse.json(

--- a/src/app/api/gacha-stats/route.ts
+++ b/src/app/api/gacha-stats/route.ts
@@ -9,6 +9,44 @@ import {
 } from "@/lib/rate-limit";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { getGachaStats, getGachaCardOwnerStats } from "@/lib/dashboard-data";
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgReadEnabled() が false を返すため getDb() は一切呼ばれず、既存の
+// supabase-js 経路が従来どおり実行される。dashboard-data.ts 側の各関数
+// （getGachaStats / getGachaCardOwnerStats）は既に pg 直結対応済みのため、この
+// route に残る唯一の supabase-js 呼び出し（streamer 取得）のみを対応する。
+// ---------------------------------------------------------------------------
+import { eq } from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
+import { isPgReadEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+import { streamers as streamersTable } from "@/lib/db/schema";
+
+/**
+ * streamer 取得の pg 直結実装 (#663)
+ * gacha-history/route.ts の fetchStreamerIdPg と同一パターン（PostgREST 実装
+ * との対応・エラー時の扱いも同じ）。
+ */
+async function fetchStreamerIdPg(twitchUserId: string): Promise<{ id: string } | null> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select({ id: streamersTable.id })
+          .from(streamersTable)
+          .where(eq(streamersTable.twitch_user_id, twitchUserId))
+          .limit(1);
+      },
+      "gacha-stats(streamer)",
+      { idempotent: true },
+    );
+    return rows[0] ?? null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * GET /api/gacha-stats
@@ -73,12 +111,16 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const supabaseAdmin = getSupabaseAdmin();
-    const { data: streamer } = await supabaseAdmin
-      .from("streamers")
-      .select("id")
-      .eq("twitch_user_id", session.twitchUserId)
-      .maybeSingle();
+    // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+    const streamer = isPgReadEnabled()
+      ? await fetchStreamerIdPg(session.twitchUserId)
+      : (
+          await getSupabaseAdmin()
+            .from("streamers")
+            .select("id")
+            .eq("twitch_user_id", session.twitchUserId)
+            .maybeSingle()
+        ).data;
 
     if (!streamer) {
       return NextResponse.json(

--- a/src/app/api/gacha/demo/route.ts
+++ b/src/app/api/gacha/demo/route.ts
@@ -4,6 +4,73 @@ import { logger } from "@/lib/logger";
 import { createClient } from "@supabase/supabase-js";
 import { broadcastGachaResult, GachaBroadcastPayload } from "@/lib/realtime";
 import { getSupabaseElevatedKey, getSupabasePublicKey } from "@/lib/supabase/keys";
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgReadEnabled() が false を返すため getDb() は一切呼ばれず、既存の
+// supabase-js 経路が従来どおり実行される。
+//
+// この route は他の対象ファイルと異なり getSupabaseAdmin() を使わず、都度
+// createClient(supabaseUrl, supabaseKey) でアドホックなクライアントを生成する
+// （認証不要の公開デモエンドポイントのため service-role キーが未設定の環境でも
+// anon キーで動作するようにする設計）。pg 直結経路は Hyperdrive/DATABASE_URL
+// 経由で接続するため supabaseUrl/supabaseKey の設定有無に依存せず動作する。
+// ---------------------------------------------------------------------------
+import { eq, and } from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
+import { isPgReadEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+import { cards as cardsTable } from "@/lib/db/schema";
+
+/**
+ * cardId 直接指定時のカード取得の pg 直結実装 (#663)
+ * PostgREST 実装との対応: .maybeSingle() は id が PK のため最大 1 行、
+ * LIMIT 1 + rows[0] ?? null で同じ外部挙動。既存コードは取得失敗時に
+ * ランダム選択へフォールバックするだけで throw しないため、pg 版もエラーは
+ * 握りつぶして null を返す（同じフォールバック挙動）。
+ */
+async function fetchCardByIdPg(cardId: string): Promise<Card | null> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db.select().from(cardsTable).where(eq(cardsTable.id, cardId)).limit(1);
+      },
+      "gacha/demo(fetch card by id)",
+      { idempotent: true },
+    );
+    return (rows[0] as unknown as Card) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 配信者のアクティブカード一覧取得の pg 直結実装 (#663)
+ * PostgREST 実装との対応: .eq('streamer_id', ...).eq('is_active', true) は
+ * and(eq(...), eq(...)) と等価。既存コードは取得失敗時にデモカードへ
+ * フォールバックするだけで throw しないため、pg 版もエラーは握りつぶして
+ * 空配列を返す（同じフォールバック挙動）。
+ */
+async function fetchActiveCardsForStreamerPg(streamerId: string): Promise<Card[]> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select()
+          .from(cardsTable)
+          .where(and(eq(cardsTable.streamer_id, streamerId), eq(cardsTable.is_active, true)));
+      },
+      "gacha/demo(fetch streamer cards)",
+      { idempotent: true },
+    );
+    return rows as unknown as Card[];
+  } catch {
+    return [];
+  }
+}
 
 // Demo cards for testing overlay (used when streamer has no cards)
 // 配信者がカードを持っていない場合に使用されるデモカード
@@ -150,18 +217,23 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ card, userTwitchUsername });
     };
 
+    const hasSupabaseCreds = !!(supabaseUrl && supabaseKey);
+
     // 特定のカードIDが指定されている場合、そのカードを直接取得
     // If specific cardId is provided, fetch that card directly
-    if (cardId && cardId !== "random" && supabaseUrl && supabaseKey) {
-      const supabase = createClient(supabaseUrl, supabaseKey);
+    // #663: 読み取り専用のため isPgReadEnabled() で分岐。pg 経路は
+    // supabaseUrl/supabaseKey の設定有無に依存しない（doc コメント参照）。
+    if (cardId && cardId !== "random" && (isPgReadEnabled() || hasSupabaseCreds)) {
+      let card: Card | null = null;
+      if (isPgReadEnabled()) {
+        card = await fetchCardByIdPg(cardId);
+      } else if (supabaseUrl && supabaseKey) {
+        const supabase = createClient(supabaseUrl, supabaseKey);
+        const result = await supabase.from("cards").select("*").eq("id", cardId).maybeSingle();
+        card = result.data;
+      }
 
-      const { data: card, error } = await supabase
-        .from("cards")
-        .select("*")
-        .eq("id", cardId)
-        .maybeSingle();
-
-      if (!error && card) {
+      if (card) {
         return respondWithCard(card, streamerId);
       }
       // カードが見つからない場合はランダム選択にフォールバック
@@ -169,17 +241,22 @@ export async function POST(request: NextRequest) {
 
     // 配信者IDが指定されている場合、その配信者のカードを取得
     // If streamerId is provided, fetch streamer's cards
-    if (streamerId && supabaseUrl && supabaseKey) {
-      const supabase = createClient(supabaseUrl, supabaseKey);
+    // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+    if (streamerId && (isPgReadEnabled() || hasSupabaseCreds)) {
+      let cards: Card[] | null = null;
+      if (isPgReadEnabled()) {
+        cards = await fetchActiveCardsForStreamerPg(streamerId);
+      } else if (supabaseUrl && supabaseKey) {
+        const supabase = createClient(supabaseUrl, supabaseKey);
+        const result = await supabase
+          .from("cards")
+          .select("*")
+          .eq("streamer_id", streamerId)
+          .eq("is_active", true);
+        cards = result.data;
+      }
 
-      // 配信者のアクティブなカードを取得
-      const { data: cards, error } = await supabase
-        .from("cards")
-        .select("*")
-        .eq("streamer_id", streamerId)
-        .eq("is_active", true);
-
-      if (!error && cards && cards.length > 0) {
+      if (cards && cards.length > 0) {
         // 配信者のカードからランダムに選択
         // Select random card from streamer's cards
         const randomCard = cards[Math.floor(Math.random() * cards.length)];

--- a/src/app/api/gacha/demo/route.ts
+++ b/src/app/api/gacha/demo/route.ts
@@ -20,6 +20,7 @@ import { getDb } from "@/lib/db/client";
 import { isPgReadEnabled } from "@/lib/db/flags";
 import { withDbRetry } from "@/lib/db/retry";
 import { cards as cardsTable } from "@/lib/db/schema";
+import { CARDS_SAFE_COLUMNS, isMissingCardsBattleColumnError } from "@/lib/db/cards-safe-columns";
 
 /**
  * cardId 直接指定時のカード取得の pg 直結実装 (#663)
@@ -27,18 +28,38 @@ import { cards as cardsTable } from "@/lib/db/schema";
  * LIMIT 1 + rows[0] ?? null で同じ外部挙動。既存コードは取得失敗時に
  * ランダム選択へフォールバックするだけで throw しないため、pg 版もエラーは
  * 握りつぶして null を返す（同じフォールバック挙動）。
+ *
+ * self-review fix (外部レビュー指摘): 無指定 `.select()` は schema.ts の静的
+ * 列リストを生成するため、本番に実在しない8列(card_number/hp/atk/...、
+ * cards-safe-columns.ts参照)を含む SELECT は必ず失敗する。このルートは元々
+ * catch で null を返し呼び出し元がデモカードへフォールバックする設計のため
+ * throw はしないが、その結果「配信者の実カードが一切表示されずデモカードに
+ * 静かにすり替わる」という気付きにくい壊れ方をする。cards/route.ts と同じ
+ * パターン（無指定 select を試行→列欠落エラー検知→CARDS_SAFE_COLUMNS で
+ * 再試行）を適用し、本番でも実カードを返せるようにする。
  */
 async function fetchCardByIdPg(cardId: string): Promise<Card | null> {
-  try {
-    const rows = await withDbRetry(
+  async function selectRow(useSafeColumns: boolean) {
+    return withDbRetry(
       async () => {
         // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
         const { db } = await getDb();
-        return db.select().from(cardsTable).where(eq(cardsTable.id, cardId)).limit(1);
+        const query = useSafeColumns ? db.select(CARDS_SAFE_COLUMNS) : db.select();
+        return query.from(cardsTable).where(eq(cardsTable.id, cardId)).limit(1);
       },
       "gacha/demo(fetch card by id)",
       { idempotent: true },
     );
+  }
+
+  try {
+    let rows;
+    try {
+      rows = await selectRow(false);
+    } catch (error) {
+      if (!isMissingCardsBattleColumnError(error)) throw error;
+      rows = await selectRow(true);
+    }
     return (rows[0] as unknown as Card) ?? null;
   } catch {
     return null;
@@ -51,21 +72,35 @@ async function fetchCardByIdPg(cardId: string): Promise<Card | null> {
  * and(eq(...), eq(...)) と等価。既存コードは取得失敗時にデモカードへ
  * フォールバックするだけで throw しないため、pg 版もエラーは握りつぶして
  * 空配列を返す（同じフォールバック挙動）。
+ *
+ * self-review fix (外部レビュー指摘): fetchCardByIdPg と同じ理由で、無指定
+ * `.select()` は本番未デプロイ8列の欠落により必ず失敗する。同じ
+ * 「無指定 select 試行→列欠落エラー検知→CARDS_SAFE_COLUMNS で再試行」を適用する。
  */
 async function fetchActiveCardsForStreamerPg(streamerId: string): Promise<Card[]> {
-  try {
-    const rows = await withDbRetry(
+  async function selectRows(useSafeColumns: boolean) {
+    return withDbRetry(
       async () => {
         // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
         const { db } = await getDb();
-        return db
-          .select()
+        const query = useSafeColumns ? db.select(CARDS_SAFE_COLUMNS) : db.select();
+        return query
           .from(cardsTable)
           .where(and(eq(cardsTable.streamer_id, streamerId), eq(cardsTable.is_active, true)));
       },
       "gacha/demo(fetch streamer cards)",
       { idempotent: true },
     );
+  }
+
+  try {
+    let rows;
+    try {
+      rows = await selectRows(false);
+    } catch (error) {
+      if (!isMissingCardsBattleColumnError(error)) throw error;
+      rows = await selectRows(true);
+    }
     return rows as unknown as Card[];
   } catch {
     return [];

--- a/src/app/api/storage-bonus/vote-campaign/route.ts
+++ b/src/app/api/storage-bonus/vote-campaign/route.ts
@@ -7,6 +7,128 @@ import { handleApiError } from '@/lib/error-handler'
 import { VOTE_CAMPAIGN_CONFIG, ERROR_MESSAGES } from '@/lib/constants'
 import { logger } from '@/lib/logger'
 import type { ApiRateLimitResponse } from '@/types/api'
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgReadEnabled() / isPgWriteEnabled() が false を返すため getDb() は一切
+// 呼ばれず、既存の supabase-js 経路が従来どおり実行される。
+// ---------------------------------------------------------------------------
+import { eq } from 'drizzle-orm'
+import { getDb } from '@/lib/db/client'
+import { isPgReadEnabled, isPgWriteEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import { streamers as streamersTable, streamerStorageBonus as streamerStorageBonusTable } from '@/lib/db/schema'
+
+interface VoteCampaignDriverError {
+  code?: string
+  message: string
+}
+
+/**
+ * streamers.id 取得（既存レコードの有無確認）の pg 直結実装 (#663)
+ * PostgREST 実装との対応: .maybeSingle() は twitch_user_id の UNIQUE 制約
+ * （migration 00001）により最大 1 行のため LIMIT 1 + rows[0] ?? null で同じ
+ * 外部挙動。既存コードは destructure で error を確認しない（data のみ利用）ため、
+ * pg 版も取得失敗時は null（=未作成扱い、後続の INSERT 分岐へ進む）に揃える。
+ */
+async function fetchStreamerIdPg(twitchUserId: string): Promise<{ id: string } | null> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({ id: streamersTable.id })
+          .from(streamersTable)
+          .where(eq(streamersTable.twitch_user_id, twitchUserId))
+          .limit(1)
+      },
+      'vote-campaign(fetch streamer)',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    )
+    return rows[0] ?? null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * streamers への INSERT（新規レコード作成）の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応: .select('id').single() は .returning({id}) の
+ * rows[0] で同じ外部挙動。UNIQUE(twitch_user_id) 違反時は既存経路と同じ
+ * '23505' を code として返す（呼び出し元が並行作成レースのリトライ判定に使う）。
+ * ON CONFLICT の無い一度きりの INSERT のため非冪等（既定 = リトライなし。
+ * 接続断で「実際は成功したか不明」な状態のまま再送すると 23505 の誤検知や
+ * 二重行作成の恐れがある）。
+ */
+async function insertStreamerPg(payload: {
+  twitchUserId: string
+  twitchUsername: string
+  twitchDisplayName: string
+}): Promise<{ data: { id: string } | null; error: VoteCampaignDriverError | null }> {
+  try {
+    const rows = await withDbRetry(async () => {
+      // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+      const { db } = await getDb()
+      return db
+        .insert(streamersTable)
+        .values({
+          twitch_user_id: payload.twitchUserId,
+          twitch_username: payload.twitchUsername,
+          twitch_display_name: payload.twitchDisplayName,
+        })
+        .returning({ id: streamersTable.id })
+    }, 'vote-campaign(insert streamer)')
+    // 非冪等のため withDbRetry の第3引数（idempotent オプション）は渡さない
+    return { data: rows[0] ?? null, error: null }
+  } catch (error) {
+    const code = (error as { code?: unknown } | null)?.code
+    return {
+      data: null,
+      error: {
+        code: typeof code === 'string' ? code : undefined,
+        message: error instanceof Error ? error.message : String(error),
+      },
+    }
+  }
+}
+
+/**
+ * streamer_storage_bonus への INSERT（ボーナス付与）の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応: UNIQUE(streamer_id, type, memo) 違反時は既存経路と
+ * 同じ '23505' を code として返す（呼び出し元が「既に適用済み」409 判定に使う）。
+ * 一度きりの状態遷移（ボーナス付与）のため非冪等（既定 = リトライなし。接続断で
+ * 「実際は成功したか不明」な状態のまま再送すると二重付与の恐れがある。この点は
+ * 課金・ポイント加算系と同じ安全側の判断）。
+ */
+async function insertStorageBonusPg(payload: {
+  streamerId: string
+}): Promise<{ error: VoteCampaignDriverError | null }> {
+  try {
+    await withDbRetry(async () => {
+      // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+      const { db } = await getDb()
+      return db.insert(streamerStorageBonusTable).values({
+        streamer_id: payload.streamerId,
+        amount_mb: VOTE_CAMPAIGN_CONFIG.BONUS_MB,
+        type: VOTE_CAMPAIGN_CONFIG.TYPE,
+        memo: VOTE_CAMPAIGN_CONFIG.MEMO,
+      })
+    }, 'vote-campaign(insert bonus)')
+    // 非冪等のため withDbRetry の第3引数（idempotent オプション）は渡さない
+    return { error: null }
+  } catch (error) {
+    const code = (error as { code?: unknown } | null)?.code
+    return {
+      error: {
+        code: typeof code === 'string' ? code : undefined,
+        message: error instanceof Error ? error.message : String(error),
+      },
+    }
+  }
+}
 
 /**
  * POST /api/storage-bonus/vote-campaign
@@ -66,11 +188,16 @@ export async function POST(request: NextRequest) {
 
     // streamer_idを取得。既存レコードがあればそのまま使用し、
     // 存在しない場合のみ新規作成（既存レコードを上書きしない）
-    const { data: existing } = await supabaseAdmin
-      .from('streamers')
-      .select('id')
-      .eq('twitch_user_id', session.twitchUserId)
-      .maybeSingle()
+    // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+    const existing = isPgReadEnabled()
+      ? await fetchStreamerIdPg(session.twitchUserId)
+      : (
+          await supabaseAdmin
+            .from('streamers')
+            .select('id')
+            .eq('twitch_user_id', session.twitchUserId)
+            .maybeSingle()
+        ).data
 
     let streamerId: string
     if (existing) {
@@ -80,28 +207,39 @@ export async function POST(request: NextRequest) {
       // 非配信者のstreamersレコードが存在しても、配信者機能はsession.broadcasterTypeで
       // ガードされるため意図しない有効化は起きない。アフィリエイト昇格時は
       // auth callbackのupsert(onConflict: twitch_user_id)で正常に統合される
-      const { data: created, error: insertError } = await supabaseAdmin
-        .from('streamers')
-        .insert({
-          twitch_user_id: session.twitchUserId,
-          twitch_username: session.twitchUsername,
-          twitch_display_name: session.twitchDisplayName,
-        })
-        .select('id')
-        .single()
+      // #663: 書き込みのため isPgWriteEnabled() で分岐。
+      const { data: created, error: insertError } = isPgWriteEnabled()
+        ? await insertStreamerPg({
+            twitchUserId: session.twitchUserId,
+            twitchUsername: session.twitchUsername,
+            twitchDisplayName: session.twitchDisplayName,
+          })
+        : await supabaseAdmin
+            .from('streamers')
+            .insert({
+              twitch_user_id: session.twitchUserId,
+              twitch_username: session.twitchUsername,
+              twitch_display_name: session.twitchDisplayName,
+            })
+            .select('id')
+            .single()
 
       if (insertError || !created) {
         // レースコンディション: 並行リクエストで既に作成された場合はリトライ
         if (insertError?.code === '23505') {
-          const { data: retried, error: retryError } = await supabaseAdmin
-            .from('streamers')
-            .select('id')
-            .eq('twitch_user_id', session.twitchUserId)
-            .maybeSingle()
+          const retried = isPgReadEnabled()
+            ? await fetchStreamerIdPg(session.twitchUserId)
+            : (
+                await supabaseAdmin
+                  .from('streamers')
+                  .select('id')
+                  .eq('twitch_user_id', session.twitchUserId)
+                  .maybeSingle()
+              ).data
           if (retried) {
             streamerId = retried.id
           } else {
-            return handleApiError(retryError ?? insertError, 'Election Campaign API (retry fetch streamer after race condition)')
+            return handleApiError(insertError, 'Election Campaign API (retry fetch streamer after race condition)')
           }
         } else {
           return handleApiError(insertError, 'Election Campaign API (insert streamer)')
@@ -112,14 +250,17 @@ export async function POST(request: NextRequest) {
     }
 
     // ボーナスを挿入（UNIQUE(streamer_id, type, memo)制約で重複適用を防止）
-    const { error } = await supabaseAdmin
-      .from('streamer_storage_bonus')
-      .insert({
-        streamer_id: streamerId,
-        amount_mb: VOTE_CAMPAIGN_CONFIG.BONUS_MB,
-        type: VOTE_CAMPAIGN_CONFIG.TYPE,
-        memo: VOTE_CAMPAIGN_CONFIG.MEMO,
-      })
+    // #663: 書き込みのため isPgWriteEnabled() で分岐。
+    const { error } = isPgWriteEnabled()
+      ? await insertStorageBonusPg({ streamerId })
+      : await supabaseAdmin
+          .from('streamer_storage_bonus')
+          .insert({
+            streamer_id: streamerId,
+            amount_mb: VOTE_CAMPAIGN_CONFIG.BONUS_MB,
+            type: VOTE_CAMPAIGN_CONFIG.TYPE,
+            memo: VOTE_CAMPAIGN_CONFIG.MEMO,
+          })
 
     if (error) {
       // PostgreSQLのUNIQUE制約違反コード = 既に適用済み

--- a/src/app/api/streamer/[streamerId]/sound-settings/route.ts
+++ b/src/app/api/streamer/[streamerId]/sound-settings/route.ts
@@ -5,9 +5,168 @@ import { handleApiError } from "@/lib/error-handler";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { logger } from "@/lib/logger";
 import { legacySoundToRules, normalizeGachaSoundRules } from "@/lib/gacha-sound-rules";
+// -----------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。GET は読み取り専用のため
+// isPgReadEnabled() で分岐する。既存 supabase-js 実装は 1 文字も変えず、
+// フラグ未設定時は完全に従来どおり動く。pg 実装は getSoundSettingsPg に置き、
+// getDb() は withDbRetry の queryFn 内で呼ぶ規約（src/lib/db/retry.ts 参照）。
+// -----------------------------------------------------------------------------
+import { eq } from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
+import { isPgReadEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+import { streamers as streamersTable } from "@/lib/db/schema";
 
 interface RouteParams {
   params: Promise<{ streamerId: string }>;
+}
+
+interface SoundSettingsRow {
+  gacha_sound_url: string | null;
+  gacha_sound_enabled: boolean | null;
+  gacha_sound_rules: unknown;
+}
+
+/**
+ * GET の DB アクセス結果を表す判別共用体。
+ * - 'ok': 取得成功（streamer が null の場合は行が存在しない = 404 対象）
+ * - 'degraded': DB エラー（gacha_sound_rules 列欠落フォールバックも含めて失敗）。
+ *   既存実装は取得失敗時に例外を投げず「効果音無効」の安全側デフォルトへ
+ *   デグレードするため、その外部挙動をそのまま型で表現する。
+ */
+type SoundSettingsLookup =
+  | { kind: "ok"; streamer: SoundSettingsRow | null }
+  | { kind: "degraded" };
+
+/**
+ * getSoundSettings の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応:
+ * - streamers を id で 1 行取得。id は PK のため LIMIT 1 + rows[0] ?? null で
+ *   .maybeSingle() と同じ外部挙動。
+ * - gacha_sound_rules 列欠落フォールバックは、既存実装と同じ汎用テキスト判定
+ *   （code === "PGRST204" || message に "gacha_sound_rules" を含む）を再利用する。
+ *   pg（postgres.js）の 42703 は code こそ異なるが、message に列名がそのまま
+ *   含まれるため message.includes(...) 側で同じ条件式のまま判定できる
+ *   （#663 の設計判断: 新規の pg 専用エラー整形ヘルパーは作らない）。
+ * - フォールバック取得も失敗した場合、または最初から gacha_sound_rules 以外の
+ *   理由で失敗した場合は 'degraded' を返し、呼び出し元が既存と同じ「効果音無効」
+ *   応答にフォールバックする。
+ */
+async function getSoundSettingsPg(streamerId: string): Promise<SoundSettingsLookup> {
+  const selectFull = () =>
+    withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select({
+            gacha_sound_url: streamersTable.gacha_sound_url,
+            gacha_sound_enabled: streamersTable.gacha_sound_enabled,
+            gacha_sound_rules: streamersTable.gacha_sound_rules,
+          })
+          .from(streamersTable)
+          .where(eq(streamersTable.id, streamerId))
+          .limit(1);
+      },
+      "getSoundSettings",
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    );
+
+  const selectLegacy = () =>
+    withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({
+            gacha_sound_url: streamersTable.gacha_sound_url,
+            gacha_sound_enabled: streamersTable.gacha_sound_enabled,
+          })
+          .from(streamersTable)
+          .where(eq(streamersTable.id, streamerId))
+          .limit(1);
+      },
+      "getLegacySoundSettings",
+      { idempotent: true },
+    );
+
+  try {
+    const rows = await selectFull();
+    return { kind: "ok", streamer: rows[0] ?? null };
+  } catch (error) {
+    const err = error as { code?: string; message?: string } | null | undefined;
+    if (err?.code === "PGRST204" || String(err?.message ?? "").includes("gacha_sound_rules")) {
+      try {
+        const rows = await selectLegacy();
+        const row = rows[0] ?? null;
+        return { kind: "ok", streamer: row ? { ...row, gacha_sound_rules: [] } : null };
+      } catch (fallbackError) {
+        logger.warn("Streamer Sound Settings API: falling back to disabled sound settings", {
+          streamerId,
+          error: fallbackError instanceof Error ? fallbackError.message : String(fallbackError),
+        });
+        return { kind: "degraded" };
+      }
+    }
+    logger.warn("Streamer Sound Settings API: falling back to disabled sound settings", {
+      streamerId,
+      error: err?.message ?? String(error),
+    });
+    return { kind: "degraded" };
+  }
+}
+
+async function getSoundSettingsPostgrest(streamerId: string): Promise<SoundSettingsLookup> {
+  const supabaseAdmin = getSupabaseAdmin();
+
+  // 配信者の効果音設定のみを取得
+  // パブリックエンドポイントなので必要最小限の情報のみ返す
+  // 502 一時障害に対するリトライ (Issue #325)
+  const soundSettingsResult = await withRetry(
+    () => supabaseAdmin
+      .from("streamers")
+      .select("gacha_sound_url, gacha_sound_enabled, gacha_sound_rules")
+      .eq("id", streamerId)
+      .maybeSingle(),
+    'getSoundSettings',
+  );
+  let streamer = soundSettingsResult.data;
+  let error = soundSettingsResult.error;
+  const { status } = soundSettingsResult;
+
+  if (error && (error.code === "PGRST204" || error.message.includes("gacha_sound_rules"))) {
+    const fallbackResult = await withRetry(
+      () => supabaseAdmin
+        .from("streamers")
+        .select("gacha_sound_url, gacha_sound_enabled")
+        .eq("id", streamerId)
+        .maybeSingle(),
+      "getLegacySoundSettings",
+    );
+    streamer = fallbackResult.data ? { ...fallbackResult.data, gacha_sound_rules: [] } : fallbackResult.data;
+    error = fallbackResult.error;
+  }
+
+  if (error) {
+    logger.warn("Streamer Sound Settings API: falling back to disabled sound settings", {
+      streamerId,
+      status,
+      error: error.message,
+    });
+    return { kind: "degraded" };
+  }
+
+  return { kind: "ok", streamer: streamer ?? null };
+}
+
+async function getSoundSettings(streamerId: string): Promise<SoundSettingsLookup> {
+  // #663: 読み取り専用の関数のため isPgReadEnabled() で分岐。
+  // フラグ未設定時（既定 'postgrest'）は素通りし、以下の既存実装が従来どおり動く。
+  if (isPgReadEnabled()) {
+    return getSoundSettingsPg(streamerId);
+  }
+  return getSoundSettingsPostgrest(streamerId);
 }
 
 /**
@@ -29,47 +188,16 @@ export async function GET(
       );
     }
 
-    const supabaseAdmin = getSupabaseAdmin();
+    const lookup = await getSoundSettings(streamerId);
 
-    // 配信者の効果音設定のみを取得
-    // パブリックエンドポイントなので必要最小限の情報のみ返す
-    // 502 一時障害に対するリトライ (Issue #325)
-    const soundSettingsResult = await withRetry(
-      () => supabaseAdmin
-        .from("streamers")
-        .select("gacha_sound_url, gacha_sound_enabled, gacha_sound_rules")
-        .eq("id", streamerId)
-        .maybeSingle(),
-      'getSoundSettings',
-    );
-    let streamer = soundSettingsResult.data;
-    let error = soundSettingsResult.error;
-    const { status } = soundSettingsResult;
-
-    if (error && (error.code === "PGRST204" || error.message.includes("gacha_sound_rules"))) {
-      const fallbackResult = await withRetry(
-        () => supabaseAdmin
-          .from("streamers")
-          .select("gacha_sound_url, gacha_sound_enabled")
-          .eq("id", streamerId)
-          .maybeSingle(),
-        "getLegacySoundSettings",
-      );
-      streamer = fallbackResult.data ? { ...fallbackResult.data, gacha_sound_rules: [] } : fallbackResult.data;
-      error = fallbackResult.error;
-    }
-
-    if (error) {
-      logger.warn("Streamer Sound Settings API: falling back to disabled sound settings", {
-        streamerId,
-        status,
-        error: error.message,
-      });
+    if (lookup.kind === "degraded") {
       return NextResponse.json({
         soundUrl: null,
         soundEnabled: false,
       });
     }
+
+    const streamer = lookup.streamer;
 
     if (!streamer) {
       return NextResponse.json(

--- a/src/app/api/streamer/additional-rewards/route.ts
+++ b/src/app/api/streamer/additional-rewards/route.ts
@@ -13,14 +13,237 @@ import {
   isMissingCollectionNameColumn,
   isMissingCardPackNamesColumnError,
 } from "@/lib/collections/collection-existence";
+// -----------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。
+// - GET は読み取り専用のため isPgReadEnabled() で分岐する。
+// - POST / DELETE は読み書きが混在する（DELETE も含め、所有権確認 SELECT を
+//   含めて）ため isPgWriteEnabled() で関数全体（の DB アクセス）を分岐する
+//   （src/lib/twitch/token-manager.ts 冒頭のフラグ使い分け方針と同じ）。
+// 既存 supabase-js 実装は 1 文字も変えず、フラグ未設定時は完全に従来どおり動く。
+// pg 実装は getDb() を withDbRetry の queryFn 内で呼ぶ規約（src/lib/db/retry.ts 参照）。
+// -----------------------------------------------------------------------------
+import { and, asc, eq } from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
+import { isPgReadEnabled, isPgWriteEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+import {
+  streamers as streamersTable,
+  streamerAdditionalGachaRewards as streamerAdditionalGachaRewardsTable,
+} from "@/lib/db/schema";
 
-function isRaidOptionsSchemaError(error: { message?: string; code?: string } | null | undefined) {
+type GenericDbError = { message?: string; code?: string; details?: string; hint?: string } | null | undefined;
+
+function isRaidOptionsSchemaError(error: GenericDbError) {
   const message = error?.message ?? "";
   return error?.code === "PGRST204" || message.includes("draw_count") || message.includes("is_raid_limited");
 }
 
 const RAID_OPTIONS_SCHEMA_PENDING_MESSAGE =
   "追加の引き換えのN連ガチャ設定がまだDBに反映されていません。少し待ってから再度追加してください。";
+
+interface AdditionalRewardRow {
+  id: string;
+  reward_id: string;
+  reward_name: string | null;
+  draw_count: number;
+  is_raid_limited: boolean;
+  collection_name: string | null;
+  created_at: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// GET: ownership lookup + reward listing (read-only → isPgReadEnabled)
+// ---------------------------------------------------------------------------
+
+async function getOwnedStreamerIdForRewardsPg(twitchUserId: string): Promise<string | null> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select({ id: streamersTable.id })
+          .from(streamersTable)
+          .where(eq(streamersTable.twitch_user_id, twitchUserId))
+          .limit(1);
+      },
+      "Additional Rewards API: ownership lookup",
+      { idempotent: true },
+    );
+    return rows[0]?.id ?? null;
+  } catch {
+    // 既存(postgrest)実装はこの SELECT のエラーを確認しない(data のみ分割代入)
+    // ため、失敗時は data=undefined と同じ「not found」扱いに揃える。
+    return null;
+  }
+}
+
+async function getOwnedStreamerIdForRewards(twitchUserId: string): Promise<string | null> {
+  // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+  if (isPgReadEnabled()) {
+    return getOwnedStreamerIdForRewardsPg(twitchUserId);
+  }
+  const supabaseAdmin = getSupabaseAdmin();
+  const { data: streamer } = await supabaseAdmin
+    .from("streamers")
+    .select("id")
+    .eq("twitch_user_id", twitchUserId)
+    .maybeSingle();
+  return streamer?.id ?? null;
+}
+
+/**
+ * listAdditionalRewardsPg の各列セレクトと 2 段フォールバックチェイン (#663)
+ *
+ * PostgREST 実装との対応: collection_name 列欠落を isRaidOptionsSchemaError より
+ * 先に判定する（両方 PGRST204 になりうるが、raid フォールバックは
+ * draw_count/is_raid_limited を巻き込んで初期化してしまうため）。collection_name
+ * 側のフォールバック取得がさらに raid 列欠落で失敗した場合は、そのままより
+ * 少ない列セット（最終フォールバック）へ続けてカスケードする。
+ */
+async function listAdditionalRewardsPg(streamerId: string): Promise<AdditionalRewardRow[]> {
+  const selectFull = () =>
+    withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({
+            id: streamerAdditionalGachaRewardsTable.id,
+            reward_id: streamerAdditionalGachaRewardsTable.reward_id,
+            reward_name: streamerAdditionalGachaRewardsTable.reward_name,
+            draw_count: streamerAdditionalGachaRewardsTable.draw_count,
+            is_raid_limited: streamerAdditionalGachaRewardsTable.is_raid_limited,
+            collection_name: streamerAdditionalGachaRewardsTable.collection_name,
+            created_at: streamerAdditionalGachaRewardsTable.created_at,
+          })
+          .from(streamerAdditionalGachaRewardsTable)
+          .where(eq(streamerAdditionalGachaRewardsTable.streamer_id, streamerId))
+          .orderBy(asc(streamerAdditionalGachaRewardsTable.created_at));
+      },
+      "Additional Rewards API: GET(full)",
+      { idempotent: true },
+    );
+
+  const selectWithoutCollectionName = () =>
+    withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({
+            id: streamerAdditionalGachaRewardsTable.id,
+            reward_id: streamerAdditionalGachaRewardsTable.reward_id,
+            reward_name: streamerAdditionalGachaRewardsTable.reward_name,
+            draw_count: streamerAdditionalGachaRewardsTable.draw_count,
+            is_raid_limited: streamerAdditionalGachaRewardsTable.is_raid_limited,
+            created_at: streamerAdditionalGachaRewardsTable.created_at,
+          })
+          .from(streamerAdditionalGachaRewardsTable)
+          .where(eq(streamerAdditionalGachaRewardsTable.streamer_id, streamerId))
+          .orderBy(asc(streamerAdditionalGachaRewardsTable.created_at));
+      },
+      "Additional Rewards API: GET(no collection_name)",
+      { idempotent: true },
+    );
+
+  const selectMinimal = () =>
+    withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({
+            id: streamerAdditionalGachaRewardsTable.id,
+            reward_id: streamerAdditionalGachaRewardsTable.reward_id,
+            reward_name: streamerAdditionalGachaRewardsTable.reward_name,
+            created_at: streamerAdditionalGachaRewardsTable.created_at,
+          })
+          .from(streamerAdditionalGachaRewardsTable)
+          .where(eq(streamerAdditionalGachaRewardsTable.streamer_id, streamerId))
+          .orderBy(asc(streamerAdditionalGachaRewardsTable.created_at));
+      },
+      "Additional Rewards API: GET(minimal)",
+      { idempotent: true },
+    );
+
+  try {
+    return await selectFull();
+  } catch (error) {
+    if (isMissingCollectionNameColumn(error as GenericDbError)) {
+      try {
+        const rows = await selectWithoutCollectionName();
+        return rows.map((row) => ({ ...row, collection_name: null }));
+      } catch (error2) {
+        if (isRaidOptionsSchemaError(error2 as GenericDbError)) {
+          const rows = await selectMinimal();
+          return rows.map((row) => ({ ...row, draw_count: 1, is_raid_limited: false, collection_name: null }));
+        }
+        throw error2;
+      }
+    }
+    if (isRaidOptionsSchemaError(error as GenericDbError)) {
+      const rows = await selectMinimal();
+      return rows.map((row) => ({ ...row, draw_count: 1, is_raid_limited: false, collection_name: null }));
+    }
+    throw error;
+  }
+}
+
+async function listAdditionalRewardsPostgrest(streamerId: string): Promise<AdditionalRewardRow[]> {
+  const supabaseAdmin = getSupabaseAdmin();
+
+  // Fetch all additional rewards for this streamer
+  // このストリーマーの全ての追加報酬を取得
+  let { data: rewards, error } = await supabaseAdmin
+    .from("streamer_additional_gacha_rewards")
+    .select("id, reward_id, reward_name, draw_count, is_raid_limited, collection_name, created_at")
+    .eq("streamer_id", streamerId)
+    .order("created_at", { ascending: true });
+
+  // Issue #393: handle "only collection_name column missing" BEFORE the raid
+  // fallback. Both match PGRST204, but the raid fallback would wrongly reset
+  // draw_count / is_raid_limited, losing N-draw config. So check this first and
+  // fall back to "all cards" (collection_name: null) while keeping raid options.
+  if (error && isMissingCollectionNameColumn(error)) {
+    const fallbackResult = await supabaseAdmin
+      .from("streamer_additional_gacha_rewards")
+      .select("id, reward_id, reward_name, draw_count, is_raid_limited, created_at")
+      .eq("streamer_id", streamerId)
+      .order("created_at", { ascending: true });
+    rewards = (fallbackResult.data || []).map((reward) => ({
+      ...reward,
+      collection_name: null,
+    }));
+    error = fallbackResult.error;
+  }
+
+  if (isRaidOptionsSchemaError(error)) {
+    const fallbackResult = await supabaseAdmin
+      .from("streamer_additional_gacha_rewards")
+      .select("id, reward_id, reward_name, created_at")
+      .eq("streamer_id", streamerId)
+      .order("created_at", { ascending: true });
+    rewards = (fallbackResult.data || []).map((reward) => ({
+      ...reward,
+      draw_count: 1,
+      is_raid_limited: false,
+      collection_name: null,
+    }));
+    error = fallbackResult.error;
+  }
+
+  if (error) {
+    throw error;
+  }
+
+  return (rewards || []) as AdditionalRewardRow[];
+}
+
+async function listAdditionalRewards(streamerId: string): Promise<AdditionalRewardRow[]> {
+  // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+  if (isPgReadEnabled()) {
+    return listAdditionalRewardsPg(streamerId);
+  }
+  return listAdditionalRewardsPostgrest(streamerId);
+}
 
 /**
  * GET: ストリーマーの追加報酬一覧を取得
@@ -51,62 +274,18 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const supabaseAdmin = getSupabaseAdmin();
-
     // Get streamer info to verify ownership
     // ストリーマー情報を取得して所有権を確認
-    const { data: streamer } = await supabaseAdmin
-      .from("streamers")
-      .select("id")
-      .eq("twitch_user_id", session.twitchUserId)
-      .maybeSingle();
+    const streamerId = await getOwnedStreamerIdForRewards(session.twitchUserId);
 
-    if (!streamer) {
+    if (!streamerId) {
       return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
     }
 
-    // Fetch all additional rewards for this streamer
-    // このストリーマーの全ての追加報酬を取得
-    let { data: rewards, error } = await supabaseAdmin
-      .from("streamer_additional_gacha_rewards")
-      .select("id, reward_id, reward_name, draw_count, is_raid_limited, collection_name, created_at")
-      .eq("streamer_id", streamer.id)
-      .order("created_at", { ascending: true });
-
-    // Issue #393: handle "only collection_name column missing" BEFORE the raid
-    // fallback. Both match PGRST204, but the raid fallback would wrongly reset
-    // draw_count / is_raid_limited, losing N-draw config. So check this first and
-    // fall back to "all cards" (collection_name: null) while keeping raid options.
-    // collection_name 列のみ未デプロイのケースを raid fallback より先に処理する。
-    if (error && isMissingCollectionNameColumn(error)) {
-      const fallbackResult = await supabaseAdmin
-        .from("streamer_additional_gacha_rewards")
-        .select("id, reward_id, reward_name, draw_count, is_raid_limited, created_at")
-        .eq("streamer_id", streamer.id)
-        .order("created_at", { ascending: true });
-      rewards = (fallbackResult.data || []).map((reward) => ({
-        ...reward,
-        collection_name: null,
-      }));
-      error = fallbackResult.error;
-    }
-
-    if (isRaidOptionsSchemaError(error)) {
-      const fallbackResult = await supabaseAdmin
-        .from("streamer_additional_gacha_rewards")
-        .select("id, reward_id, reward_name, created_at")
-        .eq("streamer_id", streamer.id)
-        .order("created_at", { ascending: true });
-      rewards = (fallbackResult.data || []).map((reward) => ({
-        ...reward,
-        draw_count: 1,
-        is_raid_limited: false,
-        collection_name: null,
-      }));
-      error = fallbackResult.error;
-    }
-
-    if (error) {
+    let rewards: AdditionalRewardRow[];
+    try {
+      rewards = await listAdditionalRewards(streamerId);
+    } catch (error) {
       return handleDatabaseError(error, "Additional Rewards API: GET");
     }
 
@@ -120,6 +299,206 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     return handleApiError(error, "Additional Rewards API: GET");
   }
+}
+
+// ---------------------------------------------------------------------------
+// POST: ownership lookup + insert (read+write mixed → isPgWriteEnabled)
+// ---------------------------------------------------------------------------
+
+interface StreamerForAdditionalRewardPost {
+  id: string;
+  channel_point_reward_id: string | null;
+  card_pack_names: string[];
+}
+
+interface GetStreamerForAdditionalRewardPostResult {
+  streamer: StreamerForAdditionalRewardPost | null;
+  cardPackNamesUnavailable: boolean;
+}
+
+async function getStreamerForAdditionalRewardPostPg(
+  twitchUserId: string
+): Promise<GetStreamerForAdditionalRewardPostResult> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({
+            id: streamersTable.id,
+            channel_point_reward_id: streamersTable.channel_point_reward_id,
+            card_pack_names: streamersTable.card_pack_names,
+          })
+          .from(streamersTable)
+          .where(eq(streamersTable.twitch_user_id, twitchUserId))
+          .limit(1);
+      },
+      "Additional Rewards API: POST ownership lookup",
+      { idempotent: true },
+    );
+    return { streamer: rows[0] ?? null, cardPackNamesUnavailable: false };
+  } catch (error) {
+    if (isMissingCardPackNamesColumnError(error as GenericDbError)) {
+      try {
+        const rows = await withDbRetry(
+          async () => {
+            const { db } = await getDb();
+            return db
+              .select({
+                id: streamersTable.id,
+                channel_point_reward_id: streamersTable.channel_point_reward_id,
+              })
+              .from(streamersTable)
+              .where(eq(streamersTable.twitch_user_id, twitchUserId))
+              .limit(1);
+          },
+          "Additional Rewards API: POST ownership lookup (no card_pack_names)",
+          { idempotent: true },
+        );
+        const row = rows[0] ?? null;
+        return {
+          streamer: row ? { ...row, card_pack_names: [] as string[] } : null,
+          cardPackNamesUnavailable: true,
+        };
+      } catch {
+        // 既存(postgrest)実装同様、リトライも失敗した場合は streamer=null(→404)に
+        // 揃える(この SELECT はエラーを 500 化しない既存の swallow パターン)。
+        return { streamer: null, cardPackNamesUnavailable: true };
+      }
+    }
+    return { streamer: null, cardPackNamesUnavailable: false };
+  }
+}
+
+async function getStreamerForAdditionalRewardPost(
+  supabaseAdmin: ReturnType<typeof getSupabaseAdmin>,
+  twitchUserId: string
+): Promise<GetStreamerForAdditionalRewardPostResult> {
+  // #663: 読み書き混在(このあと INSERT する)のため isPgWriteEnabled() で分岐。
+  if (isPgWriteEnabled()) {
+    return getStreamerForAdditionalRewardPostPg(twitchUserId);
+  }
+
+  let { data: streamer, error: streamerSelectError } = await supabaseAdmin
+    .from("streamers")
+    .select("id, channel_point_reward_id, card_pack_names")
+    .eq("twitch_user_id", twitchUserId)
+    .maybeSingle();
+
+  // Issue #393再設計: card_pack_names がデプロイ窓で未検出の場合、それだけ
+  // 外して再試行する(所有権確認・メイン報酬確認は継続できるようにする)。
+  let cardPackNamesUnavailable = false;
+  if (streamerSelectError && isMissingCardPackNamesColumnError(streamerSelectError)) {
+    const retryResult = await supabaseAdmin
+      .from("streamers")
+      .select("id, channel_point_reward_id")
+      .eq("twitch_user_id", twitchUserId)
+      .maybeSingle();
+    streamer = retryResult.data ? { ...retryResult.data, card_pack_names: [] as string[] } : null;
+    streamerSelectError = retryResult.error;
+    cardPackNamesUnavailable = true;
+  }
+
+  return { streamer: streamer ?? null, cardPackNamesUnavailable };
+}
+
+type InsertAdditionalRewardOutcome =
+  | { kind: "ok"; reward: unknown }
+  | { kind: "raid-options-unavailable"; error: unknown }
+  | { kind: "conflict" }
+  | { kind: "error"; error: unknown };
+
+async function insertAdditionalRewardPg(
+  insertPayload: Record<string, unknown>
+): Promise<InsertAdditionalRewardOutcome> {
+  const runInsert = (payload: Record<string, unknown>) =>
+    withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .insert(streamerAdditionalGachaRewardsTable)
+          .values(payload as typeof streamerAdditionalGachaRewardsTable.$inferInsert)
+          .returning();
+      },
+      "Additional Rewards API: POST insert",
+      // ON CONFLICT の無い新規行 INSERT のため非冪等（既定 = リトライなし）
+    );
+
+  const classifyError = (error: unknown): InsertAdditionalRewardOutcome => {
+    if (isRaidOptionsSchemaError(error as GenericDbError)) {
+      return { kind: "raid-options-unavailable", error };
+    }
+    const code = (error as { code?: string } | null | undefined)?.code;
+    if (code === "23505") {
+      return { kind: "conflict" };
+    }
+    return { kind: "error", error };
+  };
+
+  try {
+    const rows = await runInsert(insertPayload);
+    return { kind: "ok", reward: rows[0] ?? null };
+  } catch (error) {
+    // Issue #393: deploy-window safety. Strip collection_name and retry if the
+    // column is not migrated yet. Must run BEFORE the raid-options check because
+    // both match the same generic missing-column shape; otherwise we would
+    // return a misleading 503.
+    if (isMissingCollectionNameColumn(error as GenericDbError) && "collection_name" in insertPayload) {
+      delete insertPayload.collection_name;
+      try {
+        const rows = await runInsert(insertPayload);
+        return { kind: "ok", reward: rows[0] ?? null };
+      } catch (retryError) {
+        return classifyError(retryError);
+      }
+    }
+    return classifyError(error);
+  }
+}
+
+async function insertAdditionalReward(
+  supabaseAdmin: ReturnType<typeof getSupabaseAdmin>,
+  insertPayload: Record<string, unknown>
+): Promise<InsertAdditionalRewardOutcome> {
+  // #663: 読み書き混在のため isPgWriteEnabled() で分岐。
+  if (isPgWriteEnabled()) {
+    return insertAdditionalRewardPg(insertPayload);
+  }
+
+  let { data: newReward, error } = await supabaseAdmin
+    .from("streamer_additional_gacha_rewards")
+    .insert(insertPayload)
+    .select()
+    .maybeSingle();
+
+  // Issue #393: deploy-window safety. Strip collection_name and retry if the
+  // column is not migrated yet. Must run BEFORE the raid-options check because
+  // both match PGRST204; otherwise we would return a misleading 503.
+  if (error && isMissingCollectionNameColumn(error) && "collection_name" in insertPayload) {
+    delete insertPayload.collection_name;
+    const retryResult = await supabaseAdmin
+      .from("streamer_additional_gacha_rewards")
+      .insert(insertPayload)
+      .select()
+      .maybeSingle();
+    newReward = retryResult.data;
+    error = retryResult.error;
+  }
+
+  if (isRaidOptionsSchemaError(error)) {
+    return { kind: "raid-options-unavailable", error };
+  }
+
+  if (error) {
+    // Handle unique constraint violation (reward already added)
+    // 一意制約違反を処理（報酬は既に追加済み）
+    if (error.code === "23505") {
+      return { kind: "conflict" };
+    }
+    return { kind: "error", error };
+  }
+
+  return { kind: "ok", reward: newReward };
 }
 
 /**
@@ -196,25 +575,10 @@ export async function POST(request: NextRequest) {
 
     // Get streamer info to verify ownership
     // ストリーマー情報を取得して所有権を確認
-    let { data: streamer, error: streamerSelectError } = await supabaseAdmin
-      .from("streamers")
-      .select("id, channel_point_reward_id, card_pack_names")
-      .eq("twitch_user_id", session.twitchUserId)
-      .maybeSingle();
-
-    // Issue #393再設計: card_pack_names がデプロイ窓で未検出の場合、それだけ
-    // 外して再試行する(所有権確認・メイン報酬確認は継続できるようにする)。
-    let cardPackNamesUnavailable = false;
-    if (streamerSelectError && isMissingCardPackNamesColumnError(streamerSelectError)) {
-      const retryResult = await supabaseAdmin
-        .from("streamers")
-        .select("id, channel_point_reward_id")
-        .eq("twitch_user_id", session.twitchUserId)
-        .maybeSingle();
-      streamer = retryResult.data ? { ...retryResult.data, card_pack_names: [] as string[] } : null;
-      streamerSelectError = retryResult.error;
-      cardPackNamesUnavailable = true;
-    }
+    const { streamer, cardPackNamesUnavailable } = await getStreamerForAdditionalRewardPost(
+      supabaseAdmin,
+      session.twitchUserId
+    );
 
     if (!streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
@@ -295,32 +659,15 @@ export async function POST(request: NextRequest) {
       insertPayload.collection_name = collectionNameResult.value;
     }
 
-    let { data: newReward, error } = await supabaseAdmin
-      .from("streamer_additional_gacha_rewards")
-      .insert(insertPayload)
-      .select()
-      .maybeSingle();
+    const insertOutcome = await insertAdditionalReward(supabaseAdmin, insertPayload);
 
-    // Issue #393: deploy-window safety. Strip collection_name and retry if the
-    // column is not migrated yet. Must run BEFORE the raid-options check because
-    // both match PGRST204; otherwise we would return a misleading 503.
-    if (error && isMissingCollectionNameColumn(error) && "collection_name" in insertPayload) {
-      delete insertPayload.collection_name;
-      const retryResult = await supabaseAdmin
-        .from("streamer_additional_gacha_rewards")
-        .insert(insertPayload)
-        .select()
-        .maybeSingle();
-      newReward = retryResult.data;
-      error = retryResult.error;
-    }
-
-    if (isRaidOptionsSchemaError(error)) {
+    if (insertOutcome.kind === "raid-options-unavailable") {
+      const errForLog = insertOutcome.error as { message?: string } | null | undefined;
       logger.warn("Additional reward options schema is not ready; refusing to create a 1-draw fallback reward", {
         rewardId,
         streamerId: streamer.id,
         requestedDrawCount: normalizedDrawCount,
-        error: error?.message,
+        error: errForLog?.message,
       });
       return NextResponse.json(
         { error: RAID_OPTIONS_SCHEMA_PENDING_MESSAGE },
@@ -328,17 +675,18 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (error) {
-      // Handle unique constraint violation (reward already added)
-      // 一意制約違反を処理（報酬は既に追加済み）
-      if (error.code === "23505") {
-        return NextResponse.json(
-          { error: "このチャネルポイント引き換えは既に追加されています" },
-          { status: 409 }
-        );
-      }
-      return handleDatabaseError(error, "Additional Rewards API: POST");
+    if (insertOutcome.kind === "conflict") {
+      return NextResponse.json(
+        { error: "このチャネルポイント引き換えは既に追加されています" },
+        { status: 409 }
+      );
     }
+
+    if (insertOutcome.kind === "error") {
+      return handleDatabaseError(insertOutcome.error, "Additional Rewards API: POST");
+    }
+
+    const newReward = insertOutcome.reward;
 
     logger.info(
       `Additional reward registered: streamerId=${streamer.id}, rewardId=${rewardId}, rewardName=${rewardName}, drawCount=${normalizedDrawCount}, raidLimited=${isRaidLimited ?? false}`
@@ -351,6 +699,86 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     return handleApiError(error, "Additional Rewards API: POST");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DELETE: ownership lookup + delete (read+write mixed → isPgWriteEnabled)
+// ---------------------------------------------------------------------------
+
+async function getOwnedStreamerIdForRewardsWritePg(twitchUserId: string): Promise<string | null> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({ id: streamersTable.id })
+          .from(streamersTable)
+          .where(eq(streamersTable.twitch_user_id, twitchUserId))
+          .limit(1);
+      },
+      "Additional Rewards API: DELETE ownership lookup",
+      { idempotent: true },
+    );
+    return rows[0]?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+interface DeleteAllAdditionalRewardsResult {
+  error: unknown;
+  deletedCount: number | null;
+}
+
+async function deleteAllAdditionalRewardsPg(streamerId: string): Promise<DeleteAllAdditionalRewardsResult> {
+  try {
+    await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .delete(streamerAdditionalGachaRewardsTable)
+          .where(eq(streamerAdditionalGachaRewardsTable.streamer_id, streamerId));
+      },
+      "Additional Rewards API: DELETE ALL",
+      // フィルタ指定の DELETE は再実行しても最終状態が同じ（2回目は0行削除）ため冪等
+      { idempotent: true },
+    );
+    // #663 self-review: postgrest 経路は .delete().select() のみで
+    // { count: 'exact' } を要求していないため、Prefer: count= ヘッダーが
+    // 送られず response.count は本番でも常に null（node_modules/@supabase/
+    // postgrest-js の PostgrestQueryBuilder.delete() / PostgrestBuilder の
+    // Content-Range 解析ロジックで確認済み）。deletedCount を実際の削除件数に
+    // すると DB_DRIVER=pg 切替だけでレスポンスの値が変わってしまう
+    // （このIssueは経路切替のみが目的で、挙動改善はスコープ外）ため、
+    // 既存の（実質バグだが）null を返す挙動にそろえる。.returning() で件数を
+    // 取得しないのも同じ理由（不要なペイロード往復を避ける）。
+    return { error: null, deletedCount: null };
+  } catch (error) {
+    return { error, deletedCount: null };
+  }
+}
+
+async function deleteAdditionalRewardByIdPg(streamerId: string, rewardId: string): Promise<{ error: unknown }> {
+  try {
+    await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .delete(streamerAdditionalGachaRewardsTable)
+          .where(
+            and(
+              eq(streamerAdditionalGachaRewardsTable.streamer_id, streamerId),
+              eq(streamerAdditionalGachaRewardsTable.reward_id, rewardId)
+            )
+          );
+      },
+      "Additional Rewards API: DELETE",
+      { idempotent: true },
+    );
+    return { error: null };
+  } catch (error) {
+    return { error };
   }
 }
 
@@ -385,30 +813,48 @@ export async function DELETE(request: NextRequest) {
   }
 
   try {
-    const supabaseAdmin = getSupabaseAdmin();
     const url = new URL(request.url);
     const rewardId = url.searchParams.get("rewardId");
     const deleteAll = url.searchParams.get("deleteAll") === "true";
 
     // Get streamer info to verify ownership
     // ストリーマー情報を取得して所有権を確認
-    const { data: streamer } = await supabaseAdmin
-      .from("streamers")
-      .select("id")
-      .eq("twitch_user_id", session.twitchUserId)
-      .maybeSingle();
+    let streamerId: string | null;
+    if (isPgWriteEnabled()) {
+      streamerId = await getOwnedStreamerIdForRewardsWritePg(session.twitchUserId);
+    } else {
+      const supabaseAdmin = getSupabaseAdmin();
+      const { data: streamer } = await supabaseAdmin
+        .from("streamers")
+        .select("id")
+        .eq("twitch_user_id", session.twitchUserId)
+        .maybeSingle();
+      streamerId = streamer?.id ?? null;
+    }
 
-    if (!streamer) {
+    if (!streamerId) {
       return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
     }
 
     if (deleteAll) {
       // Delete all additional rewards for this streamer
       // このストリーマーの全ての追加報酬を削除
+      if (isPgWriteEnabled()) {
+        const { error, deletedCount } = await deleteAllAdditionalRewardsPg(streamerId);
+        if (error) {
+          return handleDatabaseError(error, "Additional Rewards API: DELETE ALL");
+        }
+        logger.info(
+          `All additional rewards deleted: streamerId=${streamerId}, count=${deletedCount}`
+        );
+        return NextResponse.json({ success: true, deletedCount });
+      }
+
+      const supabaseAdmin = getSupabaseAdmin();
       const { error, count } = await supabaseAdmin
         .from("streamer_additional_gacha_rewards")
         .delete()
-        .eq("streamer_id", streamer.id)
+        .eq("streamer_id", streamerId)
         .select();
 
       if (error) {
@@ -416,17 +862,29 @@ export async function DELETE(request: NextRequest) {
       }
 
       logger.info(
-        `All additional rewards deleted: streamerId=${streamer.id}, count=${count}`
+        `All additional rewards deleted: streamerId=${streamerId}, count=${count}`
       );
 
       return NextResponse.json({ success: true, deletedCount: count });
     } else if (rewardId) {
       // Delete specific reward
       // 特定の報酬を削除
+      if (isPgWriteEnabled()) {
+        const { error } = await deleteAdditionalRewardByIdPg(streamerId, rewardId);
+        if (error) {
+          return handleDatabaseError(error, "Additional Rewards API: DELETE");
+        }
+        logger.info(
+          `Additional reward deleted: streamerId=${streamerId}, rewardId=${rewardId}`
+        );
+        return NextResponse.json({ success: true });
+      }
+
+      const supabaseAdmin = getSupabaseAdmin();
       const { error } = await supabaseAdmin
         .from("streamer_additional_gacha_rewards")
         .delete()
-        .eq("streamer_id", streamer.id)
+        .eq("streamer_id", streamerId)
         .eq("reward_id", rewardId);
 
       if (error) {
@@ -434,7 +892,7 @@ export async function DELETE(request: NextRequest) {
       }
 
       logger.info(
-        `Additional reward deleted: streamerId=${streamer.id}, rewardId=${rewardId}`
+        `Additional reward deleted: streamerId=${streamerId}, rewardId=${rewardId}`
       );
 
       return NextResponse.json({ success: true });

--- a/src/app/api/streamer/raid-gacha/route.ts
+++ b/src/app/api/streamer/raid-gacha/route.ts
@@ -7,8 +7,23 @@ import { ERROR_MESSAGES } from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
 import { logger } from "@/lib/logger";
+// -----------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。
+// - getOwnedStreamer は読み取り専用のため isPgReadEnabled() で分岐する。
+// - POST の UPDATE（raid_gacha_draw_count）は書き込みのため isPgWriteEnabled() で
+//   分岐する。
+// 既存 supabase-js 実装は 1 文字も変えず、フラグ未設定時は完全に従来どおり動く。
+// pg 実装は getDb() を withDbRetry の queryFn 内で呼ぶ規約（src/lib/db/retry.ts 参照）。
+// -----------------------------------------------------------------------------
+import { eq } from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
+import { isPgReadEnabled, isPgWriteEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+import { streamers as streamersTable } from "@/lib/db/schema";
 
-function isRaidStateSchemaError(error: { message?: string; code?: string } | null | undefined) {
+type GenericDbError = { message?: string; code?: string } | null | undefined;
+
+function isRaidStateSchemaError(error: GenericDbError) {
   const message = error?.message ?? "";
   return error?.code === "PGRST204"
     || message.includes("raid_gacha_active_until")
@@ -21,7 +36,93 @@ function isActiveUntil(value: string | null | undefined): boolean {
   return Number.isFinite(timestamp) && timestamp > Date.now();
 }
 
-async function getOwnedStreamer(twitchUserId: string) {
+interface OwnedStreamerRaidState {
+  id: string;
+  raid_gacha_active_until: string | null;
+  raid_gacha_draw_count: number;
+}
+
+interface GetOwnedStreamerResult {
+  streamer: OwnedStreamerRaidState | null;
+  error: unknown;
+}
+
+/**
+ * getOwnedStreamer の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応:
+ * - streamers を twitch_user_id で 1 行取得。twitch_user_id は UNIQUE
+ *   （migration 00001）のため LIMIT 1 + rows[0] ?? null で .maybeSingle() と
+ *   同じ外部挙動。
+ * - isRaidStateSchemaError は既存の汎用テキスト判定（code === "PGRST204" || 列名を
+ *   含む message）をそのまま再利用する。pg（postgres.js）の 42703 は code こそ
+ *   異なるが、message に列名がそのまま含まれるため message.includes(...) 側で
+ *   同じ条件式のまま判定できる（新規の pg 専用エラー整形ヘルパーは作らない）。
+ * - 呼び出し元（GET/POST）は `{ streamer, error }` の形状に依存しているため、
+ *   pg 版もスローされた例外をこの形状へ変換して返す。
+ */
+async function getOwnedStreamerPg(twitchUserId: string): Promise<GetOwnedStreamerResult> {
+  const selectFull = () =>
+    withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select({
+            id: streamersTable.id,
+            raid_gacha_active_until: streamersTable.raid_gacha_active_until,
+            raid_gacha_draw_count: streamersTable.raid_gacha_draw_count,
+          })
+          .from(streamersTable)
+          .where(eq(streamersTable.twitch_user_id, twitchUserId))
+          .limit(1);
+      },
+      "getOwnedStreamer(raid gacha)",
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    );
+
+  const selectFallback = () =>
+    withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({ id: streamersTable.id })
+          .from(streamersTable)
+          .where(eq(streamersTable.twitch_user_id, twitchUserId))
+          .limit(1);
+      },
+      "getOwnedStreamer(raid gacha fallback)",
+      { idempotent: true },
+    );
+
+  try {
+    const rows = await selectFull();
+    return { streamer: rows[0] ?? null, error: null };
+  } catch (error) {
+    if (isRaidStateSchemaError(error as GenericDbError)) {
+      try {
+        const rows = await selectFallback();
+        const row = rows[0] ?? null;
+        return {
+          streamer: row ? { ...row, raid_gacha_active_until: null, raid_gacha_draw_count: 0 } : null,
+          error: null,
+        };
+      } catch (fallbackError) {
+        return { streamer: null, error: fallbackError };
+      }
+    }
+    return { streamer: null, error };
+  }
+}
+
+async function getOwnedStreamer(twitchUserId: string): Promise<GetOwnedStreamerResult> {
+  // #663: 読み取り専用の関数のため isPgReadEnabled() で分岐。
+  // フラグ未設定時（既定 'postgrest'）は素通りし、以下の既存実装が従来どおり動く。
+  if (isPgReadEnabled()) {
+    return getOwnedStreamerPg(twitchUserId);
+  }
+
   const supabaseAdmin = getSupabaseAdmin();
   let { data: streamer, error } = await supabaseAdmin
     .from("streamers")
@@ -42,6 +143,64 @@ async function getOwnedStreamer(twitchUserId: string) {
   }
 
   return { streamer, error };
+}
+
+interface UpdateRaidGachaDrawCountResult {
+  data: { raid_gacha_active_until: string | null; raid_gacha_draw_count: number } | null;
+  error: unknown;
+}
+
+/**
+ * updateRaidGachaDrawCount の pg 直結実装 (#663)
+ *
+ * UPDATE は毎回同じ明示値（リクエストで検証済みの drawCount）を書く全置換の
+ * ため、リトライしても最終状態は変わらない = 冪等（idempotent: true）。
+ */
+async function updateRaidGachaDrawCountPg(
+  streamerId: string,
+  drawCount: number
+): Promise<UpdateRaidGachaDrawCountResult> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .update(streamersTable)
+          .set({ raid_gacha_draw_count: drawCount })
+          .where(eq(streamersTable.id, streamerId))
+          .returning({
+            raid_gacha_active_until: streamersTable.raid_gacha_active_until,
+            raid_gacha_draw_count: streamersTable.raid_gacha_draw_count,
+          });
+      },
+      "updateRaidGachaDrawCount",
+      { idempotent: true },
+    );
+    return { data: rows[0] ?? null, error: null };
+  } catch (error) {
+    return { data: null, error };
+  }
+}
+
+async function updateRaidGachaDrawCount(
+  streamerId: string,
+  drawCount: number
+): Promise<UpdateRaidGachaDrawCountResult> {
+  // #663: 書き込みのみの関数のため isPgWriteEnabled() で分岐。
+  if (isPgWriteEnabled()) {
+    return updateRaidGachaDrawCountPg(streamerId, drawCount);
+  }
+
+  const supabaseAdmin = getSupabaseAdmin();
+  const { data, error } = await supabaseAdmin
+    .from("streamers")
+    .update({ raid_gacha_draw_count: drawCount })
+    .eq("id", streamerId)
+    .select("raid_gacha_active_until, raid_gacha_draw_count")
+    .maybeSingle();
+
+  return { data, error };
 }
 
 export async function GET(request: NextRequest) {
@@ -130,13 +289,7 @@ export async function POST(request: NextRequest) {
     if (streamerError) return handleDatabaseError(streamerError, "Raid Gacha API: POST lookup");
     if (!streamer) return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
 
-    const supabaseAdmin = getSupabaseAdmin();
-    const { data: updatedStreamer, error } = await supabaseAdmin
-      .from("streamers")
-      .update({ raid_gacha_draw_count: requestedDrawCount })
-      .eq("id", streamer.id)
-      .select("raid_gacha_active_until, raid_gacha_draw_count")
-      .maybeSingle();
+    const { data: updatedStreamer, error } = await updateRaidGachaDrawCount(streamer.id, requestedDrawCount);
 
     if (error) return handleDatabaseError(error, "Raid Gacha API: POST update");
 

--- a/src/app/api/streamer/settings/route.ts
+++ b/src/app/api/streamer/settings/route.ts
@@ -39,6 +39,28 @@ import {
   type GachaSoundRule,
 } from "@/lib/gacha-sound-rules";
 import { getUserPlan } from "@/lib/plan";
+// -----------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。
+// このファイルは POST 1 本の中に ~6 個の DB アクセス（所有権+現在値 SELECT、BOT
+// 切断の UPSERT+DELETE、streamers の 5 段階フォールバック UPDATE）が ~350 行の
+// 共有バリデーション/正規化ロジックを挟んで直列に並ぶため、DB 操作の境界ごとに
+// 小さな named helper 関数へ分解し、各 helper が自分の先頭で isPgReadEnabled() /
+// isPgWriteEnabled() 分岐を持つ（announcements.ts / token-manager.ts と同じ
+// パターン）。POST 本体の共有バリデーション/正規化コードは完全に手を触れない。
+// 既存 supabase-js 実装は 1 文字も変えず、フラグ未設定時は完全に従来どおり動く。
+// pg 実装は getDb() を withDbRetry の queryFn 内で呼ぶ規約（src/lib/db/retry.ts 参照）。
+// -----------------------------------------------------------------------------
+import { and, eq } from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
+import { isPgReadEnabled, isPgWriteEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+import {
+  streamers as streamersTable,
+  streamerChatSenderSettings as streamerChatSenderSettingsTable,
+  twitchBotAccounts as twitchBotAccountsTable,
+} from "@/lib/db/schema";
+
+type GenericDbError = { message?: string; code?: string; details?: string; hint?: string } | null | undefined;
 
 
 type RarityWeightsValidation =
@@ -235,6 +257,614 @@ function prunePackRarityWeights(
   return pruned;
 }
 
+// ---------------------------------------------------------------------------
+// DB 操作 1: 所有権 + 現在値 SELECT（読み取り専用 → isPgReadEnabled）
+// ---------------------------------------------------------------------------
+
+interface StreamerForSettingsUpdate {
+  id: string;
+  channel_point_collection_name: string | null;
+  card_pack_names: string[];
+  pack_rarity_weights: Record<string, Record<string, number>> | null;
+}
+
+/**
+ * getStreamerForSettingsUpdate の pg 直結実装 (#663)
+ *
+ * PostgREST 実装（下の getStreamerForSettingsUpdate 内の postgrest 分岐）と同じ
+ * 3段階フォールバックチェイン（pack_rarity_weights → card_pack_names →
+ * channel_point_collection_name の順で、未デプロイ列を1つずつ剥がして再試行）を
+ * throw ベースで再現する。各段は「直前の段の結果として今どのエラーを見ているか」
+ * を引き継ぐ必要があるため、currentError を明示的に持ち回る。
+ *
+ * いずれの判定にも合致しない・最終フォールバックまで失敗した場合は null を返す
+ * （postgrest 実装が streamerSelectError の種類を問わず !streamer で 403 に
+ * 倒す既存の安全側デグレードと同じ外部挙動）。
+ */
+async function getStreamerForSettingsUpdatePg(
+  streamerId: string,
+  twitchUserId: string
+): Promise<StreamerForSettingsUpdate | null> {
+  const ownerCondition = and(
+    eq(streamersTable.id, streamerId),
+    eq(streamersTable.twitch_user_id, twitchUserId)
+  );
+
+  const selectFull = () =>
+    withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select({
+            id: streamersTable.id,
+            channel_point_collection_name: streamersTable.channel_point_collection_name,
+            card_pack_names: streamersTable.card_pack_names,
+            pack_rarity_weights: streamersTable.pack_rarity_weights,
+          })
+          .from(streamersTable)
+          .where(ownerCondition)
+          .limit(1);
+      },
+      "getStreamerForSettingsUpdate(full)",
+      { idempotent: true },
+    );
+
+  const selectWithoutPackRarityWeights = () =>
+    withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({
+            id: streamersTable.id,
+            channel_point_collection_name: streamersTable.channel_point_collection_name,
+            card_pack_names: streamersTable.card_pack_names,
+          })
+          .from(streamersTable)
+          .where(ownerCondition)
+          .limit(1);
+      },
+      "getStreamerForSettingsUpdate(no pack_rarity_weights)",
+      { idempotent: true },
+    );
+
+  const selectWithoutCardPackNames = () =>
+    withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({
+            id: streamersTable.id,
+            channel_point_collection_name: streamersTable.channel_point_collection_name,
+          })
+          .from(streamersTable)
+          .where(ownerCondition)
+          .limit(1);
+      },
+      "getStreamerForSettingsUpdate(no card_pack_names)",
+      { idempotent: true },
+    );
+
+  const selectIdOnly = () =>
+    withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({ id: streamersTable.id })
+          .from(streamersTable)
+          .where(ownerCondition)
+          .limit(1);
+      },
+      "getStreamerForSettingsUpdate(id only)",
+      { idempotent: true },
+    );
+
+  try {
+    const rows = await selectFull();
+    return rows[0] ?? null;
+  } catch (initialError) {
+    let currentError: unknown = initialError;
+    let row: StreamerForSettingsUpdate | null = null;
+    let resolved = false;
+
+    if (isMissingPackRarityWeightsColumnError(currentError as GenericDbError)) {
+      try {
+        const rows = await selectWithoutPackRarityWeights();
+        row = rows[0] ? { ...rows[0], pack_rarity_weights: null } : null;
+        resolved = true;
+        currentError = null;
+      } catch (err) {
+        currentError = err;
+      }
+    }
+
+    if (currentError && isMissingCardPackNamesColumnError(currentError as GenericDbError)) {
+      try {
+        const rows = await selectWithoutCardPackNames();
+        row = rows[0] ? { ...rows[0], card_pack_names: [], pack_rarity_weights: null } : null;
+        resolved = true;
+        currentError = null;
+      } catch (err) {
+        currentError = err;
+      }
+    }
+
+    if (currentError && isMissingCollectionNameColumn(currentError as GenericDbError)) {
+      try {
+        const rows = await selectIdOnly();
+        row = rows[0]
+          ? { ...rows[0], channel_point_collection_name: null, card_pack_names: [], pack_rarity_weights: null }
+          : null;
+        resolved = true;
+        currentError = null;
+      } catch (err) {
+        currentError = err;
+      }
+    }
+
+    if (currentError) {
+      // postgrest 実装は streamerSelectError が残っていても種類を問わず
+      // !streamer → 403 に倒す（明示的な handleDatabaseError は無い）。
+      // 同じ外部挙動に合わせ、未処理のエラーは呼び出し元に伝播させず null で返す。
+      return null;
+    }
+
+    return resolved ? row : null;
+  }
+}
+
+async function getStreamerForSettingsUpdate(
+  supabaseAdmin: ReturnType<typeof getSupabaseAdmin>,
+  streamerId: string,
+  twitchUserId: string
+): Promise<StreamerForSettingsUpdate | null> {
+  // #663: 読み取り専用の関数のため isPgReadEnabled() で分岐。
+  // フラグ未設定時（既定 'postgrest'）は素通りし、以下の既存実装が従来どおり動く。
+  if (isPgReadEnabled()) {
+    return getStreamerForSettingsUpdatePg(streamerId, twitchUserId);
+  }
+
+  // Verify ownership
+  let { data: streamer, error: streamerSelectError } = await supabaseAdmin
+    .from("streamers")
+    .select("id, channel_point_collection_name, card_pack_names, pack_rarity_weights")
+    .eq("id", streamerId)
+    .eq("twitch_user_id", twitchUserId)
+    .maybeSingle();
+
+  // Issue #578: pack_rarity_weights はこのフェーズで新規追加された列。デプロイ窓では
+  // 他の列より先に(あるいは他が既に安定デプロイ済みの状態で単独で)未デプロイになり
+  // うるため、既存の card_pack_names / channel_point_collection_name と同じチェイン
+  // 方式で、まずこの列だけ剥がして再試行する。プルーニング(下記)に使う現在値の
+  // 読み取りが目的で、未デプロイなら「保存されているエントリなし」= null 扱いにする。
+  if (streamerSelectError && isMissingPackRarityWeightsColumnError(streamerSelectError)) {
+    const retryResult = await supabaseAdmin
+      .from("streamers")
+      .select("id, channel_point_collection_name, card_pack_names")
+      .eq("id", streamerId)
+      .eq("twitch_user_id", twitchUserId)
+      .maybeSingle();
+    streamer = retryResult.data
+      ? { ...retryResult.data, pack_rarity_weights: null as Record<string, Record<string, number>> | null }
+      : null;
+    streamerSelectError = retryResult.error;
+  }
+
+  // Issue #393再設計 / #269: このownership確認SELECTは channel_point_collection_name
+  // と card_pack_names の現在値を読むために2列を含む。デプロイ窓ではどちらか
+  // (または両方)が未デプロイになりうるため、都度1列だけ剥がして再試行する
+  // (既存の card_number → collection_name と同じチェイン方式)。どちらの列も
+  // 未デプロイの通常設定保存を403にしないための安全策(#269自己レビューで
+  // 発見・修正した回帰の再発防止)。
+  if (streamerSelectError && isMissingCardPackNamesColumnError(streamerSelectError)) {
+    const retryResult = await supabaseAdmin
+      .from("streamers")
+      .select("id, channel_point_collection_name")
+      .eq("id", streamerId)
+      .eq("twitch_user_id", twitchUserId)
+      .maybeSingle();
+    streamer = retryResult.data
+      ? {
+          ...retryResult.data,
+          card_pack_names: [] as string[],
+          pack_rarity_weights: null as Record<string, Record<string, number>> | null,
+        }
+      : null;
+    streamerSelectError = retryResult.error;
+  }
+
+  if (streamerSelectError && isMissingCollectionNameColumn(streamerSelectError)) {
+    const retryResult = await supabaseAdmin
+      .from("streamers")
+      .select("id")
+      .eq("id", streamerId)
+      .eq("twitch_user_id", twitchUserId)
+      .maybeSingle();
+    streamer = retryResult.data
+      ? {
+          ...retryResult.data,
+          channel_point_collection_name: null,
+          card_pack_names: [] as string[],
+          pack_rarity_weights: null as Record<string, Record<string, number>> | null,
+        }
+      : null;
+    streamerSelectError = retryResult.error;
+  }
+
+  return (streamer as StreamerForSettingsUpdate | null) ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// DB 操作 2: disconnectBot ブロック（UPSERT + DELETE、書き込み → isPgWriteEnabled）
+// ---------------------------------------------------------------------------
+
+interface DisconnectBotAccountFailure {
+  error: unknown;
+  context: string;
+}
+
+/**
+ * disconnectBotAccount の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応:
+ * - streamer_chat_sender_settings への upsert は streamer_id が PK
+ *   （migration 00040, schema.ts 参照）のため onConflictDoUpdate(target: streamer_id)
+ *   が等価。
+ * - twitch_bot_accounts の DELETE は streamer_id + owner_type='streamer' の
+ *   フィルタ指定 DELETE のため and(eq, eq) が等価。
+ * - どちらも明示値の全置換（UPSERT は同じ固定値、DELETE はフィルタ一致行の削除）
+ *   のためリトライしても最終状態は同じ = 冪等（idempotent: true）。
+ */
+async function disconnectBotAccountPg(streamerId: string): Promise<DisconnectBotAccountFailure | null> {
+  try {
+    await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .insert(streamerChatSenderSettingsTable)
+          .values({
+            streamer_id: streamerId,
+            sender_mode: "streamer",
+            custom_bot_account_id: null,
+          })
+          .onConflictDoUpdate({
+            target: streamerChatSenderSettingsTable.streamer_id,
+            set: {
+              sender_mode: "streamer",
+              custom_bot_account_id: null,
+            },
+          });
+      },
+      "disconnectBotAccount(upsert sender settings)",
+      { idempotent: true },
+    );
+  } catch (error) {
+    return { error, context: "Streamer Settings API: Disconnect BOT sender settings" };
+  }
+
+  try {
+    await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .delete(twitchBotAccountsTable)
+          .where(
+            and(
+              eq(twitchBotAccountsTable.streamer_id, streamerId),
+              eq(twitchBotAccountsTable.owner_type, "streamer")
+            )
+          );
+      },
+      "disconnectBotAccount(delete bot account)",
+      { idempotent: true },
+    );
+  } catch (error) {
+    return { error, context: "Streamer Settings API: Disconnect BOT account" };
+  }
+
+  return null;
+}
+
+async function disconnectBotAccount(
+  supabaseAdmin: ReturnType<typeof getSupabaseAdmin>,
+  streamerId: string
+): Promise<DisconnectBotAccountFailure | null> {
+  // #663: 書き込みのみの関数のため isPgWriteEnabled() で分岐。
+  if (isPgWriteEnabled()) {
+    return disconnectBotAccountPg(streamerId);
+  }
+
+  const { error: senderSettingsError } = await supabaseAdmin
+    .from("streamer_chat_sender_settings")
+    .upsert({
+      streamer_id: streamerId,
+      sender_mode: "streamer",
+      custom_bot_account_id: null,
+    });
+
+  if (senderSettingsError) {
+    return { error: senderSettingsError, context: "Streamer Settings API: Disconnect BOT sender settings" };
+  }
+
+  const { error: botDeleteError } = await supabaseAdmin
+    .from("twitch_bot_accounts")
+    .delete()
+    .eq("streamer_id", streamerId)
+    .eq("owner_type", "streamer");
+
+  if (botDeleteError) {
+    return { error: botDeleteError, context: "Streamer Settings API: Disconnect BOT account" };
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// DB 操作 3: streamers の主 UPDATE（5段階フォールバックチェイン、書き込み →
+// isPgWriteEnabled）
+// ---------------------------------------------------------------------------
+
+interface ApplyStreamerSettingsUpdateResult {
+  error: unknown;
+  rarityWeightsScopeWriteSkipped: boolean;
+  packRarityWeightsWriteSkipped: boolean;
+  cardPackNamesWriteSkipped: boolean;
+  defaultCardPackNameWriteSkipped: boolean;
+  gachaSoundRulesWriteSkipped: boolean;
+}
+
+/**
+ * gacha_sound_rules 列欠落フォールバックの判定。既存実装と同じ汎用テキスト判定
+ * （code === "PGRST204" || message に "gacha_sound_rules" を含む）で、pg
+ * （postgres.js）の 42703 も message 側でそのまま判定できる（新規の pg 専用
+ * エラー整形ヘルパーは作らない）。
+ */
+function isMissingGachaSoundRulesColumnError(error: unknown): boolean {
+  const err = error as GenericDbError;
+  return err?.code === "PGRST204" || String(err?.message ?? "").includes("gacha_sound_rules");
+}
+
+/**
+ * applyStreamerSettingsUpdate の pg 直結実装 (#663)
+ *
+ * PostgREST 実装（下の applyStreamerSettingsUpdatePostgrest）と同じ 5 段階
+ * フォールバックチェイン + gacha_sound_rules 用の最終フォールバックを throw
+ * ベースで再現する。各段の判定は「直前の段の結果として今どのエラーを見て
+ * いるか」を引き継ぐ必要があるため error 変数を持ち回る（postgrest 版の
+ * `error &&` ガードの再現）。updateData は呼び出し元と共有する同一オブジェクト
+ * 参照であることを前提に、各段で該当キーを delete する（postgrest 版と同じ
+ * 副作用の与え方。呼び出し元はこの delete 結果を使ってレスポンスの
+ * gacha_sound_url/enabled をエコーバックする）。
+ *
+ * UPDATE は明示値による全置換のため、各段の個別クエリはリトライしても最終
+ * 状態が変わらない = 冪等（idempotent: true）。ただし各段の「列を1つ剥がして
+ * 再試行する」フォールバックチェイン自体は withDbRetry の接続リトライとは
+ * 独立したデプロイ窓ロジックであり、混同しない。
+ */
+async function applyStreamerSettingsUpdatePg(
+  streamerId: string,
+  updateData: Record<string, unknown>,
+  gachaSoundRulesRequested: boolean
+): Promise<ApplyStreamerSettingsUpdateResult> {
+  let rarityWeightsScopeWriteSkipped = false;
+  let packRarityWeightsWriteSkipped = false;
+  let cardPackNamesWriteSkipped = false;
+  let defaultCardPackNameWriteSkipped = false;
+  let gachaSoundRulesWriteSkipped = false;
+
+  const runUpdate = (data: Record<string, unknown>, context: string) =>
+    withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .update(streamersTable)
+          .set(data as Partial<typeof streamersTable.$inferInsert>)
+          .where(eq(streamersTable.id, streamerId));
+      },
+      context,
+      { idempotent: true },
+    );
+
+  const attempt = async (data: Record<string, unknown>, context: string): Promise<unknown> => {
+    if (Object.keys(data).length === 0) {
+      return null;
+    }
+    try {
+      await runUpdate(data, context);
+      return null;
+    } catch (err) {
+      return err;
+    }
+  };
+
+  let error: unknown = null;
+  try {
+    await runUpdate(updateData, "applyStreamerSettingsUpdate(full)");
+  } catch (err) {
+    error = err;
+  }
+
+  if (error && isMissingRarityWeightsScopeColumnError(error as GenericDbError) && "rarity_weights_scope" in updateData) {
+    delete updateData.rarity_weights_scope;
+    rarityWeightsScopeWriteSkipped = true;
+    error = await attempt(updateData, "applyStreamerSettingsUpdate(no rarity_weights_scope)");
+  }
+
+  if (error && isMissingPackRarityWeightsColumnError(error as GenericDbError) && "pack_rarity_weights" in updateData) {
+    delete updateData.pack_rarity_weights;
+    packRarityWeightsWriteSkipped = true;
+    error = await attempt(updateData, "applyStreamerSettingsUpdate(no pack_rarity_weights)");
+  }
+
+  if (error && isMissingCardPackNamesColumnError(error as GenericDbError) && "card_pack_names" in updateData) {
+    delete updateData.card_pack_names;
+    cardPackNamesWriteSkipped = true;
+    error = await attempt(updateData, "applyStreamerSettingsUpdate(no card_pack_names)");
+  }
+
+  if (error && isMissingDefaultCardPackNameColumnError(error as GenericDbError) && "default_card_pack_name" in updateData) {
+    delete updateData.default_card_pack_name;
+    defaultCardPackNameWriteSkipped = true;
+    error = await attempt(updateData, "applyStreamerSettingsUpdate(no default_card_pack_name)");
+  }
+
+  if (error && isMissingCollectionNameColumn(error as GenericDbError) && "channel_point_collection_name" in updateData) {
+    delete updateData.channel_point_collection_name;
+    error = await attempt(updateData, "applyStreamerSettingsUpdate(no channel_point_collection_name)");
+  }
+
+  if (error && gachaSoundRulesRequested && isMissingGachaSoundRulesColumnError(error)) {
+    logger.warn("gacha_sound_rules column not available yet; saving legacy sound fallback only");
+    const legacyUpdateData = { ...updateData };
+    delete legacyUpdateData.gacha_sound_rules;
+    gachaSoundRulesWriteSkipped = true;
+    error = await attempt(legacyUpdateData, "applyStreamerSettingsUpdate(legacy gacha sound fallback)");
+  }
+
+  return {
+    error,
+    rarityWeightsScopeWriteSkipped,
+    packRarityWeightsWriteSkipped,
+    cardPackNamesWriteSkipped,
+    defaultCardPackNameWriteSkipped,
+    gachaSoundRulesWriteSkipped,
+  };
+}
+
+async function applyStreamerSettingsUpdatePostgrest(
+  supabaseAdmin: ReturnType<typeof getSupabaseAdmin>,
+  streamerId: string,
+  updateData: Record<string, unknown>,
+  gachaSoundRulesRequested: boolean
+): Promise<ApplyStreamerSettingsUpdateResult> {
+  let rarityWeightsScopeWriteSkipped = false;
+  let packRarityWeightsWriteSkipped = false;
+  let cardPackNamesWriteSkipped = false;
+  let defaultCardPackNameWriteSkipped = false;
+  let gachaSoundRulesWriteSkipped = false;
+
+  let { error } = await supabaseAdmin
+    .from("streamers")
+    .update(updateData)
+    .eq("id", streamerId);
+
+  // Issue #578: このフェーズで新規追加された列を最初に剥がす(他の既存列より
+  // 未デプロイである可能性が高いため)。
+  if (error && isMissingRarityWeightsScopeColumnError(error) && "rarity_weights_scope" in updateData) {
+    delete updateData.rarity_weights_scope;
+    rarityWeightsScopeWriteSkipped = true;
+    if (Object.keys(updateData).length > 0) {
+      const retryResult = await supabaseAdmin
+        .from("streamers")
+        .update(updateData)
+        .eq("id", streamerId);
+      error = retryResult.error;
+    } else {
+      error = null;
+    }
+  }
+
+  if (error && isMissingPackRarityWeightsColumnError(error) && "pack_rarity_weights" in updateData) {
+    delete updateData.pack_rarity_weights;
+    packRarityWeightsWriteSkipped = true;
+    if (Object.keys(updateData).length > 0) {
+      const retryResult = await supabaseAdmin
+        .from("streamers")
+        .update(updateData)
+        .eq("id", streamerId);
+      error = retryResult.error;
+    } else {
+      error = null;
+    }
+  }
+
+  // Issue #393再設計: 書き込み時点で card_pack_names / channel_point_collection_name
+  // のどちらか(または両方)が未デプロイの可能性があるため、都度1列だけ剥がして再試行する。
+  if (error && isMissingCardPackNamesColumnError(error) && "card_pack_names" in updateData) {
+    delete updateData.card_pack_names;
+    cardPackNamesWriteSkipped = true;
+    if (Object.keys(updateData).length > 0) {
+      const retryResult = await supabaseAdmin
+        .from("streamers")
+        .update(updateData)
+        .eq("id", streamerId);
+      error = retryResult.error;
+    } else {
+      error = null;
+    }
+  }
+
+  if (error && isMissingDefaultCardPackNameColumnError(error) && "default_card_pack_name" in updateData) {
+    delete updateData.default_card_pack_name;
+    defaultCardPackNameWriteSkipped = true;
+    if (Object.keys(updateData).length > 0) {
+      const retryResult = await supabaseAdmin
+        .from("streamers")
+        .update(updateData)
+        .eq("id", streamerId);
+      error = retryResult.error;
+    } else {
+      error = null;
+    }
+  }
+
+  if (error && isMissingCollectionNameColumn(error) && "channel_point_collection_name" in updateData) {
+    delete updateData.channel_point_collection_name;
+    if (Object.keys(updateData).length > 0) {
+      const retryResult = await supabaseAdmin
+        .from("streamers")
+        .update(updateData)
+        .eq("id", streamerId);
+      error = retryResult.error;
+    } else {
+      error = null;
+    }
+  }
+
+  // Issue #176: gacha_sound_rules はこのフィーチャーで新規追加された列。
+  // デプロイ窓では未デプロイの可能性があるため、列を落として旧来の
+  // gacha_sound_url/gacha_sound_enabled のみで再試行する(グレースフルデグレード)。
+  if (
+    error &&
+    gachaSoundRulesRequested &&
+    (error.code === "PGRST204" || error.message.includes("gacha_sound_rules"))
+  ) {
+    logger.warn("gacha_sound_rules column not available yet; saving legacy sound fallback only");
+    const legacyUpdateData = { ...updateData };
+    delete legacyUpdateData.gacha_sound_rules;
+    gachaSoundRulesWriteSkipped = true;
+    const fallbackResult = await supabaseAdmin
+      .from("streamers")
+      .update(legacyUpdateData)
+      .eq("id", streamerId);
+    error = fallbackResult.error;
+  }
+
+  return {
+    error: error ?? null,
+    rarityWeightsScopeWriteSkipped,
+    packRarityWeightsWriteSkipped,
+    cardPackNamesWriteSkipped,
+    defaultCardPackNameWriteSkipped,
+    gachaSoundRulesWriteSkipped,
+  };
+}
+
+async function applyStreamerSettingsUpdate(
+  supabaseAdmin: ReturnType<typeof getSupabaseAdmin>,
+  streamerId: string,
+  updateData: Record<string, unknown>,
+  gachaSoundRulesRequested: boolean
+): Promise<ApplyStreamerSettingsUpdateResult> {
+  // #663: 書き込みのみの関数のため isPgWriteEnabled() で分岐。
+  if (isPgWriteEnabled()) {
+    return applyStreamerSettingsUpdatePg(streamerId, updateData, gachaSoundRulesRequested);
+  }
+  return applyStreamerSettingsUpdatePostgrest(supabaseAdmin, streamerId, updateData, gachaSoundRulesRequested);
+}
+
 export async function POST(request: NextRequest) {
   // Content-Type validation - must be the first check
   const contentTypeValidation = validateContentType(request, 'application/json')
@@ -419,72 +1049,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
     }
 
-    // Verify ownership
-    let { data: streamer, error: streamerSelectError } = await supabaseAdmin
-      .from("streamers")
-      .select("id, channel_point_collection_name, card_pack_names, pack_rarity_weights")
-      .eq("id", streamerId)
-      .eq("twitch_user_id", session.twitchUserId)
-      .maybeSingle();
-
-    // Issue #578: pack_rarity_weights はこのフェーズで新規追加された列。デプロイ窓では
-    // 他の列より先に(あるいは他が既に安定デプロイ済みの状態で単独で)未デプロイになり
-    // うるため、既存の card_pack_names / channel_point_collection_name と同じチェイン
-    // 方式で、まずこの列だけ剥がして再試行する。プルーニング(下記)に使う現在値の
-    // 読み取りが目的で、未デプロイなら「保存されているエントリなし」= null 扱いにする。
-    if (streamerSelectError && isMissingPackRarityWeightsColumnError(streamerSelectError)) {
-      const retryResult = await supabaseAdmin
-        .from("streamers")
-        .select("id, channel_point_collection_name, card_pack_names")
-        .eq("id", streamerId)
-        .eq("twitch_user_id", session.twitchUserId)
-        .maybeSingle();
-      streamer = retryResult.data
-        ? { ...retryResult.data, pack_rarity_weights: null as Record<string, Record<string, number>> | null }
-        : null;
-      streamerSelectError = retryResult.error;
-    }
-
-    // Issue #393再設計 / #269: このownership確認SELECTは channel_point_collection_name
-    // と card_pack_names の現在値を読むために2列を含む。デプロイ窓ではどちらか
-    // (または両方)が未デプロイになりうるため、都度1列だけ剥がして再試行する
-    // (既存の card_number → collection_name と同じチェイン方式)。どちらの列も
-    // 未デプロイの通常設定保存を403にしないための安全策(#269自己レビューで
-    // 発見・修正した回帰の再発防止)。
-    if (streamerSelectError && isMissingCardPackNamesColumnError(streamerSelectError)) {
-      const retryResult = await supabaseAdmin
-        .from("streamers")
-        .select("id, channel_point_collection_name")
-        .eq("id", streamerId)
-        .eq("twitch_user_id", session.twitchUserId)
-        .maybeSingle();
-      streamer = retryResult.data
-        ? {
-            ...retryResult.data,
-            card_pack_names: [] as string[],
-            pack_rarity_weights: null as Record<string, Record<string, number>> | null,
-          }
-        : null;
-      streamerSelectError = retryResult.error;
-    }
-
-    if (streamerSelectError && isMissingCollectionNameColumn(streamerSelectError)) {
-      const retryResult = await supabaseAdmin
-        .from("streamers")
-        .select("id")
-        .eq("id", streamerId)
-        .eq("twitch_user_id", session.twitchUserId)
-        .maybeSingle();
-      streamer = retryResult.data
-        ? {
-            ...retryResult.data,
-            channel_point_collection_name: null,
-            card_pack_names: [] as string[],
-            pack_rarity_weights: null as Record<string, Record<string, number>> | null,
-          }
-        : null;
-      streamerSelectError = retryResult.error;
-    }
+    // Verify ownership + read current state (channel_point_collection_name,
+    // card_pack_names, pack_rarity_weights), with the 3-level deploy-window
+    // fallback chain.
+    const streamer = await getStreamerForSettingsUpdate(supabaseAdmin, streamerId, session.twitchUserId);
 
     if (!streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
@@ -714,28 +1282,10 @@ export async function POST(request: NextRequest) {
 
     let botDisconnected = false;
     if (disconnectBot === true) {
-      const { error: senderSettingsError } = await supabaseAdmin
-        .from("streamer_chat_sender_settings")
-        .upsert({
-          streamer_id: streamerId,
-          sender_mode: "streamer",
-          custom_bot_account_id: null,
-        });
-
-      if (senderSettingsError) {
-        return handleDatabaseError(senderSettingsError, "Streamer Settings API: Disconnect BOT sender settings");
+      const disconnectFailure = await disconnectBotAccount(supabaseAdmin, streamerId);
+      if (disconnectFailure) {
+        return handleDatabaseError(disconnectFailure.error, disconnectFailure.context);
       }
-
-      const { error: botDeleteError } = await supabaseAdmin
-        .from("twitch_bot_accounts")
-        .delete()
-        .eq("streamer_id", streamerId)
-        .eq("owner_type", "streamer");
-
-      if (botDeleteError) {
-        return handleDatabaseError(botDeleteError, "Streamer Settings API: Disconnect BOT account");
-      }
-
       botDisconnected = true;
     }
 
@@ -767,105 +1317,20 @@ export async function POST(request: NextRequest) {
     let gachaSoundRulesWriteSkipped = false;
 
     if (Object.keys(updateData).length > 0) {
-      let { error } = await supabaseAdmin
-        .from("streamers")
-        .update(updateData)
-        .eq("id", streamerId);
+      const updateResult = await applyStreamerSettingsUpdate(
+        supabaseAdmin,
+        streamerId,
+        updateData,
+        gachaSoundRules !== undefined
+      );
+      rarityWeightsScopeWriteSkipped = updateResult.rarityWeightsScopeWriteSkipped;
+      packRarityWeightsWriteSkipped = updateResult.packRarityWeightsWriteSkipped;
+      cardPackNamesWriteSkipped = updateResult.cardPackNamesWriteSkipped;
+      defaultCardPackNameWriteSkipped = updateResult.defaultCardPackNameWriteSkipped;
+      gachaSoundRulesWriteSkipped = updateResult.gachaSoundRulesWriteSkipped;
 
-      // Issue #578: このフェーズで新規追加された列を最初に剥がす(他の既存列より
-      // 未デプロイである可能性が高いため)。
-      if (error && isMissingRarityWeightsScopeColumnError(error) && "rarity_weights_scope" in updateData) {
-        delete updateData.rarity_weights_scope;
-        rarityWeightsScopeWriteSkipped = true;
-        if (Object.keys(updateData).length > 0) {
-          const retryResult = await supabaseAdmin
-            .from("streamers")
-            .update(updateData)
-            .eq("id", streamerId);
-          error = retryResult.error;
-        } else {
-          error = null;
-        }
-      }
-
-      if (error && isMissingPackRarityWeightsColumnError(error) && "pack_rarity_weights" in updateData) {
-        delete updateData.pack_rarity_weights;
-        packRarityWeightsWriteSkipped = true;
-        if (Object.keys(updateData).length > 0) {
-          const retryResult = await supabaseAdmin
-            .from("streamers")
-            .update(updateData)
-            .eq("id", streamerId);
-          error = retryResult.error;
-        } else {
-          error = null;
-        }
-      }
-
-      // Issue #393再設計: 書き込み時点で card_pack_names / channel_point_collection_name
-      // のどちらか(または両方)が未デプロイの可能性があるため、都度1列だけ剥がして再試行する。
-      if (error && isMissingCardPackNamesColumnError(error) && "card_pack_names" in updateData) {
-        delete updateData.card_pack_names;
-        cardPackNamesWriteSkipped = true;
-        if (Object.keys(updateData).length > 0) {
-          const retryResult = await supabaseAdmin
-            .from("streamers")
-            .update(updateData)
-            .eq("id", streamerId);
-          error = retryResult.error;
-        } else {
-          error = null;
-        }
-      }
-
-      if (error && isMissingDefaultCardPackNameColumnError(error) && "default_card_pack_name" in updateData) {
-        delete updateData.default_card_pack_name;
-        defaultCardPackNameWriteSkipped = true;
-        if (Object.keys(updateData).length > 0) {
-          const retryResult = await supabaseAdmin
-            .from("streamers")
-            .update(updateData)
-            .eq("id", streamerId);
-          error = retryResult.error;
-        } else {
-          error = null;
-        }
-      }
-
-      if (error && isMissingCollectionNameColumn(error) && "channel_point_collection_name" in updateData) {
-        delete updateData.channel_point_collection_name;
-        if (Object.keys(updateData).length > 0) {
-          const retryResult = await supabaseAdmin
-            .from("streamers")
-            .update(updateData)
-            .eq("id", streamerId);
-          error = retryResult.error;
-        } else {
-          error = null;
-        }
-      }
-
-      // Issue #176: gacha_sound_rules はこのフィーチャーで新規追加された列。
-      // デプロイ窓では未デプロイの可能性があるため、列を落として旧来の
-      // gacha_sound_url/gacha_sound_enabled のみで再試行する(グレースフルデグレード)。
-      if (
-        error &&
-        gachaSoundRules !== undefined &&
-        (error.code === "PGRST204" || error.message.includes("gacha_sound_rules"))
-      ) {
-        logger.warn("gacha_sound_rules column not available yet; saving legacy sound fallback only");
-        const legacyUpdateData = { ...updateData };
-        delete legacyUpdateData.gacha_sound_rules;
-        gachaSoundRulesWriteSkipped = true;
-        const fallbackResult = await supabaseAdmin
-          .from("streamers")
-          .update(legacyUpdateData)
-          .eq("id", streamerId);
-        error = fallbackResult.error;
-      }
-
-      if (error) {
-        return handleDatabaseError(error, "Streamer Settings API: PUT");
+      if (updateResult.error) {
+        return handleDatabaseError(updateResult.error, "Streamer Settings API: PUT");
       }
     }
 

--- a/src/app/api/support-inquiries/[id]/messages/route.ts
+++ b/src/app/api/support-inquiries/[id]/messages/route.ts
@@ -8,9 +8,127 @@ import { ERROR_MESSAGES } from '@/lib/constants'
 import { handleApiError } from '@/lib/error-handler'
 import { logger } from '@/lib/logger'
 import type { ApiRateLimitResponse } from '@/types/api'
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgWriteEnabled() が false を返すため getDb() は一切呼ばれず、既存の
+// supabase-js 経路が従来どおり実行される。
+// ---------------------------------------------------------------------------
+import { and, eq } from 'drizzle-orm'
+import { getDb } from '@/lib/db/client'
+import { isPgWriteEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import {
+  supportInquiries as supportInquiriesTable,
+  supportInquiryMessages as supportInquiryMessagesTable,
+} from '@/lib/db/schema'
 
 // UUID v4形式のバリデーション
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+interface AddInquiryMessagePgMessage {
+  id: string
+  inquiry_id: string
+  sender_type: string
+  sender_id: string
+  body: string
+  created_at: string | null
+}
+
+type AddInquiryMessagePgResult =
+  | { outcome: 'not_found' }
+  | { outcome: 'closed' }
+  | { outcome: 'error' }
+  | { outcome: 'success'; message: AddInquiryMessagePgMessage }
+
+/**
+ * POST /api/support-inquiries/[id]/messages の pg 直結実装 (#663)
+ *
+ * 読み取り（所有権 + status チェック）と書き込み（メッセージ INSERT）が混在する
+ * ハンドラのため、token-manager.ts の getBotAccountForChatPg と同じ流儀で
+ * 関数全体を isPgWriteEnabled() 一括分岐にする（呼び出し元は
+ * この関数の中だけで完結する結果を受け取り、そのままレスポンスを組み立てる）。
+ *
+ * PostgREST 実装との対応:
+ * - 問い合わせの存在確認 + 所有権チェックは `.single()` 相当（id が PK のため
+ *   LIMIT 1 + rows[0] ?? null）。0 行なら 'not_found'。
+ * - status が 'closed' なら 'closed'。
+ * - メッセージ INSERT は ON CONFLICT の無い一度きりの INSERT のため非冪等
+ *   （既定 = リトライなし。接続断で「実際は成功したか不明」な状態のまま再送すると
+ *   メッセージの二重作成の恐れがある）。
+ */
+async function addInquiryMessagePg(
+  id: string,
+  twitchUserId: string,
+  messageBody: string
+): Promise<AddInquiryMessagePgResult> {
+  try {
+    // 問い合わせの存在確認と所有権チェック
+    const inquiryRows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({
+            id: supportInquiriesTable.id,
+            status: supportInquiriesTable.status,
+            twitch_user_id: supportInquiriesTable.twitch_user_id,
+          })
+          .from(supportInquiriesTable)
+          .where(
+            and(eq(supportInquiriesTable.id, id), eq(supportInquiriesTable.twitch_user_id, twitchUserId))
+          )
+          .limit(1)
+      },
+      'support-inquiries/[id]/messages(fetch inquiry)',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    )
+
+    const inquiry = inquiryRows[0] ?? null
+    if (!inquiry) {
+      return { outcome: 'not_found' }
+    }
+
+    // closedステータスの問い合わせには返信不可
+    if (inquiry.status === 'closed') {
+      return { outcome: 'closed' }
+    }
+
+    // メッセージ追加
+    const messageRows = await withDbRetry(async () => {
+      const { db } = await getDb()
+      return db
+        .insert(supportInquiryMessagesTable)
+        .values({
+          inquiry_id: id,
+          sender_type: 'user',
+          sender_id: twitchUserId,
+          body: messageBody,
+        })
+        .returning({
+          id: supportInquiryMessagesTable.id,
+          inquiry_id: supportInquiryMessagesTable.inquiry_id,
+          sender_type: supportInquiryMessagesTable.sender_type,
+          sender_id: supportInquiryMessagesTable.sender_id,
+          body: supportInquiryMessagesTable.body,
+          created_at: supportInquiryMessagesTable.created_at,
+        })
+      // 非冪等のため withDbRetry の第3引数（idempotent オプション）は渡さない
+    }, 'support-inquiries/[id]/messages(insert)')
+
+    const message = messageRows[0]
+    if (!message) {
+      return { outcome: 'error' }
+    }
+
+    return { outcome: 'success', message }
+  } catch (error) {
+    logger.error('Failed to add inquiry message', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return { outcome: 'error' }
+  }
+}
 
 /**
  * POST /api/support-inquiries/[id]/messages
@@ -66,6 +184,25 @@ export async function POST(
     }
     if (messageBody.length > 2000) {
       return NextResponse.json({ error: ERROR_MESSAGES.INQUIRY_BODY_TOO_LONG }, { status: 400 })
+    }
+
+    // #663: 読み取り（所有権/status チェック）と書き込み（メッセージ INSERT）が
+    // 混在するハンドラのため isPgWriteEnabled() で「関数全体」を分岐する
+    // （token-manager.ts の getBotAccountForChat と同じ方針）。
+    if (isPgWriteEnabled()) {
+      const result = await addInquiryMessagePg(id, session.twitchUserId, messageBody.trim())
+
+      if (result.outcome === 'not_found') {
+        return NextResponse.json({ error: ERROR_MESSAGES.INQUIRY_NOT_FOUND }, { status: 404 })
+      }
+      if (result.outcome === 'closed') {
+        return NextResponse.json({ error: ERROR_MESSAGES.INQUIRY_CLOSED }, { status: 400 })
+      }
+      if (result.outcome === 'error') {
+        return NextResponse.json({ error: ERROR_MESSAGES.INTERNAL_ERROR }, { status: 500 })
+      }
+
+      return NextResponse.json({ message: result.message }, { status: 201 })
     }
 
     const supabase = getSupabaseAdmin()

--- a/src/app/api/support-inquiries/[id]/route.ts
+++ b/src/app/api/support-inquiries/[id]/route.ts
@@ -8,9 +8,147 @@ import { ERROR_MESSAGES } from '@/lib/constants'
 import { handleApiError } from '@/lib/error-handler'
 import { logger } from '@/lib/logger'
 import type { ApiRateLimitResponse } from '@/types/api'
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgReadEnabled() / isPgWriteEnabled() が false を返すため getDb() は一切
+// 呼ばれず、既存の supabase-js 経路が従来どおり実行される。
+// ---------------------------------------------------------------------------
+import { and, asc, eq } from 'drizzle-orm'
+import { getDb } from '@/lib/db/client'
+import { isPgReadEnabled, isPgWriteEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import {
+  supportInquiries as supportInquiriesTable,
+  supportInquiryMessages as supportInquiryMessagesTable,
+} from '@/lib/db/schema'
 
 // UUID v4形式のバリデーション
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+interface SupportInquiryDetailDriverError {
+  message: string
+}
+
+/**
+ * GET /api/support-inquiries/[id] の問い合わせ本体取得の pg 直結実装 (#663)
+ * PostgREST 実装との対応: `.single()` は id が PK のため LIMIT 1 + rows[0] ?? null
+ * で同じ外部挙動（0 行ならルート側で INQUIRY_NOT_FOUND の 404 を返す）。
+ */
+async function fetchInquiryByIdPg(
+  id: string,
+  twitchUserId: string
+): Promise<{ data: unknown | null; error: SupportInquiryDetailDriverError | null }> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({
+            id: supportInquiriesTable.id,
+            twitch_user_id: supportInquiriesTable.twitch_user_id,
+            twitch_display_name: supportInquiriesTable.twitch_display_name,
+            category: supportInquiriesTable.category,
+            subject: supportInquiriesTable.subject,
+            body: supportInquiriesTable.body,
+            status: supportInquiriesTable.status,
+            created_at: supportInquiriesTable.created_at,
+            updated_at: supportInquiriesTable.updated_at,
+          })
+          .from(supportInquiriesTable)
+          .where(
+            and(eq(supportInquiriesTable.id, id), eq(supportInquiriesTable.twitch_user_id, twitchUserId))
+          )
+          .limit(1)
+      },
+      'GET /api/support-inquiries/[id](inquiry)',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    )
+    return { data: rows[0] ?? null, error: null }
+  } catch (error) {
+    return {
+      data: null,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }
+  }
+}
+
+/**
+ * GET /api/support-inquiries/[id] のメッセージ一覧取得の pg 直結実装 (#663)
+ * PostgREST 実装との対応: inquiry_id で絞り込み created_at 昇順で取得するだけの
+ * 単純な読み取り。
+ */
+async function fetchInquiryMessagesPg(
+  inquiryId: string
+): Promise<{ data: unknown[] | null; error: SupportInquiryDetailDriverError | null }> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        const { db } = await getDb()
+        return db
+          .select({
+            id: supportInquiryMessagesTable.id,
+            inquiry_id: supportInquiryMessagesTable.inquiry_id,
+            sender_type: supportInquiryMessagesTable.sender_type,
+            sender_id: supportInquiryMessagesTable.sender_id,
+            body: supportInquiryMessagesTable.body,
+            created_at: supportInquiryMessagesTable.created_at,
+          })
+          .from(supportInquiryMessagesTable)
+          .where(eq(supportInquiryMessagesTable.inquiry_id, inquiryId))
+          .orderBy(asc(supportInquiryMessagesTable.created_at))
+      },
+      'GET /api/support-inquiries/[id](messages)',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    )
+    return { data: rows, error: null }
+  } catch (error) {
+    return {
+      data: null,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }
+  }
+}
+
+/**
+ * DELETE /api/support-inquiries/[id] の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応: `.delete().eq(id).eq(twitch_user_id).select('id').single()`
+ * は `.delete().where(and(eq(id), eq(twitch_user_id))).returning({ id })` の
+ * rows[0] ?? null で同じ外部挙動（対象行なし・他ユーザー所有のいずれも 0 行削除
+ * となり、ルート側で INQUIRY_NOT_FOUND の 404 を返す）。
+ * id（PK）+ 所有権フィルタ指定の DELETE は再実行しても最終状態が同じ（2 回目は
+ * 0 行削除）ため冪等（removeBlobFilePg と同じ判断。リトライ可）。
+ */
+async function deleteSupportInquiryPg(
+  id: string,
+  twitchUserId: string
+): Promise<{ data: { id: string } | null; error: SupportInquiryDetailDriverError | null }> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .delete(supportInquiriesTable)
+          .where(
+            and(eq(supportInquiriesTable.id, id), eq(supportInquiriesTable.twitch_user_id, twitchUserId))
+          )
+          .returning({ id: supportInquiriesTable.id })
+      },
+      'DELETE /api/support-inquiries/[id]',
+      { idempotent: true },
+    )
+    return { data: rows[0] ?? null, error: null }
+  } catch (error) {
+    return {
+      data: null,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }
+  }
+}
 
 /**
  * GET /api/support-inquiries/[id]
@@ -50,26 +188,28 @@ export async function GET(
       )
     }
 
-    const supabase = getSupabaseAdmin()
-
-    // 問い合わせ本体を取得（ユーザーIDで所有権チェック）
-    const { data: inquiry, error: inquiryError } = await supabase
-      .from('support_inquiries')
-      .select('id, twitch_user_id, twitch_display_name, category, subject, body, status, created_at, updated_at')
-      .eq('id', id)
-      .eq('twitch_user_id', session.twitchUserId)
-      .single()
+    // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+    const { data: inquiry, error: inquiryError } = isPgReadEnabled()
+      ? await fetchInquiryByIdPg(id, session.twitchUserId)
+      : await getSupabaseAdmin()
+          .from('support_inquiries')
+          .select('id, twitch_user_id, twitch_display_name, category, subject, body, status, created_at, updated_at')
+          .eq('id', id)
+          .eq('twitch_user_id', session.twitchUserId)
+          .single()
 
     if (inquiryError || !inquiry) {
       return NextResponse.json({ error: ERROR_MESSAGES.INQUIRY_NOT_FOUND }, { status: 404 })
     }
 
     // メッセージを時系列順で取得
-    const { data: messages, error: messagesError } = await supabase
-      .from('support_inquiry_messages')
-      .select('id, inquiry_id, sender_type, sender_id, body, created_at')
-      .eq('inquiry_id', id)
-      .order('created_at', { ascending: true })
+    const { data: messages, error: messagesError } = isPgReadEnabled()
+      ? await fetchInquiryMessagesPg(id)
+      : await getSupabaseAdmin()
+          .from('support_inquiry_messages')
+          .select('id, inquiry_id, sender_type, sender_id, body, created_at')
+          .eq('inquiry_id', id)
+          .order('created_at', { ascending: true })
 
     if (messagesError) {
       logger.error('Failed to fetch inquiry messages', { error: messagesError.message })
@@ -130,14 +270,16 @@ export async function DELETE(
       )
     }
 
-    const supabase = getSupabaseAdmin()
-    const { data: deletedInquiry, error } = await supabase
-      .from('support_inquiries')
-      .delete()
-      .eq('id', id)
-      .eq('twitch_user_id', session.twitchUserId)
-      .select('id')
-      .single()
+    // #663: 書き込みのため isPgWriteEnabled() で分岐。
+    const { data: deletedInquiry, error } = isPgWriteEnabled()
+      ? await deleteSupportInquiryPg(id, session.twitchUserId)
+      : await getSupabaseAdmin()
+          .from('support_inquiries')
+          .delete()
+          .eq('id', id)
+          .eq('twitch_user_id', session.twitchUserId)
+          .select('id')
+          .single()
 
     if (error || !deletedInquiry) {
       return NextResponse.json({ error: ERROR_MESSAGES.INQUIRY_NOT_FOUND }, { status: 404 })

--- a/src/app/api/support-inquiries/route.ts
+++ b/src/app/api/support-inquiries/route.ts
@@ -8,8 +8,104 @@ import { ERROR_MESSAGES } from '@/lib/constants'
 import { handleApiError } from '@/lib/error-handler'
 import { logger } from '@/lib/logger'
 import type { ApiRateLimitResponse } from '@/types/api'
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgReadEnabled() / isPgWriteEnabled() が false を返すため getDb() は一切
+// 呼ばれず、既存の supabase-js 経路が従来どおり実行される。
+// ---------------------------------------------------------------------------
+import { desc, eq } from 'drizzle-orm'
+import { getDb } from '@/lib/db/client'
+import { isPgReadEnabled, isPgWriteEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import { supportInquiries as supportInquiriesTable } from '@/lib/db/schema'
 
 const VALID_CATEGORIES = ['bug', 'feature', 'other'] as const
+
+interface SupportInquiriesDriverError {
+  message: string
+}
+
+/**
+ * GET /api/support-inquiries の一覧取得の pg 直結実装 (#663)
+ * PostgREST 実装との対応: twitch_user_id で絞り込み created_at 降順で取得する
+ * だけの単純な読み取り。
+ */
+async function fetchSupportInquiriesPg(
+  twitchUserId: string
+): Promise<{ data: unknown[] | null; error: SupportInquiriesDriverError | null }> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({
+            id: supportInquiriesTable.id,
+            twitch_user_id: supportInquiriesTable.twitch_user_id,
+            twitch_display_name: supportInquiriesTable.twitch_display_name,
+            category: supportInquiriesTable.category,
+            subject: supportInquiriesTable.subject,
+            body: supportInquiriesTable.body,
+            status: supportInquiriesTable.status,
+            created_at: supportInquiriesTable.created_at,
+            updated_at: supportInquiriesTable.updated_at,
+          })
+          .from(supportInquiriesTable)
+          .where(eq(supportInquiriesTable.twitch_user_id, twitchUserId))
+          .orderBy(desc(supportInquiriesTable.created_at))
+      },
+      'GET /api/support-inquiries',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    )
+    return { data: rows, error: null }
+  } catch (error) {
+    return {
+      data: null,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }
+  }
+}
+
+/**
+ * POST /api/support-inquiries の新規作成の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応: `.select('id').single()` は `.returning({ id })` の
+ * rows[0] で同じ外部挙動。ON CONFLICT の無い一度きりの INSERT のため非冪等
+ * （既定 = リトライなし。接続断で「実際は成功したか不明」な状態のまま再送すると
+ * 問い合わせの二重作成の恐れがある）。
+ */
+async function insertSupportInquiryPg(payload: {
+  twitchUserId: string
+  twitchDisplayName: string
+  category: string
+  subject: string
+  body: string
+}): Promise<{ data: { id: string } | null; error: SupportInquiriesDriverError | null }> {
+  try {
+    const rows = await withDbRetry(async () => {
+      // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+      const { db } = await getDb()
+      return db
+        .insert(supportInquiriesTable)
+        .values({
+          twitch_user_id: payload.twitchUserId,
+          twitch_display_name: payload.twitchDisplayName,
+          category: payload.category,
+          subject: payload.subject,
+          body: payload.body,
+        })
+        .returning({ id: supportInquiriesTable.id })
+    }, 'POST /api/support-inquiries')
+    // 非冪等のため withDbRetry の第3引数（idempotent オプション）は渡さない
+    return { data: rows[0] ?? null, error: null }
+  } catch (error) {
+    return {
+      data: null,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }
+  }
+}
 
 /**
  * GET /api/support-inquiries
@@ -39,12 +135,14 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    const supabase = getSupabaseAdmin()
-    const { data, error } = await supabase
-      .from('support_inquiries')
-      .select('id, twitch_user_id, twitch_display_name, category, subject, body, status, created_at, updated_at')
-      .eq('twitch_user_id', session.twitchUserId)
-      .order('created_at', { ascending: false })
+    // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+    const { data, error } = isPgReadEnabled()
+      ? await fetchSupportInquiriesPg(session.twitchUserId)
+      : await getSupabaseAdmin()
+          .from('support_inquiries')
+          .select('id, twitch_user_id, twitch_display_name, category, subject, body, status, created_at, updated_at')
+          .eq('twitch_user_id', session.twitchUserId)
+          .order('created_at', { ascending: false })
 
     if (error) {
       logger.error('Failed to fetch support inquiries', { error: error.message })
@@ -111,21 +209,29 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: ERROR_MESSAGES.INQUIRY_BODY_TOO_LONG }, { status: 400 })
     }
 
-    const supabase = getSupabaseAdmin()
-    const { data, error } = await supabase
-      .from('support_inquiries')
-      .insert({
-        twitch_user_id: session.twitchUserId,
-        twitch_display_name: session.twitchDisplayName,
-        category: category,
-        subject: subject.trim(),
-        body: inquiryBody.trim(),
-      })
-      .select('id')
-      .single()
+    // #663: 書き込みのため isPgWriteEnabled() で分岐。
+    const { data, error } = isPgWriteEnabled()
+      ? await insertSupportInquiryPg({
+          twitchUserId: session.twitchUserId,
+          twitchDisplayName: session.twitchDisplayName,
+          category: category,
+          subject: subject.trim(),
+          body: inquiryBody.trim(),
+        })
+      : await getSupabaseAdmin()
+          .from('support_inquiries')
+          .insert({
+            twitch_user_id: session.twitchUserId,
+            twitch_display_name: session.twitchDisplayName,
+            category: category,
+            subject: subject.trim(),
+            body: inquiryBody.trim(),
+          })
+          .select('id')
+          .single()
 
-    if (error) {
-      logger.error('Failed to create support inquiry', { error: error.message })
+    if (error || !data) {
+      logger.error('Failed to create support inquiry', { error: error?.message })
       return NextResponse.json({ error: ERROR_MESSAGES.INTERNAL_ERROR }, { status: 500 })
     }
 

--- a/src/app/api/user-cards/route.ts
+++ b/src/app/api/user-cards/route.ts
@@ -4,6 +4,93 @@ import { NextRequest, NextResponse } from 'next/server'
 import { checkRateLimit, rateLimits, getRateLimitIdentifier } from '@/lib/rate-limit'
 import { handleApiError, handleDatabaseError } from '@/lib/error-handler'
 import { ERROR_MESSAGES } from '@/lib/constants'
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgReadEnabled() が false を返すため getDb() は一切呼ばれず、既存の
+// supabase-js 経路が従来どおり実行される。
+// ---------------------------------------------------------------------------
+import { eq } from 'drizzle-orm'
+import { getDb } from '@/lib/db/client'
+import { isPgReadEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import { userCards as userCardsTable, users as usersTable } from '@/lib/db/schema'
+
+interface UserCardsDriverError {
+  message: string
+}
+
+/**
+ * users 取得の pg 直結実装 (#663)
+ * PostgREST 実装との対応: .maybeSingle() は twitch_user_id の UNIQUE 制約
+ * （migration 00001）により最大 1 行のため LIMIT 1 + rows[0] ?? null で同じ
+ * 外部挙動。
+ */
+async function fetchUserPg(
+  twitchUserId: string
+): Promise<{ data: { id: string; twitch_user_id: string } | null; error: UserCardsDriverError | null }> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({ id: usersTable.id, twitch_user_id: usersTable.twitch_user_id })
+          .from(usersTable)
+          .where(eq(usersTable.twitch_user_id, twitchUserId))
+          .limit(1)
+      },
+      'user-cards(fetch user)',
+      { idempotent: true },
+    )
+    return { data: rows[0] ?? null, error: null }
+  } catch (error) {
+    return {
+      data: null,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }
+  }
+}
+
+/**
+ * user_cards 取得の pg 直結実装 (#663)
+ * PostgREST 実装との対応: .range(0, 9999) は「0〜9999 行目（10000 行）」を返す
+ * PostgREST 独自の指定方法で、Drizzle の .limit(10000) と等価（デフォルト
+ * offset は 0 のため .offset() は不要）。PostgREST デフォルトの 1000 件制限
+ * 回避という既存意図をそのまま引き継ぐ。
+ */
+async function fetchUserCardsPg(
+  userId: string
+): Promise<{
+  data: Array<{ id: string; user_id: string; card_id: string; obtained_at: string | null }> | null
+  error: UserCardsDriverError | null
+}> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({
+            id: userCardsTable.id,
+            user_id: userCardsTable.user_id,
+            card_id: userCardsTable.card_id,
+            obtained_at: userCardsTable.obtained_at,
+          })
+          .from(userCardsTable)
+          .where(eq(userCardsTable.user_id, userId))
+          .limit(10000)
+      },
+      'user-cards(fetch cards)',
+      { idempotent: true },
+    )
+    return { data: rows, error: null }
+  } catch (error) {
+    return {
+      data: null,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    }
+  }
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -33,15 +120,16 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    const supabaseAdmin = getSupabaseAdmin()
-
     // Get user data
     // ユーザーデータを取得
-    const { data: userData, error: userError } = await supabaseAdmin
-      .from('users')
-      .select('id, twitch_user_id')
-      .eq('twitch_user_id', session.twitchUserId)
-      .maybeSingle()
+    // #663: 読み取り専用のため isPgReadEnabled() で分岐。
+    const { data: userData, error: userError } = isPgReadEnabled()
+      ? await fetchUserPg(session.twitchUserId)
+      : await getSupabaseAdmin()
+          .from('users')
+          .select('id, twitch_user_id')
+          .eq('twitch_user_id', session.twitchUserId)
+          .maybeSingle()
 
     if (userError || !userData) {
       return handleDatabaseError(userError ?? new Error('User not found'), "Failed to fetch user data")
@@ -50,11 +138,13 @@ export async function GET(request: NextRequest) {
     // Get user's cards with details
     // ユーザーのカード詳細を取得
     // .range(0, 9999) でPostgRESTデフォルト1000件制限を回避
-    const { data: userCards, error: cardsError } = await supabaseAdmin
-      .from('user_cards')
-      .select('id, user_id, card_id, obtained_at')
-      .eq('user_id', userData.id)
-      .range(0, 9999)
+    const { data: userCards, error: cardsError } = isPgReadEnabled()
+      ? await fetchUserCardsPg(userData.id)
+      : await getSupabaseAdmin()
+          .from('user_cards')
+          .select('id, user_id, card_id, obtained_at')
+          .eq('user_id', userData.id)
+          .range(0, 9999)
 
     if (cardsError) {
       return handleDatabaseError(cardsError, "Failed to fetch user cards")

--- a/src/lib/collections/collection-existence.ts
+++ b/src/lib/collections/collection-existence.ts
@@ -11,6 +11,16 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/database";
 import { DEFAULT_PACK_SENTINEL } from "@/lib/validation/collection-name";
+// -----------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。checkCollectionHasActiveCards は
+// 読み取り専用（COUNT のみ）のため isPgReadEnabled() で分岐する。既存 supabase-js
+// 実装は 1 文字も変えず、フラグ未設定時は完全に従来どおり動く。
+// -----------------------------------------------------------------------------
+import { and, count, eq, isNull } from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
+import { isPgReadEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+import { cards as cardsTable } from "@/lib/db/schema";
 
 /**
  * Detect the "collection_name column is not deployed yet" schema error.
@@ -201,6 +211,59 @@ export type CollectionExistenceResult =
   | "schema-not-ready"; // collection_name column not deployed yet (deploy window)
 
 /**
+ * checkCollectionHasActiveCards の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応:
+ * - `{ count: "exact", head: true }` は drizzle-orm の count() ヘルパー
+ *   （`sql`count(*)`.mapWith(Number)` 相当）で件数のみ取得する形に置き換える。
+ * - DEFAULT_PACK_SENTINEL の場合は isNull(collection_name)、それ以外は
+ *   eq(collection_name, collectionName)（postgrest 経路と同じ分岐）。
+ * - isMissingCollectionNameColumn は message テキスト（"does not exist" /
+ *   "schema cache"）ベースの汎用判定のため、pg（postgres.js）が throw する
+ *   PostgresError（code: '42703', message に "does not exist" を含む）も
+ *   そのまま判定できる。pg 専用の判定関数は不要（既存ヘルパーをそのまま再利用）。
+ * - 想定外のエラーは throw して呼び出し元で 500 にする（既存と同じ）。
+ */
+async function checkCollectionHasActiveCardsPg(
+  streamerId: string,
+  collectionName: string
+): Promise<CollectionExistenceResult> {
+  const collectionCondition =
+    collectionName === DEFAULT_PACK_SENTINEL
+      ? isNull(cardsTable.collection_name)
+      : eq(cardsTable.collection_name, collectionName);
+
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select({ count: count() })
+          .from(cardsTable)
+          .where(
+            and(
+              eq(cardsTable.streamer_id, streamerId),
+              eq(cardsTable.is_active, true),
+              collectionCondition
+            )
+          );
+      },
+      "checkCollectionHasActiveCards",
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    );
+
+    return (rows[0]?.count ?? 0) > 0 ? "exists" : "absent";
+  } catch (error) {
+    if (isMissingCollectionNameColumn(error as { message?: string; code?: string } | null | undefined)) {
+      return "schema-not-ready";
+    }
+    throw error;
+  }
+}
+
+/**
  * Check whether a streamer has at least one ACTIVE card in the given pack.
  *
  * Gacha only draws from `is_active = true` cards, so a pack made of only inactive
@@ -216,6 +279,12 @@ export async function checkCollectionHasActiveCards(
   streamerId: string,
   collectionName: string
 ): Promise<CollectionExistenceResult> {
+  // #663: 読み取り専用の関数のため isPgReadEnabled() で分岐。
+  // フラグ未設定時（既定 'postgrest'）は素通りし、以下の既存実装が従来どおり動く。
+  if (isPgReadEnabled()) {
+    return checkCollectionHasActiveCardsPg(streamerId, collectionName);
+  }
+
   let query = supabaseAdmin
     .from("cards")
     .select("id", { count: "exact", head: true })

--- a/src/lib/db/cards-safe-columns.ts
+++ b/src/lib/db/cards-safe-columns.ts
@@ -1,0 +1,96 @@
+// -----------------------------------------------------------------------------
+// cards テーブルの「本番未デプロイ8列」フォールバック用ヘルパー (#663 self-review fix)
+//
+// 背景: src/lib/db/schema.ts の cards テーブル定義には、本番 Supabase の実テーブル
+// には存在しない8列（card_number, hp, atk, def, spd, skill_type, skill_name,
+// skill_power）が含まれている(Issue #625で確認済みの既知ドリフト。マイグレーション
+// 履歴上は適用済みだが実テーブルには列が無い)。card_number は #393/#548 以降、
+// INSERT/UPDATE の入力値・ORDER BY 列としての欠落フォールバックが既に
+// card-number-errors.ts / 各ルートに実装されているが、hp/atk/def/spd/skill_*
+// (バトル機能用、未着手のカードバトル機能の残骸)は一度もフォールバック対象に
+// なっていなかった。
+//
+// Drizzle の無指定 `.select()` / `.returning()` は PostgREST の `select("*")`
+// （実在する列だけを動的に返す）と異なり、TypeScript スキーマ定義(schema.ts)に
+// 基づく「静的な列リスト」を生成する。そのため本番でこれらの列を含む
+// SELECT/RETURNING を発行すると `column "hp" does not exist` 等で必ず失敗する。
+//
+// 対応方針: 既存の「まず試す→列不足エラーを検知→列を除いて再試行」パターン
+// (card-number-errors.ts 等)を、SELECT/RETURNING の出力列リストにも適用する。
+// まず無指定(全列)を試み、失敗したらここで定義する明示列リスト
+// (CARDS_SAFE_COLUMNS)で再試行する。preview 等、実際に8列が存在する環境では
+// 無指定 select/returning がそのまま成功するため、明示列リストへは経路が
+// 到達しない(= 全列を返す挙動を維持。postgrest 経路とのパリティを保つ)。
+// -----------------------------------------------------------------------------
+
+import { cards as cardsTable } from "@/lib/db/schema";
+
+/**
+ * 本番 Supabase の cards テーブルに実在しないことが確認済みの8列 (Issue #625,
+ * scripts/verify-db-schema.js による実測)。card_number はカード番号採番用、
+ * 残り7列は未着手のカードバトル機能用に schema.ts へ定義されているだけで、
+ * 対応するマイグレーションが本番に適用されていない。
+ */
+export const CARDS_MISSING_IN_PRODUCTION_COLUMNS = [
+  "card_number",
+  "hp",
+  "atk",
+  "def",
+  "spd",
+  "skill_type",
+  "skill_name",
+  "skill_power",
+] as const;
+
+/**
+ * 上記8列を除いた cards テーブルの明示的な列オブジェクト。
+ * Drizzle の `.select({ ... })` / `.returning({ ... })` にそのまま渡せる。
+ *
+ * rarity_order は GENERATED ALWAYS AS ... STORED の生成カラムで INSERT/UPDATE
+ * 対象外だが、SELECT/RETURNING は可能かつ本番に実在するため含める
+ * (postgrest 経路の select("*") も返す)。
+ */
+export const CARDS_SAFE_COLUMNS = {
+  id: cardsTable.id,
+  streamer_id: cardsTable.streamer_id,
+  name: cardsTable.name,
+  description: cardsTable.description,
+  image_url: cardsTable.image_url,
+  rarity: cardsTable.rarity,
+  rarity_order: cardsTable.rarity_order,
+  drop_rate: cardsTable.drop_rate,
+  intra_rarity_weight: cardsTable.intra_rarity_weight,
+  max_issuance_count: cardsTable.max_issuance_count,
+  collection_name: cardsTable.collection_name,
+  is_active: cardsTable.is_active,
+  created_at: cardsTable.created_at,
+  updated_at: cardsTable.updated_at,
+} as const;
+
+/**
+ * 「cards テーブルの本番未デプロイ8列のいずれかが存在しない」ことによる
+ * SELECT/RETURNING 失敗を検知する。card-number-errors.ts の
+ * isMissingCardNumberColumnError と同じ判定ロジック（postgrest 由来の
+ * "schema cache"/PGRST204、raw postgres 由来の "column ... does not exist"
+ * (42703) の両方にマッチする汎用テキスト判定）を、8列全てに拡張したもの。
+ *
+ * pg (postgres.js) の RETURNING/SELECT は列リストをまとめて評価するため、
+ * エラーメッセージには通常「最初に解決できなかった1列」のみが含まれる
+ * (例: `column "card_number" of relation "cards" does not exist"`)。
+ * 8列は本番で常にまとめて欠落している(Issue #625)ため、いずれか1列分の
+ * エラーテキストを検知できれば、明示列リストへの再試行で残り7列も含めて
+ * 解消される。
+ */
+export function isMissingCardsBattleColumnError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const err = error as { code?: unknown; message?: unknown; details?: unknown; hint?: unknown };
+  const text = [err.message, err.details, err.hint]
+    .map((value) => String(value || ""))
+    .join(" ");
+
+  const looksLikeSchemaError =
+    text.includes("schema cache") || text.includes("column") || err.code === "PGRST204" || err.code === "42703";
+  if (!looksLikeSchemaError) return false;
+
+  return CARDS_MISSING_IN_PRODUCTION_COLUMNS.some((column) => text.includes(column));
+}

--- a/src/lib/plan.ts
+++ b/src/lib/plan.ts
@@ -20,6 +20,21 @@ import { hasTwitchSub } from '@/lib/twitch/sub-check'
 import { PLAN_PRIORITY, PLAN_STORAGE_BONUS } from '@/lib/plan-constants'
 import { logPerf, perfStart } from '@/lib/perf'
 import type { PlanType } from '@/lib/plan-constants'
+// -----------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。
+// getLicensePlan / getCachedTwitchSubPlan はどちらも読み取り専用のため
+// isPgReadEnabled() で分岐する。既存 supabase-js 実装は 1 文字も変えず、
+// フラグ未設定時は完全に従来どおり動く。
+// -----------------------------------------------------------------------------
+import { and, eq, inArray } from 'drizzle-orm'
+import { getDb } from '@/lib/db/client'
+import { isPgReadEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import {
+  supportCodes as supportCodesTable,
+  userLicenses as userLicensesTable,
+  users as usersTable,
+} from '@/lib/db/schema'
 
 // サーバー側コードからの既存 import を壊さないよう re-export
 export type { PlanType } from '@/lib/plan-constants'
@@ -86,10 +101,69 @@ export const getUserPlanSnapshot = cache(async function getUserPlanSnapshot(twit
 })
 
 /**
+ * getLicensePlan の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応:
+ * - `.select('plan_type, support_codes!inner(status)')` の埋め込み + `.in('support_codes.status', ...)`
+ *   は user_licenses INNER JOIN support_codes（FK: user_licenses.code_id →
+ *   support_codes.id、migration 00017）+ status の inArray() が等価。
+ *   戻り値の消費側は plan_type しか読まないため、support_codes.status は
+ *   JOIN 条件にのみ使い、select 列には含めない。
+ * - エラー/例外時は 'basic' を返す既存の安全側デグレードと同じ外部挙動。
+ */
+async function getLicensePlanPg(twitchUserId: string): Promise<PlanType> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({ plan_type: userLicensesTable.plan_type })
+          .from(userLicensesTable)
+          .innerJoin(supportCodesTable, eq(userLicensesTable.code_id, supportCodesTable.id))
+          .where(
+            and(
+              eq(userLicensesTable.twitch_user_id, twitchUserId),
+              inArray(supportCodesTable.status, ['active', 'rotating'])
+            )
+          )
+      },
+      'getLicensePlan',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    )
+
+    if (rows.length === 0) {
+      return 'basic'
+    }
+
+    // 最上位プランを判定（patron > support > basic）
+    let highestPlan: PlanType = 'basic'
+    for (const license of rows) {
+      const planType = license.plan_type as PlanType
+      if (PLAN_PRIORITY[planType] > PLAN_PRIORITY[highestPlan]) {
+        highestPlan = planType
+      }
+    }
+
+    return highestPlan
+  } catch (error) {
+    logger.error('[Plan] Error getting license plan:', error)
+    return 'basic'
+  }
+}
+
+/**
  * DBライセンスベースのプラン判定（従来のロジック）
  * user_licenses と support_codes(status) をJOINし、有効なコードに紐づくライセンスのみ有効とする。
  */
 async function getLicensePlan(twitchUserId: string): Promise<PlanType> {
+  // #663: 読み取り専用の関数のため isPgReadEnabled() で分岐。
+  // フラグ未設定時（既定 'postgrest'）は素通りし、以下の既存実装が従来どおり動く。
+  if (isPgReadEnabled()) {
+    return getLicensePlanPg(twitchUserId)
+  }
+
   try {
     const supabaseAdmin = getSupabaseAdmin()
 
@@ -128,7 +202,50 @@ async function getLicensePlan(twitchUserId: string): Promise<PlanType> {
   }
 }
 
+/**
+ * getCachedTwitchSubPlan の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応:
+ * - `.maybeSingle()` は twitch_user_id が UNIQUE ではない前提（database.ts に制約
+ *   記載なし）だが、既存実装が maybeSingle（0〜1行）を仮定しているため、
+ *   LIMIT 1 + rows[0] ?? null で同じ外部挙動にする。
+ * - エラー/該当なしは 'basic' を返す既存の安全側デグレードと同じ。
+ */
+async function getCachedTwitchSubPlanPg(twitchUserId: string): Promise<PlanType> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({ twitch_has_sub: usersTable.twitch_has_sub })
+          .from(usersTable)
+          .where(eq(usersTable.twitch_user_id, twitchUserId))
+          .limit(1)
+      },
+      'getCachedTwitchSubPlan',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    )
+    const user = rows[0] ?? null
+
+    if (!user) {
+      return 'basic'
+    }
+
+    return user.twitch_has_sub === true ? 'twitch_sub' : 'basic'
+  } catch (error) {
+    logger.error('[Plan] Error getting cached Twitch sub plan:', error)
+    return 'basic'
+  }
+}
+
 async function getCachedTwitchSubPlan(twitchUserId: string): Promise<PlanType> {
+  // #663: 読み取り専用の関数のため isPgReadEnabled() で分岐。
+  if (isPgReadEnabled()) {
+    return getCachedTwitchSubPlanPg(twitchUserId)
+  }
+
   try {
     const supabaseAdmin = getSupabaseAdmin()
     const { data, error } = await withRetry(

--- a/src/lib/storage-db.ts
+++ b/src/lib/storage-db.ts
@@ -21,9 +21,11 @@ import { logger } from './logger';
 //   本ファイルの書き込み関数内に閉じているため、同一ファイルを 2 段階で触らず
 //   ここで一括置換する（getDb() の sql タグで
 //   `select update_storage_usage(p_xxx => ...)` を名前付き引数呼び出しする）。
+// - storage_usage の集計読み取り（getStorageUsageFromDB / getAllStorageUsage、
+//   #663）も読み取り専用のため isPgReadEnabled() で分岐。
 // 既存 supabase-js 実装は 1 文字も変えず、フラグ未設定時は完全に従来どおり動く。
 // -----------------------------------------------------------------------------
-import { and, eq } from 'drizzle-orm';
+import { and, desc, eq, inArray } from 'drizzle-orm';
 import { getDb } from '@/lib/db/client';
 import { isPgReadEnabled, isPgWriteEnabled } from '@/lib/db/flags';
 import { withDbRetry } from '@/lib/db/retry';
@@ -31,6 +33,7 @@ import {
   blobFiles as blobFilesTable,
   streamers as streamersTable,
   streamerStorageBonus as streamerStorageBonusTable,
+  storageUsage as storageUsageTable,
 } from '@/lib/db/schema';
 
 // グローバル使用量を識別する特殊プレフィックス
@@ -58,7 +61,73 @@ export interface BlobFileInfo {
  * @param userPrefix - ユーザー識別用のプレフィックス（8文字のハッシュ）
  * @returns ストレージ使用量情報
  */
+/**
+ * getStorageUsageFromDB の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応:
+ * - storage_usage を user_prefix IN (userPrefix, GLOBAL_PREFIX) で取得する
+ *   `.in()` は inArray() が等価。
+ * - 取得失敗時は「アップロードをブロックしない」安全側のデフォルト値を返す
+ *   （既存の外側 catch と同じ外部挙動。pg はエラーが throw になるため
+ *   単一の try/catch で同じ結果に落とす）。
+ */
+async function getStorageUsageFromDBPg(userPrefix: string): Promise<StorageUsageResult> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select({
+            user_prefix: storageUsageTable.user_prefix,
+            bytes_used: storageUsageTable.bytes_used,
+          })
+          .from(storageUsageTable)
+          .where(inArray(storageUsageTable.user_prefix, [userPrefix, GLOBAL_PREFIX]));
+      },
+      'getStorageUsageFromDB',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    );
+
+    const userRow = rows.find(r => r.user_prefix === userPrefix);
+    const globalRow = rows.find(r => r.user_prefix === GLOBAL_PREFIX);
+
+    const userUsage = userRow?.bytes_used ?? 0;
+    const globalUsage = globalRow?.bytes_used ?? 0;
+
+    logger.info(`[StorageDB] Usage - User: ${userPrefix} = ${userUsage} bytes, Global = ${globalUsage} bytes`);
+
+    return {
+      userUsage,
+      globalUsage,
+      userLimitReached: userUsage >= UPLOAD_CONFIG.USER_STORAGE_LIMIT,
+      globalLimitReached: globalUsage >= UPLOAD_CONFIG.GLOBAL_STORAGE_LIMIT,
+      userLimitBytes: UPLOAD_CONFIG.USER_STORAGE_LIMIT,
+      globalLimitBytes: UPLOAD_CONFIG.GLOBAL_STORAGE_LIMIT,
+    };
+  } catch (error) {
+    // 使用量を確認できない場合は、アップロードをブロックしないように制限に達していないと仮定
+    // ただし、エラーログは出力する
+    logger.error('[StorageDB] Failed to get storage usage, returning defaults:', error);
+    return {
+      userUsage: 0,
+      globalUsage: 0,
+      userLimitReached: false,
+      globalLimitReached: false,
+      userLimitBytes: UPLOAD_CONFIG.USER_STORAGE_LIMIT,
+      globalLimitBytes: UPLOAD_CONFIG.GLOBAL_STORAGE_LIMIT,
+    };
+  }
+}
+
 export async function getStorageUsageFromDB(userPrefix: string): Promise<StorageUsageResult> {
+  // #663: 読み取り専用の関数のため isPgReadEnabled() で分岐。
+  // フラグ未設定時（既定 'postgrest'）は素通りし、以下の既存実装が従来どおり動く。
+  if (isPgReadEnabled()) {
+    return getStorageUsageFromDBPg(userPrefix);
+  }
+
   try {
     const supabaseAdmin = getSupabaseAdmin();
 
@@ -597,11 +666,60 @@ export const shouldShowVoteCampaign = cache(async function shouldShowVoteCampaig
  *
  * @returns 全ユーザーの使用量一覧
  */
+/**
+ * getAllStorageUsage の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応:
+ * - storage_usage を bytes_used 降順で全件取得。`.order('bytes_used', { ascending: false })`
+ *   は orderBy(desc(...)) が等価。
+ * - 失敗時は log + throw（recordBlobFilePg 等と同じ「取得できないなら呼び出し元に
+ *   伝播する」既存の流れ。デフォルト値へのフォールバックは行わない）。
+ */
+async function getAllStorageUsagePg(): Promise<Array<{
+  userPrefix: string;
+  bytesUsed: number;
+  blobCount: number;
+}>> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb();
+        return db
+          .select({
+            user_prefix: storageUsageTable.user_prefix,
+            bytes_used: storageUsageTable.bytes_used,
+            blob_count: storageUsageTable.blob_count,
+          })
+          .from(storageUsageTable)
+          .orderBy(desc(storageUsageTable.bytes_used));
+      },
+      'getAllStorageUsage',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    );
+
+    return rows.map(row => ({
+      userPrefix: row.user_prefix,
+      bytesUsed: row.bytes_used,
+      blobCount: row.blob_count,
+    }));
+  } catch (error) {
+    logger.error('[StorageDB] Error getting all storage usage:', error);
+    throw error;
+  }
+}
+
 export async function getAllStorageUsage(): Promise<Array<{
   userPrefix: string;
   bytesUsed: number;
   blobCount: number;
 }>> {
+  // #663: 読み取り専用の関数のため isPgReadEnabled() で分岐。
+  if (isPgReadEnabled()) {
+    return getAllStorageUsagePg();
+  }
+
   try {
     const supabaseAdmin = getSupabaseAdmin();
 

--- a/src/lib/support-inquiries.ts
+++ b/src/lib/support-inquiries.ts
@@ -7,6 +7,19 @@
  */
 
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
+// ---------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。フラグ未設定時（既定 'postgrest'）は
+// isPgReadEnabled() が false を返すため getDb() は一切呼ばれず、既存の
+// supabase-js 経路が従来どおり実行される。
+// ---------------------------------------------------------------------------
+import { and, asc, desc, eq } from 'drizzle-orm'
+import { getDb } from '@/lib/db/client'
+import { isPgReadEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import {
+  supportInquiries as supportInquiriesTable,
+  supportInquiryMessages as supportInquiryMessagesTable,
+} from '@/lib/db/schema'
 import { logger } from './logger'
 
 export type InquiryCategory = 'bug' | 'feature' | 'other'
@@ -34,12 +47,60 @@ export interface SupportInquiryMessage {
 }
 
 /**
+ * getUserInquiries の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応: 対象列を twitch_user_id で絞り込み created_at 降順で
+ * 取得するだけの単純な読み取り。取得失敗時は空配列を返す既存の安全側デグレードと
+ * 同じ外部挙動（両方の catch ブロックを 1 つに集約するが、呼び出し元から見た
+ * 結果は変わらない）。
+ */
+async function getUserInquiriesPg(twitchUserId: string): Promise<SupportInquiry[]> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({
+            id: supportInquiriesTable.id,
+            twitch_user_id: supportInquiriesTable.twitch_user_id,
+            twitch_display_name: supportInquiriesTable.twitch_display_name,
+            category: supportInquiriesTable.category,
+            subject: supportInquiriesTable.subject,
+            body: supportInquiriesTable.body,
+            status: supportInquiriesTable.status,
+            created_at: supportInquiriesTable.created_at,
+            updated_at: supportInquiriesTable.updated_at,
+          })
+          .from(supportInquiriesTable)
+          .where(eq(supportInquiriesTable.twitch_user_id, twitchUserId))
+          .orderBy(desc(supportInquiriesTable.created_at))
+      },
+      'getUserInquiries',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    )
+
+    return rows as SupportInquiry[]
+  } catch (error) {
+    logger.error('Error in getUserInquiries', { error })
+    return []
+  }
+}
+
+/**
  * ユーザーの問い合わせ一覧を取得
  *
  * @param twitchUserId - TwitchユーザーID
  * @returns 問い合わせ一覧（作成日時の降順）
  */
 export async function getUserInquiries(twitchUserId: string): Promise<SupportInquiry[]> {
+  // #663: 読み取り専用の関数のため isPgReadEnabled() で分岐。
+  // フラグ未設定時（既定 'postgrest'）は素通りし、以下の既存実装が従来どおり動く。
+  if (isPgReadEnabled()) {
+    return getUserInquiriesPg(twitchUserId)
+  }
+
   try {
     const supabase = getSupabaseAdmin()
 
@@ -62,6 +123,96 @@ export async function getUserInquiries(twitchUserId: string): Promise<SupportInq
 }
 
 /**
+ * getInquiryWithMessages の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応:
+ * - 問い合わせ本体は id + twitch_user_id（所有権チェック）で絞り込む。
+ *   `.single()` は id が PK のため LIMIT 1 + rows[0] ?? null で同じ外部挙動
+ *   （0 行なら null、呼び出し元は関数全体で null を返す）。
+ * - メッセージ取得は既存実装と同じく「独立した try/catch」でラップし、
+ *   本体取得は成功したがメッセージ取得だけ失敗した場合は関数全体を null にせず
+ *   `{ inquiry, messages: [] }` にフォールバックする（既存の部分失敗時の挙動を再現）。
+ */
+async function getInquiryWithMessagesPg(
+  inquiryId: string,
+  twitchUserId: string
+): Promise<{ inquiry: SupportInquiry; messages: SupportInquiryMessage[] } | null> {
+  try {
+    // 問い合わせ本体を取得（ユーザーIDで所有権チェック）
+    const inquiryRows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({
+            id: supportInquiriesTable.id,
+            twitch_user_id: supportInquiriesTable.twitch_user_id,
+            twitch_display_name: supportInquiriesTable.twitch_display_name,
+            category: supportInquiriesTable.category,
+            subject: supportInquiriesTable.subject,
+            body: supportInquiriesTable.body,
+            status: supportInquiriesTable.status,
+            created_at: supportInquiriesTable.created_at,
+            updated_at: supportInquiriesTable.updated_at,
+          })
+          .from(supportInquiriesTable)
+          .where(
+            and(
+              eq(supportInquiriesTable.id, inquiryId),
+              eq(supportInquiriesTable.twitch_user_id, twitchUserId)
+            )
+          )
+          .limit(1)
+      },
+      'getInquiryWithMessages(inquiry)',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    )
+
+    const inquiry = (inquiryRows[0] ?? null) as SupportInquiry | null
+    if (!inquiry) {
+      return null
+    }
+
+    // メッセージを時系列順で取得。この取得だけが失敗しても関数全体は失敗させず
+    // messages: [] にフォールバックする（既存実装と同じ部分失敗時の挙動）。
+    try {
+      const messages = await withDbRetry(
+        async () => {
+          const { db } = await getDb()
+          return db
+            .select({
+              id: supportInquiryMessagesTable.id,
+              inquiry_id: supportInquiryMessagesTable.inquiry_id,
+              sender_type: supportInquiryMessagesTable.sender_type,
+              sender_id: supportInquiryMessagesTable.sender_id,
+              body: supportInquiryMessagesTable.body,
+              created_at: supportInquiryMessagesTable.created_at,
+            })
+            .from(supportInquiryMessagesTable)
+            .where(eq(supportInquiryMessagesTable.inquiry_id, inquiryId))
+            .orderBy(asc(supportInquiryMessagesTable.created_at))
+        },
+        'getInquiryWithMessages(messages)',
+        // 読み取り専用クエリのため冪等（リトライ可）
+        { idempotent: true },
+      )
+
+      return {
+        inquiry,
+        messages: messages as SupportInquiryMessage[],
+      }
+    } catch (messagesError) {
+      logger.error('Failed to fetch inquiry messages', { error: messagesError })
+      return { inquiry, messages: [] }
+    }
+  } catch (error) {
+    logger.error('Error in getInquiryWithMessages', { error })
+    return null
+  }
+}
+
+/**
  * 問い合わせ詳細とメッセージを取得（所有権チェック付き）
  *
  * @param inquiryId - 問い合わせID
@@ -72,6 +223,12 @@ export async function getInquiryWithMessages(
   inquiryId: string,
   twitchUserId: string
 ): Promise<{ inquiry: SupportInquiry; messages: SupportInquiryMessage[] } | null> {
+  // #663: 読み取り専用の関数のため isPgReadEnabled() で分岐。
+  // フラグ未設定時（既定 'postgrest'）は素通りし、以下の既存実装が従来どおり動く。
+  if (isPgReadEnabled()) {
+    return getInquiryWithMessagesPg(inquiryId, twitchUserId)
+  }
+
   try {
     const supabase = getSupabaseAdmin()
 

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -1,23 +1,22 @@
 import { getSupabaseAdmin } from './supabase/admin'
 import { CARD_DESCRIPTION_MAX_CHARACTERS, ERROR_MESSAGES } from './constants'
 import { countCharacters } from './text-utils'
+// -----------------------------------------------------------------------------
+// #663 (#570 パイロット踏襲): pg 直結経路。validateDropRateSum は読み取り専用の
+// ため isPgReadEnabled() で分岐する。既存 supabase-js 実装は 1 文字も変えず、
+// フラグ未設定時は完全に従来どおり動く。
+// -----------------------------------------------------------------------------
+import { and, eq } from 'drizzle-orm'
+import { getDb } from './db/client'
+import { isPgReadEnabled } from './db/flags'
+import { withDbRetry } from './db/retry'
+import { cards as cardsTable } from './db/schema'
 
-export async function validateDropRateSum(
-  supabaseAdmin: ReturnType<typeof getSupabaseAdmin>,
-  streamerId: string,
+function sumDropRates(
+  cards: Array<{ id: string; drop_rate: number }>,
   newDropRate: number,
   excludeCardId?: string
-): Promise<{ valid: boolean; error?: string }> {
-  const { data: cards, error } = await supabaseAdmin
-    .from('cards')
-    .select('id, drop_rate')
-    .eq('streamer_id', streamerId)
-    .eq('is_active', true)
-
-  if (error) {
-    return { valid: false, error: 'Failed to validate drop rates' }
-  }
-
+): { valid: boolean; error?: string } {
   const currentSum = cards
     .filter((c) => c.id !== excludeCardId)
     .reduce((sum, c) => sum + (c.drop_rate || 0), 0)
@@ -32,6 +31,65 @@ export async function validateDropRateSum(
   }
 
   return { valid: true }
+}
+
+/**
+ * validateDropRateSum の pg 直結実装 (#663)
+ *
+ * PostgREST 実装との対応:
+ * - cards を streamer_id = X AND is_active = true で取得。
+ * - 取得失敗時は同じエラーメッセージ（'Failed to validate drop rates'）を返す。
+ */
+async function validateDropRateSumPg(
+  streamerId: string,
+  newDropRate: number,
+  excludeCardId?: string
+): Promise<{ valid: boolean; error?: string }> {
+  let cards: Array<{ id: string; drop_rate: number }>
+  try {
+    cards = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({ id: cardsTable.id, drop_rate: cardsTable.drop_rate })
+          .from(cardsTable)
+          .where(and(eq(cardsTable.streamer_id, streamerId), eq(cardsTable.is_active, true)))
+      },
+      'validateDropRateSum',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true },
+    )
+  } catch {
+    return { valid: false, error: 'Failed to validate drop rates' }
+  }
+
+  return sumDropRates(cards, newDropRate, excludeCardId)
+}
+
+export async function validateDropRateSum(
+  supabaseAdmin: ReturnType<typeof getSupabaseAdmin>,
+  streamerId: string,
+  newDropRate: number,
+  excludeCardId?: string
+): Promise<{ valid: boolean; error?: string }> {
+  // #663: 読み取り専用の関数のため isPgReadEnabled() で分岐。
+  // フラグ未設定時（既定 'postgrest'）は素通りし、以下の既存実装が従来どおり動く。
+  if (isPgReadEnabled()) {
+    return validateDropRateSumPg(streamerId, newDropRate, excludeCardId)
+  }
+
+  const { data: cards, error } = await supabaseAdmin
+    .from('cards')
+    .select('id, drop_rate')
+    .eq('streamer_id', streamerId)
+    .eq('is_active', true)
+
+  if (error) {
+    return { valid: false, error: 'Failed to validate drop rates' }
+  }
+
+  return sumDropRates(cards, newDropRate, excludeCardId)
 }
 
 export function validateCardName(name: unknown): { valid: boolean; error?: string } {

--- a/tests/unit/additional-rewards-driver-parity.test.ts
+++ b/tests/unit/additional-rewards-driver-parity.test.ts
@@ -1,0 +1,547 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — 追加ガチャ報酬APIの
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * 対象: GET/POST/DELETE /api/streamer/additional-rewards
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { getSession, canUseStreamerFeatures } from "@/lib/session";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { validateCSRFToken } from "@/lib/csrf";
+import { validateContentType } from "@/lib/request-validation";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { getDb } from "@/lib/db/client";
+import { streamerAdditionalGachaRewards as streamerAdditionalGachaRewardsTable } from "@/lib/db/schema";
+import { createMockQueryBuilder } from "../utils/supabase-mock";
+
+vi.mock("@/lib/session");
+vi.mock("@/lib/rate-limit");
+vi.mock("@/lib/csrf");
+vi.mock("@/lib/request-validation");
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/supabase/admin", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/supabase/admin")>();
+  return { ...actual, getSupabaseAdmin: vi.fn() };
+});
+
+const mockGetSession = vi.mocked(getSession);
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures);
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken);
+const mockValidateContentType = vi.mocked(validateContentType);
+
+const STREAMER_SESSION = {
+  twitchUserId: "streamer-twitch-1",
+  twitchUsername: "streamer",
+  twitchDisplayName: "Streamer",
+  twitchProfileImageUrl: null,
+  broadcasterType: "affiliate",
+  expiresAt: Date.now() + 60_000,
+  version: 1,
+};
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>;
+  error?: unknown;
+}
+
+function createDrizzleDbMock(
+  config: { selects?: PgResponse[]; inserts?: PgResponse[]; deletes?: PgResponse[] } = {}
+) {
+  let selectIndex = 0;
+  let insertIndex = 0;
+  let deleteIndex = 0;
+  const selectCalls: Array<{ where?: unknown; orderBy?: unknown }> = [];
+  const insertCalls: Array<{ table: unknown; values?: unknown }> = [];
+  const deleteCalls: Array<{ table: unknown; where?: unknown }> = [];
+
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }];
+      const response = responses[Math.min(selectIndex, responses.length - 1)];
+      selectIndex += 1;
+      const call: { where?: unknown; orderBy?: unknown } = {};
+      selectCalls.push(call);
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              (response.rows ?? []).map((row) =>
+                Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+              )
+            );
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        orderBy: vi.fn((condition: unknown) => {
+          call.orderBy = condition;
+          return builder;
+        }),
+        limit: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+    insert: vi.fn((table: unknown) => {
+      const responses = config.inserts ?? [{ rows: [{}] }];
+      const response = responses[Math.min(insertIndex, responses.length - 1)];
+      insertIndex += 1;
+      const call: { table: unknown; values?: unknown } = { table };
+      insertCalls.push(call);
+      const resolve = () => (response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? [{}]));
+      const builder: any = {
+        values: vi.fn((values: unknown) => {
+          call.values = values;
+          return builder;
+        }),
+        returning: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+    delete: vi.fn((table: unknown) => {
+      const responses = config.deletes ?? [{ rows: [] }];
+      const response = responses[Math.min(deleteIndex, responses.length - 1)];
+      deleteIndex += 1;
+      const call: { table: unknown; where?: unknown } = { table };
+      deleteCalls.push(call);
+      const resolve = () => (response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []));
+      const builder: any = {
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        returning: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+  };
+  return { db, selectCalls, insertCalls, deleteCalls };
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any);
+}
+
+function jsonRequest(url: string, method: string, body?: unknown) {
+  return new NextRequest(url, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+async function loadRoute() {
+  return import("@/app/api/streamer/additional-rewards/route");
+}
+
+describe("streamer/additional-rewards: postgrest / pg 経路の互換 (#663)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(STREAMER_SESSION as any);
+    mockCanUseStreamerFeatures.mockReturnValue(true);
+    mockCheckRateLimit.mockResolvedValue({ success: true, limit: 10, remaining: 9, reset: Date.now() + 60_000 } as any);
+    mockValidateCSRFToken.mockResolvedValue({ valid: true } as any);
+    mockValidateContentType.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("GET", () => {
+    it("フラグ未設定時は getDb が呼ばれない（挙動不変の検証）", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const streamerQuery = createMockQueryBuilder();
+      (streamerQuery.maybeSingle as any).mockResolvedValue({ data: { id: "streamer-1" }, error: null });
+      const rewardsQuery = createMockQueryBuilder();
+      (rewardsQuery as any).then = (resolve: (v: unknown) => void) => {
+        resolve({ data: [], error: null });
+        return rewardsQuery;
+      };
+      const fromMock = vi.fn((table: string) => (table === "streamers" ? streamerQuery : rewardsQuery));
+      vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as any);
+
+      const { GET } = await loadRoute();
+      const response = await GET(new NextRequest("http://localhost/api/streamer/additional-rewards"));
+
+      expect(response.status).toBe(200);
+      expect(getDb).not.toHaveBeenCalled();
+    });
+
+    it("DB_DRIVER=pg-read: 同一fixtureで両経路の戻り値が一致する", async () => {
+      const REWARD_ROW = {
+        id: "reward-1",
+        reward_id: "extra-1",
+        reward_name: "Extra",
+        draw_count: 3,
+        is_raid_limited: true,
+        collection_name: "weapons",
+        created_at: "2026-01-01T00:00:00.000Z",
+      };
+
+      vi.stubEnv("DB_DRIVER", undefined);
+      const streamerQuery = createMockQueryBuilder();
+      (streamerQuery.maybeSingle as any).mockResolvedValue({ data: { id: "streamer-1" }, error: null });
+      const rewardsQuery = createMockQueryBuilder();
+      (rewardsQuery as any).then = (resolve: (v: unknown) => void) => {
+        resolve({ data: [REWARD_ROW], error: null });
+        return rewardsQuery;
+      };
+      const fromMock = vi.fn((table: string) => (table === "streamers" ? streamerQuery : rewardsQuery));
+      vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as any);
+      const { GET: postgrestGET } = await loadRoute();
+      const postgrestResponse = await postgrestGET(new NextRequest("http://localhost/api/streamer/additional-rewards"));
+      const postgrestBody = await postgrestResponse.json();
+
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [{ id: "streamer-1" }] }, { rows: [REWARD_ROW] }],
+      });
+      primePgDb(pg);
+      const { GET: pgGET } = await loadRoute();
+      const pgResponse = await pgGET(new NextRequest("http://localhost/api/streamer/additional-rewards"));
+      const pgBody = await pgResponse.json();
+
+      expect(pgResponse.status).toBe(postgrestResponse.status);
+      expect(pgBody).toEqual(postgrestBody);
+      expect(getDb).toHaveBeenCalled();
+      expect(pg.selectCalls[1].where).toEqual(eq(streamerAdditionalGachaRewardsTable.streamer_id, "streamer-1"));
+    });
+
+    it("DB_DRIVER=pg-read: streamerが見つからなければ両経路とも404", async () => {
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] });
+      primePgDb(pg);
+
+      const { GET } = await loadRoute();
+      const response = await GET(new NextRequest("http://localhost/api/streamer/additional-rewards"));
+      expect(response.status).toBe(404);
+    });
+
+    it("DB_DRIVER=pg-read: collection_name列欠落 → raid列欠落の2段カスケードで最小列セットにフォールバックする", async () => {
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      let selectCall = 0;
+      const db = {
+        select: vi.fn((fields: Record<string, unknown>) => {
+          selectCall += 1;
+          const thisCall = selectCall;
+          const builder: any = {
+            from: vi.fn(() => builder),
+            where: vi.fn(() => builder),
+            orderBy: vi.fn(() => builder),
+            limit: vi.fn(() => builder),
+            then: (onFulfilled: any, onRejected: any) => {
+              if (thisCall === 1) {
+                // ownership lookup
+                return Promise.resolve([{ id: "streamer-1" }]).then(onFulfilled, onRejected);
+              }
+              if (thisCall === 2) {
+                // full reward select: collection_name missing
+                return Promise.reject({
+                  code: "42703",
+                  message: "column streamer_additional_gacha_rewards.collection_name does not exist",
+                }).then(onFulfilled, onRejected);
+              }
+              if (thisCall === 3) {
+                // without collection_name: draw_count / is_raid_limited missing
+                return Promise.reject({
+                  code: "42703",
+                  message: "column streamer_additional_gacha_rewards.draw_count does not exist",
+                }).then(onFulfilled, onRejected);
+              }
+              // minimal select
+              return Promise.resolve([
+                Object.fromEntries(
+                  Object.keys(fields).map((k) => [
+                    k,
+                    ({ id: "reward-1", reward_id: "legacy", reward_name: "Legacy", created_at: "2026-01-01T00:00:00.000Z" } as any)[k] ?? null,
+                  ])
+                ),
+              ]).then(onFulfilled, onRejected);
+            },
+          };
+          return builder;
+        }),
+      };
+      vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any);
+
+      const { GET } = await loadRoute();
+      const response = await GET(new NextRequest("http://localhost/api/streamer/additional-rewards"));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual([
+        expect.objectContaining({
+          reward_id: "legacy",
+          draw_count: 1,
+          is_raid_limited: false,
+          collection_name: null,
+        }),
+      ]);
+    });
+  });
+
+  describe("POST", () => {
+    it("DB_DRIVER=pg: 所有権確認 + INSERT が正しいテーブル/値で実行され、戻り値が postgrest 経路と一致する", async () => {
+      const OWNED_STREAMER = { id: "streamer-1", channel_point_reward_id: "main-reward", card_pack_names: [] as string[] };
+      const NEW_REWARD = { id: "additional-1", reward_id: "extra-reward", reward_name: "Extra", draw_count: 5, is_raid_limited: false };
+
+      vi.stubEnv("DB_DRIVER", undefined);
+      const streamerQuery = createMockQueryBuilder();
+      (streamerQuery.maybeSingle as any).mockResolvedValue({ data: OWNED_STREAMER, error: null });
+      const insertQuery = createMockQueryBuilder();
+      (insertQuery.maybeSingle as any).mockResolvedValue({ data: NEW_REWARD, error: null });
+      const fromMock = vi.fn((table: string) => (table === "streamers" ? streamerQuery : insertQuery));
+      vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as any);
+      const { POST: postgrestPOST } = await loadRoute();
+      const postgrestResponse = await postgrestPOST(
+        jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", {
+          rewardId: "extra-reward",
+          rewardName: "Extra",
+          drawCount: 5,
+        })
+      );
+      const postgrestBody = await postgrestResponse.json();
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [OWNED_STREAMER] }],
+        inserts: [{ rows: [NEW_REWARD] }],
+      });
+      primePgDb(pg);
+      const { POST: pgPOST } = await loadRoute();
+      const pgResponse = await pgPOST(
+        jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", {
+          rewardId: "extra-reward",
+          rewardName: "Extra",
+          drawCount: 5,
+        })
+      );
+      const pgBody = await pgResponse.json();
+
+      expect(pgResponse.status).toBe(postgrestResponse.status);
+      expect(pgBody).toEqual(postgrestBody);
+      expect(getDb).toHaveBeenCalled();
+      expect(pg.insertCalls[0].table).toBe(streamerAdditionalGachaRewardsTable);
+      expect(pg.insertCalls[0].values).toEqual(
+        expect.objectContaining({ streamer_id: "streamer-1", reward_id: "extra-reward", draw_count: 5, is_raid_limited: false })
+      );
+    });
+
+    it("DB_DRIVER=pg: raid列欠落エラーなら両経路とも503", async () => {
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [{ id: "streamer-1", channel_point_reward_id: "main-reward", card_pack_names: [] }] }],
+        inserts: [{ error: { code: "PGRST204", message: "Could not find the 'draw_count' column" } }],
+      });
+      primePgDb(pg);
+
+      const { POST } = await loadRoute();
+      const response = await POST(
+        jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", {
+          rewardId: "extra-reward",
+          drawCount: 10,
+          isRaidLimited: true,
+        })
+      );
+
+      expect(response.status).toBe(503);
+    });
+
+    it("DB_DRIVER=pg: 一意制約違反(23505)なら両経路とも409", async () => {
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [{ id: "streamer-1", channel_point_reward_id: "main-reward", card_pack_names: [] }] }],
+        inserts: [{ error: { code: "23505", message: "duplicate key value" } }],
+      });
+      primePgDb(pg);
+
+      const { POST } = await loadRoute();
+      const response = await POST(
+        jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", { rewardId: "extra-reward" })
+      );
+
+      expect(response.status).toBe(409);
+    });
+
+    it("DB_DRIVER=pg: card_pack_names列欠落時は報酬作成を続行しパック紐付けのみ見送る（collectionNameSkippedDeployWindow）", async () => {
+      vi.stubEnv("DB_DRIVER", "pg");
+      let selectCall = 0;
+      const db = {
+        select: vi.fn((fields: Record<string, unknown>) => {
+          selectCall += 1;
+          const thisCall = selectCall;
+          const builder: any = {
+            from: vi.fn(() => builder),
+            where: vi.fn(() => builder),
+            limit: vi.fn(() => builder),
+            then: (onFulfilled: any, onRejected: any) => {
+              if (thisCall === 1) {
+                return Promise.reject({
+                  code: "42703",
+                  message: "column streamers.card_pack_names does not exist",
+                }).then(onFulfilled, onRejected);
+              }
+              return Promise.resolve([
+                Object.fromEntries(
+                  Object.keys(fields).map((k) => [k, ({ id: "streamer-1", channel_point_reward_id: "main-reward" } as any)[k] ?? null])
+                ),
+              ]).then(onFulfilled, onRejected);
+            },
+          };
+          return builder;
+        }),
+        insert: vi.fn(() => {
+          const builder: any = {
+            values: vi.fn(() => builder),
+            returning: vi.fn(() => builder),
+            then: (onFulfilled: any, onRejected: any) =>
+              Promise.resolve([{ id: "additional-1", reward_id: "extra-reward", collection_name: null }]).then(onFulfilled, onRejected),
+          };
+          return builder;
+        }),
+      };
+      vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any);
+
+      const { POST } = await loadRoute();
+      const response = await POST(
+        jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", {
+          rewardId: "extra-reward",
+          rewardName: "Weapons",
+          collectionName: "weapons",
+        })
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.collectionNameSkippedDeployWindow).toBe(true);
+      expect(db.insert).toHaveBeenCalled();
+    });
+
+    it("フラグ未設定 / pg-read では getDb が呼ばれない（POSTは書き込み関数のため isPgWriteEnabled のみで切替）", async () => {
+      const OWNED_STREAMER = { id: "streamer-1", channel_point_reward_id: "main-reward", card_pack_names: [] as string[] };
+      for (const driver of [undefined, "pg-read"]) {
+        vi.clearAllMocks();
+        mockGetSession.mockResolvedValue(STREAMER_SESSION as any);
+        mockCanUseStreamerFeatures.mockReturnValue(true);
+        mockCheckRateLimit.mockResolvedValue({ success: true, limit: 10, remaining: 9, reset: Date.now() + 60_000 } as any);
+        mockValidateCSRFToken.mockResolvedValue({ valid: true } as any);
+        mockValidateContentType.mockReturnValue(null);
+
+        vi.stubEnv("DB_DRIVER", driver as string);
+        const streamerQuery = createMockQueryBuilder();
+        (streamerQuery.maybeSingle as any).mockResolvedValue({ data: OWNED_STREAMER, error: null });
+        const insertQuery = createMockQueryBuilder();
+        (insertQuery.maybeSingle as any).mockResolvedValue({
+          data: { id: "additional-1", reward_id: "extra-reward" },
+          error: null,
+        });
+        const fromMock = vi.fn((table: string) => (table === "streamers" ? streamerQuery : insertQuery));
+        vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as any);
+
+        const { POST } = await loadRoute();
+        const response = await POST(
+          jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", { rewardId: "extra-reward" })
+        );
+        expect(response.status).toBe(200);
+        expect(getDb).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe("DELETE", () => {
+    it("DB_DRIVER=pg: deleteAll=true が正しいテーブル/条件で実行され、deletedCountはpostgrest経路と同じnullを返す", async () => {
+      // postgrest 経路は .delete().select() のみで { count: 'exact' } を要求しない
+      // ため、本番でも response.count は常に null（node_modules/@supabase/
+      // postgrest-js の PostgrestQueryBuilder.delete() で確認済み）。この
+      // #663 移行は「経路の切替のみ」が目的で挙動改善はスコープ外のため、
+      // pg 経路も deletedCount: null で揃える（実際の削除件数を返すよう
+      // 「直した」場合、DB_DRIVER=pg 切替だけでレスポンスの値が変わってしまう）。
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [{ id: "streamer-1" }] }],
+        deletes: [{ rows: [{ id: "r1" }, { id: "r2" }] }],
+      });
+      primePgDb(pg);
+
+      const { DELETE } = await loadRoute();
+      const response = await DELETE(
+        new NextRequest("http://localhost/api/streamer/additional-rewards?deleteAll=true", { method: "DELETE" })
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({ success: true, deletedCount: null });
+      expect(pg.deleteCalls[0].table).toBe(streamerAdditionalGachaRewardsTable);
+      expect(pg.deleteCalls[0].where).toEqual(eq(streamerAdditionalGachaRewardsTable.streamer_id, "streamer-1"));
+    });
+
+    it("DB_DRIVER=pg: rewardId指定の単一削除が正しい条件で実行される", async () => {
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [{ id: "streamer-1" }] }],
+        deletes: [{ rows: [] }],
+      });
+      primePgDb(pg);
+
+      const { DELETE } = await loadRoute();
+      const response = await DELETE(
+        new NextRequest("http://localhost/api/streamer/additional-rewards?rewardId=reward-9", { method: "DELETE" })
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({ success: true });
+      expect(pg.deleteCalls[0].where).toEqual(
+        and(
+          eq(streamerAdditionalGachaRewardsTable.streamer_id, "streamer-1"),
+          eq(streamerAdditionalGachaRewardsTable.reward_id, "reward-9")
+        )
+      );
+    });
+
+    it("DB_DRIVER=pg: streamerが見つからなければ404", async () => {
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] });
+      primePgDb(pg);
+
+      const { DELETE } = await loadRoute();
+      const response = await DELETE(
+        new NextRequest("http://localhost/api/streamer/additional-rewards?deleteAll=true", { method: "DELETE" })
+      );
+      expect(response.status).toBe(404);
+    });
+
+    it("フラグ未設定 / pg-read では getDb が呼ばれない（DELETEは読み書き混在のため isPgWriteEnabled のみで切替）", async () => {
+      for (const driver of [undefined, "pg-read"]) {
+        vi.clearAllMocks();
+        mockGetSession.mockResolvedValue(STREAMER_SESSION as any);
+        mockCanUseStreamerFeatures.mockReturnValue(true);
+        mockCheckRateLimit.mockResolvedValue({ success: true, limit: 10, remaining: 9, reset: Date.now() + 60_000 } as any);
+
+        vi.stubEnv("DB_DRIVER", driver as string);
+        const streamerQuery = createMockQueryBuilder();
+        (streamerQuery.maybeSingle as any).mockResolvedValue({ data: { id: "streamer-1" }, error: null });
+        const deleteQuery = createMockQueryBuilder();
+        const fromMock = vi.fn((table: string) => (table === "streamers" ? streamerQuery : deleteQuery));
+        vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as any);
+
+        const { DELETE } = await loadRoute();
+        const response = await DELETE(
+          new NextRequest("http://localhost/api/streamer/additional-rewards?rewardId=r1", { method: "DELETE" })
+        );
+        expect(response.status).toBe(200);
+        expect(getDb).not.toHaveBeenCalled();
+      }
+    });
+  });
+});

--- a/tests/unit/announcements-read-api-driver-parity.test.ts
+++ b/tests/unit/announcements-read-api-driver-parity.test.ts
@@ -1,0 +1,150 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — POST /api/announcements/read の
+ * postgrest経路 / pg経路パリティテスト
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/announcements/read/route'
+import { getSession } from '@/lib/session'
+import { validateCSRFToken } from '@/lib/csrf'
+import { getDb } from '@/lib/db/client'
+import { announcementReads as announcementReadsTable } from '@/lib/db/schema'
+
+vi.mock('@/lib/session')
+vi.mock('@/lib/csrf')
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn().mockResolvedValue({ success: true, limit: 5, remaining: 4, reset: Date.now() + 60000 }),
+  rateLimits: { announcementRead: {} },
+  getRateLimitIdentifier: vi.fn().mockResolvedValue('user:user123'),
+}))
+
+const mockGetSession = vi.mocked(getSession)
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken)
+
+const ANNOUNCEMENT_ID = '11111111-1111-4111-8111-111111111111'
+
+function createRequest(announcementId: string | null = ANNOUNCEMENT_ID): NextRequest {
+  return new NextRequest('http://localhost:3000/api/announcements/read', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ announcementId }),
+  })
+}
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>
+  error?: unknown
+}
+
+function createDrizzleDbMock(config: { inserts?: PgResponse[] } = {}) {
+  let insertIndex = 0
+  const insertCalls: Array<{ table: unknown; values?: Record<string, unknown>; conflictTarget?: unknown }> = []
+  const db = {
+    insert: vi.fn((table: unknown) => {
+      const responses = config.inserts ?? [{ rows: [] }]
+      const response = responses[Math.min(insertIndex, responses.length - 1)]
+      insertIndex += 1
+      const call: { table: unknown; values?: Record<string, unknown>; conflictTarget?: unknown } = { table }
+      insertCalls.push(call)
+      const resolve = () => (response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []))
+      const builder: any = {
+        values: vi.fn((values: Record<string, unknown>) => {
+          call.values = values
+          return builder
+        }),
+        onConflictDoNothing: vi.fn((opts: { target: unknown }) => {
+          call.conflictTarget = opts.target
+          return builder
+        }),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      }
+      return builder
+    }),
+  }
+  return { db, insertCalls }
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any)
+}
+
+describe('POST /api/announcements/read: postgrest / pg 経路の互換 (#663)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'user123',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: '',
+      broadcasterType: '',
+      expiresAt: Date.now() + 60000,
+      version: 1,
+    } as any)
+    mockValidateCSRFToken.mockResolvedValue({ valid: true } as any)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('フラグ未設定時は getDb が呼ばれない（挙動不変の検証）', async () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue({
+      from: vi.fn(() => ({ upsert: vi.fn().mockResolvedValue({ error: null }) })),
+    } as any)
+
+    const response = await POST(createRequest())
+    expect(response.status).toBe(200)
+    expect(getDb).not.toHaveBeenCalled()
+  })
+
+  it('DB_DRIVER=pg: 正しいテーブル/値でUPSERTされ、200を返す（postgrest経路と同じ外部挙動）', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    const pg = createDrizzleDbMock()
+    primePgDb(pg)
+
+    const response = await POST(createRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ success: true })
+    expect(pg.insertCalls[0].table).toBe(announcementReadsTable)
+    expect(pg.insertCalls[0].values).toEqual({
+      announcement_id: ANNOUNCEMENT_ID,
+      twitch_user_id: 'user123',
+    })
+    expect(pg.insertCalls[0].conflictTarget).toEqual([
+      announcementReadsTable.announcement_id,
+      announcementReadsTable.twitch_user_id,
+    ])
+  })
+
+  it('DB_DRIVER=pg: 重複呼び出し（ON CONFLICT DO NOTHING）でもエラーにならず200を返す', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    const pg = createDrizzleDbMock({ inserts: [{ rows: [] }] })
+    primePgDb(pg)
+
+    const response = await POST(createRequest())
+    expect(response.status).toBe(200)
+  })
+
+  it('DB_DRIVER=pg: DBエラー時は500を返す（postgrest経路と同じ外部挙動）', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    const pg = createDrizzleDbMock({ inserts: [{ error: new Error('connection failure') }] })
+    primePgDb(pg)
+
+    const response = await POST(createRequest())
+    expect(response.status).toBe(500)
+  })
+
+  it('不正なUUID形式では400を返す（DB未到達）', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    const response = await POST(createRequest('not-a-uuid'))
+    expect(response.status).toBe(400)
+    expect(getDb).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/api/cards-batch-route-driver-parity.test.ts
+++ b/tests/unit/api/cards-batch-route-driver-parity.test.ts
@@ -1,0 +1,433 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — POST /api/cards/batch の
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * support-inquiries-routes-driver-parity.test.ts / storage-db-driver-parity.test.ts
+ * と同じ流儀: 同一 fixture を両経路のモックに与え、戻り値・ステータスコードが
+ * deepEqual になることと、pg 経路で正しいテーブル/条件(values)が使われることを
+ * 検証する。このルートにはフォールバックチェーンが無い(postgrest経路にも無い)。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/cards/batch/route";
+import { getSession, canUseStreamerFeatures } from "@/lib/session";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { validateCSRFToken } from "@/lib/csrf";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { getDb } from "@/lib/db/client";
+import { CARDS_SAFE_COLUMNS } from "@/lib/db/cards-safe-columns";
+
+vi.mock("@/lib/session");
+vi.mock("@/lib/rate-limit");
+vi.mock("@/lib/csrf");
+vi.mock("@/lib/supabase/admin", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/supabase/admin")>();
+  return { ...actual, getSupabaseAdmin: vi.fn() };
+});
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/sentry/error-handler", () => ({
+  reportError: vi.fn(),
+  reportApiError: vi.fn(),
+  logErrorFromLogger: vi.fn(),
+}));
+
+const mockGetSession = vi.mocked(getSession);
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures);
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken);
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin);
+
+const SESSION = {
+  twitchUserId: "user1",
+  twitchUsername: "streamer",
+  twitchDisplayName: "Streamer",
+  twitchProfileImageUrl: "",
+  broadcasterType: "affiliate" as const,
+  expiresAt: Date.now() + 60_000,
+  version: 1,
+};
+
+// ---------------------------------------------------------------------------
+// postgrest 経路のモック
+// ---------------------------------------------------------------------------
+
+interface PostgrestResult {
+  data?: unknown;
+  error?: unknown;
+}
+
+function createSupabaseClientMock(resultsByTable: Record<string, PostgrestResult[]>) {
+  const queues = Object.fromEntries(
+    Object.entries(resultsByTable).map(([table, results]) => [table, [...results]])
+  );
+  const insertCalls: Array<{ table: string; values: unknown }> = [];
+
+  const from = vi.fn((table: string) => {
+    const queue = queues[table];
+    if (!queue || queue.length === 0) {
+      throw new Error(`no mock result configured for table: ${table}`);
+    }
+    const result = queue.length > 1 ? (queue.shift() as PostgrestResult) : queue[0];
+    const resolved = { data: result.data ?? null, error: result.error ?? null };
+    const builder: any = {
+      select: vi.fn(() => builder),
+      insert: vi.fn((values: unknown) => {
+        insertCalls.push({ table, values });
+        return builder;
+      }),
+      eq: vi.fn(() => builder),
+      maybeSingle: vi.fn(() => Promise.resolve(resolved)),
+      then: (onFulfilled: any, onRejected: any) => Promise.resolve(resolved).then(onFulfilled, onRejected),
+    };
+    return builder;
+  });
+
+  return { from, insertCalls };
+}
+
+// ---------------------------------------------------------------------------
+// pg 経路のモック
+// ---------------------------------------------------------------------------
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>;
+  error?: unknown;
+}
+
+function createDrizzleDbMock(config: { selects?: PgResponse[]; inserts?: PgResponse[] } = {}) {
+  let selectIndex = 0;
+  let insertIndex = 0;
+  const selectCalls: Array<{ where?: unknown }> = [];
+  const insertCalls: Array<{
+    table: unknown;
+    values?: Record<string, unknown>[];
+    returningFields?: Record<string, unknown>;
+  }> = [];
+
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }];
+      const response = responses[Math.min(selectIndex, responses.length - 1)];
+      selectIndex += 1;
+      const call: { where?: unknown } = {};
+      selectCalls.push(call);
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              (response.rows ?? []).map((row) =>
+                Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+              )
+            );
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        limit: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+    insert: vi.fn((table: unknown) => {
+      const responses = config.inserts ?? [{ rows: [] }];
+      const response = responses[Math.min(insertIndex, responses.length - 1)];
+      insertIndex += 1;
+      const call: {
+        table: unknown;
+        values?: Record<string, unknown>[];
+        returningFields?: Record<string, unknown>;
+      } = { table };
+      insertCalls.push(call);
+      const resolve = () => {
+        if (response.error) return Promise.reject(response.error);
+        const rows = response.rows ?? [];
+        // self-review fix (#663): .returning(CARDS_SAFE_COLUMNS) のような明示列指定時は
+        // fields のキーだけを持つ行にマップし、本番未デプロイ8列(hp/atk等)が実際に
+        // 応答から除外されることをテストで検証できるようにする。
+        const fields = call.returningFields;
+        return Promise.resolve(
+          fields ? rows.map((row) => Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))) : rows
+        );
+      };
+      const builder: any = {
+        values: vi.fn((values: Record<string, unknown>[]) => {
+          call.values = values;
+          return builder;
+        }),
+        returning: vi.fn((fields?: Record<string, unknown>) => {
+          call.returningFields = fields;
+          return builder;
+        }),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+  };
+
+  return { db, selectCalls, insertCalls };
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any);
+}
+
+function createBatchRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/cards/batch", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/cards/batch: postgrest / pg 経路の互換 (#663)", () => {
+  // rarity_weights: null にして recalculateIfAutoMode を即 return null（DB非到達）にする
+  const STREAMER_ROW = { id: "streamer-1", rarity_weights: null };
+  const REQUEST_BODY = {
+    streamerId: "streamer-1",
+    cards: [
+      { name: "Card A", imageUrl: "https://example.com/a.png", rarity: "common", dropRate: 0.5 },
+      { name: "Card B", imageUrl: "https://example.com/b.png", rarity: "rare", dropRate: 0.2, description: "desc" },
+    ],
+  };
+  const CREATED_ROWS = [
+    {
+      id: "card-1",
+      streamer_id: "streamer-1",
+      name: "Card A",
+      description: "",
+      image_url: "https://example.com/a.png",
+      rarity: "common",
+      drop_rate: 0.5,
+    },
+    {
+      id: "card-2",
+      streamer_id: "streamer-1",
+      name: "Card B",
+      description: "desc",
+      image_url: "https://example.com/b.png",
+      rarity: "rare",
+      drop_rate: 0.2,
+    },
+  ];
+  const EXPECTED_INSERT_VALUES = [
+    {
+      streamer_id: "streamer-1",
+      name: "Card A",
+      description: "",
+      image_url: "https://example.com/a.png",
+      rarity: "common",
+      drop_rate: 0.5,
+    },
+    {
+      streamer_id: "streamer-1",
+      name: "Card B",
+      description: "desc",
+      image_url: "https://example.com/b.png",
+      rarity: "rare",
+      drop_rate: 0.2,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(SESSION);
+    mockCanUseStreamerFeatures.mockReturnValue(true);
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: Date.now() + 60_000,
+    });
+    mockValidateCSRFToken.mockResolvedValue({ valid: true });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("成功時: 同一 fixture で両経路の戻り値が deepEqual になり、pg 経路が正しい一括 INSERT values を使う", async () => {
+    vi.stubEnv("DB_DRIVER", undefined);
+    const client = createSupabaseClientMock({
+      streamers: [{ data: STREAMER_ROW }],
+      cards: [{ data: CREATED_ROWS }],
+    });
+    mockGetSupabaseAdmin.mockReturnValue(client as any);
+    const postgrestRes = await POST(createBatchRequest(REQUEST_BODY));
+    expect(postgrestRes.status).toBe(200);
+    const postgrestJson = await postgrestRes.json();
+    expect(client.insertCalls[0].values).toEqual(EXPECTED_INSERT_VALUES);
+
+    vi.stubEnv("DB_DRIVER", "pg");
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [STREAMER_ROW] }],
+      inserts: [{ rows: CREATED_ROWS }],
+    });
+    primePgDb(pg);
+    const pgRes = await POST(createBatchRequest(REQUEST_BODY));
+    expect(pgRes.status).toBe(200);
+    const pgJson = await pgRes.json();
+
+    expect(pgJson).toEqual(postgrestJson);
+    expect(pgJson).toEqual({
+      success: true,
+      created: 2,
+      cards: CREATED_ROWS,
+      recalculatedCards: null,
+    });
+    expect(pg.insertCalls[0].table).toBeDefined();
+    expect(pg.insertCalls[0].values).toEqual(EXPECTED_INSERT_VALUES);
+    expect(pg.insertCalls[0].values).toEqual(client.insertCalls[0].values);
+  });
+
+  it("streamer所有権なし: 両経路とも403を返しINSERTは発生しない", async () => {
+    vi.stubEnv("DB_DRIVER", undefined);
+    const client = createSupabaseClientMock({ streamers: [{ data: null }] });
+    mockGetSupabaseAdmin.mockReturnValue(client as any);
+    const postgrestRes = await POST(createBatchRequest(REQUEST_BODY));
+    expect(postgrestRes.status).toBe(403);
+
+    vi.stubEnv("DB_DRIVER", "pg");
+    const pg = createDrizzleDbMock({ selects: [{ rows: [] }] });
+    primePgDb(pg);
+    const pgRes = await POST(createBatchRequest(REQUEST_BODY));
+    expect(pgRes.status).toBe(403);
+    expect(pg.insertCalls).toHaveLength(0);
+  });
+
+  it("INSERT失敗: 両経路とも500を返す", async () => {
+    const dbError = { code: "XX000", message: "unexpected database error" };
+
+    vi.stubEnv("DB_DRIVER", undefined);
+    const client = createSupabaseClientMock({
+      streamers: [{ data: STREAMER_ROW }],
+      cards: [{ data: null, error: dbError }],
+    });
+    mockGetSupabaseAdmin.mockReturnValue(client as any);
+    const postgrestRes = await POST(createBatchRequest(REQUEST_BODY));
+    expect(postgrestRes.status).toBe(500);
+
+    vi.stubEnv("DB_DRIVER", "pg");
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [STREAMER_ROW] }],
+      inserts: [{ error: dbError }],
+    });
+    primePgDb(pg);
+    const pgRes = await POST(createBatchRequest(REQUEST_BODY));
+    expect(pgRes.status).toBe(500);
+  });
+
+  // self-review fix (#663): 本番 cards テーブルには card_number/hp/atk/def/spd/
+  // skill_type/skill_name/skill_power の8列が実在しない(Issue #625)。cardsToInsert
+  // 自体はこれらの列を一切含まない(batch route はそもそも card_number 等を
+  // 入力しない)ため INSERT の VALUES 自体は成功しうるが、無指定 `.returning()`
+  // が無条件に全列を要求するため hp 等の欠落で失敗する。このルートには入力値の
+  // デプロイ窓フォールバックチェーンが元々無い(点4: 再試行ロジックが一切
+  // 無かった)ため、RETURNING フォールバックが唯一の再試行経路になる。
+  it("本番未デプロイ8列(hp等)RETURNINGフォールバック: 明示列リストで再試行し200を返す", async () => {
+    const missingHpErrorPg = {
+      code: "42703",
+      message: 'column "hp" of relation "cards" does not exist',
+    };
+    // 応答マッピングは CARDS_SAFE_COLUMNS の全キーを含む(未設定分は null)。
+    // モックの returning(fields) が select(fields) と同じ「fields のキーだけを
+    // 持つ行にマップする」実装のため。
+    const CREATED_ROWS_SAFE = [
+      {
+        id: "card-1",
+        streamer_id: "streamer-1",
+        name: "Card A",
+        description: "",
+        image_url: "https://example.com/a.png",
+        rarity: "common",
+        rarity_order: null,
+        drop_rate: 0.5,
+        intra_rarity_weight: null,
+        max_issuance_count: null,
+        collection_name: null,
+        is_active: null,
+        created_at: null,
+        updated_at: null,
+      },
+      {
+        id: "card-2",
+        streamer_id: "streamer-1",
+        name: "Card B",
+        description: "desc",
+        image_url: "https://example.com/b.png",
+        rarity: "rare",
+        rarity_order: null,
+        drop_rate: 0.2,
+        intra_rarity_weight: null,
+        max_issuance_count: null,
+        collection_name: null,
+        is_active: null,
+        created_at: null,
+        updated_at: null,
+      },
+    ];
+
+    vi.stubEnv("DB_DRIVER", "pg");
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [STREAMER_ROW] }],
+      inserts: [
+        { error: missingHpErrorPg }, // attempt1: 無指定RETURNINGがhpで失敗
+        { rows: CREATED_ROWS_SAFE }, // attempt2: SAFE_COLUMNSで再試行し成功
+      ],
+    });
+    primePgDb(pg);
+    const pgRes = await POST(createBatchRequest(REQUEST_BODY));
+    expect(pgRes.status).toBe(200);
+    const pgJson = await pgRes.json();
+
+    expect(pgJson).toEqual({
+      success: true,
+      created: 2,
+      cards: CREATED_ROWS_SAFE,
+      recalculatedCards: null,
+    });
+    expect(pg.insertCalls).toHaveLength(2);
+    expect(pg.insertCalls[0].values).toEqual(EXPECTED_INSERT_VALUES);
+    expect(pg.insertCalls[1].returningFields).toEqual(CARDS_SAFE_COLUMNS);
+    expect(Object.keys(pg.insertCalls[1].returningFields ?? {})).not.toContain("card_number");
+    expect(Object.keys(pg.insertCalls[1].returningFields ?? {})).not.toContain("hp");
+  });
+
+  it("フラグ未設定時は getDb が呼ばれない（挙動不変の検証）", async () => {
+    vi.stubEnv("DB_DRIVER", undefined);
+    const client = createSupabaseClientMock({
+      streamers: [{ data: STREAMER_ROW }],
+      cards: [{ data: CREATED_ROWS }],
+    });
+    mockGetSupabaseAdmin.mockReturnValue(client as any);
+    await POST(createBatchRequest(REQUEST_BODY));
+    expect(getDb).not.toHaveBeenCalled();
+  });
+
+  it("pg-read では書き込み関数のため postgrest のまま（getDb が呼ばれない）", async () => {
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    const client = createSupabaseClientMock({
+      streamers: [{ data: STREAMER_ROW }],
+      cards: [{ data: CREATED_ROWS }],
+    });
+    mockGetSupabaseAdmin.mockReturnValue(client as any);
+    await POST(createBatchRequest(REQUEST_BODY));
+    expect(getDb).not.toHaveBeenCalled();
+  });
+
+  it("pg 経路では supabase-js の .from() が一切呼ばれない", async () => {
+    vi.stubEnv("DB_DRIVER", "pg");
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [STREAMER_ROW] }],
+      inserts: [{ rows: CREATED_ROWS }],
+    });
+    primePgDb(pg);
+    const client = createSupabaseClientMock({});
+    mockGetSupabaseAdmin.mockReturnValue(client as any);
+    await POST(createBatchRequest(REQUEST_BODY));
+    expect(client.from).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/api/cards-id-route-driver-parity.test.ts
+++ b/tests/unit/api/cards-id-route-driver-parity.test.ts
@@ -1,0 +1,630 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — PUT/DELETE /api/cards/[id] の
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * support-inquiries-routes-driver-parity.test.ts / storage-db-driver-parity.test.ts
+ * と同じ流儀: 同一 fixture を両経路のモックに与え、戻り値・ステータスコードが
+ * deepEqual になることと、pg 経路で正しいテーブル/条件(values/where)が使われる
+ * ことを検証する。既存の tests/unit/api/cards-collection-membership.test.ts
+ * （postgrest 経路のみ検証）は変更しない。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { PUT, DELETE } from "@/app/api/cards/[id]/route";
+import { getSession, canUseStreamerFeatures } from "@/lib/session";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { validateCSRFToken } from "@/lib/csrf";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { getDb } from "@/lib/db/client";
+import { removeBlobFile } from "@/lib/storage-db";
+import { CARDS_SAFE_COLUMNS } from "@/lib/db/cards-safe-columns";
+
+vi.mock("@/lib/session");
+vi.mock("@/lib/rate-limit");
+vi.mock("@/lib/csrf");
+vi.mock("@/lib/storage-db");
+vi.mock("@/lib/supabase/admin", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/supabase/admin")>();
+  return { ...actual, getSupabaseAdmin: vi.fn() };
+});
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/sentry/error-handler", () => ({
+  reportError: vi.fn(),
+  reportApiError: vi.fn(),
+  logErrorFromLogger: vi.fn(),
+}));
+
+const mockGetSession = vi.mocked(getSession);
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures);
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken);
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin);
+const mockRemoveBlobFile = vi.mocked(removeBlobFile);
+
+const SESSION = {
+  twitchUserId: "user1",
+  twitchUsername: "streamer",
+  twitchDisplayName: "Streamer",
+  twitchProfileImageUrl: "",
+  broadcasterType: "affiliate" as const,
+  expiresAt: Date.now() + 60_000,
+  version: 1,
+};
+
+const CARD_ID = "card-1";
+
+// ---------------------------------------------------------------------------
+// postgrest 経路のモック: table ごとの結果キュー + insert/update/delete の呼び出し記録
+// ---------------------------------------------------------------------------
+
+interface PostgrestResult {
+  data?: unknown;
+  error?: unknown;
+}
+
+function createSupabaseClientMock(resultsByTable: Record<string, PostgrestResult[]>) {
+  const queues = Object.fromEntries(
+    Object.entries(resultsByTable).map(([table, results]) => [table, [...results]])
+  );
+  const updateCalls: Array<{ table: string; values: unknown }> = [];
+  const deleteCalls: Array<{ table: string }> = [];
+
+  const from = vi.fn((table: string) => {
+    const queue = queues[table];
+    if (!queue || queue.length === 0) {
+      throw new Error(`no mock result configured for table: ${table}`);
+    }
+    const result = queue.length > 1 ? (queue.shift() as PostgrestResult) : queue[0];
+    const resolved = { data: result.data ?? null, error: result.error ?? null };
+    const builder: any = {
+      select: vi.fn(() => builder),
+      update: vi.fn((values: unknown) => {
+        updateCalls.push({ table, values });
+        return builder;
+      }),
+      delete: vi.fn(() => {
+        deleteCalls.push({ table });
+        return builder;
+      }),
+      eq: vi.fn(() => builder),
+      maybeSingle: vi.fn(() => Promise.resolve(resolved)),
+      then: (onFulfilled: any, onRejected: any) => Promise.resolve(resolved).then(onFulfilled, onRejected),
+    };
+    return builder;
+  });
+
+  return { from, updateCalls, deleteCalls };
+}
+
+// ---------------------------------------------------------------------------
+// pg 経路のモック: select(fields).from(table).innerJoin().where().limit() /
+// update(table).set().where().returning() / delete(table).where().returning()
+// を await できる thenable builder
+// ---------------------------------------------------------------------------
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>;
+  error?: unknown;
+}
+
+function createDrizzleDbMock(
+  config: { selects?: PgResponse[]; updates?: PgResponse[]; deletes?: PgResponse[] } = {}
+) {
+  let selectIndex = 0;
+  let updateIndex = 0;
+  let deleteIndex = 0;
+  const selectCalls: Array<{ joins: Array<{ table: unknown; on: unknown }>; where?: unknown }> = [];
+  const updateCalls: Array<{
+    table: unknown;
+    values?: Record<string, unknown>;
+    where?: unknown;
+    returningFields?: Record<string, unknown>;
+  }> = [];
+  const deleteCalls: Array<{ table: unknown; where?: unknown }> = [];
+
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }];
+      const response = responses[Math.min(selectIndex, responses.length - 1)];
+      selectIndex += 1;
+      const call: { joins: Array<{ table: unknown; on: unknown }>; where?: unknown } = { joins: [] };
+      selectCalls.push(call);
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              (response.rows ?? []).map((row) =>
+                Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+              )
+            );
+      const builder: any = {
+        from: vi.fn(() => builder),
+        innerJoin: vi.fn((table: unknown, on: unknown) => {
+          call.joins.push({ table, on });
+          return builder;
+        }),
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        limit: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+    update: vi.fn((table: unknown) => {
+      const responses = config.updates ?? [{ rows: [] }];
+      const response = responses[Math.min(updateIndex, responses.length - 1)];
+      updateIndex += 1;
+      const call: {
+        table: unknown;
+        values?: Record<string, unknown>;
+        where?: unknown;
+        returningFields?: Record<string, unknown>;
+      } = { table };
+      updateCalls.push(call);
+      const resolve = () => {
+        if (response.error) return Promise.reject(response.error);
+        const rows = response.rows ?? [];
+        // self-review fix (#663): .returning(CARDS_SAFE_COLUMNS) のような明示列指定時は
+        // fields のキーだけを持つ行にマップし、本番未デプロイ8列(hp/atk等)が実際に
+        // 応答から除外されることをテストで検証できるようにする。
+        const fields = call.returningFields;
+        return Promise.resolve(
+          fields ? rows.map((row) => Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))) : rows
+        );
+      };
+      const builder: any = {
+        set: vi.fn((values: Record<string, unknown>) => {
+          call.values = values;
+          return builder;
+        }),
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        returning: vi.fn((fields?: Record<string, unknown>) => {
+          call.returningFields = fields;
+          return builder;
+        }),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+    delete: vi.fn((table: unknown) => {
+      const responses = config.deletes ?? [{ rows: [] }];
+      const response = responses[Math.min(deleteIndex, responses.length - 1)];
+      deleteIndex += 1;
+      const call: { table: unknown; where?: unknown } = { table };
+      deleteCalls.push(call);
+      const resolve = () => (response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []));
+      const builder: any = {
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        returning: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+  };
+
+  return { db, selectCalls, updateCalls, deleteCalls };
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any);
+}
+
+function createPutRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest(`http://localhost/api/cards/${CARD_ID}`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function createDeleteRequest(): NextRequest {
+  return new NextRequest(`http://localhost/api/cards/${CARD_ID}`, { method: "DELETE" });
+}
+
+describe("PUT/DELETE /api/cards/[id]: postgrest / pg 経路の互換 (#663)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(SESSION);
+    mockCanUseStreamerFeatures.mockReturnValue(true);
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: Date.now() + 60_000,
+    });
+    mockValidateCSRFToken.mockResolvedValue({ valid: true });
+    mockRemoveBlobFile.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("PUT /api/cards/[id]（読み書き混在: isPgWriteEnabled で関数全体を分岐）", () => {
+    // rarity_weights: null にして recalculateIfAutoMode を即 return null（DB非到達）にする
+    //
+    // postgrest 経路は streamers を「埋め込みオブジェクト」として返す
+    // (card.streamers = {...}) のに対し、pg 経路は cards/streamers を
+    // INNER JOIN したフラットな行を select し、ルート側の fetchCardForUpdatePg が
+    // 同じネスト形状に再構成する。モックの fixture もそれぞれの形状に合わせる。
+    const OWNERSHIP_ROW_POSTGREST = {
+      streamer_id: "streamer-1",
+      image_url: null,
+      rarity: "common",
+      is_active: true,
+      intra_rarity_weight: 1,
+      collection_name: null,
+      streamers: { twitch_user_id: "user1", rarity_weights: null, card_pack_names: [] },
+    };
+    const OWNERSHIP_ROW_PG = {
+      streamer_id: "streamer-1",
+      image_url: null,
+      rarity: "common",
+      is_active: true,
+      intra_rarity_weight: 1,
+      collection_name: null,
+      twitch_user_id: "user1",
+      rarity_weights: null,
+      card_pack_names: [],
+    };
+    const UPDATED_ROW = {
+      id: CARD_ID,
+      streamer_id: "streamer-1",
+      name: "Renamed",
+      description: null,
+      image_url: null,
+      rarity: "common",
+      card_number: null,
+      max_issuance_count: null,
+      collection_name: null,
+      drop_rate: 0.5,
+      intra_rarity_weight: 1,
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+    };
+
+    it("成功時: 同一 fixture で両経路の戻り値が deepEqual になり、pg 経路が正しい UPDATE values を使う", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        cards: [{ data: OWNERSHIP_ROW_POSTGREST }, { data: UPDATED_ROW }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await PUT(createPutRequest({ name: "Renamed" }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+      expect(postgrestRes.status).toBe(200);
+      const postgrestJson = await postgrestRes.json();
+      expect(client.updateCalls[0].values).toEqual({ name: "Renamed" });
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [OWNERSHIP_ROW_PG] }],
+        updates: [{ rows: [UPDATED_ROW] }],
+      });
+      primePgDb(pg);
+      const pgRes = await PUT(createPutRequest({ name: "Renamed" }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+      expect(pgRes.status).toBe(200);
+      const pgJson = await pgRes.json();
+
+      expect(pgJson).toEqual(postgrestJson);
+      expect(pgJson).toEqual({ ...UPDATED_ROW, recalculatedCards: null });
+      expect(pg.updateCalls[0].values).toEqual({ name: "Renamed" });
+      expect(pg.selectCalls[0].joins).toHaveLength(1);
+    });
+
+    it("所有者不一致: 両経路とも403を返しUPDATEは発生しない", async () => {
+      const otherOwnerRowPostgrest = {
+        ...OWNERSHIP_ROW_POSTGREST,
+        streamers: { ...OWNERSHIP_ROW_POSTGREST.streamers, twitch_user_id: "someone-else" },
+      };
+      const otherOwnerRowPg = { ...OWNERSHIP_ROW_PG, twitch_user_id: "someone-else" };
+
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({ cards: [{ data: otherOwnerRowPostgrest }] });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await PUT(createPutRequest({ name: "Renamed" }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+      expect(postgrestRes.status).toBe(403);
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [otherOwnerRowPg] }] });
+      primePgDb(pg);
+      const pgRes = await PUT(createPutRequest({ name: "Renamed" }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+      expect(pgRes.status).toBe(403);
+      expect(pg.updateCalls).toHaveLength(0);
+    });
+
+    it("card_pack_names列デプロイ窓フォールバック: 両経路とも他フィールド編集は継続し200を返す", async () => {
+      const missingColumnErrorPostgrest = {
+        code: "42703",
+        message: "column streamers.card_pack_names does not exist",
+      };
+      const missingColumnErrorPg = {
+        code: "42703",
+        message: "column streamers.card_pack_names does not exist",
+      };
+      const ownershipWithoutPackNamesPostgrest = {
+        ...OWNERSHIP_ROW_POSTGREST,
+        streamers: { twitch_user_id: "user1", rarity_weights: null },
+      };
+      const ownershipWithoutPackNamesPg = { ...OWNERSHIP_ROW_PG };
+      delete (ownershipWithoutPackNamesPg as Record<string, unknown>).card_pack_names;
+
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        cards: [
+          { data: null, error: missingColumnErrorPostgrest },
+          { data: ownershipWithoutPackNamesPostgrest },
+          { data: UPDATED_ROW },
+        ],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await PUT(createPutRequest({ name: "Renamed" }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+      expect(postgrestRes.status).toBe(200);
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ error: missingColumnErrorPg }, { rows: [ownershipWithoutPackNamesPg] }],
+        updates: [{ rows: [UPDATED_ROW] }],
+      });
+      primePgDb(pg);
+      const pgRes = await PUT(createPutRequest({ name: "Renamed" }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+      const pgJson = await pgRes.json();
+
+      expect(pgRes.status).toBe(200);
+      expect(pgJson).toEqual({ ...UPDATED_ROW, recalculatedCards: null });
+    });
+
+    it("card_number列デプロイ窓フォールバック(UPDATE): 両経路とも列を落として再試行し200を返す", async () => {
+      const missingColumnErrorPostgrest = {
+        code: "PGRST204",
+        message: "Could not find the 'card_number' column of 'cards' in the schema cache",
+      };
+      const missingColumnErrorPg = {
+        code: "42703",
+        message: 'column "card_number" of relation "cards" does not exist',
+      };
+
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        cards: [
+          { data: OWNERSHIP_ROW_POSTGREST },
+          { data: null, error: missingColumnErrorPostgrest },
+          { data: UPDATED_ROW },
+        ],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await PUT(createPutRequest({ name: "Renamed", cardNumber: 3 }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+      expect(postgrestRes.status).toBe(200);
+      expect(client.updateCalls[1].values).not.toHaveProperty("card_number");
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [OWNERSHIP_ROW_PG] }],
+        updates: [{ error: missingColumnErrorPg }, { rows: [UPDATED_ROW] }],
+      });
+      primePgDb(pg);
+      const pgRes = await PUT(createPutRequest({ name: "Renamed", cardNumber: 3 }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+      expect(pgRes.status).toBe(200);
+      expect(pg.updateCalls).toHaveLength(2);
+      expect(pg.updateCalls[1].values).not.toHaveProperty("card_number");
+    });
+
+    // self-review fix (#663): 本番 cards テーブルには card_number/hp/atk/def/spd/
+    // skill_type/skill_name/skill_power の8列が実在しない(Issue #625)。無指定
+    // `.returning()` は schema.ts の静的列リストを生成するため、リクエストが
+    // card_number/max_issuance_count/collection_name のどれも変更していない
+    // （updateData に含まれない）場合でも、RETURNING 自体は無条件に全列を
+    // 要求するため hp 等の欠落で失敗する。この末尾フォールバック(SAFE_COLUMNS
+    // への切替)が正しく発動することを検証する。
+    it("本番未デプロイ8列(hp等)RETURNINGフォールバック: card_number等を一切変更しないUPDATEでもRETURNING失敗時に明示列リストで再試行し200を返す", async () => {
+      const missingHpErrorPg = {
+        code: "42703",
+        message: 'column "hp" of relation "cards" does not exist',
+      };
+      const UPDATED_ROW_SAFE = {
+        id: CARD_ID,
+        streamer_id: "streamer-1",
+        name: "Renamed",
+        description: null,
+        image_url: null,
+        rarity: "common",
+        rarity_order: null,
+        max_issuance_count: null,
+        collection_name: null,
+        drop_rate: 0.5,
+        intra_rarity_weight: 1,
+        is_active: true,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-02T00:00:00Z",
+      };
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [OWNERSHIP_ROW_PG] }],
+        updates: [
+          { error: missingHpErrorPg }, // attempt1: 無指定RETURNINGがhpで失敗（updateDataはcard_number等を含まない）
+          { rows: [UPDATED_ROW_SAFE] }, // attempt2: SAFE_COLUMNSで再試行し成功
+        ],
+      });
+      primePgDb(pg);
+      // name のみ変更。card_number/max_issuance_count/collection_name は
+      // リクエストに含めない = updateData に含まれない。
+      const pgRes = await PUT(createPutRequest({ name: "Renamed" }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+      expect(pgRes.status).toBe(200);
+      const pgJson = await pgRes.json();
+
+      expect(pgJson).toEqual({ ...UPDATED_ROW_SAFE, recalculatedCards: null });
+      expect(pg.updateCalls).toHaveLength(2);
+      expect(pg.updateCalls[1].returningFields).toEqual(CARDS_SAFE_COLUMNS);
+      expect(Object.keys(pg.updateCalls[1].returningFields ?? {})).not.toContain("card_number");
+      expect(Object.keys(pg.updateCalls[1].returningFields ?? {})).not.toContain("hp");
+    });
+
+    it("card_number一意制約違反(23505): 両経路とも409を返す", async () => {
+      const conflictError = {
+        code: "23505",
+        message: 'duplicate key value violates unique constraint "cards_streamer_card_number_unique"',
+      };
+
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        cards: [{ data: OWNERSHIP_ROW_POSTGREST }, { data: null, error: conflictError }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await PUT(createPutRequest({ cardNumber: 3 }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+      expect(postgrestRes.status).toBe(409);
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [OWNERSHIP_ROW_PG] }],
+        updates: [{ error: conflictError }],
+      });
+      primePgDb(pg);
+      const pgRes = await PUT(createPutRequest({ cardNumber: 3 }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+      expect(pgRes.status).toBe(409);
+    });
+
+    it("フラグ未設定時は getDb が呼ばれない（挙動不変の検証）", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        cards: [{ data: OWNERSHIP_ROW_POSTGREST }, { data: UPDATED_ROW }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      await PUT(createPutRequest({ name: "Renamed" }), { params: Promise.resolve({ id: CARD_ID }) });
+      expect(getDb).not.toHaveBeenCalled();
+    });
+
+    it("pg-read では書き込み関数のため postgrest のまま（getDb が呼ばれない）", async () => {
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const client = createSupabaseClientMock({
+        cards: [{ data: OWNERSHIP_ROW_POSTGREST }, { data: UPDATED_ROW }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      await PUT(createPutRequest({ name: "Renamed" }), { params: Promise.resolve({ id: CARD_ID }) });
+      expect(getDb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("DELETE /api/cards/[id]（読み書き混在: isPgWriteEnabled で関数全体を分岐、DELETEはidempotent: true）", () => {
+    // postgrest 経路: streamers は埋め込みオブジェクト。pg 経路: cards/streamers を
+    // INNER JOIN したフラットな行を select し、selectCardOwnershipForDeletePg が
+    // 同じネスト形状に再構成する。
+    const OWNERSHIP_ROW_POSTGREST = {
+      streamer_id: "streamer-1",
+      image_url: null,
+      streamers: { twitch_user_id: "user1", rarity_weights: null },
+    };
+    const OWNERSHIP_ROW_PG = {
+      streamer_id: "streamer-1",
+      image_url: null,
+      twitch_user_id: "user1",
+      rarity_weights: null,
+    };
+
+    it("成功時: 同一 fixture で両経路の戻り値が deepEqual になり、pg 経路が id で DELETE する", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({ cards: [{ data: OWNERSHIP_ROW_POSTGREST }] });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await DELETE(createDeleteRequest(), { params: Promise.resolve({ id: CARD_ID }) });
+      expect(postgrestRes.status).toBe(200);
+      const postgrestJson = await postgrestRes.json();
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [OWNERSHIP_ROW_PG] }],
+        deletes: [{ rows: [{ id: CARD_ID }] }],
+      });
+      primePgDb(pg);
+      const pgRes = await DELETE(createDeleteRequest(), { params: Promise.resolve({ id: CARD_ID }) });
+      expect(pgRes.status).toBe(200);
+      const pgJson = await pgRes.json();
+
+      expect(pgJson).toEqual(postgrestJson);
+      expect(pgJson).toEqual({ success: true, recalculatedCards: null });
+      expect(pg.deleteCalls).toHaveLength(1);
+      expect(pg.selectCalls[0].joins).toHaveLength(1);
+    });
+
+    it("所有者不一致: 両経路とも403を返しDELETEは発生しない", async () => {
+      const otherOwnerRowPostgrest = {
+        ...OWNERSHIP_ROW_POSTGREST,
+        streamers: { ...OWNERSHIP_ROW_POSTGREST.streamers, twitch_user_id: "someone-else" },
+      };
+      const otherOwnerRowPg = { ...OWNERSHIP_ROW_PG, twitch_user_id: "someone-else" };
+
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({ cards: [{ data: otherOwnerRowPostgrest }] });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await DELETE(createDeleteRequest(), { params: Promise.resolve({ id: CARD_ID }) });
+      expect(postgrestRes.status).toBe(403);
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [otherOwnerRowPg] }] });
+      primePgDb(pg);
+      const pgRes = await DELETE(createDeleteRequest(), { params: Promise.resolve({ id: CARD_ID }) });
+      expect(pgRes.status).toBe(403);
+      expect(pg.deleteCalls).toHaveLength(0);
+    });
+
+    it("対象カードが存在しない: 両経路とも403を返す", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({ cards: [{ data: null }] });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await DELETE(createDeleteRequest(), { params: Promise.resolve({ id: CARD_ID }) });
+      expect(postgrestRes.status).toBe(403);
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] });
+      primePgDb(pg);
+      const pgRes = await DELETE(createDeleteRequest(), { params: Promise.resolve({ id: CARD_ID }) });
+      expect(pgRes.status).toBe(403);
+    });
+
+    it("フラグ未設定時は getDb が呼ばれない（挙動不変の検証）", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({ cards: [{ data: OWNERSHIP_ROW_POSTGREST }] });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      await DELETE(createDeleteRequest(), { params: Promise.resolve({ id: CARD_ID }) });
+      expect(getDb).not.toHaveBeenCalled();
+    });
+
+    it("pg-read では書き込み関数のため postgrest のまま（getDb が呼ばれない）", async () => {
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const client = createSupabaseClientMock({ cards: [{ data: OWNERSHIP_ROW_POSTGREST }] });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      await DELETE(createDeleteRequest(), { params: Promise.resolve({ id: CARD_ID }) });
+      expect(getDb).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/api/cards-route-driver-parity.test.ts
+++ b/tests/unit/api/cards-route-driver-parity.test.ts
@@ -1,0 +1,639 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — POST/GET /api/cards の
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * support-inquiries-routes-driver-parity.test.ts / storage-db-driver-parity.test.ts
+ * と同じ流儀: 同一 fixture を両経路のモックに与え、戻り値・ステータスコードが
+ * deepEqual になることと、pg 経路で正しいテーブル/条件(values/where)が使われる
+ * ことを検証する。既存の tests/unit/cards-get-api.test.ts /
+ * tests/unit/api/cards-collection-membership.test.ts（postgrest 経路のみ検証）は
+ * 変更しない。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { POST, GET } from "@/app/api/cards/route";
+import { getSession, canUseStreamerFeatures } from "@/lib/session";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { validateCSRFToken } from "@/lib/csrf";
+import { getStorageUsage } from "@/lib/storage-usage";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { getDb } from "@/lib/db/client";
+import { CARDS_SAFE_COLUMNS } from "@/lib/db/cards-safe-columns";
+
+vi.mock("@/lib/session");
+vi.mock("@/lib/rate-limit");
+vi.mock("@/lib/csrf");
+vi.mock("@/lib/storage-usage");
+vi.mock("@/lib/supabase/admin", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/supabase/admin")>();
+  return { ...actual, getSupabaseAdmin: vi.fn() };
+});
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/sentry/error-handler", () => ({
+  reportError: vi.fn(),
+  reportApiError: vi.fn(),
+  logErrorFromLogger: vi.fn(),
+}));
+// GET は unstable_cache でラップされているため、bypass して直接実行させる
+vi.mock("next/cache", () => ({
+  unstable_cache: (fn: () => Promise<unknown>) => fn,
+}));
+
+const mockGetSession = vi.mocked(getSession);
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures);
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken);
+const mockGetStorageUsage = vi.mocked(getStorageUsage);
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin);
+
+const SESSION = {
+  twitchUserId: "user1",
+  twitchUsername: "streamer",
+  twitchDisplayName: "Streamer",
+  twitchProfileImageUrl: "",
+  broadcasterType: "affiliate" as const,
+  expiresAt: Date.now() + 60_000,
+  version: 1,
+};
+
+// ---------------------------------------------------------------------------
+// postgrest 経路のモック: table ごとの結果キュー + insert/update の呼び出し記録
+// ---------------------------------------------------------------------------
+
+interface PostgrestResult {
+  data?: unknown;
+  error?: unknown;
+  count?: number | null;
+}
+
+function createSupabaseClientMock(resultsByTable: Record<string, PostgrestResult[]>) {
+  const queues = Object.fromEntries(
+    Object.entries(resultsByTable).map(([table, results]) => [table, [...results]])
+  );
+  const insertCalls: Array<{ table: string; values: unknown }> = [];
+
+  const from = vi.fn((table: string) => {
+    const queue = queues[table];
+    if (!queue || queue.length === 0) {
+      throw new Error(`no mock result configured for table: ${table}`);
+    }
+    const result = queue.length > 1 ? (queue.shift() as PostgrestResult) : queue[0];
+    const resolved = { data: result.data ?? null, error: result.error ?? null, count: result.count ?? null };
+    const builder: any = {
+      select: vi.fn(() => builder),
+      insert: vi.fn((values: unknown) => {
+        insertCalls.push({ table, values });
+        return builder;
+      }),
+      eq: vi.fn(() => builder),
+      in: vi.fn(() => builder),
+      order: vi.fn(() => builder),
+      range: vi.fn(() => builder),
+      maybeSingle: vi.fn(() => Promise.resolve(resolved)),
+      then: (onFulfilled: any, onRejected: any) => Promise.resolve(resolved).then(onFulfilled, onRejected),
+    };
+    return builder;
+  });
+
+  return { from, insertCalls };
+}
+
+// ---------------------------------------------------------------------------
+// pg 経路のモック: select(fields?).from(table).where().orderBy().limit().offset() /
+// insert(table).values().returning() を await できる thenable builder
+// ---------------------------------------------------------------------------
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>;
+  error?: unknown;
+}
+
+function createDrizzleDbMock(
+  config: { selects?: PgResponse[]; inserts?: PgResponse[] } = {}
+) {
+  let selectIndex = 0;
+  let insertIndex = 0;
+  const selectCalls: Array<{ where?: unknown; orderBy?: unknown[]; limit?: number; offset?: number }> = [];
+  const insertCalls: Array<{
+    table: unknown;
+    values?: Record<string, unknown>;
+    returningFields?: Record<string, unknown>;
+  }> = [];
+
+  const db = {
+    select: vi.fn((fields?: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }];
+      const response = responses[Math.min(selectIndex, responses.length - 1)];
+      selectIndex += 1;
+      const call: { where?: unknown; orderBy?: unknown[]; limit?: number; offset?: number } = {};
+      selectCalls.push(call);
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              fields
+                ? (response.rows ?? []).map((row) =>
+                    Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+                  )
+                : (response.rows ?? [])
+            );
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        orderBy: vi.fn((...conditions: unknown[]) => {
+          call.orderBy = conditions;
+          return builder;
+        }),
+        limit: vi.fn((n: number) => {
+          call.limit = n;
+          return builder;
+        }),
+        offset: vi.fn((n: number) => {
+          call.offset = n;
+          return builder;
+        }),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+    insert: vi.fn((table: unknown) => {
+      const responses = config.inserts ?? [{ rows: [] }];
+      const response = responses[Math.min(insertIndex, responses.length - 1)];
+      insertIndex += 1;
+      const call: { table: unknown; values?: Record<string, unknown>; returningFields?: Record<string, unknown> } = {
+        table,
+      };
+      insertCalls.push(call);
+      const resolve = () => {
+        if (response.error) return Promise.reject(response.error);
+        const rows = response.rows ?? [];
+        // self-review fix (#663): .returning(CARDS_SAFE_COLUMNS) のような明示列指定時は、
+        // select(fields) と同じ「fields のキーだけを持つ行にマップする」フェイクを行い、
+        // 本番未デプロイ8列(hp/atk等)が実際に応答から除外されることをテストで検証できるようにする。
+        const fields = call.returningFields;
+        return Promise.resolve(
+          fields ? rows.map((row) => Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))) : rows
+        );
+      };
+      const builder: any = {
+        values: vi.fn((values: Record<string, unknown>) => {
+          call.values = values;
+          return builder;
+        }),
+        returning: vi.fn((fields?: Record<string, unknown>) => {
+          call.returningFields = fields;
+          return builder;
+        }),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+  };
+
+  return { db, selectCalls, insertCalls };
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any);
+}
+
+function createPostRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/cards", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function createGetRequest(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/cards");
+  Object.entries(params).forEach(([key, value]) => url.searchParams.set(key, value));
+  return new NextRequest(url);
+}
+
+describe("POST/GET /api/cards: postgrest / pg 経路の互換 (#663)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(SESSION);
+    mockCanUseStreamerFeatures.mockReturnValue(true);
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: Date.now() + 60_000,
+    });
+    mockValidateCSRFToken.mockResolvedValue({ valid: true });
+    mockGetStorageUsage.mockResolvedValue({ planOverLimit: false } as Awaited<ReturnType<typeof getStorageUsage>>);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("POST /api/cards（読み書き混在: isPgWriteEnabled で関数全体を分岐）", () => {
+    // rarity_weights: null にして recalculateIfAutoMode を即 return null（DB非到達）にする
+    const STREAMER_ROW = { id: "streamer-1", rarity_weights: null, card_pack_names: [] };
+    const REQUEST_BODY = {
+      streamerId: "streamer-1",
+      name: "Test Card",
+      description: "desc",
+      imageUrl: "https://example.com/a.png",
+      rarity: "common",
+      dropRate: 0.5,
+    };
+    const CREATED_ROW = {
+      id: "card-1",
+      streamer_id: "streamer-1",
+      name: "Test Card",
+      description: "desc",
+      image_url: "https://example.com/a.png",
+      rarity: "common",
+      card_number: null,
+      max_issuance_count: null,
+      collection_name: null,
+      drop_rate: 0.5,
+      intra_rarity_weight: 1,
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+    const EXPECTED_INSERT_VALUES = {
+      streamer_id: "streamer-1",
+      name: "Test Card",
+      description: "desc",
+      image_url: "https://example.com/a.png",
+      rarity: "common",
+      card_number: null,
+      max_issuance_count: null,
+      drop_rate: 0.5,
+    };
+
+    it("成功時: 同一 fixture で両経路の戻り値が deepEqual になり、pg 経路が正しい INSERT values を使う", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        streamers: [{ data: STREAMER_ROW }],
+        cards: [{ data: CREATED_ROW }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await POST(createPostRequest(REQUEST_BODY));
+      expect(postgrestRes.status).toBe(200);
+      const postgrestJson = await postgrestRes.json();
+      expect(client.insertCalls[0].values).toEqual(EXPECTED_INSERT_VALUES);
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [STREAMER_ROW] }],
+        inserts: [{ rows: [CREATED_ROW] }],
+      });
+      primePgDb(pg);
+      const pgRes = await POST(createPostRequest(REQUEST_BODY));
+      expect(pgRes.status).toBe(200);
+      const pgJson = await pgRes.json();
+
+      expect(pgJson).toEqual(postgrestJson);
+      expect(pgJson).toEqual({ ...CREATED_ROW, recalculatedCards: null });
+      expect(pg.insertCalls[0].values).toEqual(EXPECTED_INSERT_VALUES);
+      expect(pg.insertCalls[0].values).toEqual(client.insertCalls[0].values);
+    });
+
+    it("streamer所有権なし: 両経路とも403を返しINSERTは発生しない", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({ streamers: [{ data: null }] });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await POST(createPostRequest(REQUEST_BODY));
+      expect(postgrestRes.status).toBe(403);
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] });
+      primePgDb(pg);
+      const pgRes = await POST(createPostRequest(REQUEST_BODY));
+      expect(pgRes.status).toBe(403);
+      expect(pg.insertCalls).toHaveLength(0);
+    });
+
+    it("card_number列デプロイ窓フォールバック: 両経路とも列を落として再試行し200を返す", async () => {
+      const missingColumnErrorPostgrest = {
+        code: "PGRST204",
+        message: "Could not find the 'card_number' column of 'cards' in the schema cache",
+      };
+      const missingColumnErrorPg = {
+        code: "42703",
+        message: 'column "card_number" of relation "cards" does not exist',
+      };
+
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        streamers: [{ data: STREAMER_ROW }],
+        cards: [{ data: null, error: missingColumnErrorPostgrest }, { data: CREATED_ROW }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await POST(createPostRequest(REQUEST_BODY));
+      expect(postgrestRes.status).toBe(200);
+      expect(client.insertCalls[1].values).not.toHaveProperty("card_number");
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [STREAMER_ROW] }],
+        inserts: [{ error: missingColumnErrorPg }, { rows: [CREATED_ROW] }],
+      });
+      primePgDb(pg);
+      const pgRes = await POST(createPostRequest(REQUEST_BODY));
+      expect(pgRes.status).toBe(200);
+      expect(pg.insertCalls).toHaveLength(2);
+      expect(pg.insertCalls[1].values).not.toHaveProperty("card_number");
+    });
+
+    it("card_number一意制約違反(23505): 両経路とも409を返す", async () => {
+      const conflictErrorPostgrest = {
+        code: "23505",
+        message: 'duplicate key value violates unique constraint "cards_streamer_card_number_unique"',
+      };
+      const conflictErrorPg = {
+        code: "23505",
+        message: 'duplicate key value violates unique constraint "cards_streamer_card_number_unique"',
+      };
+
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        streamers: [{ data: STREAMER_ROW }],
+        cards: [{ data: null, error: conflictErrorPostgrest }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await POST(createPostRequest({ ...REQUEST_BODY, cardNumber: 5 }));
+      expect(postgrestRes.status).toBe(409);
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [STREAMER_ROW] }],
+        inserts: [{ error: conflictErrorPg }],
+      });
+      primePgDb(pg);
+      const pgRes = await POST(createPostRequest({ ...REQUEST_BODY, cardNumber: 5 }));
+      expect(pgRes.status).toBe(409);
+    });
+
+    it("フラグ未設定時は getDb が呼ばれない（挙動不変の検証）", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        streamers: [{ data: STREAMER_ROW }],
+        cards: [{ data: CREATED_ROW }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      await POST(createPostRequest(REQUEST_BODY));
+      expect(getDb).not.toHaveBeenCalled();
+    });
+
+    it("pg-read では書き込み関数のため postgrest のまま（getDb が呼ばれない）", async () => {
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const client = createSupabaseClientMock({
+        streamers: [{ data: STREAMER_ROW }],
+        cards: [{ data: CREATED_ROW }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      await POST(createPostRequest(REQUEST_BODY));
+      expect(getDb).not.toHaveBeenCalled();
+    });
+
+    // self-review fix (#663): 本番 cards テーブルには card_number/hp/atk/def/spd/
+    // skill_type/skill_name/skill_power の8列が実在しない(Issue #625)。無指定
+    // `.returning()` は schema.ts の静的列リストを生成するため、card_number の
+    // 入力値フォールバック(既存3段階)を尽くしてもなお RETURNING 自体が
+    // hp 等の欠落で失敗し続ける。この末尾フォールバック(SAFE_COLUMNS への
+    // 切替)が正しく発動することを検証する。
+    it("本番未デプロイ8列(hp等)RETURNINGフォールバック: card_number除去後もRETURNINGが失敗する場合、明示列リストで再試行し200を返す", async () => {
+      const missingCardNumberErrorPg = {
+        code: "42703",
+        message: 'column "card_number" of relation "cards" does not exist',
+      };
+      const missingHpErrorPg = {
+        code: "42703",
+        message: 'column "hp" of relation "cards" does not exist',
+      };
+      // 本番相当: card_number/hp/atk 等を含まない安全な行（実際に返る形）
+      const CREATED_ROW_SAFE = {
+        id: "card-1",
+        streamer_id: "streamer-1",
+        name: "Test Card",
+        description: "desc",
+        image_url: "https://example.com/a.png",
+        rarity: "common",
+        rarity_order: null,
+        max_issuance_count: null,
+        collection_name: null,
+        drop_rate: 0.5,
+        intra_rarity_weight: 1,
+        is_active: true,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      };
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [STREAMER_ROW] }],
+        inserts: [
+          { error: missingCardNumberErrorPg }, // attempt1: card_number がVALUES+RETURNING両方で失敗
+          { error: missingHpErrorPg }, // attempt2: card_number除去後もRETURNING無指定がhpで失敗
+          { rows: [CREATED_ROW_SAFE] }, // attempt3: SAFE_COLUMNSで再試行し成功
+        ],
+      });
+      primePgDb(pg);
+      const pgRes = await POST(createPostRequest(REQUEST_BODY));
+      expect(pgRes.status).toBe(200);
+      const pgJson = await pgRes.json();
+
+      expect(pgJson).toEqual({ ...CREATED_ROW_SAFE, recalculatedCards: null });
+      expect(pg.insertCalls).toHaveLength(3);
+      expect(pg.insertCalls[1].values).not.toHaveProperty("card_number");
+      expect(pg.insertCalls[2].returningFields).toEqual(CARDS_SAFE_COLUMNS);
+      expect(Object.keys(pg.insertCalls[2].returningFields ?? {})).not.toContain("card_number");
+      expect(Object.keys(pg.insertCalls[2].returningFields ?? {})).not.toContain("hp");
+    });
+  });
+
+  describe("GET /api/cards（読み取り: isPgReadEnabled）", () => {
+    const STREAMER_OWNERSHIP_ROW = { id: "streamer-1" };
+    const CARD_ROWS = [
+      {
+        id: "card-1",
+        streamer_id: "streamer-1",
+        name: "Card A",
+        description: null,
+        image_url: null,
+        rarity: "common",
+        rarity_order: 4,
+        card_number: null,
+        max_issuance_count: null,
+        collection_name: null,
+        drop_rate: 0.5,
+        intra_rarity_weight: 1,
+        is_active: true,
+        created_at: "2026-01-02T00:00:00Z",
+        updated_at: "2026-01-02T00:00:00Z",
+      },
+      {
+        id: "card-2",
+        streamer_id: "streamer-1",
+        name: "Card B",
+        description: null,
+        image_url: null,
+        rarity: "rare",
+        rarity_order: 3,
+        card_number: null,
+        max_issuance_count: null,
+        collection_name: null,
+        drop_rate: 0.2,
+        intra_rarity_weight: 1,
+        is_active: true,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+
+    it("成功時: 同一 fixture で両経路の戻り値(cards/pagination)が deepEqual になる", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        streamers: [{ data: STREAMER_OWNERSHIP_ROW }],
+        cards: [{ data: CARD_ROWS, count: 2 }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await GET(createGetRequest({ streamerId: "streamer-1" }));
+      expect(postgrestRes.status).toBe(200);
+      const postgrestJson = await postgrestRes.json();
+
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [STREAMER_OWNERSHIP_ROW] }, { rows: [{ count: 2 }] }, { rows: CARD_ROWS }],
+      });
+      primePgDb(pg);
+      const pgRes = await GET(createGetRequest({ streamerId: "streamer-1" }));
+      expect(pgRes.status).toBe(200);
+      const pgJson = await pgRes.json();
+
+      expect(pgJson).toEqual(postgrestJson);
+      expect(pgJson.cards).toHaveLength(2);
+      expect(pgJson.pagination).toEqual({ total: 2, limit: 12, offset: 0, hasMore: false });
+    });
+
+    it("streamer所有権なし: 両経路とも403を返す", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({ streamers: [{ data: null }] });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await GET(createGetRequest({ streamerId: "streamer-1" }));
+      expect(postgrestRes.status).toBe(403);
+
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] });
+      primePgDb(pg);
+      const pgRes = await GET(createGetRequest({ streamerId: "streamer-1" }));
+      expect(pgRes.status).toBe(403);
+    });
+
+    it("card_number ソート列デプロイ窓フォールバック: 両経路とも created_at ソートへフォールバックし同じ件数を返す", async () => {
+      const missingColumnErrorPostgrest = {
+        code: "PGRST204",
+        message: "Could not find the 'card_number' column of 'cards' in the schema cache",
+      };
+      const missingColumnErrorPg = {
+        code: "42703",
+        message: 'column "card_number" does not exist',
+      };
+
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        streamers: [{ data: STREAMER_OWNERSHIP_ROW }],
+        cards: [
+          { data: null, error: missingColumnErrorPostgrest, count: null },
+          { data: CARD_ROWS, count: 2 },
+        ],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await GET(createGetRequest({ streamerId: "streamer-1", sortField: "card_number" }));
+      expect(postgrestRes.status).toBe(200);
+      const postgrestJson = await postgrestRes.json();
+
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({
+        selects: [
+          { rows: [STREAMER_OWNERSHIP_ROW] },
+          { rows: [{ count: 2 }] },
+          { error: missingColumnErrorPg },
+          { rows: CARD_ROWS },
+        ],
+      });
+      primePgDb(pg);
+      const pgRes = await GET(createGetRequest({ streamerId: "streamer-1", sortField: "card_number" }));
+      expect(pgRes.status).toBe(200);
+      const pgJson = await pgRes.json();
+
+      expect(pgJson).toEqual(postgrestJson);
+      expect(pgJson.cards).toHaveLength(2);
+      expect(pgJson.pagination.total).toBe(2);
+    });
+
+    // self-review fix (#663): 本番 cards テーブルには card_number/hp/atk/def/spd/
+    // skill_type/skill_name/skill_power の8列が実在しない(Issue #625)。無指定
+    // `.select()` は schema.ts の静的列リストを生成するため、ソート列
+    // フォールバック(card_number→created_at)を伴わないケース(sortField が
+    // created_at 等)でも、hp 等の欠落で SELECT 自体が失敗しうる。明示列リスト
+    // (CARDS_SAFE_COLUMNS)への切替フォールバックが正しく発動することを検証する。
+    it("本番未デプロイ8列(hp等)SELECTフォールバック: 列を落とした明示列リストで再試行し200を返す", async () => {
+      const missingHpErrorPg = {
+        code: "42703",
+        message: 'column "hp" of relation "cards" does not exist',
+      };
+
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({
+        selects: [
+          { rows: [STREAMER_OWNERSHIP_ROW] }, // streamer ownership
+          { rows: [{ count: 2 }] }, // count
+          { error: missingHpErrorPg }, // rows attempt1: unqualified select fails on hp
+          { rows: CARD_ROWS }, // rows attempt2: CARDS_SAFE_COLUMNS select succeeds
+        ],
+      });
+      primePgDb(pg);
+      const pgRes = await GET(createGetRequest({ streamerId: "streamer-1" }));
+      expect(pgRes.status).toBe(200);
+      const pgJson = await pgRes.json();
+
+      expect(pgJson.pagination.total).toBe(2);
+      expect(pgJson.cards).toHaveLength(2);
+      // CARDS_SAFE_COLUMNS は card_number を含まないため、フォールバック後の
+      // 行には card_number キー自体が存在しない（production の select("*") と同じ）。
+      expect(pgJson.cards[0]).not.toHaveProperty("card_number");
+      expect(pgJson.cards[1]).not.toHaveProperty("card_number");
+      expect(pgJson.cards[0]).toMatchObject({ id: "card-1", name: "Card A" });
+      // 3回目(最後)の select 呼び出しが CARDS_SAFE_COLUMNS の明示列リストであることを確認
+      const lastSelectFields = pg.db.select.mock.calls[pg.db.select.mock.calls.length - 1][0];
+      expect(lastSelectFields).toEqual(CARDS_SAFE_COLUMNS);
+    });
+
+    it("フラグ未設定時は getDb が呼ばれない（挙動不変の検証）", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        streamers: [{ data: STREAMER_OWNERSHIP_ROW }],
+        cards: [{ data: CARD_ROWS, count: 2 }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      await GET(createGetRequest({ streamerId: "streamer-1" }));
+      expect(getDb).not.toHaveBeenCalled();
+    });
+
+    it("pg 経路では supabase-js の .from() が一切呼ばれない（getSupabaseAdmin() 自体はDB非到達の軽量呼び出しのため許容）", async () => {
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const client = createSupabaseClientMock({});
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [STREAMER_OWNERSHIP_ROW] }, { rows: [{ count: 2 }] }, { rows: CARD_ROWS }],
+      });
+      primePgDb(pg);
+      await GET(createGetRequest({ streamerId: "streamer-1" }));
+      expect(client.from).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/auth-callback-driver-parity.test.ts
+++ b/tests/unit/auth-callback-driver-parity.test.ts
@@ -1,0 +1,306 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — GET /api/auth/twitch/callback の
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * このルートは4箇所で supabase-js の .from() を呼ぶ:
+ *   1. 既存スコープ読み取り（isPgReadEnabled、スコープ乖離チェック）
+ *   2. users への UPSERT（isPgWriteEnabled、トークン・プロフィール保存）
+ *   3. streamers への UPSERT（isPgWriteEnabled、アフィリエイト時のみ・結果を確認しない best-effort）
+ *   4. users.tos_accepted_at 読み取り（isPgReadEnabled、TOS 同意確認）
+ *
+ * tests/unit/auth-scope-preservation.test.ts のモック構成（next/headers・
+ * next/server・session・supabase/admin 等）を踏襲しつつ、pg 経路のアサーション
+ * を追加する。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { getDb } from '@/lib/db/client'
+import { streamers as streamersTable, users as usersTable } from '@/lib/db/schema'
+
+// next/headers: cookies() mock
+const mockCookieStore = {
+  get: vi.fn(),
+  set: vi.fn(),
+  delete: vi.fn(),
+}
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(() => Promise.resolve(mockCookieStore)),
+}))
+
+vi.mock('@/lib/session', () => ({
+  signSession: (payload: string) => Promise.resolve(payload),
+}))
+
+vi.mock('@/lib/twitch/auth', () => ({
+  getTwitchAuthUrl: vi.fn(() => 'https://twitch.tv/authorize'),
+  exchangeCodeForTokens: vi.fn(),
+  getTwitchUser: vi.fn(),
+  isInvalidAuthorizationCodeError: vi.fn(() => false),
+}))
+
+const mockSaveTwitchScopes = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/twitch/token-manager', () => ({
+  saveTwitchScopes: (...args: unknown[]) => mockSaveTwitchScopes(...args),
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn(() => Promise.resolve({ success: true, limit: 5, remaining: 4, reset: Date.now() + 60000 })),
+  rateLimits: { authCallback: 'authCallback' },
+  getClientIp: vi.fn(() => '127.0.0.1'),
+}))
+
+const mockHandleAuthError = vi.fn((...args: unknown[]) => {
+  const [error, code] = args
+  return {
+    type: 'error',
+    code,
+    error,
+    cookies: { set: vi.fn(), delete: vi.fn() },
+    headers: { get: vi.fn() },
+  }
+})
+vi.mock('@/lib/auth-error-handler', () => ({
+  handleAuthError: (...args: unknown[]) => mockHandleAuthError(...args),
+}))
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('@/lib/url-utils', () => ({
+  getBaseUrl: vi.fn(() => 'http://localhost:3000'),
+}))
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>
+  error?: unknown
+}
+
+function createDrizzleDbMock(config: { selects?: PgResponse[]; inserts?: PgResponse[] } = {}) {
+  let selectIndex = 0
+  let insertIndex = 0
+  const insertCalls: Array<{ table: unknown; values?: Record<string, unknown>; conflictSet?: Record<string, unknown> }> = []
+
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }]
+      const response = responses[Math.min(selectIndex, responses.length - 1)]
+      selectIndex += 1
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              (response.rows ?? []).map((row) =>
+                Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+              )
+            )
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      }
+      return builder
+    }),
+    insert: vi.fn((table: unknown) => {
+      const responses = config.inserts ?? [{ rows: [{}] }]
+      const response = responses[Math.min(insertIndex, responses.length - 1)]
+      insertIndex += 1
+      const call: { table: unknown; values?: Record<string, unknown>; conflictSet?: Record<string, unknown> } = { table }
+      insertCalls.push(call)
+      const resolve = () => (response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []))
+      const builder: any = {
+        values: vi.fn((values: Record<string, unknown>) => {
+          call.values = values
+          return builder
+        }),
+        onConflictDoUpdate: vi.fn((opts: { set: Record<string, unknown> }) => {
+          call.conflictSet = opts.set
+          return builder
+        }),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      }
+      return builder
+    }),
+  }
+  return { db, insertCalls }
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any)
+}
+
+function createSupabaseCallbackMock(options: { existingScopes?: string[] | null; tosAcceptedAt?: string | null } = {}) {
+  const { existingScopes = null, tosAcceptedAt = '2024-01-01' } = options
+  let selectCallCount = 0
+  const maybeSingle = vi.fn(() => {
+    selectCallCount += 1
+    if (selectCallCount === 1) {
+      return Promise.resolve({ data: existingScopes !== null ? { twitch_scopes: existingScopes } : null, error: null })
+    }
+    return Promise.resolve({ data: { tos_accepted_at: tosAcceptedAt }, error: null })
+  })
+  const eqFn = vi.fn(() => ({ maybeSingle }))
+  const select = vi.fn(() => ({ eq: eqFn }))
+  const upsert = vi.fn().mockResolvedValue({ error: null })
+  return { from: vi.fn(() => ({ select, upsert })) }
+}
+
+describe('GET /api/auth/twitch/callback: postgrest / pg 経路の互換 (#663)', () => {
+  let exchangeCodeForTokens: ReturnType<typeof vi.fn>
+  let getTwitchUser: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockSaveTwitchScopes.mockResolvedValue(undefined)
+
+    const auth = await import('@/lib/twitch/auth')
+    exchangeCodeForTokens = vi.mocked(auth.exchangeCodeForTokens)
+    getTwitchUser = vi.mocked(auth.getTwitchUser)
+
+    mockCookieStore.get.mockImplementation((name: string) => {
+      if (name === 'twitch_auth_state') return { value: 'test-state-123' }
+      return undefined
+    })
+
+    exchangeCodeForTokens.mockResolvedValue({
+      access_token: 'test-access-token',
+      refresh_token: 'test-refresh-token',
+      expires_in: 3600,
+      token_type: 'bearer',
+      scope: ['user:read:email'],
+    })
+    getTwitchUser.mockResolvedValue({
+      id: 'user123',
+      login: 'testuser',
+      display_name: 'Test User',
+      profile_image_url: 'https://example.com/avatar.png',
+      broadcaster_type: 'affiliate',
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  function createCallbackRequest() {
+    return new NextRequest('http://localhost:3000/api/auth/twitch/callback?code=test-code&state=test-state-123')
+  }
+
+  it('フラグ未設定時は getDb が呼ばれない（挙動不変の検証）', async () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue(createSupabaseCallbackMock() as any)
+
+    const { GET } = await import('@/app/api/auth/twitch/callback/route')
+    await GET(createCallbackRequest())
+
+    expect(getDb).not.toHaveBeenCalled()
+  })
+
+  it('DB_DRIVER=pg: 既存スコープ読み取り・users UPSERT・streamers UPSERT・TOS読み取りが正しいテーブル/値で実行される', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    const pg = createDrizzleDbMock({
+      selects: [
+        { rows: [] }, // 既存スコープなし（乖離チェック通過）
+        { rows: [{ tos_accepted_at: '2024-01-01' }] }, // TOS同意済み
+      ],
+      inserts: [
+        { rows: [{}] }, // users upsert
+        { rows: [{ id: 'streamer-1' }] }, // streamers upsert（affiliateのため実行される）
+      ],
+    })
+    primePgDb(pg)
+
+    const { GET } = await import('@/app/api/auth/twitch/callback/route')
+    const response = await GET(createCallbackRequest())
+
+    expect(getDb).toHaveBeenCalled()
+    // リダイレクトが成功していること（database_errorに落ちていない）
+    expect(response.status).toBeGreaterThanOrEqual(300)
+    expect(response.status).toBeLessThan(400)
+
+    // 1件目の insert は users（トークン・プロフィール保存）
+    expect(pg.insertCalls[0].table).toBe(usersTable)
+    expect(pg.insertCalls[0].values).toMatchObject({
+      twitch_user_id: 'user123',
+      twitch_username: 'testuser',
+      twitch_access_token: 'test-access-token',
+      twitch_refresh_token: 'test-refresh-token',
+    })
+    expect(pg.insertCalls[0].conflictSet).toEqual(pg.insertCalls[0].values)
+
+    // 2件目の insert は streamers（affiliateのため実行される）
+    expect(pg.insertCalls[1].table).toBe(streamersTable)
+    expect(pg.insertCalls[1].values).toMatchObject({
+      twitch_user_id: 'user123',
+      twitch_username: 'testuser',
+      twitch_display_name: 'Test User',
+    })
+  })
+
+  it('DB_DRIVER=pg: streamers UPSERT が失敗してもコールバック全体は成功する（既存postgrest経路のbest-effort挙動を再現）', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [] }, { rows: [{ tos_accepted_at: '2024-01-01' }] }],
+      inserts: [
+        { rows: [{}] }, // users upsert 成功
+        { error: new Error('constraint violation') }, // streamers upsert 失敗（握りつぶされるはず）
+      ],
+    })
+    primePgDb(pg)
+
+    const { GET } = await import('@/app/api/auth/twitch/callback/route')
+    const response = await GET(createCallbackRequest())
+
+    // streamers upsertが失敗しても database_error にならず、正常にリダイレクトされる
+    expect(response.status).toBeGreaterThanOrEqual(300)
+    expect(response.status).toBeLessThan(400)
+    expect(mockHandleAuthError).not.toHaveBeenCalledWith(
+      expect.anything(),
+      'database_error',
+      expect.objectContaining({ operation: 'upsert_streamer' }),
+      expect.anything()
+    )
+  })
+
+  it('DB_DRIVER=pg: users UPSERT が失敗すると database_error になる（postgrest経路と同じ外部挙動）', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [] }],
+      inserts: [{ error: new Error('connection lost') }],
+    })
+    primePgDb(pg)
+
+    const { GET } = await import('@/app/api/auth/twitch/callback/route')
+    await GET(createCallbackRequest())
+
+    expect(mockHandleAuthError).toHaveBeenCalledWith(
+      expect.anything(),
+      'database_error',
+      expect.objectContaining({ operation: 'upsert_user' }),
+      { baseUrl: 'http://localhost:3000' }
+    )
+  })
+
+  it('postgrest経路とpg経路で最終的なリダイレクト先（TOS同意状況）が一致する', async () => {
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue(createSupabaseCallbackMock({ tosAcceptedAt: null }) as any)
+
+    const { GET: getWithPostgrest } = await import('@/app/api/auth/twitch/callback/route')
+    const postgrestResponse = await getWithPostgrest(createCallbackRequest())
+    const postgrestLocation = postgrestResponse.headers.get('location')
+
+    vi.stubEnv('DB_DRIVER', 'pg')
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [] }, { rows: [{ tos_accepted_at: null }] }],
+      inserts: [{ rows: [{}] }, { rows: [{ id: 'streamer-1' }] }],
+    })
+    primePgDb(pg)
+
+    const { GET: getWithPg } = await import('@/app/api/auth/twitch/callback/route')
+    const pgResponse = await getWithPg(createCallbackRequest())
+    const pgLocation = pgResponse.headers.get('location')
+
+    expect(pgLocation).toContain('/tos')
+    expect(postgrestLocation).toContain('/tos')
+  })
+})

--- a/tests/unit/auth-simple-reads-driver-parity.test.ts
+++ b/tests/unit/auth-simple-reads-driver-parity.test.ts
@@ -1,0 +1,283 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — 単純な読み取り系認証ルートの
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * 対象:
+ *   - GET /api/auth/twitch/login（スコープ復元の読み取り）
+ *   - POST /api/auth/reauth（既存スコープ取得の読み取り）
+ *   - POST /api/auth/bot/connect（streamer存在確認の読み取り）
+ *
+ * write-rpc-driver-parity.test.ts の流儀（複数ルートを1ファイルにまとめ、
+ * 共通の session/rate-limit/csrf/supabase-admin/getDb モックを共有する）を踏襲する。
+ * 各ルートについて「postgrest経路（フラグ未設定）では getDb が一切呼ばれない」
+ * 「pg経路（DB_DRIVER=pg-read等）では正しいテーブル/条件で SELECT され、
+ * postgrest経路と同じ外部挙動になる」ことを検証する。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { getSession } from '@/lib/session'
+import { validateCSRFToken } from '@/lib/csrf'
+import { checkRateLimit, getRateLimitIdentifier } from '@/lib/rate-limit'
+import { getTwitchAuthUrl } from '@/lib/twitch/auth'
+import { deleteTwitchTokens } from '@/lib/twitch/token-manager'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { getDb } from '@/lib/db/client'
+
+const mockCookieStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn() }
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(() => Promise.resolve(mockCookieStore)),
+}))
+vi.mock('@/lib/session', () => ({
+  getSession: vi.fn(),
+  parseSession: vi.fn(),
+  verifySession: vi.fn(),
+  canUseStreamerFeatures: vi.fn(() => true),
+}))
+vi.mock('@/lib/csrf', () => ({
+  validateCSRFToken: vi.fn(),
+}))
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn(),
+  getRateLimitIdentifier: vi.fn(),
+  getClientIp: vi.fn(() => '127.0.0.1'),
+  rateLimits: { authLogin: 'authLogin', authReauth: 'authReauth' },
+}))
+vi.mock('@/lib/twitch/auth', () => ({
+  getTwitchAuthUrl: vi.fn(() => 'https://twitch.tv/authorize'),
+}))
+vi.mock('@/lib/twitch/token-manager', () => ({
+  deleteTwitchTokens: vi.fn(() => Promise.resolve()),
+}))
+vi.mock('@/lib/auth-error-handler', () => ({ handleAuthError: vi.fn() }))
+vi.mock('@/lib/error-handler', () => ({
+  handleApiError: vi.fn((error: unknown) => ({
+    json: async () => ({ error: String(error) }),
+    status: 500,
+  })),
+}))
+vi.mock('@/lib/sentry/error-handler', () => ({ reportAuthError: vi.fn() }))
+vi.mock('@/lib/sentry/user-context', () => ({
+  setRequestContext: vi.fn(),
+  clearUserContext: vi.fn(),
+}))
+vi.mock('@/lib/url-utils', () => ({ getBaseUrl: vi.fn(() => 'http://localhost:3000') }))
+vi.mock('@/lib/crypto-utils', () => ({ randomBytesHex: vi.fn(() => 'random-state-hex') }))
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+// ---------------------------------------------------------------------------
+// pg 経路のモック（token-manager-driver-parity.test.ts の createDrizzleDbMock と同じ流儀）
+// ---------------------------------------------------------------------------
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>
+  error?: unknown
+}
+
+function createDrizzleDbMock(config: { selects?: PgResponse[] } = {}) {
+  let selectIndex = 0
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }]
+      const response = responses[Math.min(selectIndex, responses.length - 1)]
+      selectIndex += 1
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              (response.rows ?? []).map((row) =>
+                Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+              )
+            )
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      }
+      return builder
+    }),
+  }
+  return { db }
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any)
+}
+
+function createSupabaseUsersMock(result: { data: unknown; error: unknown }) {
+  const maybeSingle = vi.fn().mockResolvedValue(result)
+  const eq = vi.fn(() => ({ maybeSingle }))
+  const select = vi.fn(() => ({ eq }))
+  return { from: vi.fn(() => ({ select })) }
+}
+
+function createSupabaseStreamersMock(result: { data: unknown; error: unknown }) {
+  const maybeSingle = vi.fn().mockResolvedValue(result)
+  const eq = vi.fn(() => ({ maybeSingle }))
+  const select = vi.fn(() => ({ eq }))
+  return { from: vi.fn(() => ({ select })) }
+}
+
+describe('低頻度認証ルート: postgrest / pg 経路の互換 (#663)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCookieStore.get.mockReturnValue(undefined)
+    vi.mocked(checkRateLimit).mockResolvedValue({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      reset: Date.now() + 60000,
+    } as any)
+    vi.mocked(getRateLimitIdentifier).mockResolvedValue('user:123456789')
+    vi.mocked(validateCSRFToken).mockResolvedValue({ valid: true } as any)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('GET /api/auth/twitch/login', () => {
+    it('フラグ未設定時は getDb が呼ばれない（挙動不変の検証）', async () => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      vi.mocked(getSession).mockResolvedValue({ twitchUserId: '123456789' } as any)
+      vi.mocked(getSupabaseAdmin).mockReturnValue(
+        createSupabaseUsersMock({ data: { twitch_scopes: ['user:write:chat'] }, error: null }) as any
+      )
+
+      const { GET } = await import('@/app/api/auth/twitch/login/route')
+      const response = await GET(new Request('http://localhost:3000/api/auth/twitch/login'))
+
+      expect(response.status).toBe(200)
+      expect(getDb).not.toHaveBeenCalled()
+    })
+
+    it('DB_DRIVER=pg-read: pg経路で読み取られた既存スコープが OAuth URL に反映される（postgrest 経路と同じ結果）', async () => {
+      vi.mocked(getSession).mockResolvedValue({ twitchUserId: '123456789' } as any)
+      vi.mocked(getSupabaseAdmin).mockReturnValue(
+        createSupabaseUsersMock({ data: { twitch_scopes: ['user:write:chat'] }, error: null }) as any
+      )
+      const { GET: getWithPostgrest } = await import('@/app/api/auth/twitch/login/route')
+      await getWithPostgrest(new Request('http://localhost:3000/api/auth/twitch/login'))
+      const postgrestCallArgs = vi.mocked(getTwitchAuthUrl).mock.calls[0]
+
+      vi.mocked(getTwitchAuthUrl).mockClear()
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      const pg = createDrizzleDbMock({ selects: [{ rows: [{ twitch_scopes: ['user:write:chat'] }] }] })
+      primePgDb(pg)
+
+      const { GET: getWithPg } = await import('@/app/api/auth/twitch/login/route')
+      const response = await getWithPg(new Request('http://localhost:3000/api/auth/twitch/login'))
+      const pgCallArgs = vi.mocked(getTwitchAuthUrl).mock.calls[0]
+
+      expect(response.status).toBe(200)
+      expect(getDb).toHaveBeenCalled()
+      // 両経路とも同じ既存スコープ（preservedScopes）が OAuth URL 生成に渡される
+      expect(pgCallArgs[2]).toEqual(postgrestCallArgs[2])
+      expect(pgCallArgs[2]).toEqual(['user:write:chat'])
+    })
+  })
+
+  describe('POST /api/auth/reauth', () => {
+    it('フラグ未設定時は getDb が呼ばれない（挙動不変の検証）', async () => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      vi.mocked(getSession).mockResolvedValue({ twitchUserId: '123456789' } as any)
+      vi.mocked(getSupabaseAdmin).mockReturnValue(
+        createSupabaseUsersMock({ data: { twitch_scopes: ['user:write:chat'] }, error: null }) as any
+      )
+
+      const { POST } = await import('@/app/api/auth/reauth/route')
+      const response = await POST(new Request('http://localhost:3000/api/auth/reauth', { method: 'POST' }))
+
+      expect(response.status).toBe(200)
+      expect(getDb).not.toHaveBeenCalled()
+      expect(deleteTwitchTokens).toHaveBeenCalledWith('123456789')
+    })
+
+    it('DB_DRIVER=pg-read: pg経路で正しいテーブル/条件から既存スコープが読み取られる', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      vi.mocked(getSession).mockResolvedValue({ twitchUserId: '123456789' } as any)
+      const pg = createDrizzleDbMock({ selects: [{ rows: [{ twitch_scopes: ['user:write:chat'] }] }] })
+      primePgDb(pg)
+
+      const { POST } = await import('@/app/api/auth/reauth/route')
+      const response = await POST(new Request('http://localhost:3000/api/auth/reauth', { method: 'POST' }))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(getDb).toHaveBeenCalled()
+      expect(body.loginUrl).toBeDefined()
+    })
+
+    it('DB_DRIVER=pg-read: 列欠落(42703)は PGRST204 相当のデプロイ窓として許容され 200 を返す', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      vi.mocked(getSession).mockResolvedValue({ twitchUserId: '123456789' } as any)
+      const pg = createDrizzleDbMock({
+        selects: [{ error: { code: '42703', message: 'column "twitch_scopes" does not exist' } }],
+      })
+      primePgDb(pg)
+
+      const { POST } = await import('@/app/api/auth/reauth/route')
+      const response = await POST(new Request('http://localhost:3000/api/auth/reauth', { method: 'POST' }))
+
+      expect(response.status).toBe(200)
+    })
+
+    it('DB_DRIVER=pg-read: 列欠落以外のエラーは 503 を返す', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      vi.mocked(getSession).mockResolvedValue({ twitchUserId: '123456789' } as any)
+      const pg = createDrizzleDbMock({
+        selects: [{ error: { code: '08006', message: 'connection failure' } }],
+      })
+      primePgDb(pg)
+
+      const { POST } = await import('@/app/api/auth/reauth/route')
+      const response = await POST(new Request('http://localhost:3000/api/auth/reauth', { method: 'POST' }))
+
+      expect(response.status).toBe(503)
+    })
+  })
+
+  describe('POST /api/auth/bot/connect', () => {
+    it('フラグ未設定時は getDb が呼ばれない（挙動不変の検証）', async () => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      vi.mocked(getSession).mockResolvedValue({ twitchUserId: '123456789', broadcasterType: 'affiliate' } as any)
+      vi.mocked(getSupabaseAdmin).mockReturnValue(
+        createSupabaseStreamersMock({ data: { id: 'streamer-1' }, error: null }) as any
+      )
+
+      const { POST } = await import('@/app/api/auth/bot/connect/route')
+      const response = await POST(new Request('http://localhost:3000/api/auth/bot/connect', { method: 'POST' }) as any)
+
+      expect(response.status).toBe(200)
+      expect(getDb).not.toHaveBeenCalled()
+    })
+
+    it('DB_DRIVER=pg-read: pg経路でstreamerが見つかれば200、postgrest経路と同じ結果', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      vi.mocked(getSession).mockResolvedValue({ twitchUserId: '123456789', broadcasterType: 'affiliate' } as any)
+      const pg = createDrizzleDbMock({ selects: [{ rows: [{ id: 'streamer-1' }] }] })
+      primePgDb(pg)
+
+      const { POST } = await import('@/app/api/auth/bot/connect/route')
+      const response = await POST(new Request('http://localhost:3000/api/auth/bot/connect', { method: 'POST' }) as any)
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(getDb).toHaveBeenCalled()
+      expect(body.success).toBe(true)
+    })
+
+    it('DB_DRIVER=pg-read: streamerが存在しなければ403（データなしはエラーではなくnull）', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      vi.mocked(getSession).mockResolvedValue({ twitchUserId: '123456789', broadcasterType: 'affiliate' } as any)
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] })
+      primePgDb(pg)
+
+      const { POST } = await import('@/app/api/auth/bot/connect/route')
+      const response = await POST(new Request('http://localhost:3000/api/auth/bot/connect', { method: 'POST' }) as any)
+
+      expect(response.status).toBe(403)
+    })
+  })
+})

--- a/tests/unit/auth-subscription-cache-driver-parity.test.ts
+++ b/tests/unit/auth-subscription-cache-driver-parity.test.ts
@@ -1,0 +1,285 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — サブスク状態キャッシュ書き込みルートの
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * 対象:
+ *   - POST /api/auth/twitch/check-subscription（UPSERT + 読み戻し検証）
+ *   - POST /api/auth/twitch/disable-subscription（UPDATE）
+ *
+ * token-manager-driver-parity.test.ts の流儀を踏襲する。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { getSession } from '@/lib/session'
+import { validateCSRFToken } from '@/lib/csrf'
+import { checkRateLimit, getRateLimitIdentifier } from '@/lib/rate-limit'
+import { hasScope } from '@/lib/twitch/token-manager'
+import { checkTwitchSubViaApi, isTwitchSubCheckEnabled } from '@/lib/twitch/sub-check'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { getDb } from '@/lib/db/client'
+import { users as usersTable } from '@/lib/db/schema'
+
+vi.mock('@/lib/csrf')
+vi.mock('@/lib/session')
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn(),
+  getRateLimitIdentifier: vi.fn(),
+  rateLimits: { twitchCheckSubscription: {}, twitchDisableSubscription: {} },
+}))
+vi.mock('@/lib/twitch/token-manager', () => ({
+  hasScope: vi.fn(),
+  removeScope: vi.fn(),
+}))
+vi.mock('@/lib/twitch/sub-check', () => ({
+  checkTwitchSubViaApi: vi.fn(),
+  isTwitchSubCheckEnabled: vi.fn(),
+}))
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+const SESSION = {
+  twitchUserId: '123456789',
+  twitchUsername: 'test-user',
+  twitchDisplayName: 'Test User',
+  twitchProfileImageUrl: 'https://example.com/avatar.png',
+  broadcasterType: 'affiliate',
+  expiresAt: Date.now() + 60_000,
+  version: 1,
+}
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>
+  error?: unknown
+}
+
+/** pg 経路の insert/update/select 兼用モック（onConflictDoUpdate/returning 対応） */
+function createDrizzleDbMock(config: { selects?: PgResponse[]; inserts?: PgResponse[]; updates?: PgResponse[] } = {}) {
+  let selectIndex = 0
+  let insertIndex = 0
+  let updateIndex = 0
+  const insertCalls: Array<{ table: unknown; values?: Record<string, unknown>; conflictSet?: Record<string, unknown> }> = []
+  const updateCalls: Array<{ table: unknown; set?: Record<string, unknown>; where?: unknown }> = []
+
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }]
+      const response = responses[Math.min(selectIndex, responses.length - 1)]
+      selectIndex += 1
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              (response.rows ?? []).map((row) =>
+                Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+              )
+            )
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      }
+      return builder
+    }),
+    insert: vi.fn((table: unknown) => {
+      const responses = config.inserts ?? [{ rows: [{}] }]
+      const response = responses[Math.min(insertIndex, responses.length - 1)]
+      insertIndex += 1
+      const call: { table: unknown; values?: Record<string, unknown>; conflictSet?: Record<string, unknown> } = { table }
+      insertCalls.push(call)
+      const resolve = () => (response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []))
+      const builder: any = {
+        values: vi.fn((values: Record<string, unknown>) => {
+          call.values = values
+          return builder
+        }),
+        onConflictDoUpdate: vi.fn((opts: { set: Record<string, unknown> }) => {
+          call.conflictSet = opts.set
+          return builder
+        }),
+        returning: vi.fn(() => resolve()),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      }
+      return builder
+    }),
+    update: vi.fn((table: unknown) => {
+      const responses = config.updates ?? [{ rows: [{}] }]
+      const response = responses[Math.min(updateIndex, responses.length - 1)]
+      updateIndex += 1
+      const call: { table: unknown; set?: Record<string, unknown>; where?: unknown } = { table }
+      updateCalls.push(call)
+      const resolve = () => (response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []))
+      const builder: any = {
+        set: vi.fn((values: Record<string, unknown>) => {
+          call.set = values
+          return builder
+        }),
+        where: vi.fn((condition: unknown) => {
+          call.where = condition
+          return builder
+        }),
+        returning: vi.fn(() => resolve()),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      }
+      return builder
+    }),
+  }
+  return { db, insertCalls, updateCalls }
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any)
+}
+
+function createSupabaseUpsertMock(upsertResult: { data: unknown; error: unknown }, readBackResult?: { data: unknown; error: unknown }) {
+  const upsertMaybeSingle = vi.fn().mockResolvedValue(upsertResult)
+  const upsertSelect = vi.fn().mockReturnValue({ maybeSingle: upsertMaybeSingle })
+  const upsert = vi.fn().mockReturnValue({ select: upsertSelect })
+
+  const readBackMaybeSingle = vi.fn().mockResolvedValue(readBackResult ?? upsertResult)
+  const readBackEq = vi.fn().mockReturnValue({ maybeSingle: readBackMaybeSingle })
+  const readBackSelect = vi.fn().mockReturnValue({ eq: readBackEq })
+
+  const update = vi.fn().mockReturnValue({
+    eq: vi.fn().mockReturnValue({ select: vi.fn().mockReturnValue({ maybeSingle: readBackMaybeSingle }) }),
+  })
+
+  return { from: vi.fn().mockReturnValue({ upsert, select: readBackSelect, update }) }
+}
+
+function createRequest(path: string): Request {
+  return new Request(`http://localhost:3000${path}`, { method: 'POST', headers: { 'Content-Type': 'application/json' } })
+}
+
+describe('サブスク状態キャッシュ書き込みルート: postgrest / pg 経路の互換 (#663)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(validateCSRFToken).mockResolvedValue({ valid: true } as any)
+    vi.mocked(getSession).mockResolvedValue(SESSION as any)
+    vi.mocked(getRateLimitIdentifier).mockResolvedValue('user:123456789')
+    vi.mocked(checkRateLimit).mockResolvedValue({ success: true, limit: 5, remaining: 4, reset: Date.now() + 60000 } as any)
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(checkTwitchSubViaApi).mockResolvedValue({ hasSub: true, authError: false })
+    vi.mocked(isTwitchSubCheckEnabled).mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('POST /api/auth/twitch/check-subscription', () => {
+    it('フラグ未設定時は getDb が呼ばれない（挙動不変の検証）', async () => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      vi.mocked(getSupabaseAdmin).mockReturnValue(
+        createSupabaseUpsertMock({ data: { twitch_user_id: '123456789' }, error: null }) as any
+      )
+
+      const { POST } = await import('@/app/api/auth/twitch/check-subscription/route')
+      const response = await POST(createRequest('/api/auth/twitch/check-subscription'))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({ success: true, hasSub: true, saved: true })
+      expect(getDb).not.toHaveBeenCalled()
+    })
+
+    it('DB_DRIVER=pg: pg経路で正しい set/onConflict の UPSERT が行われ、postgrest経路と同じレスポンス', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+      const pg = createDrizzleDbMock({ inserts: [{ rows: [{ twitch_user_id: '123456789' }] }] })
+      primePgDb(pg)
+
+      const { POST } = await import('@/app/api/auth/twitch/check-subscription/route')
+      const response = await POST(createRequest('/api/auth/twitch/check-subscription'))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({ success: true, hasSub: true, saved: true })
+      expect(getDb).toHaveBeenCalled()
+      expect(pg.insertCalls[0].table).toBe(usersTable)
+      expect(pg.insertCalls[0].values).toMatchObject({
+        twitch_user_id: '123456789',
+        twitch_username: 'test-user',
+        twitch_has_sub: true,
+      })
+    })
+
+    it('DB_DRIVER=pg: 列欠落(42703)はPGRST204相当のスキーマ不一致として saved=false・200 を返す', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+      const pg = createDrizzleDbMock({
+        inserts: [{ error: { code: '42703', message: 'column does not exist' } }],
+      })
+      primePgDb(pg)
+
+      const { POST } = await import('@/app/api/auth/twitch/check-subscription/route')
+      const response = await POST(createRequest('/api/auth/twitch/check-subscription'))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({ success: true, hasSub: true, saved: false, saveFailureCode: '42703' })
+    })
+
+    it('DB_DRIVER=pg: returning行が空の場合は読み戻しで検証し saved=true を返す', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+      const pg = createDrizzleDbMock({
+        inserts: [{ rows: [] }],
+        selects: [{ rows: [{ twitch_has_sub: true, twitch_sub_verified_at: new Date().toISOString() }] }],
+      })
+      primePgDb(pg)
+
+      const { POST } = await import('@/app/api/auth/twitch/check-subscription/route')
+      const response = await POST(createRequest('/api/auth/twitch/check-subscription'))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({ success: true, hasSub: true, saved: true })
+    })
+  })
+
+  describe('POST /api/auth/twitch/disable-subscription', () => {
+    it('フラグ未設定時は getDb が呼ばれない（挙動不変の検証）', async () => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      vi.mocked(getSupabaseAdmin).mockReturnValue(
+        createSupabaseUpsertMock({ data: { twitch_user_id: '123456789' }, error: null }) as any
+      )
+
+      const { POST } = await import('@/app/api/auth/twitch/disable-subscription/route')
+      const response = await POST(createRequest('/api/auth/twitch/disable-subscription'))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({ success: true, hasSub: false, twitchSubVerifiedAt: '9999-12-31T00:00:00.000Z' })
+      expect(getDb).not.toHaveBeenCalled()
+    })
+
+    it('DB_DRIVER=pg: pg経路で正しい set/where で UPDATE され、postgrest経路と同じレスポンス', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+      const pg = createDrizzleDbMock({ updates: [{ rows: [{ twitch_user_id: '123456789' }] }] })
+      primePgDb(pg)
+
+      const { POST } = await import('@/app/api/auth/twitch/disable-subscription/route')
+      const response = await POST(createRequest('/api/auth/twitch/disable-subscription'))
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({ success: true, hasSub: false, twitchSubVerifiedAt: '9999-12-31T00:00:00.000Z' })
+      expect(pg.updateCalls[0].table).toBe(usersTable)
+      expect(pg.updateCalls[0].set).toEqual({
+        twitch_has_sub: false,
+        twitch_sub_verified_at: '9999-12-31T00:00:00.000Z',
+      })
+      expect(pg.updateCalls[0].where).toEqual(eq(usersTable.twitch_user_id, '123456789'))
+    })
+
+    it('DB_DRIVER=pg: 更新対象行が無ければ500を返す', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+      const pg = createDrizzleDbMock({ updates: [{ rows: [] }] })
+      primePgDb(pg)
+
+      const { POST } = await import('@/app/api/auth/twitch/disable-subscription/route')
+      const response = await POST(createRequest('/api/auth/twitch/disable-subscription'))
+
+      expect(response.status).toBe(500)
+    })
+  })
+})

--- a/tests/unit/collections/collection-existence.test.ts
+++ b/tests/unit/collections/collection-existence.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { and, eq, isNull } from "drizzle-orm";
 import {
   isMissingCollectionNameColumn,
   isMissingDefaultCardPackNameColumnError,
@@ -7,6 +8,8 @@ import {
 } from "@/lib/collections/collection-existence";
 import { DEFAULT_PACK_SENTINEL } from "@/lib/validation/collection-name";
 import { createMockQueryBuilder } from "../../utils/supabase-mock";
+import { getDb } from "@/lib/db/client";
+import { cards as cardsTable } from "@/lib/db/schema";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/database";
 
@@ -208,5 +211,122 @@ describe("checkCollectionHasActiveCards", () => {
 
     const result = await checkCollectionHasActiveCards(supabase, "streamer-1", DEFAULT_PACK_SENTINEL);
     expect(result).toBe("schema-not-ready");
+  });
+});
+
+// #663: pg 直結経路（postgrest 経路との形状互換）
+describe("checkCollectionHasActiveCards: postgrest / pg 経路の互換 (#663)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function createDrizzleDbMock(config: { rowCount?: number; error?: unknown }) {
+    const calls: Array<{ whereCondition?: unknown }> = [];
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => {
+          const call: { whereCondition?: unknown } = {};
+          calls.push(call);
+          const builder: any = {
+            where: vi.fn((condition: unknown) => {
+              call.whereCondition = condition;
+              return builder;
+            }),
+            then: (onFulfilled: any, onRejected: any) =>
+              (config.error
+                ? Promise.reject(config.error)
+                : Promise.resolve([{ count: config.rowCount ?? 0 }])
+              ).then(onFulfilled, onRejected),
+          };
+          return builder;
+        }),
+      })),
+    };
+    return { db, calls };
+  }
+
+  it("通常のパック名: 両経路とも exists/absent が一致する", async () => {
+    const cardsQuery = createMockQueryBuilder();
+    (cardsQuery as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
+      resolve({ count: 3, error: null });
+      return cardsQuery;
+    };
+    const supabase = { from: vi.fn(() => cardsQuery) } as unknown as SupabaseClient<Database>;
+
+    vi.stubEnv("DB_DRIVER", undefined);
+    const postgrestResult = await checkCollectionHasActiveCards(supabase, "streamer-1", "weapons");
+
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    const pg = createDrizzleDbMock({ rowCount: 3 });
+    vi.mocked(getDb).mockResolvedValue({ db: pg.db, sql: {} } as any);
+    const pgResult = await checkCollectionHasActiveCards(supabase, "streamer-1", "weapons");
+
+    expect(pgResult).toEqual(postgrestResult);
+    expect(pgResult).toBe("exists");
+    expect(pg.calls[0].whereCondition).toEqual(
+      and(
+        eq(cardsTable.streamer_id, "streamer-1"),
+        eq(cardsTable.is_active, true),
+        eq(cardsTable.collection_name, "weapons")
+      )
+    );
+  });
+
+  it("DEFAULT_PACK_SENTINEL: pg 経路は isNull(collection_name) で判定し absent を返す", async () => {
+    const supabase = { from: vi.fn() } as unknown as SupabaseClient<Database>;
+
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    const pg = createDrizzleDbMock({ rowCount: 0 });
+    vi.mocked(getDb).mockResolvedValue({ db: pg.db, sql: {} } as any);
+    const pgResult = await checkCollectionHasActiveCards(supabase, "streamer-1", DEFAULT_PACK_SENTINEL);
+
+    expect(pgResult).toBe("absent");
+    expect(pg.calls[0].whereCondition).toEqual(
+      and(
+        eq(cardsTable.streamer_id, "streamer-1"),
+        eq(cardsTable.is_active, true),
+        isNull(cardsTable.collection_name)
+      )
+    );
+  });
+
+  it("pg 経路で列未デプロイエラー(42703)時は schema-not-ready を返す", async () => {
+    const supabase = { from: vi.fn() } as unknown as SupabaseClient<Database>;
+
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    const pg = createDrizzleDbMock({
+      error: { code: "42703", message: "column cards.collection_name does not exist" },
+    });
+    vi.mocked(getDb).mockResolvedValue({ db: pg.db, sql: {} } as any);
+
+    const result = await checkCollectionHasActiveCards(supabase, "streamer-1", "weapons");
+    expect(result).toBe("schema-not-ready");
+  });
+
+  it("pg 経路で想定外のエラーは throw する", async () => {
+    const supabase = { from: vi.fn() } as unknown as SupabaseClient<Database>;
+
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    const pg = createDrizzleDbMock({ error: { code: "08006", message: "connection failure" } });
+    vi.mocked(getDb).mockResolvedValue({ db: pg.db, sql: {} } as any);
+
+    await expect(checkCollectionHasActiveCards(supabase, "streamer-1", "weapons")).rejects.toBeTruthy();
+  });
+
+  it("postgrest 経路（フラグ未設定）では getDb が一切呼ばれない", async () => {
+    const cardsQuery = createMockQueryBuilder();
+    (cardsQuery as unknown as Record<string, unknown>).then = (resolve: (v: unknown) => void) => {
+      resolve({ count: 1, error: null });
+      return cardsQuery;
+    };
+    const supabase = { from: vi.fn(() => cardsQuery) } as unknown as SupabaseClient<Database>;
+
+    vi.stubEnv("DB_DRIVER", undefined);
+    await checkCollectionHasActiveCards(supabase, "streamer-1", "weapons");
+    expect(getDb).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/gacha-demo-driver-parity.test.ts
+++ b/tests/unit/gacha-demo-driver-parity.test.ts
@@ -1,0 +1,177 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — POST /api/gacha/demo の
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * このルートは他の対象ルートと異なり getSupabaseAdmin() を使わず
+ * createClient(supabaseUrl, supabaseKey) でアドホックなクライアントを生成する
+ * （公開デモエンドポイントのため）。pg 経路は supabaseUrl/supabaseKey の設定
+ * 有無に依存しないことも検証する。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { getDb } from '@/lib/db/client'
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('@/lib/realtime', () => ({
+  broadcastGachaResult: vi.fn(() => Promise.resolve()),
+}))
+
+const CARD_ROW = {
+  id: 'card-1',
+  streamer_id: 'streamer-1',
+  name: 'カード1',
+  description: null,
+  image_url: null,
+  rarity: 'common',
+  rarity_order: 4,
+  drop_rate: 0.25,
+  intra_rarity_weight: 1,
+  card_number: null,
+  max_issuance_count: null,
+  collection_name: null,
+  is_active: true,
+  hp: 100,
+  atk: 30,
+  def: 15,
+  spd: 5,
+  skill_type: 'attack',
+  skill_name: '通常攻撃',
+  skill_power: 10,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>
+  error?: unknown
+}
+
+function createDrizzleDbMock(config: { selects?: PgResponse[] } = {}) {
+  let selectIndex = 0
+  const db = {
+    select: vi.fn(() => {
+      const responses = config.selects ?? [{ rows: [] }]
+      const response = responses[Math.min(selectIndex, responses.length - 1)]
+      selectIndex += 1
+      const resolve = () => (response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []))
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      }
+      return builder
+    }),
+  }
+  return { db }
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any)
+}
+
+function createRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost:3000/api/gacha/demo', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/gacha/demo: postgrest / pg 経路の互換 (#663)', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key'
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    process.env = { ...originalEnv }
+  })
+
+  it('フラグ未設定時は getDb が呼ばれない（挙動不変の検証。cardIdでカードが見つかる場合）', async () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: vi.fn(() => ({
+        from: vi.fn(() => ({
+          select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: CARD_ROW, error: null }) })) })),
+        })),
+      })),
+    }))
+
+    const { POST } = await import('@/app/api/gacha/demo/route')
+    const response = await POST(createRequest({ cardId: 'card-1' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.card.id).toBe('card-1')
+    expect(getDb).not.toHaveBeenCalled()
+    vi.doUnmock('@supabase/supabase-js')
+  })
+
+  it('DB_DRIVER=pg-read: cardId指定時、pg経路でカードが取得される', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock({ selects: [{ rows: [CARD_ROW] }] })
+    primePgDb(pg)
+
+    const { POST } = await import('@/app/api/gacha/demo/route')
+    const response = await POST(createRequest({ cardId: 'card-1' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.card.id).toBe('card-1')
+    expect(getDb).toHaveBeenCalled()
+  })
+
+  it('DB_DRIVER=pg-read: streamerId指定時、pg経路でアクティブカードからランダム選択される', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock({ selects: [{ rows: [CARD_ROW] }] })
+    primePgDb(pg)
+
+    const { POST } = await import('@/app/api/gacha/demo/route')
+    const response = await POST(createRequest({ streamerId: 'streamer-1' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.card.streamer_id).toBe('streamer-1')
+    expect(getDb).toHaveBeenCalled()
+  })
+
+  it('DB_DRIVER=pg-read: pg経路が失敗してもデモカードにフォールバックする（既存の安全側フォールバック挙動を維持）', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock({ selects: [{ error: new Error('connection failure') }] })
+    primePgDb(pg)
+
+    const { POST } = await import('@/app/api/gacha/demo/route')
+    const response = await POST(createRequest({ cardId: 'nonexistent' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.card).toBeDefined()
+    expect(body.userTwitchUsername).toBe('DemoUser')
+  })
+
+  it('DB_DRIVER=pg-read: supabaseUrl/supabaseKey が未設定でもpg経路は動作する（アドホッククライアント非依存の検証）', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    delete process.env.SUPABASE_SECRET_KEY
+    delete process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    const pg = createDrizzleDbMock({ selects: [{ rows: [CARD_ROW] }] })
+    primePgDb(pg)
+
+    const { POST } = await import('@/app/api/gacha/demo/route')
+    const response = await POST(createRequest({ cardId: 'card-1' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.card.id).toBe('card-1')
+    expect(getDb).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/gacha-demo-driver-parity.test.ts
+++ b/tests/unit/gacha-demo-driver-parity.test.ts
@@ -43,6 +43,35 @@ const CARD_ROW = {
   updated_at: '2026-01-01T00:00:00Z',
 }
 
+// 本番未デプロイ8列(card_number/hp/atk/def/spd/skill_type/skill_name/skill_power)を
+// 除いた行。CARDS_SAFE_COLUMNS 再試行の成功レスポンスを模す (#663 self-review fix、
+// 外部レビュー指摘: fetchCardByIdPg/fetchActiveCardsForStreamerPg にも
+// cards/route.ts と同じ列欠落フォールバックが必要)。
+const SAFE_CARD_ROW = {
+  id: 'card-1',
+  streamer_id: 'streamer-1',
+  name: 'カード1',
+  description: null,
+  image_url: null,
+  rarity: 'common',
+  rarity_order: 4,
+  drop_rate: 0.25,
+  intra_rarity_weight: 1,
+  max_issuance_count: null,
+  collection_name: null,
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+// pg (postgres.js) が本番未デプロイ列に対して throw する 42703 相当のエラー。
+// isMissingCardsBattleColumnError の判定ロジック（"column" を含むテキスト +
+// 欠落8列のいずれかの列名を含む）に一致させる。
+const MISSING_BATTLE_COLUMN_ERROR = {
+  code: '42703',
+  message: 'column "hp" of relation "cards" does not exist',
+}
+
 interface PgResponse {
   rows?: Array<Record<string, unknown>>
   error?: unknown
@@ -154,6 +183,43 @@ describe('POST /api/gacha/demo: postgrest / pg 経路の互換 (#663)', () => {
     expect(response.status).toBe(200)
     expect(body.card).toBeDefined()
     expect(body.userTwitchUsername).toBe('DemoUser')
+  })
+
+  it('DB_DRIVER=pg-read: cardId指定時、cardsテーブルの本番未デプロイ8列欠落エラーからCARDS_SAFE_COLUMNSで再試行し実カードが返る（#663 self-review fix）', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock({
+      selects: [{ error: MISSING_BATTLE_COLUMN_ERROR }, { rows: [SAFE_CARD_ROW] }],
+    })
+    primePgDb(pg)
+
+    const { POST } = await import('@/app/api/gacha/demo/route')
+    const response = await POST(createRequest({ cardId: 'card-1' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    // デモカードへのフォールバックではなく、実カード(card-1)が返ることを検証する。
+    // 列欠落フォールバックが無いと catch で null 扱いになりデモカードにすり替わる。
+    expect(body.card.id).toBe('card-1')
+    expect(body.card.streamer_id).toBe('streamer-1')
+    expect(pg.db.select).toHaveBeenCalledTimes(2)
+  })
+
+  it('DB_DRIVER=pg-read: streamerId指定時、cardsテーブルの本番未デプロイ8列欠落エラーからCARDS_SAFE_COLUMNSで再試行し実カードが返る（#663 self-review fix）', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock({
+      selects: [{ error: MISSING_BATTLE_COLUMN_ERROR }, { rows: [SAFE_CARD_ROW] }],
+    })
+    primePgDb(pg)
+
+    const { POST } = await import('@/app/api/gacha/demo/route')
+    const response = await POST(createRequest({ streamerId: 'streamer-1' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    // デモカードへのフォールバックではなく、配信者の実カード(card-1)が返ることを検証する。
+    expect(body.card.id).toBe('card-1')
+    expect(body.card.streamer_id).toBe('streamer-1')
+    expect(pg.db.select).toHaveBeenCalledTimes(2)
   })
 
   it('DB_DRIVER=pg-read: supabaseUrl/supabaseKey が未設定でもpg経路は動作する（アドホッククライアント非依存の検証）', async () => {

--- a/tests/unit/gacha-history-routes-driver-parity.test.ts
+++ b/tests/unit/gacha-history-routes-driver-parity.test.ts
@@ -1,0 +1,289 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — ガチャ履歴/統計ルート群の
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * 対象:
+ *   - GET /api/gacha-history（streamer取得のみ対象。getGachaHistoryForStreamer等は
+ *     #571で既にpg直結対応済みのためモックで切り離す）
+ *   - DELETE /api/gacha-history/[id]（所有者確認の読み取り + DELETE）
+ *   - GET /api/gacha-stats（streamer取得のみ対象。getGachaStats等は既にpg直結対応済み）
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { getSession, canUseStreamerFeatures } from '@/lib/session'
+import { checkRateLimit, getRateLimitIdentifier } from '@/lib/rate-limit'
+import { validateCSRFToken } from '@/lib/csrf'
+import { getDb } from '@/lib/db/client'
+import { gachaHistory as gachaHistoryTable } from '@/lib/db/schema'
+import { getGachaHistoryForStreamer, getGachaStats } from '@/lib/dashboard-data'
+
+vi.mock('@/lib/session')
+vi.mock('@/lib/csrf')
+vi.mock('@/lib/rate-limit')
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('@/lib/dashboard-data', () => ({
+  getGachaHistoryForStreamer: vi.fn(),
+  getGachaHistoryForUser: vi.fn(),
+  getGachaUsersForStreamer: vi.fn(),
+  getGachaStats: vi.fn(),
+  getGachaCardOwnerStats: vi.fn(),
+}))
+
+const mockGetSession = vi.mocked(getSession)
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)
+const mockCheckRateLimit = vi.mocked(checkRateLimit)
+const mockGetRateLimitIdentifier = vi.mocked(getRateLimitIdentifier)
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken)
+
+const STREAMER_SESSION = {
+  twitchUserId: 'streamer1',
+  twitchUsername: 'streamer1',
+  twitchDisplayName: 'Streamer 1',
+  twitchProfileImageUrl: '',
+  broadcasterType: 'affiliate',
+  expiresAt: Date.now() + 100000,
+  version: 1,
+}
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>
+  error?: unknown
+}
+
+function createDrizzleDbMock(config: { selects?: PgResponse[]; deletes?: PgResponse[] } = {}) {
+  let selectIndex = 0
+  let deleteIndex = 0
+  const deleteCalls: Array<{ table: unknown; where?: unknown }> = []
+
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }]
+      const response = responses[Math.min(selectIndex, responses.length - 1)]
+      selectIndex += 1
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              (response.rows ?? []).map((row) =>
+                Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+              )
+            )
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      }
+      return builder
+    }),
+    delete: vi.fn((table: unknown) => {
+      const responses = config.deletes ?? [{ rows: [] }]
+      const response = responses[Math.min(deleteIndex, responses.length - 1)]
+      deleteIndex += 1
+      const call: { table: unknown; where?: unknown } = { table }
+      deleteCalls.push(call)
+      const resolve = () => (response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []))
+      const builder: any = {
+        where: vi.fn((condition: unknown) => {
+          call.where = condition
+          return builder
+        }),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      }
+      return builder
+    }),
+  }
+  return { db, deleteCalls }
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any)
+}
+
+function createSupabaseStreamersMock(result: { data: unknown; error: unknown }) {
+  const maybeSingle = vi.fn().mockResolvedValue(result)
+  const eq = vi.fn(() => ({ maybeSingle }))
+  const select = vi.fn(() => ({ eq }))
+  return { from: vi.fn(() => ({ select })) }
+}
+
+describe('ガチャ履歴/統計ルート: postgrest / pg 経路の互換 (#663)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockCheckRateLimit.mockResolvedValue({ success: true, limit: 60, remaining: 59, reset: Date.now() + 60000 } as any)
+    mockGetRateLimitIdentifier.mockResolvedValue('user:streamer1')
+    mockValidateCSRFToken.mockResolvedValue({ valid: true } as any)
+    mockGetSession.mockResolvedValue(STREAMER_SESSION as any)
+    mockCanUseStreamerFeatures.mockReturnValue(true)
+    vi.mocked(getGachaHistoryForStreamer).mockResolvedValue({ items: [], total: 0, page: 1, perPage: 20 } as any)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('GET /api/gacha-history', () => {
+    it('フラグ未設定時は getDb が呼ばれない（挙動不変の検証）', async () => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(
+        createSupabaseStreamersMock({ data: { id: 'streamer-id-1' }, error: null }) as any
+      )
+
+      const { GET } = await import('@/app/api/gacha-history/route')
+      const url = new URL('http://localhost/api/gacha-history')
+      const response = await GET(new NextRequest(url))
+
+      expect(response.status).toBe(200)
+      expect(getDb).not.toHaveBeenCalled()
+    })
+
+    it('DB_DRIVER=pg-read: pg経路でstreamerが見つかれば既存関数（getGachaHistoryForStreamer）に正しいidを渡す', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      const pg = createDrizzleDbMock({ selects: [{ rows: [{ id: 'streamer-id-1' }] }] })
+      primePgDb(pg)
+
+      const { GET } = await import('@/app/api/gacha-history/route')
+      const url = new URL('http://localhost/api/gacha-history')
+      const response = await GET(new NextRequest(url))
+
+      expect(response.status).toBe(200)
+      expect(getDb).toHaveBeenCalled()
+      expect(getGachaHistoryForStreamer).toHaveBeenCalledWith('streamer-id-1', expect.any(Object))
+    })
+
+    it('DB_DRIVER=pg-read: streamerが見つからなければ404（postgrest経路と同じ外部挙動）', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] })
+      primePgDb(pg)
+
+      const { GET } = await import('@/app/api/gacha-history/route')
+      const url = new URL('http://localhost/api/gacha-history')
+      const response = await GET(new NextRequest(url))
+
+      expect(response.status).toBe(404)
+    })
+  })
+
+  describe('GET /api/gacha-stats', () => {
+    beforeEach(() => {
+      vi.mocked(getGachaStats).mockResolvedValue({ totalDraws: 0 } as any)
+    })
+
+    it('フラグ未設定時は getDb が呼ばれない（挙動不変の検証）', async () => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(
+        createSupabaseStreamersMock({ data: { id: 'streamer-id-1' }, error: null }) as any
+      )
+
+      const { GET } = await import('@/app/api/gacha-stats/route')
+      const url = new URL('http://localhost/api/gacha-stats')
+      url.searchParams.set('period', '7d')
+      const response = await GET(new NextRequest(url))
+
+      expect(response.status).toBe(200)
+      expect(getDb).not.toHaveBeenCalled()
+    })
+
+    it('DB_DRIVER=pg-read: pg経路でstreamerが見つかれば既存関数（getGachaStats）に正しいidを渡す', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      const pg = createDrizzleDbMock({ selects: [{ rows: [{ id: 'streamer-id-1' }] }] })
+      primePgDb(pg)
+
+      const { GET } = await import('@/app/api/gacha-stats/route')
+      const url = new URL('http://localhost/api/gacha-stats')
+      url.searchParams.set('period', '30d')
+      const response = await GET(new NextRequest(url))
+
+      expect(response.status).toBe(200)
+      expect(getDb).toHaveBeenCalled()
+      expect(getGachaStats).toHaveBeenCalledWith('streamer-id-1', '30d')
+    })
+
+    it('DB_DRIVER=pg-read: streamerが見つからなければ404（postgrest経路と同じ外部挙動）', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] })
+      primePgDb(pg)
+
+      const { GET } = await import('@/app/api/gacha-stats/route')
+      const url = new URL('http://localhost/api/gacha-stats')
+      url.searchParams.set('period', '7d')
+      const response = await GET(new NextRequest(url))
+
+      expect(response.status).toBe(404)
+    })
+  })
+
+  describe('DELETE /api/gacha-history/[id]', () => {
+    const HISTORY_ID = '22222222-2222-4222-8222-222222222222'
+
+    function createDeleteRequest(): NextRequest {
+      return new NextRequest(`http://localhost/api/gacha-history/${HISTORY_ID}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: 'streamer1' }),
+      })
+    }
+
+    it('フラグ未設定時は getDb が呼ばれない（挙動不変の検証）', async () => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      const maybeSingle = vi.fn().mockResolvedValue({ data: { user_twitch_id: 'streamer1' }, error: null })
+      const eqSelect = vi.fn(() => ({ maybeSingle }))
+      const select = vi.fn(() => ({ eq: eqSelect }))
+      const eqDelete = vi.fn().mockResolvedValue({ error: null })
+      const del = vi.fn(() => ({ eq: eqDelete }))
+      vi.mocked(getSupabaseAdmin).mockReturnValue({ from: vi.fn(() => ({ select, delete: del })) } as any)
+
+      const { DELETE } = await import('@/app/api/gacha-history/[id]/route')
+      const response = await DELETE(createDeleteRequest(), { params: Promise.resolve({ id: HISTORY_ID }) })
+
+      expect(response.status).toBe(200)
+      expect(getDb).not.toHaveBeenCalled()
+    })
+
+    it('DB_DRIVER=pg: 所有者確認 + DELETE が正しいテーブル/条件で実行される', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [{ user_twitch_id: 'streamer1' }] }],
+        deletes: [{ rows: [] }],
+      })
+      primePgDb(pg)
+
+      const { DELETE } = await import('@/app/api/gacha-history/[id]/route')
+      const response = await DELETE(createDeleteRequest(), { params: Promise.resolve({ id: HISTORY_ID }) })
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({ success: true })
+      expect(getDb).toHaveBeenCalled()
+      expect(pg.deleteCalls[0].table).toBe(gachaHistoryTable)
+    })
+
+    it('DB_DRIVER=pg: 所有者が一致しなければ403（postgrest経路と同じ外部挙動）', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+      const pg = createDrizzleDbMock({ selects: [{ rows: [{ user_twitch_id: 'someone-else' }] }] })
+      primePgDb(pg)
+
+      const { DELETE } = await import('@/app/api/gacha-history/[id]/route')
+      const response = await DELETE(createDeleteRequest(), { params: Promise.resolve({ id: HISTORY_ID }) })
+
+      expect(response.status).toBe(403)
+      expect(pg.deleteCalls).toHaveLength(0)
+    })
+
+    it('DB_DRIVER=pg: 対象行が存在しなければ500（handleDatabaseError、postgrest経路と同じ外部挙動）', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] })
+      primePgDb(pg)
+
+      const { DELETE } = await import('@/app/api/gacha-history/[id]/route')
+      const response = await DELETE(createDeleteRequest(), { params: Promise.resolve({ id: HISTORY_ID }) })
+
+      expect(response.status).toBe(500)
+    })
+  })
+})

--- a/tests/unit/plan-driver-parity.test.ts
+++ b/tests/unit/plan-driver-parity.test.ts
@@ -1,0 +1,216 @@
+/**
+ * #663: getUserPlanSnapshot（getLicensePlan / getCachedTwitchSubPlan）の
+ * postgrest 経路 / pg 経路の形状互換テスト
+ *
+ * getUserPlanSnapshot は Twitch API を呼ばず DB 状態のみで判定するため、
+ * getLicensePlan と getCachedTwitchSubPlan の両方の pg 実装を
+ * 副作用なしで検証できる（tests/unit/announcements-driver-parity.test.ts と同じ流儀）。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { and, eq, inArray } from 'drizzle-orm'
+import { getUserPlanSnapshot } from '@/lib/plan'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { getDb } from '@/lib/db/client'
+import {
+  supportCodes as supportCodesTable,
+  userLicenses as userLicensesTable,
+  users as usersTable,
+} from '@/lib/db/schema'
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+// ---------------------------------------------------------------------------
+// postgrest 経路のモック: from(table) ごとに異なる結果を返す thenable builder
+// ---------------------------------------------------------------------------
+
+function createThenableBuilder(result: { data: unknown; error: unknown }) {
+  const builder: any = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    in: vi.fn(() => builder),
+    maybeSingle: vi.fn(() => Promise.resolve(result)),
+    then: (onFulfilled: any, onRejected: any) =>
+      Promise.resolve(result).then(onFulfilled, onRejected),
+  }
+  return builder
+}
+
+function createSupabaseClientMock(config: {
+  licenseRows?: Array<{ plan_type: string; support_codes: { status: string } }>
+  hasSub?: boolean | null
+}) {
+  const from = vi.fn((table: string) => {
+    if (table === 'user_licenses') {
+      return createThenableBuilder({ data: config.licenseRows ?? [], error: null })
+    }
+    return createThenableBuilder({
+      data: config.hasSub === null ? null : { twitch_has_sub: config.hasSub ?? false },
+      error: null,
+    })
+  })
+  return { from }
+}
+
+// ---------------------------------------------------------------------------
+// pg 経路のモック: select(fields).from(table)[.innerJoin()].where()[.limit()]
+// ---------------------------------------------------------------------------
+
+interface DrizzleCallRecord {
+  table: unknown
+  joinTable?: unknown
+  joinCondition?: unknown
+  whereCondition?: unknown
+}
+
+function createDrizzleDbMock(config: {
+  licenseRows?: Array<{ plan_type: string }>
+  userRows?: Array<{ twitch_has_sub: boolean | null }>
+}) {
+  const calls: DrizzleCallRecord[] = []
+  return {
+    calls,
+    select: vi.fn((fields: Record<string, unknown>) => ({
+      from: vi.fn((table: unknown) => {
+        const call: DrizzleCallRecord = { table }
+        calls.push(call)
+        const isLicenseQuery = table === userLicensesTable
+        const rows = isLicenseQuery ? (config.licenseRows ?? []) : (config.userRows ?? [])
+        const projected = rows.map((row) =>
+          Object.fromEntries(
+            Object.keys(fields).map((key) => [key, (row as Record<string, unknown>)[key] ?? null])
+          )
+        )
+        const builder: any = {
+          innerJoin: vi.fn((joinTable: unknown, condition: unknown) => {
+            call.joinTable = joinTable
+            call.joinCondition = condition
+            return builder
+          }),
+          where: vi.fn((condition: unknown) => {
+            call.whereCondition = condition
+            return builder
+          }),
+          limit: vi.fn(() => builder),
+          then: (onFulfilled: any, onRejected: any) =>
+            Promise.resolve(projected).then(onFulfilled, onRejected),
+        }
+        return builder
+      }),
+    })),
+  }
+}
+
+describe('getUserPlanSnapshot: postgrest / pg 経路の形状互換 (#663)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('ライセンスなし・サブなしの場合、両経路とも basic を返す', async () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    const client = createSupabaseClientMock({ licenseRows: [], hasSub: false })
+    vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+    const postgrestResult = await getUserPlanSnapshot('user-1')
+
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock({ licenseRows: [], userRows: [{ twitch_has_sub: false }] })
+    vi.mocked(getDb).mockResolvedValue({ db: pg, sql: {} } as any)
+    const pgResult = await getUserPlanSnapshot('user-1')
+
+    expect(pgResult).toEqual(postgrestResult)
+    expect(pgResult).toBe('basic')
+  })
+
+  it('support ライセンス保持時、両経路とも support を返す', async () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    const client = createSupabaseClientMock({
+      licenseRows: [{ plan_type: 'support', support_codes: { status: 'active' } }],
+      hasSub: false,
+    })
+    vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+    const postgrestResult = await getUserPlanSnapshot('user-2')
+
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock({
+      licenseRows: [{ plan_type: 'support' }],
+      userRows: [{ twitch_has_sub: false }],
+    })
+    vi.mocked(getDb).mockResolvedValue({ db: pg, sql: {} } as any)
+    const pgResult = await getUserPlanSnapshot('user-2')
+
+    expect(pgResult).toEqual(postgrestResult)
+    expect(pgResult).toBe('support')
+  })
+
+  it('twitch_has_sub=true が支援プランより優先されない場合、上位プランが勝つ（patron > twitch_sub）', async () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    const client = createSupabaseClientMock({
+      licenseRows: [{ plan_type: 'patron', support_codes: { status: 'rotating' } }],
+      hasSub: true,
+    })
+    vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+    const postgrestResult = await getUserPlanSnapshot('user-3')
+
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock({
+      licenseRows: [{ plan_type: 'patron' }],
+      userRows: [{ twitch_has_sub: true }],
+    })
+    vi.mocked(getDb).mockResolvedValue({ db: pg, sql: {} } as any)
+    const pgResult = await getUserPlanSnapshot('user-3')
+
+    expect(pgResult).toEqual(postgrestResult)
+    expect(pgResult).toBe('patron')
+  })
+
+  it('users 行が存在しない場合、両経路とも basic 扱い', async () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    const client = createSupabaseClientMock({ licenseRows: [], hasSub: null })
+    vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+    const postgrestResult = await getUserPlanSnapshot('user-4')
+
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock({ licenseRows: [], userRows: [] })
+    vi.mocked(getDb).mockResolvedValue({ db: pg, sql: {} } as any)
+    const pgResult = await getUserPlanSnapshot('user-4')
+
+    expect(pgResult).toEqual(postgrestResult)
+    expect(pgResult).toBe('basic')
+  })
+
+  it('pg クエリが user_licenses INNER JOIN support_codes + status IN 条件で発行される', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock({
+      licenseRows: [{ plan_type: 'support' }],
+      userRows: [{ twitch_has_sub: false }],
+    })
+    vi.mocked(getDb).mockResolvedValue({ db: pg, sql: {} } as any)
+
+    await getUserPlanSnapshot('user-5')
+
+    const licenseCall = pg.calls.find((c) => c.table === userLicensesTable)
+    expect(licenseCall).toBeDefined()
+    expect(licenseCall!.joinTable).toBe(supportCodesTable)
+    expect(licenseCall!.joinCondition).toEqual(eq(userLicensesTable.code_id, supportCodesTable.id))
+    expect(licenseCall!.whereCondition).toEqual(
+      and(eq(userLicensesTable.twitch_user_id, 'user-5'), inArray(supportCodesTable.status, ['active', 'rotating']))
+    )
+
+    const userCall = pg.calls.find((c) => c.table === usersTable)
+    expect(userCall).toBeDefined()
+    expect(userCall!.whereCondition).toEqual(eq(usersTable.twitch_user_id, 'user-5'))
+  })
+
+  it('postgrest 経路（フラグ未設定）では getDb が一切呼ばれない', async () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    const client = createSupabaseClientMock({ licenseRows: [], hasSub: false })
+    vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+    await getUserPlanSnapshot('user-6')
+    expect(getDb).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/raid-gacha-driver-parity.test.ts
+++ b/tests/unit/raid-gacha-driver-parity.test.ts
@@ -1,0 +1,334 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — レイドガチャAPIの
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * 対象: GET/POST /api/streamer/raid-gacha
+ * この API には既存の専用テストファイルが無いため、postgrest経路のベースライン
+ * カバレッジも本ファイルでまとめて用意する。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { eq } from "drizzle-orm";
+import { getSession, canUseStreamerFeatures } from "@/lib/session";
+import { checkRateLimit, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { validateCSRFToken } from "@/lib/csrf";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { getDb } from "@/lib/db/client";
+import { streamers as streamersTable } from "@/lib/db/schema";
+
+vi.mock("@/lib/session");
+vi.mock("@/lib/csrf");
+vi.mock("@/lib/rate-limit");
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/supabase/admin", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/supabase/admin")>();
+  return { ...actual, getSupabaseAdmin: vi.fn() };
+});
+
+const mockGetSession = vi.mocked(getSession);
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures);
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+const mockGetRateLimitIdentifier = vi.mocked(getRateLimitIdentifier);
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken);
+
+const STREAMER_SESSION = {
+  twitchUserId: "streamer1",
+  twitchUsername: "streamer1",
+  twitchDisplayName: "Streamer 1",
+  twitchProfileImageUrl: "",
+  broadcasterType: "affiliate",
+  expiresAt: Date.now() + 100000,
+  version: 1,
+};
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>;
+  error?: unknown;
+}
+
+function createDrizzleDbMock(config: { selects?: PgResponse[]; updates?: PgResponse[] } = {}) {
+  let selectIndex = 0;
+  let updateIndex = 0;
+  const selectCalls: Array<{ where?: unknown }> = [];
+  const updateCalls: Array<{ set?: unknown; where?: unknown }> = [];
+
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }];
+      const response = responses[Math.min(selectIndex, responses.length - 1)];
+      selectIndex += 1;
+      const call: { where?: unknown } = {};
+      selectCalls.push(call);
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              (response.rows ?? []).map((row) =>
+                Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+              )
+            );
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        limit: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+    update: vi.fn(() => {
+      const responses = config.updates ?? [{ rows: [] }];
+      const response = responses[Math.min(updateIndex, responses.length - 1)];
+      updateIndex += 1;
+      const call: { set?: unknown; where?: unknown } = {};
+      updateCalls.push(call);
+      const resolve = () => (response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []));
+      const builder: any = {
+        set: vi.fn((values: unknown) => {
+          call.set = values;
+          return builder;
+        }),
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        returning: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+  };
+  return { db, selectCalls, updateCalls };
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any);
+}
+
+function createStreamersSupabaseMock(selectResult: { data: unknown; error: unknown }, updateResult?: { data: unknown; error: unknown }) {
+  const selectMaybeSingle = vi.fn().mockResolvedValue(selectResult);
+  const selectEq = vi.fn(() => ({ maybeSingle: selectMaybeSingle }));
+  const select = vi.fn(() => ({ eq: selectEq }));
+
+  const updateMaybeSingle = vi.fn().mockResolvedValue(updateResult ?? { data: null, error: null });
+  const updateSelect = vi.fn(() => ({ maybeSingle: updateMaybeSingle }));
+  const updateEq = vi.fn(() => ({ select: updateSelect }));
+  const update = vi.fn(() => ({ eq: updateEq }));
+
+  return { from: vi.fn(() => ({ select, update })), select, update };
+}
+
+async function loadRoute() {
+  return import("@/app/api/streamer/raid-gacha/route");
+}
+
+function getRequest() {
+  return new NextRequest("http://localhost/api/streamer/raid-gacha");
+}
+
+function postRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/streamer/raid-gacha", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("streamer/raid-gacha: postgrest / pg 経路の互換 (#663)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(STREAMER_SESSION as any);
+    mockCanUseStreamerFeatures.mockReturnValue(true);
+    mockCheckRateLimit.mockResolvedValue({ success: true, limit: 60, remaining: 59, reset: Date.now() + 60000 } as any);
+    mockGetRateLimitIdentifier.mockResolvedValue("user:streamer1");
+    mockValidateCSRFToken.mockResolvedValue({ valid: true } as any);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("GET", () => {
+    it("フラグ未設定時は getDb が呼ばれない（postgrest 経路のベースライン）", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const supabase = createStreamersSupabaseMock({
+        data: { id: "streamer-id-1", raid_gacha_active_until: null, raid_gacha_draw_count: 0 },
+        error: null,
+      });
+      vi.mocked(getSupabaseAdmin).mockReturnValue(supabase as any);
+
+      const { GET } = await loadRoute();
+      const response = await GET(getRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({ active: false, activeUntil: null, drawCount: 0 });
+      expect(getDb).not.toHaveBeenCalled();
+    });
+
+    it("postgrest 経路: 401 (未認証)", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      mockGetSession.mockResolvedValue(null);
+      const { GET } = await loadRoute();
+      const response = await GET(getRequest());
+      expect(response.status).toBe(401);
+    });
+
+    it("DB_DRIVER=pg-read: 同一fixtureで両経路の戻り値が一致する", async () => {
+      const FIXTURE = { id: "streamer-id-1", raid_gacha_active_until: "2999-01-01T00:00:00.000+00:00", raid_gacha_draw_count: 5 };
+
+      vi.stubEnv("DB_DRIVER", undefined);
+      const supabase = createStreamersSupabaseMock({ data: FIXTURE, error: null });
+      vi.mocked(getSupabaseAdmin).mockReturnValue(supabase as any);
+      const { GET: postgrestGET } = await loadRoute();
+      const postgrestResponse = await postgrestGET(getRequest());
+      const postgrestBody = await postgrestResponse.json();
+
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [FIXTURE] }] });
+      primePgDb(pg);
+      const { GET: pgGET } = await loadRoute();
+      const pgResponse = await pgGET(getRequest());
+      const pgBody = await pgResponse.json();
+
+      expect(pgResponse.status).toBe(postgrestResponse.status);
+      expect(pgBody).toEqual(postgrestBody);
+      expect(getDb).toHaveBeenCalled();
+      expect(pg.selectCalls[0].where).toEqual(eq(streamersTable.twitch_user_id, "streamer1"));
+    });
+
+    it("DB_DRIVER=pg-read: streamerが見つからなければ両経路とも404", async () => {
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] });
+      primePgDb(pg);
+
+      const { GET } = await loadRoute();
+      const response = await GET(getRequest());
+      expect(response.status).toBe(404);
+    });
+
+    it("DB_DRIVER=pg-read: raid列欠落エラー時は列を落としてフォールバックし、デフォルト値を返す", async () => {
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      let call = 0;
+      const db = {
+        select: vi.fn((fields: Record<string, unknown>) => {
+          call += 1;
+          const builder: any = {
+            from: vi.fn(() => builder),
+            where: vi.fn(() => builder),
+            limit: vi.fn(() => builder),
+            then: (onFulfilled: any, onRejected: any) => {
+              if (call === 1) {
+                return Promise.reject({
+                  code: "42703",
+                  message: 'column "raid_gacha_active_until" of relation "streamers" does not exist',
+                }).then(onFulfilled, onRejected);
+              }
+              return Promise.resolve(
+                Object.keys(fields).includes("id") && Object.keys(fields).length === 1
+                  ? [{ id: "streamer-id-1" }]
+                  : []
+              ).then(onFulfilled, onRejected);
+            },
+          };
+          return builder;
+        }),
+      };
+      vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any);
+
+      const { GET } = await loadRoute();
+      const response = await GET(getRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({ active: false, activeUntil: null, drawCount: 0 });
+    });
+  });
+
+  describe("POST", () => {
+    it("フラグ未設定時は getDb が呼ばれない（postgrest 経路のベースライン）", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const supabase = createStreamersSupabaseMock(
+        { data: { id: "streamer-id-1", raid_gacha_active_until: null, raid_gacha_draw_count: 0 }, error: null },
+        { data: { raid_gacha_active_until: null, raid_gacha_draw_count: 3 }, error: null }
+      );
+      vi.mocked(getSupabaseAdmin).mockReturnValue(supabase as any);
+
+      const { POST } = await loadRoute();
+      const response = await POST(postRequest({ drawCount: 3 }));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({ success: true, active: false, activeUntil: null, drawCount: 3 });
+      expect(getDb).not.toHaveBeenCalled();
+    });
+
+    it("postgrest 経路: drawCount が範囲外なら400", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const { POST } = await loadRoute();
+      const response = await POST(postRequest({ drawCount: 11 }));
+      expect(response.status).toBe(400);
+    });
+
+    it("DB_DRIVER=pg: 所有権確認 + UPDATE が正しいテーブル/条件/値で実行され、戻り値が postgrest 経路と一致する", async () => {
+      const OWNED_STREAMER = { id: "streamer-id-1", raid_gacha_active_until: null, raid_gacha_draw_count: 0 };
+      const UPDATED = { raid_gacha_active_until: null, raid_gacha_draw_count: 7 };
+
+      vi.stubEnv("DB_DRIVER", undefined);
+      const supabase = createStreamersSupabaseMock({ data: OWNED_STREAMER, error: null }, { data: UPDATED, error: null });
+      vi.mocked(getSupabaseAdmin).mockReturnValue(supabase as any);
+      const { POST: postgrestPOST } = await loadRoute();
+      const postgrestResponse = await postgrestPOST(postRequest({ drawCount: 7 }));
+      const postgrestBody = await postgrestResponse.json();
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [OWNED_STREAMER] }],
+        updates: [{ rows: [UPDATED] }],
+      });
+      primePgDb(pg);
+      const { POST: pgPOST } = await loadRoute();
+      const pgResponse = await pgPOST(postRequest({ drawCount: 7 }));
+      const pgBody = await pgResponse.json();
+
+      expect(pgResponse.status).toBe(postgrestResponse.status);
+      expect(pgBody).toEqual(postgrestBody);
+      expect(getDb).toHaveBeenCalled();
+      expect(pg.updateCalls[0].set).toEqual({ raid_gacha_draw_count: 7 });
+      expect(pg.updateCalls[0].where).toEqual(eq(streamersTable.id, "streamer-id-1"));
+    });
+
+    it("DB_DRIVER=pg-read (書き込みは postgrest のまま): POST の UPDATE は getDb を呼ばない", async () => {
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [{ id: "streamer-id-1", raid_gacha_active_until: null, raid_gacha_draw_count: 0 }] }] });
+      primePgDb(pg);
+      const supabase = createStreamersSupabaseMock(
+        { data: null, error: null },
+        { data: { raid_gacha_active_until: null, raid_gacha_draw_count: 2 }, error: null }
+      );
+      vi.mocked(getSupabaseAdmin).mockReturnValue(supabase as any);
+
+      const { POST } = await loadRoute();
+      const response = await POST(postRequest({ drawCount: 2 }));
+
+      expect(response.status).toBe(200);
+      // 所有権確認(読み取り)は pg-read で pg 経由、UPDATE(書き込み)は postgrest 経由
+      expect(getDb).toHaveBeenCalledTimes(1);
+      expect(supabase.update).toHaveBeenCalled();
+    });
+
+    it("DB_DRIVER=pg: streamerが見つからなければ両経路とも404", async () => {
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] });
+      primePgDb(pg);
+
+      const { POST } = await loadRoute();
+      const response = await POST(postRequest({ drawCount: 1 }));
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/tests/unit/sound-settings-driver-parity.test.ts
+++ b/tests/unit/sound-settings-driver-parity.test.ts
@@ -1,0 +1,194 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — 配信者効果音設定(公開エンドポイント)の
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * 対象: GET /api/streamer/[streamerId]/sound-settings（認証不要の公開API）
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { eq } from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
+import { streamers as streamersTable } from "@/lib/db/schema";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>;
+  error?: unknown;
+}
+
+function createDrizzleDbMock(config: { selects?: PgResponse[] } = {}) {
+  let selectIndex = 0;
+  const selectCalls: Array<{ where?: unknown }> = [];
+
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }];
+      const response = responses[Math.min(selectIndex, responses.length - 1)];
+      selectIndex += 1;
+      const call: { where?: unknown } = {};
+      selectCalls.push(call);
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              (response.rows ?? []).map((row) =>
+                Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+              )
+            );
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        limit: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+  };
+  return { db, selectCalls };
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any);
+}
+
+function createSoundSettingsSupabaseMock(response: { data: unknown; error: unknown; status?: number }) {
+  const query = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(response),
+  };
+  return { from: vi.fn(() => query), query };
+}
+
+async function loadRoute() {
+  const mod = await import("@/app/api/streamer/[streamerId]/sound-settings/route");
+  return mod.GET;
+}
+
+function request() {
+  return new NextRequest("http://localhost:3000/api/streamer/streamer-1/sound-settings");
+}
+
+describe("GET /api/streamer/[streamerId]/sound-settings: postgrest / pg 経路の互換 (#663)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("フラグ未設定時は getDb が呼ばれない（挙動不変の検証）", async () => {
+    vi.stubEnv("DB_DRIVER", undefined);
+    const mockSupabase = createSoundSettingsSupabaseMock({
+      data: { gacha_sound_url: "https://cdn.example.com/sound.mp3", gacha_sound_enabled: true, gacha_sound_rules: [] },
+      error: null,
+      status: 200,
+    });
+    vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabase as any);
+
+    const GET = await loadRoute();
+    const response = await GET(request(), { params: Promise.resolve({ streamerId: "streamer-1" }) });
+
+    expect(response.status).toBe(200);
+    expect(getDb).not.toHaveBeenCalled();
+  });
+
+  it("DB_DRIVER=pg-read: 同一fixtureで両経路の戻り値が一致する", async () => {
+    const FIXTURE = { gacha_sound_url: "https://cdn.example.com/sound.mp3", gacha_sound_enabled: true, gacha_sound_rules: [] };
+
+    vi.stubEnv("DB_DRIVER", undefined);
+    const client = createSoundSettingsSupabaseMock({ data: FIXTURE, error: null, status: 200 });
+    vi.mocked(getSupabaseAdmin).mockReturnValue(client as any);
+    const postgrestGET = await loadRoute();
+    const postgrestResponse = await postgrestGET(request(), { params: Promise.resolve({ streamerId: "streamer-1" }) });
+    const postgrestBody = await postgrestResponse.json();
+
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    const pg = createDrizzleDbMock({ selects: [{ rows: [FIXTURE] }] });
+    primePgDb(pg);
+    const pgGET = await loadRoute();
+    const pgResponse = await pgGET(request(), { params: Promise.resolve({ streamerId: "streamer-1" }) });
+    const pgBody = await pgResponse.json();
+
+    expect(pgResponse.status).toBe(postgrestResponse.status);
+    expect(pgBody).toEqual(postgrestBody);
+    expect(getDb).toHaveBeenCalled();
+    expect(pg.selectCalls[0].where).toEqual(eq(streamersTable.id, "streamer-1"));
+  });
+
+  it("DB_DRIVER=pg-read: streamerが見つからなければ両経路とも404", async () => {
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    const pg = createDrizzleDbMock({ selects: [{ rows: [] }] });
+    primePgDb(pg);
+
+    const GET = await loadRoute();
+    const response = await GET(request(), { params: Promise.resolve({ streamerId: "missing-streamer" }) });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Streamer not found" });
+  });
+
+  it("DB_DRIVER=pg-read: gacha_sound_rules列欠落エラーからのフォールバックが両経路で一致する", async () => {
+    const LEGACY_FIXTURE = { gacha_sound_url: "https://cdn.example.com/legacy.mp3", gacha_sound_enabled: true };
+
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    let call = 0;
+    const db = {
+      select: vi.fn((fields: Record<string, unknown>) => {
+        call += 1;
+        const builder: any = {
+          from: vi.fn(() => builder),
+          where: vi.fn(() => builder),
+          limit: vi.fn(() => builder),
+          then: (onFulfilled: any, onRejected: any) => {
+            if (call === 1) {
+              // フル select は gacha_sound_rules 列欠落で失敗（pg ネイティブの 42703 相当）
+              return Promise.reject({
+                code: "42703",
+                message: 'column "gacha_sound_rules" of relation "streamers" does not exist',
+              }).then(onFulfilled, onRejected);
+            }
+            return Promise.resolve(
+              Object.keys(fields).map(() => LEGACY_FIXTURE)[0]
+                ? [Object.fromEntries(Object.keys(fields).map((k) => [k, (LEGACY_FIXTURE as any)[k] ?? null]))]
+                : []
+            ).then(onFulfilled, onRejected);
+          },
+        };
+        return builder;
+      }),
+    };
+    vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any);
+
+    const GET = await loadRoute();
+    const response = await GET(request(), { params: Promise.resolve({ streamerId: "streamer-1" }) });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.soundUrl).toBe("https://cdn.example.com/legacy.mp3");
+    expect(body.soundEnabled).toBe(true);
+  });
+
+  it("DB_DRIVER=pg-read: 未分類のDBエラーは両経路とも安全側デフォルト（効果音無効）に落ちる", async () => {
+    vi.stubEnv("DB_DRIVER", "pg-read");
+    const pg = createDrizzleDbMock({ selects: [{ error: { code: "08006", message: "connection failure" } }] });
+    primePgDb(pg);
+
+    const GET = await loadRoute();
+    const response = await GET(request(), { params: Promise.resolve({ streamerId: "streamer-1" }) });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ soundUrl: null, soundEnabled: false });
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/storage-db-driver-parity.test.ts
+++ b/tests/unit/storage-db-driver-parity.test.ts
@@ -10,12 +10,14 @@
  *   同一 fixture での戻り値一致を検証する。
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { and, eq } from 'drizzle-orm'
+import { and, desc, eq, inArray } from 'drizzle-orm'
 import {
   recordBlobFile,
   removeBlobFile,
   getStorageBonusBytes,
   hasStorageBonusByTwitchUserId,
+  getStorageUsageFromDB,
+  getAllStorageUsage,
 } from '@/lib/storage-db'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { getDb } from '@/lib/db/client'
@@ -23,6 +25,7 @@ import {
   blobFiles as blobFilesTable,
   streamers as streamersTable,
   streamerStorageBonus as streamerStorageBonusTable,
+  storageUsage as storageUsageTable,
 } from '@/lib/db/schema'
 
 vi.mock('@/lib/logger', () => ({
@@ -55,6 +58,7 @@ function createSupabaseClientMock(resultsByTable: Record<string, PostgrestResult
       select: vi.fn(() => builder),
       eq: vi.fn(() => builder),
       in: vi.fn(() => builder),
+      order: vi.fn(() => builder),
       maybeSingle: vi.fn(() => Promise.resolve(resolved)),
       insert: vi.fn((values: unknown) => {
         insertCalls.push({ table, values })
@@ -87,7 +91,7 @@ function createDrizzleDbMock(config: {
   let selectIndex = 0
   let insertIndex = 0
   let deleteIndex = 0
-  const selectCalls: Array<{ joins: Array<{ table: unknown; on: unknown }>; where?: unknown }> = []
+  const selectCalls: Array<{ joins: Array<{ table: unknown; on: unknown }>; where?: unknown; orderBy?: unknown }> = []
   const insertCalls: Array<{ table: unknown; values?: Record<string, unknown> }> = []
   const deleteCalls: Array<{ table: unknown; where?: unknown }> = []
 
@@ -96,7 +100,7 @@ function createDrizzleDbMock(config: {
       const responses = config.selects ?? [{ rows: [] }]
       const response = responses[Math.min(selectIndex, responses.length - 1)]
       selectIndex += 1
-      const call: { joins: Array<{ table: unknown; on: unknown }>; where?: unknown } = { joins: [] }
+      const call: { joins: Array<{ table: unknown; on: unknown }>; where?: unknown; orderBy?: unknown } = { joins: [] }
       selectCalls.push(call)
       const resolve = () =>
         response.error
@@ -118,6 +122,10 @@ function createDrizzleDbMock(config: {
         }),
         where: vi.fn((condition: unknown) => {
           call.where = condition
+          return builder
+        }),
+        orderBy: vi.fn((condition: unknown) => {
+          call.orderBy = condition
           return builder
         }),
         limit: vi.fn(() => builder),
@@ -408,6 +416,120 @@ describe('storage-db: postgrest / pg 経路の互換 (#572)', () => {
         )
         expect(pg.selectCalls[0].where).toEqual(eq(streamersTable.twitch_user_id, 'twitch-user-1'))
       }
+    })
+  })
+
+  describe('getStorageUsageFromDB（読み取り: isPgReadEnabled、#663）', () => {
+    const USER_PREFIX = 'prefix12'
+    const GLOBAL_PREFIX = '_global_'
+
+    it('userとglobal両方の行がある場合、両経路の戻り値が一致する', async () => {
+      const rows = [
+        { user_prefix: USER_PREFIX, bytes_used: 1000 },
+        { user_prefix: GLOBAL_PREFIX, bytes_used: 5000 },
+      ]
+
+      vi.stubEnv('DB_DRIVER', undefined)
+      const client = createSupabaseClientMock({ storage_usage: [{ data: rows }] })
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+      const postgrestResult = await getStorageUsageFromDB(USER_PREFIX)
+
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      const pg = createDrizzleDbMock({ selects: [{ rows }] })
+      primePgDb(pg)
+      const pgResult = await getStorageUsageFromDB(USER_PREFIX)
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect(pgResult).toEqual({
+        userUsage: 1000,
+        globalUsage: 5000,
+        userLimitReached: false,
+        globalLimitReached: false,
+        userLimitBytes: pgResult.userLimitBytes,
+        globalLimitBytes: pgResult.globalLimitBytes,
+      })
+
+      // pg 経路のクエリが user_prefix IN (userPrefix, GLOBAL_PREFIX) 相当で発行される
+      expect(pg.selectCalls[0].where).toEqual(
+        inArray(storageUsageTable.user_prefix, [USER_PREFIX, GLOBAL_PREFIX])
+      )
+    })
+
+    it('該当行が無い場合、両経路とも0を返す', async () => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      const client = createSupabaseClientMock({ storage_usage: [{ data: [] }] })
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+      const postgrestResult = await getStorageUsageFromDB(USER_PREFIX)
+
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] })
+      primePgDb(pg)
+      const pgResult = await getStorageUsageFromDB(USER_PREFIX)
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect(pgResult.userUsage).toBe(0)
+      expect(pgResult.globalUsage).toBe(0)
+    })
+
+    it('pg 経路で取得エラー時は例外を投げず安全側のデフォルト値を返す（既存と同じ外部挙動）', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      const pg = createDrizzleDbMock({ selects: [{ error: { code: '08006', message: 'connection failure' } }] })
+      primePgDb(pg)
+
+      const result = await getStorageUsageFromDB(USER_PREFIX)
+
+      expect(result).toEqual({
+        userUsage: 0,
+        globalUsage: 0,
+        userLimitReached: false,
+        globalLimitReached: false,
+        userLimitBytes: result.userLimitBytes,
+        globalLimitBytes: result.globalLimitBytes,
+      })
+    })
+  })
+
+  describe('getAllStorageUsage（読み取り: isPgReadEnabled、#663）', () => {
+    const ROWS = [
+      { user_prefix: 'aaaaaaaa', bytes_used: 9000, blob_count: 3 },
+      { user_prefix: 'bbbbbbbb', bytes_used: 1000, blob_count: 1 },
+    ]
+
+    it('bytes_used降順で両経路の戻り値が一致する', async () => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      const client = createSupabaseClientMock({ storage_usage: [{ data: ROWS }] })
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+      const postgrestResult = await getAllStorageUsage()
+
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      const pg = createDrizzleDbMock({ selects: [{ rows: ROWS }] })
+      primePgDb(pg)
+      const pgResult = await getAllStorageUsage()
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect(pgResult).toEqual([
+        { userPrefix: 'aaaaaaaa', bytesUsed: 9000, blobCount: 3 },
+        { userPrefix: 'bbbbbbbb', bytesUsed: 1000, blobCount: 1 },
+      ])
+
+      // pg 経路のクエリが bytes_used 降順で発行される
+      expect(pg.selectCalls[0].orderBy).toEqual(desc(storageUsageTable.bytes_used))
+    })
+
+    it('pg 経路で取得エラー時は throw する（既存と同じ外部挙動、デフォルト値へのフォールバックはしない）', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+      const pg = createDrizzleDbMock({ selects: [{ error: { code: '08006', message: 'connection failure' } }] })
+      primePgDb(pg)
+
+      await expect(getAllStorageUsage()).rejects.toBeTruthy()
+    })
+
+    it('postgrest 経路（フラグ未設定）では getDb が一切呼ばれない', async () => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      const client = createSupabaseClientMock({ storage_usage: [{ data: ROWS }] })
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+      await getAllStorageUsage()
+      expect(getDb).not.toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/streamer-settings-driver-parity.test.ts
+++ b/tests/unit/streamer-settings-driver-parity.test.ts
@@ -1,0 +1,426 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — 配信者設定APIの
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * 対象: POST /api/streamer/settings
+ * ここでは DB アクセスの形状（クエリ対象テーブル/条件/値、フォールバック
+ * チェインの発火順序、skip フラグの立ち方）に焦点を当てる。バリデーション/
+ * 正規化ロジックそのものの網羅的な検証は既存の tests/unit/streamer-settings-api.test.ts
+ * （postgrest経路、76ケース）に委ねる。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { getSession, canUseStreamerFeatures } from "@/lib/session";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { validateCSRFToken } from "@/lib/csrf";
+import { validateContentType } from "@/lib/request-validation";
+import { getUserPlan } from "@/lib/plan";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { getDb } from "@/lib/db/client";
+import {
+  streamers as streamersTable,
+  streamerChatSenderSettings as streamerChatSenderSettingsTable,
+  twitchBotAccounts as twitchBotAccountsTable,
+} from "@/lib/db/schema";
+import { createSupabaseMock } from "../utils/supabase-mock";
+
+vi.mock("@/lib/session");
+vi.mock("@/lib/rate-limit");
+vi.mock("@/lib/csrf");
+vi.mock("@/lib/request-validation");
+vi.mock("@/lib/plan");
+vi.mock("@/lib/constants", async (importOriginal) => await importOriginal());
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@/lib/supabase/admin", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/supabase/admin")>();
+  return { ...actual, getSupabaseAdmin: vi.fn() };
+});
+
+const mockGetSession = vi.mocked(getSession);
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures);
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken);
+const mockValidateContentType = vi.mocked(validateContentType);
+const mockGetUserPlan = vi.mocked(getUserPlan);
+
+const SESSION = {
+  twitchUserId: "streamer123",
+  twitchUsername: "testuser",
+  twitchDisplayName: "Test User",
+  twitchProfileImageUrl: "https://example.com/avatar.jpg",
+  broadcasterType: "affiliate",
+  expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+  version: 1,
+};
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>;
+  error?: unknown;
+}
+
+function createDrizzleDbMock(
+  config: { selects?: PgResponse[]; updates?: PgResponse[]; inserts?: PgResponse[]; deletes?: PgResponse[] } = {}
+) {
+  let selectIndex = 0;
+  let updateIndex = 0;
+  let insertIndex = 0;
+  let deleteIndex = 0;
+  const selectCalls: Array<{ where?: unknown }> = [];
+  const updateCalls: Array<{ table: unknown; set?: unknown; where?: unknown }> = [];
+  const insertCalls: Array<{ table: unknown; values?: unknown; onConflict?: unknown }> = [];
+  const deleteCalls: Array<{ table: unknown; where?: unknown }> = [];
+
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }];
+      const response = responses[Math.min(selectIndex, responses.length - 1)];
+      selectIndex += 1;
+      const call: { where?: unknown } = {};
+      selectCalls.push(call);
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              (response.rows ?? []).map((row) =>
+                Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+              )
+            );
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        limit: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+    update: vi.fn((table: unknown) => {
+      const responses = config.updates ?? [{ rows: [] }];
+      const response = responses[Math.min(updateIndex, responses.length - 1)];
+      updateIndex += 1;
+      const call: { table: unknown; set?: unknown; where?: unknown } = { table };
+      updateCalls.push(call);
+      const resolve = () => (response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []));
+      const builder: any = {
+        set: vi.fn((values: Record<string, unknown>) => {
+          // updateData は呼び出し元(applyStreamerSettingsUpdatePg)と共有する同一
+          // オブジェクト参照であり、カスケード内で後続の delete によって
+          // ミューテートされる。呼び出し記録として使うため、記録時点の
+          // スナップショット(浅いコピー)を保存する(参照だとテスト側の
+          // アサーション時点で最終状態しか見えなくなる)。
+          call.set = { ...values };
+          return builder;
+        }),
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+    insert: vi.fn((table: unknown) => {
+      const responses = config.inserts ?? [{ rows: [] }];
+      const response = responses[Math.min(insertIndex, responses.length - 1)];
+      insertIndex += 1;
+      const call: { table: unknown; values?: unknown; onConflict?: unknown } = { table };
+      insertCalls.push(call);
+      const resolve = () => (response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []));
+      const builder: any = {
+        values: vi.fn((values: unknown) => {
+          call.values = values;
+          return builder;
+        }),
+        onConflictDoUpdate: vi.fn((options: unknown) => {
+          call.onConflict = options;
+          return builder;
+        }),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+    delete: vi.fn((table: unknown) => {
+      const responses = config.deletes ?? [{ rows: [] }];
+      const response = responses[Math.min(deleteIndex, responses.length - 1)];
+      deleteIndex += 1;
+      const call: { table: unknown; where?: unknown } = { table };
+      deleteCalls.push(call);
+      const resolve = () => (response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []));
+      const builder: any = {
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+  };
+  return { db, selectCalls, updateCalls, insertCalls, deleteCalls };
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any);
+}
+
+function postRequest(body: unknown) {
+  return new NextRequest("http://localhost:3000/api/streamer/settings", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function loadRoute() {
+  return import("@/app/api/streamer/settings/route");
+}
+
+describe("streamer/settings POST: postgrest / pg 経路の互換 (#663)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(SESSION as any);
+    mockCanUseStreamerFeatures.mockReturnValue(true);
+    mockCheckRateLimit.mockResolvedValue({ success: true, limit: 10, remaining: 9, reset: Date.now() + 60000 } as any);
+    mockValidateCSRFToken.mockResolvedValue({ valid: true } as any);
+    mockValidateContentType.mockReturnValue(null);
+    mockGetUserPlan.mockResolvedValue("support" as any);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("フラグ未設定時は getDb が呼ばれない（挙動不変の検証）", async () => {
+    vi.stubEnv("DB_DRIVER", undefined);
+    const mockSupabase = createSupabaseMock()
+      .withMaybeSingleResponse({ id: "streamer123", twitch_user_id: "streamer123" })
+      .build();
+    vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabase as any);
+
+    const { POST } = await loadRoute();
+    const response = await POST(
+      postRequest({ streamerId: "streamer123", channelPointRewardId: "reward-123" })
+    );
+
+    expect(response.status).toBe(200);
+    expect(getDb).not.toHaveBeenCalled();
+  });
+
+  it("DB_DRIVER=pg: 所有権SELECT + UPDATE が正しいテーブル/条件/値で実行され、戻り値が postgrest 経路と一致する", async () => {
+    vi.stubEnv("DB_DRIVER", undefined);
+    const supabaseMock = createSupabaseMock()
+      .withMaybeSingleResponse({
+        id: "streamer123",
+        channel_point_collection_name: null,
+        card_pack_names: [],
+        pack_rarity_weights: null,
+      })
+      .build();
+    vi.mocked(getSupabaseAdmin).mockReturnValue(supabaseMock as any);
+    const { POST: postgrestPOST } = await loadRoute();
+    const postgrestResponse = await postgrestPOST(
+      postRequest({
+        streamerId: "streamer123",
+        channelPointRewardId: "reward-123",
+        channelPointRewardName: "Test Reward",
+      })
+    );
+    const postgrestBody = await postgrestResponse.json();
+
+    vi.stubEnv("DB_DRIVER", "pg");
+    const pg = createDrizzleDbMock({
+      selects: [
+        {
+          rows: [
+            { id: "streamer123", channel_point_collection_name: null, card_pack_names: [], pack_rarity_weights: null },
+          ],
+        },
+      ],
+      updates: [{ rows: [] }],
+    });
+    primePgDb(pg);
+    const { POST: pgPOST } = await loadRoute();
+    const pgResponse = await pgPOST(
+      postRequest({
+        streamerId: "streamer123",
+        channelPointRewardId: "reward-123",
+        channelPointRewardName: "Test Reward",
+      })
+    );
+    const pgBody = await pgResponse.json();
+
+    expect(pgResponse.status).toBe(postgrestResponse.status);
+    expect(pgBody).toEqual(postgrestBody);
+    expect(getDb).toHaveBeenCalled();
+    expect(pg.selectCalls[0].where).toEqual(
+      and(eq(streamersTable.id, "streamer123"), eq(streamersTable.twitch_user_id, "streamer123"))
+    );
+    expect(pg.updateCalls[0].table).toBe(streamersTable);
+    expect(pg.updateCalls[0].set).toEqual(
+      expect.objectContaining({ channel_point_reward_id: "reward-123", channel_point_reward_name: "Test Reward" })
+    );
+    expect(pg.updateCalls[0].where).toEqual(eq(streamersTable.id, "streamer123"));
+  });
+
+  it("DB_DRIVER=pg: streamer所有権が無ければ両経路とも403", async () => {
+    vi.stubEnv("DB_DRIVER", "pg");
+    const pg = createDrizzleDbMock({ selects: [{ rows: [] }] });
+    primePgDb(pg);
+
+    const { POST } = await loadRoute();
+    const response = await POST(postRequest({ streamerId: "streamer123", channelPointRewardId: "reward-1" }));
+    expect(response.status).toBe(403);
+  });
+
+  it("DB_DRIVER=pg: rarity_weights_scope 列欠落 → 剥がして再試行し、rarityWeightsScopeSkippedDeployWindow を返す", async () => {
+    vi.stubEnv("DB_DRIVER", "pg");
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [{ id: "streamer123", channel_point_collection_name: null, card_pack_names: [], pack_rarity_weights: null }] }],
+      updates: [
+        { error: { code: "42703", message: 'column "rarity_weights_scope" of relation "streamers" does not exist' } },
+        { rows: [] },
+      ],
+    });
+    primePgDb(pg);
+
+    const { POST } = await loadRoute();
+    // rarityWeightsScope 単独だと剥がした後 updateData が空になり2回目のDB呼び出しが
+    // 発生しない(postgrest経路と同じ「空になったら error=null」短絡)ため、剥がされない
+    // 別フィールド(showUnownedCards)を同時に送って実際にリトライが発火することを検証する。
+    const response = await POST(
+      postRequest({ streamerId: "streamer123", rarityWeightsScope: "per_pack", showUnownedCards: true })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.rarityWeightsScopeSkippedDeployWindow).toBe(true);
+    expect(pg.updateCalls).toHaveLength(2);
+    expect(pg.updateCalls[0].set).toEqual({ rarity_weights_scope: "per_pack", show_unowned_cards: true });
+    expect(pg.updateCalls[1].set).toEqual({ show_unowned_cards: true });
+  });
+
+  it("DB_DRIVER=pg: gacha_sound_rules 列欠落 → legacy fallback で保存し、gachaSoundRulesSkippedDeployWindow を返す", async () => {
+    vi.stubEnv("DB_DRIVER", "pg");
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [{ id: "streamer123", channel_point_collection_name: null, card_pack_names: [], pack_rarity_weights: null }] }],
+      updates: [
+        { error: { code: "PGRST204", message: "Could not find the 'gacha_sound_rules' column" } },
+        { rows: [] },
+      ],
+    });
+    primePgDb(pg);
+
+    const { POST } = await loadRoute();
+    const response = await POST(
+      postRequest({
+        streamerId: "streamer123",
+        gachaSoundRules: [
+          { id: "catch-all", url: "https://example.com/all.mp3", enabled: true, label: "A", targetType: "all", rarity: null, rewardId: null, rewardName: null },
+        ],
+      })
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.gachaSoundRulesSkippedDeployWindow).toBe(true);
+    expect(pg.updateCalls).toHaveLength(2);
+    // legacy fallback: gacha_sound_rules は含まれないが gacha_sound_url/enabled は含まれる
+    expect(pg.updateCalls[1].set).toEqual(
+      expect.objectContaining({ gacha_sound_url: "https://example.com/all.mp3", gacha_sound_enabled: true })
+    );
+    expect(pg.updateCalls[1].set).not.toHaveProperty("gacha_sound_rules");
+  });
+
+  it("DB_DRIVER=pg: disconnectBot=true が UPSERT(onConflictDoUpdate) + DELETE を正しい条件で実行する", async () => {
+    vi.stubEnv("DB_DRIVER", "pg");
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [{ id: "streamer123", channel_point_collection_name: null, card_pack_names: [], pack_rarity_weights: null }] }],
+      inserts: [{ rows: [] }],
+      deletes: [{ rows: [] }],
+    });
+    primePgDb(pg);
+
+    const { POST } = await loadRoute();
+    const response = await POST(postRequest({ streamerId: "streamer123", disconnectBot: true }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(pg.insertCalls[0].table).toBe(streamerChatSenderSettingsTable);
+    expect(pg.insertCalls[0].values).toEqual({
+      streamer_id: "streamer123",
+      sender_mode: "streamer",
+      custom_bot_account_id: null,
+    });
+    expect(pg.insertCalls[0].onConflict).toEqual({
+      target: streamerChatSenderSettingsTable.streamer_id,
+      set: { sender_mode: "streamer", custom_bot_account_id: null },
+    });
+    expect(pg.deleteCalls[0].table).toBe(twitchBotAccountsTable);
+    expect(pg.deleteCalls[0].where).toEqual(
+      and(eq(twitchBotAccountsTable.streamer_id, "streamer123"), eq(twitchBotAccountsTable.owner_type, "streamer"))
+    );
+  });
+
+  it("DB_DRIVER=pg: disconnectBot 失敗時は両経路とも handleDatabaseError(500) を返す", async () => {
+    vi.stubEnv("DB_DRIVER", "pg");
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [{ id: "streamer123", channel_point_collection_name: null, card_pack_names: [], pack_rarity_weights: null }] }],
+      inserts: [{ error: { code: "08006", message: "connection failure" } }],
+    });
+    primePgDb(pg);
+
+    const { POST } = await loadRoute();
+    const response = await POST(postRequest({ streamerId: "streamer123", disconnectBot: true }));
+    expect(response.status).toBe(500);
+  });
+
+  it("DB_DRIVER=pg: card_pack_names列欠落の所有権SELECTフォールバックが正しい列セットで再試行される", async () => {
+    vi.stubEnv("DB_DRIVER", "pg");
+    let selectCall = 0;
+    const db = {
+      select: vi.fn((fields: Record<string, unknown>) => {
+        selectCall += 1;
+        const thisCall = selectCall;
+        const builder: any = {
+          from: vi.fn(() => builder),
+          where: vi.fn(() => builder),
+          limit: vi.fn(() => builder),
+          then: (onFulfilled: any, onRejected: any) => {
+            if (thisCall === 1) {
+              return Promise.reject({
+                code: "42703",
+                message: "column streamers.card_pack_names does not exist",
+              }).then(onFulfilled, onRejected);
+            }
+            // 2回目は card_pack_names / pack_rarity_weights を落とした列セット
+            expect(Object.keys(fields).sort()).toEqual(["channel_point_collection_name", "id"].sort());
+            return Promise.resolve([{ id: "streamer123", channel_point_collection_name: null }]).then(onFulfilled, onRejected);
+          },
+        };
+        return builder;
+      }),
+      update: vi.fn(() => {
+        const builder: any = {
+          set: vi.fn(() => builder),
+          where: vi.fn(() => builder),
+          then: (onFulfilled: any, onRejected: any) => Promise.resolve([]).then(onFulfilled, onRejected),
+        };
+        return builder;
+      }),
+    };
+    vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any);
+
+    const { POST } = await loadRoute();
+    const response = await POST(postRequest({ streamerId: "streamer123", channelPointRewardId: "reward-1" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+});

--- a/tests/unit/support-inquiries-lib-driver-parity.test.ts
+++ b/tests/unit/support-inquiries-lib-driver-parity.test.ts
@@ -1,0 +1,277 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — src/lib/support-inquiries.ts の
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * 対象:
+ *   - getUserInquiries        （一覧取得: isPgReadEnabled）
+ *   - getInquiryWithMessages  （詳細+メッセージ取得: isPgReadEnabled、
+ *                                メッセージ取得だけの部分失敗を messages: [] にフォールバック）
+ *
+ * これらは src/app/api/support-inquiries/ 配下のルートハンドラとは独立した
+ * データアクセス関数（ダッシュボードの Server Component から呼ばれる）。
+ * クエリ形状はルート側の実装とほぼ同じだが、意図的に別実装として保守する方針
+ * （brief 記載のとおり、共有ヘルパーへの統合はスコープ外）。
+ *
+ * announcements-driver-parity.test.ts / storage-db-driver-parity.test.ts の流儀を踏襲。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { and, asc, desc, eq } from "drizzle-orm";
+import { getUserInquiries, getInquiryWithMessages } from "@/lib/support-inquiries";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { getDb } from "@/lib/db/client";
+import {
+  supportInquiries as supportInquiriesTable,
+  supportInquiryMessages as supportInquiryMessagesTable,
+} from "@/lib/db/schema";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const TWITCH_USER_ID = "user123";
+const INQUIRY_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+const INQUIRY_ROWS = [
+  {
+    id: INQUIRY_ID,
+    twitch_user_id: TWITCH_USER_ID,
+    twitch_display_name: "TestUser",
+    category: "bug",
+    subject: "Test bug",
+    body: "Bug description",
+    status: "open",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+const MESSAGE_ROWS = [
+  {
+    id: "msg-1",
+    inquiry_id: INQUIRY_ID,
+    sender_type: "user",
+    sender_id: TWITCH_USER_ID,
+    body: "Hello",
+    created_at: "2026-01-01T01:00:00Z",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// postgrest 経路のモック: table ごとの結果キュー
+// ---------------------------------------------------------------------------
+
+interface PostgrestResult {
+  data?: unknown;
+  error?: unknown;
+}
+
+function createSupabaseClientMock(resultsByTable: Record<string, PostgrestResult[]>) {
+  const queues = Object.fromEntries(
+    Object.entries(resultsByTable).map(([table, results]) => [table, [...results]])
+  );
+  const from = vi.fn((table: string) => {
+    const queue = queues[table];
+    if (!queue || queue.length === 0) {
+      throw new Error(`no mock result configured for table: ${table}`);
+    }
+    const result = queue.length > 1 ? (queue.shift() as PostgrestResult) : queue[0];
+    const resolved = { data: result.data ?? null, error: result.error ?? null };
+    const builder: any = {
+      select: vi.fn(() => builder),
+      eq: vi.fn(() => builder),
+      order: vi.fn(() => builder),
+      single: vi.fn(() => Promise.resolve(resolved)),
+      then: (onFulfilled: any, onRejected: any) =>
+        Promise.resolve(resolved).then(onFulfilled, onRejected),
+    };
+    return builder;
+  });
+  return { from };
+}
+
+// ---------------------------------------------------------------------------
+// pg 経路のモック: select(fields).from(table).where().orderBy().limit()
+// を await できる thenable builder
+// ---------------------------------------------------------------------------
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>;
+  error?: unknown;
+}
+
+function createDrizzleDbMock(config: { selects?: PgResponse[] } = {}) {
+  let selectIndex = 0;
+  const selectCalls: Array<{ where?: unknown; orderBy?: unknown; limit?: number }> = [];
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }];
+      const response = responses[Math.min(selectIndex, responses.length - 1)];
+      selectIndex += 1;
+      const call: { where?: unknown; orderBy?: unknown; limit?: number } = {};
+      selectCalls.push(call);
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              (response.rows ?? []).map((row) =>
+                Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+              )
+            );
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        orderBy: vi.fn((condition: unknown) => {
+          call.orderBy = condition;
+          return builder;
+        }),
+        limit: vi.fn((n: number) => {
+          call.limit = n;
+          return builder;
+        }),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+  };
+  return { db, selectCalls };
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any);
+}
+
+describe("support-inquiries lib: postgrest / pg 経路の互換 (#663)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("getUserInquiries（読み取り: isPgReadEnabled）", () => {
+    it("同一 fixture で両経路の戻り値が deepEqual になり、pg 経路が正しい where/orderBy を使う", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({ support_inquiries: [{ data: INQUIRY_ROWS }] });
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any);
+      const postgrestResult = await getUserInquiries(TWITCH_USER_ID);
+
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({ selects: [{ rows: INQUIRY_ROWS }] });
+      primePgDb(pg);
+      const pgResult = await getUserInquiries(TWITCH_USER_ID);
+
+      expect(pgResult).toEqual(postgrestResult);
+      expect(pgResult).toEqual(INQUIRY_ROWS);
+
+      expect(pg.selectCalls[0].where).toEqual(eq(supportInquiriesTable.twitch_user_id, TWITCH_USER_ID));
+      expect(pg.selectCalls[0].orderBy).toEqual(desc(supportInquiriesTable.created_at));
+    });
+
+    it("取得失敗時は両経路とも空配列を返す（安全側デグレード）", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        support_inquiries: [{ data: null, error: new Error("db error") }],
+      });
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any);
+      const postgrestResult = await getUserInquiries(TWITCH_USER_ID);
+      expect(postgrestResult).toEqual([]);
+
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({ selects: [{ error: { code: "08006", message: "connection failure" } }] });
+      primePgDb(pg);
+      const pgResult = await getUserInquiries(TWITCH_USER_ID);
+      expect(pgResult).toEqual([]);
+    });
+
+    it("postgrest 経路（フラグ未設定）では getDb が一切呼ばれない", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({ support_inquiries: [{ data: INQUIRY_ROWS }] });
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any);
+      await getUserInquiries(TWITCH_USER_ID);
+      expect(getDb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getInquiryWithMessages（読み取り: isPgReadEnabled）", () => {
+    it("同一 fixture で両経路の戻り値が deepEqual になり、pg 経路が正しい where/orderBy を使う", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        support_inquiries: [{ data: INQUIRY_ROWS[0] }],
+        support_inquiry_messages: [{ data: MESSAGE_ROWS }],
+      });
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any);
+      const postgrestResult = await getInquiryWithMessages(INQUIRY_ID, TWITCH_USER_ID);
+
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [INQUIRY_ROWS[0]] }, { rows: MESSAGE_ROWS }],
+      });
+      primePgDb(pg);
+      const pgResult = await getInquiryWithMessages(INQUIRY_ID, TWITCH_USER_ID);
+
+      expect(pgResult).toEqual(postgrestResult);
+      expect(pgResult).toEqual({ inquiry: INQUIRY_ROWS[0], messages: MESSAGE_ROWS });
+
+      expect(pg.selectCalls[0].where).toEqual(
+        and(eq(supportInquiriesTable.id, INQUIRY_ID), eq(supportInquiriesTable.twitch_user_id, TWITCH_USER_ID))
+      );
+      expect(pg.selectCalls[1].where).toEqual(eq(supportInquiryMessagesTable.inquiry_id, INQUIRY_ID));
+      expect(pg.selectCalls[1].orderBy).toEqual(asc(supportInquiryMessagesTable.created_at));
+    });
+
+    it("問い合わせが見つからない場合、両経路とも null を返す", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        support_inquiries: [{ data: null, error: new Error("Not found") }],
+      });
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any);
+      const postgrestResult = await getInquiryWithMessages(INQUIRY_ID, TWITCH_USER_ID);
+      expect(postgrestResult).toBeNull();
+
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] });
+      primePgDb(pg);
+      const pgResult = await getInquiryWithMessages(INQUIRY_ID, TWITCH_USER_ID);
+      expect(pgResult).toBeNull();
+    });
+
+    it("問い合わせ本体は取得できるがメッセージ取得だけ失敗した場合、両経路とも messages: [] にフォールバックする（部分失敗）", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        support_inquiries: [{ data: INQUIRY_ROWS[0] }],
+        support_inquiry_messages: [{ data: null, error: new Error("messages query failed") }],
+      });
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any);
+      const postgrestResult = await getInquiryWithMessages(INQUIRY_ID, TWITCH_USER_ID);
+      expect(postgrestResult).toEqual({ inquiry: INQUIRY_ROWS[0], messages: [] });
+
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({
+        selects: [
+          { rows: [INQUIRY_ROWS[0]] },
+          { error: { code: "08006", message: "connection failure" } },
+        ],
+      });
+      primePgDb(pg);
+      const pgResult = await getInquiryWithMessages(INQUIRY_ID, TWITCH_USER_ID);
+      expect(pgResult).toEqual({ inquiry: INQUIRY_ROWS[0], messages: [] });
+
+      expect(pgResult).toEqual(postgrestResult);
+    });
+
+    it("postgrest 経路（フラグ未設定）では getDb が一切呼ばれない", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        support_inquiries: [{ data: INQUIRY_ROWS[0] }],
+        support_inquiry_messages: [{ data: MESSAGE_ROWS }],
+      });
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any);
+      await getInquiryWithMessages(INQUIRY_ID, TWITCH_USER_ID);
+      expect(getDb).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/support-inquiries-routes-driver-parity.test.ts
+++ b/tests/unit/support-inquiries-routes-driver-parity.test.ts
@@ -1,0 +1,637 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — support-inquiries API群の
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * 対象:
+ *   - GET  /api/support-inquiries               （一覧取得: isPgReadEnabled）
+ *   - POST /api/support-inquiries               （新規作成: isPgWriteEnabled）
+ *   - GET  /api/support-inquiries/[id]           （詳細+メッセージ取得: isPgReadEnabled）
+ *   - DELETE /api/support-inquiries/[id]         （削除: isPgWriteEnabled）
+ *   - POST /api/support-inquiries/[id]/messages  （返信追加: isPgWriteEnabled、読み書き混在）
+ *
+ * storage-db-driver-parity.test.ts / gacha-history 系の流儀を踏襲:
+ * 同一 fixture を両経路のモックに与え、戻り値・ステータスコードが deepEqual に
+ * なることと、pg 経路で正しいテーブル/条件（where/orderBy/values）が使われる
+ * ことを検証する。既存の tests/unit/support-inquiries-api.test.ts
+ * （フラグ未設定の postgrest 経路のみを検証）は変更しない。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { and, asc, desc, eq } from "drizzle-orm";
+import { GET, POST } from "@/app/api/support-inquiries/route";
+import { DELETE as DELETE_DETAIL, GET as GET_DETAIL } from "@/app/api/support-inquiries/[id]/route";
+import { POST as POST_MESSAGE } from "@/app/api/support-inquiries/[id]/messages/route";
+import { getSession } from "@/lib/session";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { getUserPlan } from "@/lib/plan";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { validateCSRFToken } from "@/lib/csrf";
+import { getDb } from "@/lib/db/client";
+import {
+  supportInquiries as supportInquiriesTable,
+  supportInquiryMessages as supportInquiryMessagesTable,
+} from "@/lib/db/schema";
+
+vi.mock("@/lib/session");
+vi.mock("@/lib/rate-limit");
+vi.mock("@/lib/plan");
+vi.mock("@/lib/csrf");
+vi.mock("@/lib/supabase/admin", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/supabase/admin")>();
+  return { ...actual, getSupabaseAdmin: vi.fn() };
+});
+vi.mock("@/lib/sentry/error-handler", () => ({
+  reportError: vi.fn(),
+  reportApiError: vi.fn(),
+  logErrorFromLogger: vi.fn(),
+}));
+vi.mock("next/cache", () => ({
+  unstable_cache: (fn: () => Promise<unknown>) => fn,
+}));
+
+const mockGetSession = vi.mocked(getSession);
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+const mockGetUserPlan = vi.mocked(getUserPlan);
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin);
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken);
+
+const MOCK_SESSION = {
+  twitchUserId: "user123",
+  twitchUsername: "testuser",
+  twitchDisplayName: "TestUser",
+  twitchProfileImageUrl: "",
+  broadcasterType: "" as const,
+  expiresAt: Date.now() + 100000,
+  version: 1,
+};
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+function createGetRequest(path = "/api/support-inquiries"): NextRequest {
+  return new NextRequest(new URL(`http://localhost${path}`));
+}
+
+function createPostRequest(
+  body: Record<string, unknown>,
+  path = "/api/support-inquiries"
+): NextRequest {
+  return new NextRequest(new URL(`http://localhost${path}`), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function createDeleteRequest(path: string): NextRequest {
+  return new NextRequest(new URL(`http://localhost${path}`), {
+    method: "DELETE",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// postgrest 経路のモック: table ごとの結果キュー + insert/delete の呼び出し記録
+// ---------------------------------------------------------------------------
+
+interface PostgrestResult {
+  data?: unknown;
+  error?: unknown;
+}
+
+function createSupabaseClientMock(resultsByTable: Record<string, PostgrestResult[]>) {
+  const queues = Object.fromEntries(
+    Object.entries(resultsByTable).map(([table, results]) => [table, [...results]])
+  );
+  const insertCalls: Array<{ table: string; values: unknown }> = [];
+  const deleteCalls: Array<{ table: string }> = [];
+  const eqCalls: Array<{ table: string; column: string; value: unknown }> = [];
+
+  const from = vi.fn((table: string) => {
+    const queue = queues[table];
+    if (!queue || queue.length === 0) {
+      throw new Error(`no mock result configured for table: ${table}`);
+    }
+    const result = queue.length > 1 ? (queue.shift() as PostgrestResult) : queue[0];
+    const resolved = { data: result.data ?? null, error: result.error ?? null };
+    const builder: any = {
+      select: vi.fn(() => builder),
+      insert: vi.fn((values: unknown) => {
+        insertCalls.push({ table, values });
+        return builder;
+      }),
+      delete: vi.fn(() => {
+        deleteCalls.push({ table });
+        return builder;
+      }),
+      eq: vi.fn((column: string, value: unknown) => {
+        eqCalls.push({ table, column, value });
+        return builder;
+      }),
+      order: vi.fn(() => builder),
+      single: vi.fn(() => Promise.resolve(resolved)),
+      then: (onFulfilled: any, onRejected: any) =>
+        Promise.resolve(resolved).then(onFulfilled, onRejected),
+    };
+    return builder;
+  });
+
+  return { from, insertCalls, deleteCalls, eqCalls };
+}
+
+// ---------------------------------------------------------------------------
+// pg 経路のモック: select(fields).from(table).where().orderBy().limit() /
+// insert(table).values().returning() / delete(table).where().returning()
+// を await できる thenable builder。実引数を calls に記録する。
+// ---------------------------------------------------------------------------
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>;
+  error?: unknown;
+}
+
+function createDrizzleDbMock(
+  config: { selects?: PgResponse[]; inserts?: PgResponse[]; deletes?: PgResponse[] } = {}
+) {
+  let selectIndex = 0;
+  let insertIndex = 0;
+  let deleteIndex = 0;
+  const selectCalls: Array<{ where?: unknown; orderBy?: unknown; limit?: number }> = [];
+  const insertCalls: Array<{ table: unknown; values?: Record<string, unknown> }> = [];
+  const deleteCalls: Array<{ table: unknown; where?: unknown }> = [];
+
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }];
+      const response = responses[Math.min(selectIndex, responses.length - 1)];
+      selectIndex += 1;
+      const call: { where?: unknown; orderBy?: unknown; limit?: number } = {};
+      selectCalls.push(call);
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              (response.rows ?? []).map((row) =>
+                Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+              )
+            );
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        orderBy: vi.fn((condition: unknown) => {
+          call.orderBy = condition;
+          return builder;
+        }),
+        limit: vi.fn((n: number) => {
+          call.limit = n;
+          return builder;
+        }),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+    insert: vi.fn((table: unknown) => {
+      const responses = config.inserts ?? [{ rows: [] }];
+      const response = responses[Math.min(insertIndex, responses.length - 1)];
+      insertIndex += 1;
+      const call: { table: unknown; values?: Record<string, unknown> } = { table };
+      insertCalls.push(call);
+      const resolve = () =>
+        response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []);
+      const builder: any = {
+        values: vi.fn((values: Record<string, unknown>) => {
+          call.values = values;
+          return builder;
+        }),
+        returning: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+    delete: vi.fn((table: unknown) => {
+      const responses = config.deletes ?? [{ rows: [] }];
+      const response = responses[Math.min(deleteIndex, responses.length - 1)];
+      deleteIndex += 1;
+      const call: { table: unknown; where?: unknown } = { table };
+      deleteCalls.push(call);
+      const resolve = () =>
+        response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []);
+      const builder: any = {
+        where: vi.fn((condition: unknown) => {
+          call.where = condition;
+          return builder;
+        }),
+        returning: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      };
+      return builder;
+    }),
+  };
+
+  return { db, selectCalls, insertCalls, deleteCalls };
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any);
+}
+
+describe("support-inquiries API群: postgrest / pg 経路の互換 (#663)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(MOCK_SESSION);
+    mockGetUserPlan.mockResolvedValue("support");
+    mockValidateCSRFToken.mockResolvedValue({ valid: true });
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 60,
+      remaining: 59,
+      reset: Date.now() + 60000,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("GET /api/support-inquiries（読み取り: isPgReadEnabled）", () => {
+    const ROWS = [
+      {
+        id: "inq-1",
+        twitch_user_id: "user123",
+        twitch_display_name: "TestUser",
+        category: "bug",
+        subject: "Test bug",
+        body: "Bug description",
+        status: "open",
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+
+    it("同一 fixture で両経路の戻り値が deepEqual になり、pg 経路が正しい where/orderBy を使う", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({ support_inquiries: [{ data: ROWS }] });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await GET(createGetRequest());
+      expect(postgrestRes.status).toBe(200);
+      const postgrestJson = await postgrestRes.json();
+
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({ selects: [{ rows: ROWS }] });
+      primePgDb(pg);
+      const pgRes = await GET(createGetRequest());
+      expect(pgRes.status).toBe(200);
+      const pgJson = await pgRes.json();
+
+      expect(pgJson).toEqual(postgrestJson);
+      expect(pgJson.inquiries).toEqual(ROWS);
+
+      expect(pg.selectCalls[0].where).toEqual(eq(supportInquiriesTable.twitch_user_id, "user123"));
+      expect(pg.selectCalls[0].orderBy).toEqual(desc(supportInquiriesTable.created_at));
+    });
+
+    it("postgrest 経路（フラグ未設定）では getDb が一切呼ばれない", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({ support_inquiries: [{ data: ROWS }] });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      await GET(createGetRequest());
+      expect(getDb).not.toHaveBeenCalled();
+    });
+
+    it("pg 経路では supabase-js クライアントが一切呼ばれない", async () => {
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({ selects: [{ rows: ROWS }] });
+      primePgDb(pg);
+      await GET(createGetRequest());
+      expect(mockGetSupabaseAdmin).not.toHaveBeenCalled();
+    });
+
+    it("pg 経路で取得エラー時は両経路とも500を返す", async () => {
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({ selects: [{ error: { code: "08006", message: "connection failure" } }] });
+      primePgDb(pg);
+      const res = await GET(createGetRequest());
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe("POST /api/support-inquiries（書き込み: isPgWriteEnabled、非冪等）", () => {
+    const REQUEST_BODY = { category: "bug", subject: "Test Bug", body: "Found a bug" };
+
+    it("同一 fixture で両経路の戻り値が deepEqual になり、pg 経路が正しい INSERT values を使う", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({ support_inquiries: [{ data: { id: "new-inq-id" } }] });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await POST(createPostRequest(REQUEST_BODY));
+      expect(postgrestRes.status).toBe(201);
+      const postgrestJson = await postgrestRes.json();
+      expect(client.insertCalls[0].values).toEqual({
+        twitch_user_id: "user123",
+        twitch_display_name: "TestUser",
+        category: "bug",
+        subject: "Test Bug",
+        body: "Found a bug",
+      });
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({ inserts: [{ rows: [{ id: "new-inq-id" }] }] });
+      primePgDb(pg);
+      const pgRes = await POST(createPostRequest(REQUEST_BODY));
+      expect(pgRes.status).toBe(201);
+      const pgJson = await pgRes.json();
+
+      expect(pgJson).toEqual(postgrestJson);
+      expect(pgJson).toEqual({ id: "new-inq-id" });
+
+      expect(pg.insertCalls[0].table).toBe(supportInquiriesTable);
+      expect(pg.insertCalls[0].values).toEqual(client.insertCalls[0].values);
+    });
+
+    it("INSERT 失敗: 両経路とも500を返す", async () => {
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({ inserts: [{ error: { code: "23505", message: "duplicate key" } }] });
+      primePgDb(pg);
+      const res = await POST(createPostRequest(REQUEST_BODY));
+      expect(res.status).toBe(500);
+    });
+
+    it("フラグ未設定 / pg-read では getDb が呼ばれない（書き込み関数のため pg-read でも postgrest のまま）", async () => {
+      for (const driver of [undefined, "pg-read"]) {
+        vi.stubEnv("DB_DRIVER", driver as string);
+        const client = createSupabaseClientMock({ support_inquiries: [{ data: { id: "new-inq-id" } }] });
+        mockGetSupabaseAdmin.mockReturnValue(client as any);
+        await POST(createPostRequest(REQUEST_BODY));
+        expect(getDb).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe("GET /api/support-inquiries/[id]（読み取り: isPgReadEnabled）", () => {
+    const INQUIRY_ROW = {
+      id: VALID_UUID,
+      twitch_user_id: "user123",
+      twitch_display_name: "TestUser",
+      category: "bug",
+      subject: "Test bug",
+      body: "Bug description",
+      status: "open",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+    const MESSAGE_ROWS = [
+      {
+        id: "msg-1",
+        inquiry_id: VALID_UUID,
+        sender_type: "user",
+        sender_id: "user123",
+        body: "Hello",
+        created_at: "2026-01-01T01:00:00Z",
+      },
+    ];
+
+    it("同一 fixture で両経路の戻り値が deepEqual になり、pg 経路が正しい where/orderBy を使う", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        support_inquiries: [{ data: INQUIRY_ROW }],
+        support_inquiry_messages: [{ data: MESSAGE_ROWS }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await GET_DETAIL(createGetRequest(`/api/support-inquiries/${VALID_UUID}`), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(postgrestRes.status).toBe(200);
+      const postgrestJson = await postgrestRes.json();
+
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [INQUIRY_ROW] }, { rows: MESSAGE_ROWS }] });
+      primePgDb(pg);
+      const pgRes = await GET_DETAIL(createGetRequest(`/api/support-inquiries/${VALID_UUID}`), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(pgRes.status).toBe(200);
+      const pgJson = await pgRes.json();
+
+      expect(pgJson).toEqual(postgrestJson);
+      expect(pgJson).toEqual({ inquiry: INQUIRY_ROW, messages: MESSAGE_ROWS });
+
+      // 問い合わせ本体: id + twitch_user_id の所有権フィルタ
+      expect(pg.selectCalls[0].where).toEqual(
+        and(eq(supportInquiriesTable.id, VALID_UUID), eq(supportInquiriesTable.twitch_user_id, "user123"))
+      );
+      // メッセージ: inquiry_id の絞り込み + created_at 昇順
+      expect(pg.selectCalls[1].where).toEqual(eq(supportInquiryMessagesTable.inquiry_id, VALID_UUID));
+      expect(pg.selectCalls[1].orderBy).toEqual(asc(supportInquiryMessagesTable.created_at));
+    });
+
+    it("問い合わせが見つからない場合、両経路とも404を返す", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        support_inquiries: [{ data: null, error: new Error("Not found") }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await GET_DETAIL(createGetRequest(`/api/support-inquiries/${VALID_UUID}`), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(postgrestRes.status).toBe(404);
+
+      vi.stubEnv("DB_DRIVER", "pg-read");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] });
+      primePgDb(pg);
+      const pgRes = await GET_DETAIL(createGetRequest(`/api/support-inquiries/${VALID_UUID}`), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(pgRes.status).toBe(404);
+    });
+
+    it("postgrest 経路（フラグ未設定）では getDb が一切呼ばれない", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        support_inquiries: [{ data: INQUIRY_ROW }],
+        support_inquiry_messages: [{ data: MESSAGE_ROWS }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      await GET_DETAIL(createGetRequest(`/api/support-inquiries/${VALID_UUID}`), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(getDb).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("DELETE /api/support-inquiries/[id]（書き込み: isPgWriteEnabled、idempotent: true）", () => {
+    it("削除成功: 両経路の戻り値が一致し、pg 経路が id + twitch_user_id の where で DELETE する", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({ support_inquiries: [{ data: { id: VALID_UUID } }] });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await DELETE_DETAIL(createDeleteRequest(`/api/support-inquiries/${VALID_UUID}`), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(postgrestRes.status).toBe(200);
+      const postgrestJson = await postgrestRes.json();
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({ deletes: [{ rows: [{ id: VALID_UUID }] }] });
+      primePgDb(pg);
+      const pgRes = await DELETE_DETAIL(createDeleteRequest(`/api/support-inquiries/${VALID_UUID}`), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(pgRes.status).toBe(200);
+      const pgJson = await pgRes.json();
+
+      expect(pgJson).toEqual(postgrestJson);
+      expect(pgJson).toEqual({ success: true });
+
+      expect(pg.deleteCalls[0].table).toBe(supportInquiriesTable);
+      expect(pg.deleteCalls[0].where).toEqual(
+        and(eq(supportInquiriesTable.id, VALID_UUID), eq(supportInquiriesTable.twitch_user_id, "user123"))
+      );
+    });
+
+    it("他ユーザー所有 / 存在しない場合、両経路とも404を返し何も削除されない", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        support_inquiries: [{ data: null, error: new Error("Not found") }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await DELETE_DETAIL(createDeleteRequest(`/api/support-inquiries/${VALID_UUID}`), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(postgrestRes.status).toBe(404);
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({ deletes: [{ rows: [] }] });
+      primePgDb(pg);
+      const pgRes = await DELETE_DETAIL(createDeleteRequest(`/api/support-inquiries/${VALID_UUID}`), {
+        params: Promise.resolve({ id: VALID_UUID }),
+      });
+      expect(pgRes.status).toBe(404);
+    });
+
+    it("フラグ未設定 / pg-read では getDb が呼ばれない（書き込み関数のため pg-read でも postgrest のまま）", async () => {
+      for (const driver of [undefined, "pg-read"]) {
+        vi.stubEnv("DB_DRIVER", driver as string);
+        const client = createSupabaseClientMock({ support_inquiries: [{ data: { id: VALID_UUID } }] });
+        mockGetSupabaseAdmin.mockReturnValue(client as any);
+        await DELETE_DETAIL(createDeleteRequest(`/api/support-inquiries/${VALID_UUID}`), {
+          params: Promise.resolve({ id: VALID_UUID }),
+        });
+        expect(getDb).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe("POST /api/support-inquiries/[id]/messages（読み書き混在: isPgWriteEnabled で関数全体を分岐）", () => {
+    const OPEN_INQUIRY_ROW = { id: VALID_UUID, status: "open", twitch_user_id: "user123" };
+    const CLOSED_INQUIRY_ROW = { id: VALID_UUID, status: "closed", twitch_user_id: "user123" };
+    const MESSAGE_ROW = {
+      id: "msg-1",
+      inquiry_id: VALID_UUID,
+      sender_type: "user",
+      sender_id: "user123",
+      body: "Reply",
+      created_at: "2026-01-01T02:00:00Z",
+    };
+
+    it("返信追加成功: 両経路の戻り値が一致し、pg 経路が正しい INSERT values を使う", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        support_inquiries: [{ data: OPEN_INQUIRY_ROW }],
+        support_inquiry_messages: [{ data: MESSAGE_ROW }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await POST_MESSAGE(
+        createPostRequest({ body: "Reply" }, `/api/support-inquiries/${VALID_UUID}/messages`),
+        { params: Promise.resolve({ id: VALID_UUID }) }
+      );
+      expect(postgrestRes.status).toBe(201);
+      const postgrestJson = await postgrestRes.json();
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [OPEN_INQUIRY_ROW] }],
+        inserts: [{ rows: [MESSAGE_ROW] }],
+      });
+      primePgDb(pg);
+      const pgRes = await POST_MESSAGE(
+        createPostRequest({ body: "Reply" }, `/api/support-inquiries/${VALID_UUID}/messages`),
+        { params: Promise.resolve({ id: VALID_UUID }) }
+      );
+      expect(pgRes.status).toBe(201);
+      const pgJson = await pgRes.json();
+
+      expect(pgJson).toEqual(postgrestJson);
+      expect(pgJson).toEqual({ message: MESSAGE_ROW });
+
+      expect(pg.insertCalls[0].table).toBe(supportInquiryMessagesTable);
+      expect(pg.insertCalls[0].values).toEqual({
+        inquiry_id: VALID_UUID,
+        sender_type: "user",
+        sender_id: "user123",
+        body: "Reply",
+      });
+    });
+
+    it("問い合わせが見つからない場合、両経路とも404を返しINSERTは発生しない", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        support_inquiries: [{ data: null, error: new Error("Not found") }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await POST_MESSAGE(
+        createPostRequest({ body: "Reply" }, `/api/support-inquiries/${VALID_UUID}/messages`),
+        { params: Promise.resolve({ id: VALID_UUID }) }
+      );
+      expect(postgrestRes.status).toBe(404);
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [] }] });
+      primePgDb(pg);
+      const pgRes = await POST_MESSAGE(
+        createPostRequest({ body: "Reply" }, `/api/support-inquiries/${VALID_UUID}/messages`),
+        { params: Promise.resolve({ id: VALID_UUID }) }
+      );
+      expect(pgRes.status).toBe(404);
+      expect(pg.insertCalls).toHaveLength(0);
+    });
+
+    it("closedステータスの問い合わせには両経路とも400を返しINSERTは発生しない", async () => {
+      vi.stubEnv("DB_DRIVER", undefined);
+      const client = createSupabaseClientMock({
+        support_inquiries: [{ data: CLOSED_INQUIRY_ROW }],
+      });
+      mockGetSupabaseAdmin.mockReturnValue(client as any);
+      const postgrestRes = await POST_MESSAGE(
+        createPostRequest({ body: "Reply" }, `/api/support-inquiries/${VALID_UUID}/messages`),
+        { params: Promise.resolve({ id: VALID_UUID }) }
+      );
+      expect(postgrestRes.status).toBe(400);
+
+      vi.stubEnv("DB_DRIVER", "pg");
+      const pg = createDrizzleDbMock({ selects: [{ rows: [CLOSED_INQUIRY_ROW] }] });
+      primePgDb(pg);
+      const pgRes = await POST_MESSAGE(
+        createPostRequest({ body: "Reply" }, `/api/support-inquiries/${VALID_UUID}/messages`),
+        { params: Promise.resolve({ id: VALID_UUID }) }
+      );
+      expect(pgRes.status).toBe(400);
+      expect(pg.insertCalls).toHaveLength(0);
+    });
+
+    it("フラグ未設定 / pg-read では getDb が呼ばれない（書き込み関数のため pg-read でも postgrest のまま）", async () => {
+      for (const driver of [undefined, "pg-read"]) {
+        vi.stubEnv("DB_DRIVER", driver as string);
+        const client = createSupabaseClientMock({
+          support_inquiries: [{ data: OPEN_INQUIRY_ROW }],
+          support_inquiry_messages: [{ data: MESSAGE_ROW }],
+        });
+        mockGetSupabaseAdmin.mockReturnValue(client as any);
+        await POST_MESSAGE(
+          createPostRequest({ body: "Reply" }, `/api/support-inquiries/${VALID_UUID}/messages`),
+          { params: Promise.resolve({ id: VALID_UUID }) }
+        );
+        expect(getDb).not.toHaveBeenCalled();
+      }
+    });
+  });
+});

--- a/tests/unit/user-cards-driver-parity.test.ts
+++ b/tests/unit/user-cards-driver-parity.test.ts
@@ -1,0 +1,140 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — GET /api/user-cards の
+ * postgrest経路 / pg経路パリティテスト
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET } from '@/app/api/user-cards/route'
+import { getSession } from '@/lib/session'
+import { getDb } from '@/lib/db/client'
+
+vi.mock('@/lib/session')
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn().mockResolvedValue({ success: true, limit: 60, remaining: 59, reset: Date.now() + 60000 }),
+  rateLimits: { cardsGet: {} },
+  getRateLimitIdentifier: vi.fn().mockResolvedValue('user:user123'),
+}))
+vi.mock('@/lib/sentry/error-handler', () => ({
+  reportError: vi.fn(),
+  reportApiError: vi.fn(),
+  logErrorFromLogger: vi.fn(),
+}))
+
+const mockGetSession = vi.mocked(getSession)
+
+function createRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/user-cards')
+}
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>
+  error?: unknown
+}
+
+function createDrizzleDbMock(config: { selects?: PgResponse[] } = {}) {
+  let selectIndex = 0
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }]
+      const response = responses[Math.min(selectIndex, responses.length - 1)]
+      selectIndex += 1
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              (response.rows ?? []).map((row) =>
+                Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+              )
+            )
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      }
+      return builder
+    }),
+  }
+  return { db }
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any)
+}
+
+function createSupabaseMock(userResult: { data: unknown; error: unknown }, cardsResult: { data: unknown; error: unknown }) {
+  return {
+    from: vi.fn((table: string) => {
+      if (table === 'users') {
+        return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue(userResult) })) })) }
+      }
+      return { select: vi.fn(() => ({ eq: vi.fn(() => ({ range: vi.fn().mockResolvedValue(cardsResult) })) })) }
+    }),
+  }
+}
+
+describe('GET /api/user-cards: postgrest / pg 経路の互換 (#663)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'user123',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: '',
+      broadcasterType: '',
+      expiresAt: Date.now() + 60000,
+      version: 1,
+    } as any)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('フラグ未設定時は getDb が呼ばれない（挙動不変の検証）', async () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue(
+      createSupabaseMock(
+        { data: { id: 'user-uuid-1', twitch_user_id: 'user123' }, error: null },
+        { data: [{ id: 'uc1', user_id: 'user-uuid-1', card_id: 'card1', obtained_at: '2026-01-01T00:00:00Z' }], error: null }
+      ) as any
+    )
+
+    const response = await GET(createRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toHaveLength(1)
+    expect(getDb).not.toHaveBeenCalled()
+  })
+
+  it('DB_DRIVER=pg-read: pg経路で正しいuser_idを条件にuser_cardsが取得される（postgrest経路と同じ結果）', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock({
+      selects: [
+        { rows: [{ id: 'user-uuid-1', twitch_user_id: 'user123' }] },
+        { rows: [{ id: 'uc1', user_id: 'user-uuid-1', card_id: 'card1', obtained_at: '2026-01-01T00:00:00Z' }] },
+      ],
+    })
+    primePgDb(pg)
+
+    const response = await GET(createRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(getDb).toHaveBeenCalled()
+    expect(body).toEqual([
+      { id: 'uc1', user_id: 'user-uuid-1', card_id: 'card1', obtained_at: '2026-01-01T00:00:00Z' },
+    ])
+  })
+
+  it('DB_DRIVER=pg-read: ユーザーが見つからなければ500（handleDatabaseError、postgrest経路と同じ外部挙動）', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock({ selects: [{ rows: [] }] })
+    primePgDb(pg)
+
+    const response = await GET(createRequest())
+    expect(response.status).toBe(500)
+  })
+})

--- a/tests/unit/validations-driver-parity.test.ts
+++ b/tests/unit/validations-driver-parity.test.ts
@@ -1,0 +1,147 @@
+/**
+ * #663: validateDropRateSum の postgrest 経路 / pg 経路の形状互換テスト
+ *
+ * tests/unit/announcements-driver-parity.test.ts と同じ流儀。
+ * validateDropRateSum は supabaseAdmin を引数で受け取るため、postgrest 経路は
+ * モッククライアントを直接渡す。pg 経路は getDb() をモックする。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { and, eq } from 'drizzle-orm'
+import { validateDropRateSum } from '@/lib/validations'
+import { getDb } from '@/lib/db/client'
+import { cards as cardsTable } from '@/lib/db/schema'
+
+const CARD_ROWS = [
+  { id: 'card-1', drop_rate: 0.3 },
+  { id: 'card-2', drop_rate: 0.5 },
+  { id: 'card-3', drop_rate: 0.1 },
+]
+
+function createThenableBuilder(result: { data: unknown; error: null }) {
+  const builder: any = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    then: (onFulfilled: any, onRejected: any) =>
+      Promise.resolve(result).then(onFulfilled, onRejected),
+  }
+  return builder
+}
+
+function createSupabaseClientMock(rows: unknown = CARD_ROWS) {
+  const from = vi.fn(() => createThenableBuilder({ data: rows, error: null }))
+  return { from }
+}
+
+function createDrizzleDbMock(rows: unknown = CARD_ROWS) {
+  const calls: Array<{ table: unknown; whereCondition?: unknown }> = []
+  return {
+    calls,
+    select: vi.fn((fields: Record<string, unknown>) => ({
+      from: vi.fn((table: unknown) => {
+        const call: { table: unknown; whereCondition?: unknown } = { table }
+        calls.push(call)
+        const projected = (rows as Array<Record<string, unknown>>).map((row) =>
+          Object.fromEntries(Object.keys(fields).map((key) => [key, row[key]]))
+        )
+        const builder: any = {
+          where: vi.fn((condition: unknown) => {
+            call.whereCondition = condition
+            return builder
+          }),
+          then: (onFulfilled: any, onRejected: any) =>
+            Promise.resolve(projected).then(onFulfilled, onRejected),
+        }
+        return builder
+      }),
+    })),
+  }
+}
+
+describe('validateDropRateSum: postgrest / pg 経路の形状互換 (#663)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('合計が100%以下なら両経路とも valid:true を返す', async () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    const client = createSupabaseClientMock()
+    const postgrestResult = await validateDropRateSum(client as any, 'streamer-1', 0.05)
+
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock()
+    vi.mocked(getDb).mockResolvedValue({ db: pg, sql: {} } as any)
+    const pgResult = await validateDropRateSum(client as any, 'streamer-1', 0.05)
+
+    expect(pgResult).toEqual(postgrestResult)
+    expect(pgResult).toEqual({ valid: true })
+  })
+
+  it('合計が100%を超える場合、両経路とも同じエラーメッセージを返す', async () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    const client = createSupabaseClientMock()
+    const postgrestResult = await validateDropRateSum(client as any, 'streamer-1', 0.5)
+
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock()
+    vi.mocked(getDb).mockResolvedValue({ db: pg, sql: {} } as any)
+    const pgResult = await validateDropRateSum(client as any, 'streamer-1', 0.5)
+
+    expect(pgResult).toEqual(postgrestResult)
+    expect(pgResult.valid).toBe(false)
+    expect(pgResult.error).toContain('max 100%')
+  })
+
+  it('excludeCardId で除外したカードは合計に含まれない（両経路一致）', async () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    const client = createSupabaseClientMock()
+    const postgrestResult = await validateDropRateSum(client as any, 'streamer-1', 0.3, 'card-2')
+
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock()
+    vi.mocked(getDb).mockResolvedValue({ db: pg, sql: {} } as any)
+    const pgResult = await validateDropRateSum(client as any, 'streamer-1', 0.3, 'card-2')
+
+    expect(pgResult).toEqual(postgrestResult)
+    expect(pgResult).toEqual({ valid: true })
+  })
+
+  it('pgクエリが streamer_id・is_active=true の条件で正しい実引数で呼び出される', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const pg = createDrizzleDbMock()
+    vi.mocked(getDb).mockResolvedValue({ db: pg, sql: {} } as any)
+
+    await validateDropRateSum({} as any, 'streamer-1', 0.05)
+
+    expect(pg.calls).toHaveLength(1)
+    expect(pg.calls[0].table).toBe(cardsTable)
+    expect(pg.calls[0].whereCondition).toEqual(
+      and(eq(cardsTable.streamer_id, 'streamer-1'), eq(cardsTable.is_active, true))
+    )
+  })
+
+  it('pg経路で取得失敗時は既存と同じエラーメッセージを返す', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg-read')
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => Promise.reject(new Error('connection failure'))),
+        })),
+      })),
+    }
+    vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any)
+
+    const result = await validateDropRateSum({} as any, 'streamer-1', 0.05)
+    expect(result).toEqual({ valid: false, error: 'Failed to validate drop rates' })
+  })
+
+  it('postgrest 経路（フラグ未設定）では getDb が一切呼ばれない', async () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    const client = createSupabaseClientMock()
+    await validateDropRateSum(client as any, 'streamer-1', 0.05)
+    expect(getDb).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/vote-campaign-driver-parity.test.ts
+++ b/tests/unit/vote-campaign-driver-parity.test.ts
@@ -1,0 +1,214 @@
+/**
+ * #663: 低頻度APIルート群のpg直結移行 — POST /api/storage-bonus/vote-campaign の
+ * postgrest経路 / pg経路パリティテスト
+ *
+ * tests/unit/vote-campaign.test.ts が既存postgrest経路の詳細な挙動を検証済みの
+ * ため、本ファイルは pg 経路固有の観点（正しいテーブル/値での INSERT・
+ * 23505競合時のリトライ・接続断時の非冪等挙動）に絞る。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/storage-bonus/vote-campaign/route'
+import { getSession } from '@/lib/session'
+import { validateCSRFToken } from '@/lib/csrf'
+import { getDb } from '@/lib/db/client'
+import { VOTE_CAMPAIGN_CONFIG } from '@/lib/constants'
+import { streamers as streamersTable, streamerStorageBonus as streamerStorageBonusTable } from '@/lib/db/schema'
+
+vi.mock('@/lib/session')
+vi.mock('@/lib/csrf')
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('@/lib/sentry/error-handler')
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn().mockResolvedValue({ success: true, limit: 5, remaining: 4, reset: Date.now() + 60000 }),
+  rateLimits: { voteCampaign: {} },
+  getRateLimitIdentifier: vi.fn().mockResolvedValue('user:user123'),
+}))
+
+const mockGetSession = vi.mocked(getSession)
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken)
+
+function createRequest(): NextRequest {
+  return new NextRequest('http://localhost:3000/api/storage-bonus/vote-campaign', { method: 'POST' })
+}
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>
+  error?: unknown
+}
+
+function createDrizzleDbMock(config: { selects?: PgResponse[]; inserts?: PgResponse[] } = {}) {
+  let selectIndex = 0
+  let insertIndex = 0
+  const insertCalls: Array<{ table: unknown; values?: Record<string, unknown> }> = []
+
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const responses = config.selects ?? [{ rows: [] }]
+      const response = responses[Math.min(selectIndex, responses.length - 1)]
+      selectIndex += 1
+      const resolve = () =>
+        response.error
+          ? Promise.reject(response.error)
+          : Promise.resolve(
+              (response.rows ?? []).map((row) =>
+                Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+              )
+            )
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      }
+      return builder
+    }),
+    insert: vi.fn((table: unknown) => {
+      const responses = config.inserts ?? [{ rows: [{ id: 'x' }] }]
+      const response = responses[Math.min(insertIndex, responses.length - 1)]
+      insertIndex += 1
+      const call: { table: unknown; values?: Record<string, unknown> } = { table }
+      insertCalls.push(call)
+      const resolve = () => (response.error ? Promise.reject(response.error) : Promise.resolve(response.rows ?? []))
+      const builder: any = {
+        values: vi.fn((values: Record<string, unknown>) => {
+          call.values = values
+          return builder
+        }),
+        returning: vi.fn(() => resolve()),
+        then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+      }
+      return builder
+    }),
+  }
+  return { db, insertCalls }
+}
+
+function primePgDb(mock: ReturnType<typeof createDrizzleDbMock>) {
+  vi.mocked(getDb).mockResolvedValue({ db: mock.db, sql: {} } as any)
+}
+
+describe('POST /api/storage-bonus/vote-campaign: postgrest / pg 経路の互換 (#663)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'user123',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/avatar.jpg',
+      broadcasterType: '',
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      version: 1,
+    } as any)
+    mockValidateCSRFToken.mockResolvedValue({ valid: true } as any)
+
+    vi.useFakeTimers()
+    const campaignMidpoint = new Date(
+      (VOTE_CAMPAIGN_CONFIG.START_DATE.getTime() + VOTE_CAMPAIGN_CONFIG.END_DATE.getTime()) / 2
+    )
+    vi.setSystemTime(campaignMidpoint)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+  })
+
+  it('フラグ未設定時は getDb が呼ばれない（挙動不変の検証）', async () => {
+    vi.stubEnv('DB_DRIVER', undefined)
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: { id: 's1' }, error: null }) })) })),
+        insert: vi.fn(() => Promise.resolve({ data: null, error: null })),
+      })),
+    } as any)
+
+    const response = await POST(createRequest())
+    expect(response.status).toBe(200)
+    expect(getDb).not.toHaveBeenCalled()
+  })
+
+  it('DB_DRIVER=pg: 既存streamerがあれば新規INSERTせず、正しいstreamer_idでボーナスがINSERTされる', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    const pg = createDrizzleDbMock({ selects: [{ rows: [{ id: 'existing-streamer-uuid' }] }] })
+    primePgDb(pg)
+
+    const response = await POST(createRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(pg.insertCalls).toHaveLength(1)
+    expect(pg.insertCalls[0].table).toBe(streamerStorageBonusTable)
+    expect(pg.insertCalls[0].values).toMatchObject({ streamer_id: 'existing-streamer-uuid' })
+  })
+
+  it('DB_DRIVER=pg: 既存streamerが無ければ新規INSERTしてからボーナスをINSERTする', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [] }],
+      inserts: [{ rows: [{ id: 'new-streamer-uuid' }] }, { rows: [{ id: 'bonus-1' }] }],
+    })
+    primePgDb(pg)
+
+    const response = await POST(createRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(pg.insertCalls[0].table).toBe(streamersTable)
+    expect(pg.insertCalls[0].values).toMatchObject({ twitch_user_id: 'user123' })
+    expect(pg.insertCalls[1].table).toBe(streamerStorageBonusTable)
+    expect(pg.insertCalls[1].values).toMatchObject({ streamer_id: 'new-streamer-uuid' })
+  })
+
+  it('DB_DRIVER=pg: ボーナスINSERTが23505で失敗した場合は409（postgrest経路と同じ外部挙動）', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [{ id: 'existing-streamer-uuid' }] }],
+      inserts: [{ error: { code: '23505', message: 'duplicate key' } }],
+    })
+    primePgDb(pg)
+
+    const response = await POST(createRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(body.error).toBe('このキャンペーンは既に適用済みです')
+  })
+
+  it('DB_DRIVER=pg: streamer作成が23505で失敗した場合はリトライして既存行を再取得する（レースコンディション対応）', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [] }, { rows: [{ id: 'race-streamer-uuid' }] }],
+      inserts: [{ error: { code: '23505', message: 'duplicate key' } }, { rows: [{ id: 'bonus-1' }] }],
+    })
+    primePgDb(pg)
+
+    const response = await POST(createRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.success).toBe(true)
+    // streamer_storage_bonus への INSERT はリトライで取得した race-streamer-uuid を使う
+    expect(pg.insertCalls[pg.insertCalls.length - 1].values).toMatchObject({ streamer_id: 'race-streamer-uuid' })
+  })
+
+  it('DB_DRIVER=pg: streamer_storage_bonus の INSERT は接続断でもリトライされない（非冪等・二重付与防止）', async () => {
+    vi.stubEnv('DB_DRIVER', 'pg')
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [{ id: 'existing-streamer-uuid' }] }],
+      inserts: [{ error: Object.assign(new Error('connection closed'), { code: 'CONNECTION_CLOSED' }) }],
+    })
+    primePgDb(pg)
+
+    const response = await POST(createRequest())
+    // 接続断はリトライされず、そのまま500エラーとしてhandleApiErrorに渡る
+    expect(response.status).toBe(500)
+    // insert が呼ばれたのは1回のみ（リトライされていない）
+    expect(pg.insertCalls).toHaveLength(1)
+  })
+})

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -91,16 +91,13 @@ preview_bucket_name = "twica-sound-dev"
 #   PostgREST（毎回実クエリ）との完全パリティが目的であり、キャッシュが有効だと
 #   overlay ポーリングの新着イベントが最大 60 秒遅延する等の挙動差が出るため。
 #
-# 実 id は上記コマンドの出力をユーザーが作成後に記入すること。
-# プレースホルダ id のまま有効化（コメント解除）してはならない（デプロイが壊れる）。
-#
 # localConnectionString は `wrangler dev` 実行時のみ使われるローカル接続先
 # （next dev は process.env.DATABASE_URL を使う。docs/db-driver-migration.md 参照）。
-#
-# [[hyperdrive]]
-# binding = "HYPERDRIVE"
-# id = "<wrangler hyperdrive create twica-hyperdrive-prod の出力 id を記入>"
-# localConnectionString = "postgres://user:password@localhost:5432/postgres"
+
+[[hyperdrive]]
+binding = "HYPERDRIVE"
+id = "38f11f06161c4c538694522e4ede74f5"
+localConnectionString = "postgres://user:password@localhost:5432/postgres"
 
 # Environment variables that must survive deploys (Dashboard-only vars get overwritten)
 # デプロイ時に上書きされないよう、Dashboard のみで設定していた変数をここに明示する
@@ -203,8 +200,8 @@ bucket_name = "twica-sound-dev"
 #     --connection-string="<preview Supabase の Direct connection 文字列>" \
 #     --caching-disabled
 # --caching-disabled 必須の理由・id 記入ルールはトップレベルの [[hyperdrive]] コメント参照。
-#
-# [[env.preview.hyperdrive]]
-# binding = "HYPERDRIVE"
-# id = "<wrangler hyperdrive create twica-hyperdrive-preview の出力 id を記入>"
-# localConnectionString = "postgres://user:password@localhost:5432/postgres"
+
+[[env.preview.hyperdrive]]
+binding = "HYPERDRIVE"
+id = "1e3f6c4569bf4202a41c42711c878b86"
+localConnectionString = "postgres://user:password@localhost:5432/postgres"


### PR DESCRIPTION
## Summary
- #570〜#573で確立したpatternで低頻度APIルート28ファイル・libをpg直結対応（`DB_DRIVER`未設定時は完全に従来動作、本番影響ゼロ）
- battle系(battles/battle_stats)は#625で本番実体が無いと確認済みのため対象外
- **重大バグ修正**: cardsテーブルのDrizzle無指定select/returningが本番に存在しない8列（#625と同根のmigrationドリフト）を要求し、`DB_DRIVER=pg-read/pg`有効化時に確実に500になる問題を修正（`CARDS_SAFE_COLUMNS`フォールバック追加）
- Hyperdrive binding(prod/preview)を`wrangler.toml`で有効化（#662）

## Test plan
- [x] 全154ファイル/1855テストgreen（フルスイート実行済み）
- [x] `tsc --noEmit`: 新規エラーゼロ（既存24件は無関係な未変更テストファイル）
- [x] lint: エラーゼロ
- [x] gacha-service.test.ts 50件を個別に再確認（作業中の事故復旧を検証）
- [ ] preview環境での実機検証（このPRのブランチを手動デプロイして実施予定）

Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DBfHhRzkAatcSDfQh4mEt