### PR TITLE
fix(types): raid-gacha-api.test.tsのtwitchProfileImageUrl型エラーを修正

### DIFF
--- a/tests/unit/raid-gacha-api.test.ts
+++ b/tests/unit/raid-gacha-api.test.ts
@@ -44,7 +44,7 @@ describe('/api/streamer/raid-gacha drawCount boundary validation', () => {
       twitchUserId: 'streamer-twitch-1',
       twitchUsername: 'streamer',
       twitchDisplayName: 'Streamer',
-      twitchProfileImageUrl: null,
+      twitchProfileImageUrl: 'https://example.com/avatar.png',
       broadcasterType: 'affiliate',
       expiresAt: Date.now() + 60_000,
       version: 1,


### PR DESCRIPTION
## 概要

`preview` ブランチで PR #677 と PR #679 をマージした結果として顕在化した回帰を修正します。

## 背景

- PR #677（連ガチャ上限15枚）が追加した `tests/unit/raid-gacha-api.test.ts` は、PR #679（tsc型エラー解消 + CIにtypecheckゲート追加）より前に書かれたため、`SessionPayload.twitchProfileImageUrl`（null非許容の`string`必須フィールド）に`null`を渡す型エラーが未検出のままマージされていました。
- #677単体のCIはtypecheckゲート導入前だったため green でしたが、両PRがpreviewにマージされた結果、preview HEAD自体が`tsc --noEmit`で失敗する状態になっていました（PR #678のCI再実行で発覚）。

## 変更内容

- `tests/unit/raid-gacha-api.test.ts:47`: `twitchProfileImageUrl: null` → `twitchProfileImageUrl: 'https://example.com/avatar.png'`（#679が他ファイルで使った既存のプレースホルダーURLパターンに統一）

## 検証

- `npx tsc --noEmit`: preview HEAD時点で1件だったエラーが0件に
- `npx vitest run tests/unit/raid-gacha-api.test.ts`: 4テスト全成功

テストデータの1行修正のみ・ロジック変更なしです。

---

Co-Authored-By: Claude Sonnet 5

https://claude.ai/code/session_01X58SsjpRRR44xxTbCa6HEV

---
_Generated by [Claude Code](https://claude.ai/code/session_01X58SsjpRRR44xxTbCa6HEV)_