### PR TITLE
fix(db): dashboard-data.tsのcards無指定selectにCARDS_SAFE_COLUMNSフォールバックを追加 (#685)

### DIFF
--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -30,6 +30,12 @@ import { getDb, type DbHandle } from "@/lib/db/client";
 import { isPgFunctionNotFoundError, isPgMissingColumnError } from "@/lib/db/errors";
 import { isPgReadEnabled } from "@/lib/db/flags";
 import { withDbRetry } from "@/lib/db/retry";
+// Issue #685: cards テーブルの本番未デプロイ8列（card_number/hp/atk/def/spd/
+// skill_type/skill_name/skill_power、#625 参照）に対する SELECT フォールバック。
+// src/app/api/cards/route.ts の fetchCardsFromDBPg で確立したパターン（無指定
+// select → 列欠落エラー検知 → CARDS_SAFE_COLUMNS で再試行）を本モジュールにも
+// 適用する。詳細は cards-safe-columns.ts のコメント参照。
+import { CARDS_SAFE_COLUMNS, isMissingCardsBattleColumnError } from "@/lib/db/cards-safe-columns";
 // schema のテーブル名（cards / streamers 等）は本モジュールのローカル変数名・
 // 型名と紛らわしいため、Table サフィックスを付けて import する
 // （announcements.ts パイロットと同じ規約）
@@ -85,14 +91,20 @@ interface GachaHistoryWithCard extends GachaHistory {
 async function getStreamerDataPg(
   twitchUserId: string
 ): Promise<{ streamer: Streamer; cards: Card[] } | null> {
-  try {
-    const rows = await withDbRetry(
+  // Issue #685: card: cardsTable のネスト select は cards の全列（本番未デプロイ
+  // 8列を含む）を要求する。まず無指定で試み、列欠落エラーなら CARDS_SAFE_COLUMNS
+  // へ差し替えて再試行する（cards-safe-columns.ts 参照）。
+  async function selectStreamerWithCards(useSafeColumns: boolean) {
+    return withDbRetry(
       async () => {
         // 規約: getDb() は queryFn の中で呼ぶ（リクエストスコープ破棄からの
         // 回復にはクライアント再取得が必要。src/lib/db/retry.ts 参照）
         const { db } = await getDb();
         return db
-          .select({ streamer: streamersTable, card: cardsTable })
+          .select({
+            streamer: streamersTable,
+            card: useSafeColumns ? CARDS_SAFE_COLUMNS : cardsTable,
+          })
           .from(streamersTable)
           .leftJoin(cardsTable, eq(cardsTable.streamer_id, streamersTable.id))
           .where(eq(streamersTable.twitch_user_id, twitchUserId));
@@ -100,6 +112,16 @@ async function getStreamerDataPg(
       "getStreamerData",
       { idempotent: true },
     );
+  }
+
+  try {
+    let rows: Awaited<ReturnType<typeof selectStreamerWithCards>>;
+    try {
+      rows = await selectStreamerWithCards(false);
+    } catch (error) {
+      if (!isMissingCardsBattleColumnError(error)) throw error;
+      rows = await selectStreamerWithCards(true);
+    }
 
     if (rows.length === 0) return null;
 
@@ -259,12 +281,14 @@ async function getStreamerDataPaginatedPg(
 
   const offset = (page - 1) * perPage;
   let cards: Card[] = [];
-  try {
-    const rows = await withDbRetry(
+  // Issue #685: 無指定 select() は cards の本番未デプロイ8列を要求する。
+  // 列欠落エラーなら CARDS_SAFE_COLUMNS へ差し替えて再試行する。
+  async function selectCards(useSafeColumns: boolean) {
+    return withDbRetry(
       async () => {
         const { db } = await getDb();
-        return db
-          .select()
+        const query = useSafeColumns ? db.select(CARDS_SAFE_COLUMNS) : db.select();
+        return query
           .from(cardsTable)
           .where(eq(cardsTable.streamer_id, streamerId))
           .orderBy(desc(cardsTable.created_at))
@@ -274,6 +298,15 @@ async function getStreamerDataPaginatedPg(
       "getStreamerDataPaginated(cards)",
       { idempotent: true },
     );
+  }
+  try {
+    let rows: Awaited<ReturnType<typeof selectCards>>;
+    try {
+      rows = await selectCards(false);
+    } catch (error) {
+      if (!isMissingCardsBattleColumnError(error)) throw error;
+      rows = await selectCards(true);
+    }
     cards = rows as unknown as Card[];
   } catch (error) {
     // 既存実装は cards エラー時 null → `cards || []` で [] 扱い
@@ -588,21 +621,36 @@ export const getUserCards = cache(async (twitchUserId: string): Promise<CardWith
  * する。card_id は NOT NULL FK のため実データでは常にオブジェクト）。
  * エラー時は既存実装（分割代入で握り潰し → []）と同じ外部挙動。
  */
+// Issue #685: cards: cardsTable のネスト select は cards の本番未デプロイ8列を
+// 要求する。列欠落エラーなら CARDS_SAFE_COLUMNS へ差し替えて再試行する。
+async function selectRecentGachaHistory(useSafeColumns: boolean) {
+  return withDbRetry(
+    async () => {
+      const { db } = await getDb();
+      return db
+        .select({
+          ...getTableColumns(gachaHistoryTable),
+          cards: useSafeColumns ? CARDS_SAFE_COLUMNS : cardsTable,
+        })
+        .from(gachaHistoryTable)
+        .leftJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
+        .orderBy(desc(gachaHistoryTable.redeemed_at))
+        .limit(10);
+    },
+    "getRecentGachaHistory",
+    { idempotent: true },
+  );
+}
+
 async function getRecentGachaHistoryPg(): Promise<GachaHistoryWithCard[]> {
   try {
-    const rows = await withDbRetry(
-      async () => {
-        const { db } = await getDb();
-        return db
-          .select({ ...getTableColumns(gachaHistoryTable), cards: cardsTable })
-          .from(gachaHistoryTable)
-          .leftJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
-          .orderBy(desc(gachaHistoryTable.redeemed_at))
-          .limit(10);
-      },
-      "getRecentGachaHistory",
-      { idempotent: true },
-    );
+    let rows: Awaited<ReturnType<typeof selectRecentGachaHistory>>;
+    try {
+      rows = await selectRecentGachaHistory(false);
+    } catch (error) {
+      if (!isMissingCardsBattleColumnError(error)) throw error;
+      rows = await selectRecentGachaHistory(true);
+    }
     // 既存実装と同じく戻り値型へのキャストのみ（値の変換はしない）
     return rows as unknown as GachaHistoryWithCard[];
   } catch (error) {
@@ -716,23 +764,41 @@ async function getGachaHistoryForStreamerPg(
   const whereClause = and(...conditions);
   const offset = (page - 1) * perPage;
 
+  // Issue #685: cards: cardsTable のネスト select は cards の本番未デプロイ8列を
+  // 要求する。count クエリは cards の列を選択しない（leftJoin は行数維持のみ）ため
+  // 対象外。列欠落エラーなら CARDS_SAFE_COLUMNS へ差し替えて再試行する。
+  async function selectRows(useSafeColumns: boolean) {
+    return withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({
+            ...getTableColumns(gachaHistoryTable),
+            cards: useSafeColumns ? CARDS_SAFE_COLUMNS : cardsTable,
+          })
+          .from(gachaHistoryTable)
+          .leftJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
+          .where(whereClause)
+          .orderBy(desc(gachaHistoryTable.redeemed_at))
+          .limit(perPage)
+          .offset(offset);
+      },
+      "getGachaHistoryForStreamer(rows)",
+      { idempotent: true },
+    );
+  }
+  async function fetchRowsWithFallback() {
+    try {
+      return await selectRows(false);
+    } catch (error) {
+      if (!isMissingCardsBattleColumnError(error)) throw error;
+      return selectRows(true);
+    }
+  }
+
   try {
     const [rows, total] = await Promise.all([
-      withDbRetry(
-        async () => {
-          const { db } = await getDb();
-          return db
-            .select({ ...getTableColumns(gachaHistoryTable), cards: cardsTable })
-            .from(gachaHistoryTable)
-            .leftJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
-            .where(whereClause)
-            .orderBy(desc(gachaHistoryTable.redeemed_at))
-            .limit(perPage)
-            .offset(offset);
-        },
-        "getGachaHistoryForStreamer(rows)",
-        { idempotent: true },
-      ),
+      fetchRowsWithFallback(),
       withDbRetry(
         async () => {
           const { db } = await getDb();
@@ -865,28 +931,43 @@ async function getGachaHistoryForUserPg(
   const { page = 1, perPage = 20 } = filters;
   const offset = (page - 1) * perPage;
 
+  // Issue #685: cards: cardsTable のネスト select は cards の本番未デプロイ8列を
+  // 要求する。count クエリは cards を選択しない（JOINすら行わない）ため対象外。
+  // 列欠落エラーなら CARDS_SAFE_COLUMNS へ差し替えて再試行する。
+  async function selectRows(useSafeColumns: boolean) {
+    return withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({
+            ...getTableColumns(gachaHistoryTable),
+            cards: useSafeColumns ? CARDS_SAFE_COLUMNS : cardsTable,
+            streamers: { twitch_display_name: streamersTable.twitch_display_name },
+          })
+          .from(gachaHistoryTable)
+          .leftJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
+          .leftJoin(streamersTable, eq(gachaHistoryTable.streamer_id, streamersTable.id))
+          .where(eq(gachaHistoryTable.user_twitch_id, userTwitchId))
+          .orderBy(desc(gachaHistoryTable.redeemed_at))
+          .limit(perPage)
+          .offset(offset);
+      },
+      "getGachaHistoryForUser(rows)",
+      { idempotent: true },
+    );
+  }
+  async function fetchRowsWithFallback() {
+    try {
+      return await selectRows(false);
+    } catch (error) {
+      if (!isMissingCardsBattleColumnError(error)) throw error;
+      return selectRows(true);
+    }
+  }
+
   try {
     const [rows, total] = await Promise.all([
-      withDbRetry(
-        async () => {
-          const { db } = await getDb();
-          return db
-            .select({
-              ...getTableColumns(gachaHistoryTable),
-              cards: cardsTable,
-              streamers: { twitch_display_name: streamersTable.twitch_display_name },
-            })
-            .from(gachaHistoryTable)
-            .leftJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
-            .leftJoin(streamersTable, eq(gachaHistoryTable.streamer_id, streamersTable.id))
-            .where(eq(gachaHistoryTable.user_twitch_id, userTwitchId))
-            .orderBy(desc(gachaHistoryTable.redeemed_at))
-            .limit(perPage)
-            .offset(offset);
-        },
-        "getGachaHistoryForUser(rows)",
-        { idempotent: true },
-      ),
+      fetchRowsWithFallback(),
       withDbRetry(
         async () => {
           const { db } = await getDb();
@@ -2025,26 +2106,38 @@ async function fetchCardOwnerStatsFromUserCards(
  * （挙動パリティ優先。上限撤廃は移行完了後に別途判断する）。
  * エラー時は既存実装（分割代入で握り潰し → cards=null → []）と同じ外部挙動。
  */
+// Issue #685: 無指定 select() は cards の本番未デプロイ8列を要求する。
+// 列欠落エラーなら CARDS_SAFE_COLUMNS へ差し替えて再試行する。
+async function selectActiveCardsForStreamer(streamerId: string, useSafeColumns: boolean) {
+  return withDbRetry(
+    async () => {
+      const { db } = await getDb();
+      const query = useSafeColumns ? db.select(CARDS_SAFE_COLUMNS) : db.select();
+      return query
+        .from(cardsTable)
+        .where(and(eq(cardsTable.streamer_id, streamerId), eq(cardsTable.is_active, true)))
+        // generated column rarity_order によるレアリティ順の安定ソート
+        // （PostgREST 版と同一。asc/desc の NULL 順序は両経路とも PostgreSQL
+        // 既定（ASC=NULLS LAST / DESC=NULLS FIRST）で一致する）
+        .orderBy(asc(cardsTable.rarity_order), desc(cardsTable.created_at))
+        .limit(1000);
+    },
+    "getActiveCardsForStreamer",
+    { idempotent: true },
+  );
+}
+
 async function fetchActiveCardsForStreamerFromDBPg(streamerId: string): Promise<Card[]> {
   const startTotal = Date.now();
   const startQuery = Date.now();
   try {
-    const cards = await withDbRetry(
-      async () => {
-        const { db } = await getDb();
-        return db
-          .select()
-          .from(cardsTable)
-          .where(and(eq(cardsTable.streamer_id, streamerId), eq(cardsTable.is_active, true)))
-          // generated column rarity_order によるレアリティ順の安定ソート
-          // （PostgREST 版と同一。asc/desc の NULL 順序は両経路とも PostgreSQL
-          // 既定（ASC=NULLS LAST / DESC=NULLS FIRST）で一致する）
-          .orderBy(asc(cardsTable.rarity_order), desc(cardsTable.created_at))
-          .limit(1000);
-      },
-      "getActiveCardsForStreamer",
-      { idempotent: true },
-    );
+    let cards: Awaited<ReturnType<typeof selectActiveCardsForStreamer>>;
+    try {
+      cards = await selectActiveCardsForStreamer(streamerId, false);
+    } catch (error) {
+      if (!isMissingCardsBattleColumnError(error)) throw error;
+      cards = await selectActiveCardsForStreamer(streamerId, true);
+    }
     logger.info(`[Perf] getActiveCardsForStreamer query: ${Date.now() - startQuery}ms`);
     logger.info(`[Perf] getActiveCardsForStreamer total: ${Date.now() - startTotal}ms`);
     return normalizeDropRate(cards as unknown as Card[]);
@@ -2439,13 +2532,17 @@ async function getUserCardDetailPg(
 ): Promise<CardWithDetails | null> {
   const start = Date.now();
 
-  let card: (Card & { streamers: Streamer }) | null;
-  try {
-    const rows = await withDbRetry(
+  // Issue #685: getTableColumns(cardsTable) は cards の本番未デプロイ8列を
+  // 要求する。列欠落エラーなら CARDS_SAFE_COLUMNS へ差し替えて再試行する。
+  async function selectCardDetail(useSafeColumns: boolean) {
+    return withDbRetry(
       async () => {
         const { db } = await getDb();
         return db
-          .select({ ...getTableColumns(cardsTable), streamers: streamersTable })
+          .select({
+            ...(useSafeColumns ? CARDS_SAFE_COLUMNS : getTableColumns(cardsTable)),
+            streamers: streamersTable,
+          })
           .from(cardsTable)
           .leftJoin(streamersTable, eq(cardsTable.streamer_id, streamersTable.id))
           // id は主キーのため最大1行（LIMIT 1 は .maybeSingle() と同挙動）
@@ -2455,6 +2552,17 @@ async function getUserCardDetailPg(
       "getUserCardDetail(card)",
       { idempotent: true },
     );
+  }
+
+  let card: (Card & { streamers: Streamer }) | null;
+  try {
+    let rows: Awaited<ReturnType<typeof selectCardDetail>>;
+    try {
+      rows = await selectCardDetail(false);
+    } catch (error) {
+      if (!isMissingCardsBattleColumnError(error)) throw error;
+      rows = await selectCardDetail(true);
+    }
     // streamer_id は NOT NULL FK のため streamers は実データで常に非 null。
     // 既存の消費形状（Card & { streamers: Streamer }）へのキャストのみ行う。
     card = (rows[0] ?? null) as unknown as (Card & { streamers: Streamer }) | null;

--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -35,7 +35,7 @@ import { withDbRetry } from "@/lib/db/retry";
 // src/app/api/cards/route.ts の fetchCardsFromDBPg で確立したパターン（無指定
 // select → 列欠落エラー検知 → CARDS_SAFE_COLUMNS で再試行）を本モジュールにも
 // 適用する。詳細は cards-safe-columns.ts のコメント参照。
-import { CARDS_SAFE_COLUMNS, isMissingCardsBattleColumnError } from "@/lib/db/cards-safe-columns";
+import { CARDS_SAFE_COLUMNS, withCardsBattleColumnFallback } from "@/lib/db/cards-safe-columns";
 // schema のテーブル名（cards / streamers 等）は本モジュールのローカル変数名・
 // 型名と紛らわしいため、Table サフィックスを付けて import する
 // （announcements.ts パイロットと同じ規約）
@@ -115,13 +115,7 @@ async function getStreamerDataPg(
   }
 
   try {
-    let rows: Awaited<ReturnType<typeof selectStreamerWithCards>>;
-    try {
-      rows = await selectStreamerWithCards(false);
-    } catch (error) {
-      if (!isMissingCardsBattleColumnError(error)) throw error;
-      rows = await selectStreamerWithCards(true);
-    }
+    const rows = await withCardsBattleColumnFallback(selectStreamerWithCards);
 
     if (rows.length === 0) return null;
 
@@ -300,13 +294,7 @@ async function getStreamerDataPaginatedPg(
     );
   }
   try {
-    let rows: Awaited<ReturnType<typeof selectCards>>;
-    try {
-      rows = await selectCards(false);
-    } catch (error) {
-      if (!isMissingCardsBattleColumnError(error)) throw error;
-      rows = await selectCards(true);
-    }
+    const rows = await withCardsBattleColumnFallback(selectCards);
     cards = rows as unknown as Card[];
   } catch (error) {
     // 既存実装は cards エラー時 null → `cards || []` で [] 扱い
@@ -644,13 +632,7 @@ async function selectRecentGachaHistory(useSafeColumns: boolean) {
 
 async function getRecentGachaHistoryPg(): Promise<GachaHistoryWithCard[]> {
   try {
-    let rows: Awaited<ReturnType<typeof selectRecentGachaHistory>>;
-    try {
-      rows = await selectRecentGachaHistory(false);
-    } catch (error) {
-      if (!isMissingCardsBattleColumnError(error)) throw error;
-      rows = await selectRecentGachaHistory(true);
-    }
+    const rows = await withCardsBattleColumnFallback(selectRecentGachaHistory);
     // 既存実装と同じく戻り値型へのキャストのみ（値の変換はしない）
     return rows as unknown as GachaHistoryWithCard[];
   } catch (error) {
@@ -787,18 +769,9 @@ async function getGachaHistoryForStreamerPg(
       { idempotent: true },
     );
   }
-  async function fetchRowsWithFallback() {
-    try {
-      return await selectRows(false);
-    } catch (error) {
-      if (!isMissingCardsBattleColumnError(error)) throw error;
-      return selectRows(true);
-    }
-  }
-
   try {
     const [rows, total] = await Promise.all([
-      fetchRowsWithFallback(),
+      withCardsBattleColumnFallback(selectRows),
       withDbRetry(
         async () => {
           const { db } = await getDb();
@@ -956,18 +929,9 @@ async function getGachaHistoryForUserPg(
       { idempotent: true },
     );
   }
-  async function fetchRowsWithFallback() {
-    try {
-      return await selectRows(false);
-    } catch (error) {
-      if (!isMissingCardsBattleColumnError(error)) throw error;
-      return selectRows(true);
-    }
-  }
-
   try {
     const [rows, total] = await Promise.all([
-      fetchRowsWithFallback(),
+      withCardsBattleColumnFallback(selectRows),
       withDbRetry(
         async () => {
           const { db } = await getDb();
@@ -2131,13 +2095,9 @@ async function fetchActiveCardsForStreamerFromDBPg(streamerId: string): Promise<
   const startTotal = Date.now();
   const startQuery = Date.now();
   try {
-    let cards: Awaited<ReturnType<typeof selectActiveCardsForStreamer>>;
-    try {
-      cards = await selectActiveCardsForStreamer(streamerId, false);
-    } catch (error) {
-      if (!isMissingCardsBattleColumnError(error)) throw error;
-      cards = await selectActiveCardsForStreamer(streamerId, true);
-    }
+    const cards = await withCardsBattleColumnFallback((useSafeColumns) =>
+      selectActiveCardsForStreamer(streamerId, useSafeColumns)
+    );
     logger.info(`[Perf] getActiveCardsForStreamer query: ${Date.now() - startQuery}ms`);
     logger.info(`[Perf] getActiveCardsForStreamer total: ${Date.now() - startTotal}ms`);
     return normalizeDropRate(cards as unknown as Card[]);
@@ -2556,13 +2516,7 @@ async function getUserCardDetailPg(
 
   let card: (Card & { streamers: Streamer }) | null;
   try {
-    let rows: Awaited<ReturnType<typeof selectCardDetail>>;
-    try {
-      rows = await selectCardDetail(false);
-    } catch (error) {
-      if (!isMissingCardsBattleColumnError(error)) throw error;
-      rows = await selectCardDetail(true);
-    }
+    const rows = await withCardsBattleColumnFallback(selectCardDetail);
     // streamer_id は NOT NULL FK のため streamers は実データで常に非 null。
     // 既存の消費形状（Card & { streamers: Streamer }）へのキャストのみ行う。
     card = (rows[0] ?? null) as unknown as (Card & { streamers: Streamer }) | null;

--- a/src/lib/db/cards-safe-columns.ts
+++ b/src/lib/db/cards-safe-columns.ts
@@ -94,3 +94,24 @@ export function isMissingCardsBattleColumnError(error: unknown): boolean {
 
   return CARDS_MISSING_IN_PRODUCTION_COLUMNS.some((column) => text.includes(column));
 }
+
+/**
+ * 「まず無指定/全列で試行 → 列欠落エラー検知 → CARDS_SAFE_COLUMNS で再試行」
+ * パターンの共通化 (#685 self-review fix)。src/lib/dashboard-data.ts の7箇所
+ * （getStreamerDataPg 等）で同一の try/catch/retry が反復していたため抽出した。
+ *
+ * attempt(useSafeColumns) は呼び出し側が useSafeColumns の値に応じてクエリの
+ * 列指定（無指定 or CARDS_SAFE_COLUMNS 等への差し替え）を切り替える形で実装する。
+ * isMissingCardsBattleColumnError に該当しないエラーはそのまま再送出し、
+ * 呼び出し側の既存 catch（エラー時の外部挙動パリティ維持）に委ねる。
+ */
+export async function withCardsBattleColumnFallback<T>(
+  attempt: (useSafeColumns: boolean) => Promise<T>
+): Promise<T> {
+  try {
+    return await attempt(false);
+  } catch (error) {
+    if (!isMissingCardsBattleColumnError(error)) throw error;
+    return attempt(true);
+  }
+}

--- a/tests/unit/cards-safe-columns.test.ts
+++ b/tests/unit/cards-safe-columns.test.ts
@@ -1,0 +1,78 @@
+/**
+ * cards-safe-columns.ts の withCardsBattleColumnFallback 単体テスト (#685)
+ *
+ * isMissingCardsBattleColumnError / CARDS_SAFE_COLUMNS 自体は既存の
+ * cards-route-driver-parity.test.ts / dashboard-data-driver-parity.test.ts が
+ * 実クエリ経由で間接的に検証しているため、ここでは #685 で新設した
+ * withCardsBattleColumnFallback の制御フロー（成功・フォールバック・再送出）
+ * のみを、Drizzle モックを介さず直接テストする。
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { withCardsBattleColumnFallback } from '@/lib/db/cards-safe-columns'
+
+function missingCardsBattleColumnError(column: string = 'hp') {
+  return Object.assign(new Error(`column "${column}" of relation "cards" does not exist`), {
+    code: '42703',
+  })
+}
+
+describe('withCardsBattleColumnFallback', () => {
+  it('初回試行が成功すればそのまま結果を返す（フォールバックは呼ばれない）', async () => {
+    const attempt = vi.fn(async (useSafeColumns: boolean) =>
+      useSafeColumns ? 'safe' : 'full'
+    )
+
+    const result = await withCardsBattleColumnFallback(attempt)
+
+    expect(result).toBe('full')
+    expect(attempt).toHaveBeenCalledTimes(1)
+    expect(attempt).toHaveBeenCalledWith(false)
+  })
+
+  it('本番未デプロイ8列由来のエラーなら useSafeColumns=true で再試行する', async () => {
+    const attempt = vi.fn(async (useSafeColumns: boolean) => {
+      if (!useSafeColumns) throw missingCardsBattleColumnError('hp')
+      return 'safe'
+    })
+
+    const result = await withCardsBattleColumnFallback(attempt)
+
+    expect(result).toBe('safe')
+    expect(attempt).toHaveBeenCalledTimes(2)
+    expect(attempt).toHaveBeenNthCalledWith(1, false)
+    expect(attempt).toHaveBeenNthCalledWith(2, true)
+  })
+
+  it('8列のいずれでもエラーを検知する', async () => {
+    const columns = ['card_number', 'hp', 'atk', 'def', 'spd', 'skill_type', 'skill_name', 'skill_power']
+    for (const column of columns) {
+      const attempt = vi.fn(async (useSafeColumns: boolean) => {
+        if (!useSafeColumns) throw missingCardsBattleColumnError(column)
+        return 'safe'
+      })
+      await expect(withCardsBattleColumnFallback(attempt)).resolves.toBe('safe')
+    }
+  })
+
+  it('本番未デプロイ8列に該当しないエラーはフォールバックせずそのまま再送出する', async () => {
+    const permissionError = Object.assign(new Error('permission denied'), { code: '42501' })
+    const attempt = vi.fn(async () => {
+      throw permissionError
+    })
+
+    await expect(withCardsBattleColumnFallback(attempt)).rejects.toBe(permissionError)
+    // 該当しないエラーでは2回目の再試行（useSafeColumns=true）を行わない
+    expect(attempt).toHaveBeenCalledTimes(1)
+  })
+
+  it('フォールバック後（useSafeColumns=true）の失敗はそのまま再送出する（三度目の試行はしない）', async () => {
+    const fallbackError = Object.assign(new Error('connection reset'), { code: 'ECONNRESET' })
+    const attempt = vi.fn(async (useSafeColumns: boolean) => {
+      if (!useSafeColumns) throw missingCardsBattleColumnError('hp')
+      throw fallbackError
+    })
+
+    await expect(withCardsBattleColumnFallback(attempt)).rejects.toBe(fallbackError)
+    expect(attempt).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/unit/dashboard-data-driver-parity.test.ts
+++ b/tests/unit/dashboard-data-driver-parity.test.ts
@@ -35,6 +35,16 @@ import {
   userCards as userCardsTable,
   users as usersTable,
 } from '@/lib/db/schema'
+// Issue #685: cards の本番未デプロイ8列（card_number/hp/atk/def/spd/skill_type/
+// skill_name/skill_power、#625）に対する SELECT フォールバックの検証に使う
+import { CARDS_SAFE_COLUMNS } from '@/lib/db/cards-safe-columns'
+
+/** postgres.js が投げる SQLSTATE 42703（列欠落）相当のエラー（cards-safe-columns.ts 参照） */
+function missingCardsBattleColumnError(column: string = 'hp') {
+  return Object.assign(new Error(`column "${column}" of relation "cards" does not exist`), {
+    code: '42703',
+  })
+}
 
 // logger.error は実装だと Supabase errors パイプラインへ fire-and-forget するため、
 // テストでは副作用のないモックに差し替える（既存 dashboard 系テストと同じ）
@@ -433,6 +443,54 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
       expect(postgrestResult).toBeNull()
       expect(pgResult).toBeNull()
     })
+
+    // Issue #685: card: cardsTable のネスト select は cards の本番未デプロイ8列
+    // （card_number/hp/atk/def/spd/skill_type/skill_name/skill_power、#625）を
+    // 要求するため本番で 42703 になる。列欠落エラーなら CARDS_SAFE_COLUMNS へ
+    // 差し替えて再試行することを検証する（rows/count の Promise.all を伴わない
+    // 単一クエリのため、エラーキューの消費順序に曖昧さがない）。
+    it('本番未デプロイ8列(hp等)SELECTフォールバック: CARDS_SAFE_COLUMNSで再試行し成功する', async () => {
+      const { result: pgResult, db } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [streamersTable, [STREAMER]],
+            [cardsTable, [CARD_OLD, CARD_NEW]],
+          ]),
+          errors: new Map([[streamersTable, [missingCardsBattleColumnError()]]]),
+        },
+        () => getStreamerData('twitch-user-1')
+      )
+
+      expect((pgResult as any).cards).toHaveLength(2)
+      // CARDS_SAFE_COLUMNS は hp 等の8列を含まないため、フォールバック後の
+      // カードにはこれらのキー自体が存在しない（production の select("*") と同じ）。
+      expect((pgResult as any).cards[0]).not.toHaveProperty('hp')
+      expect((pgResult as any).cards[0]).not.toHaveProperty('card_number')
+      expect((pgResult as any).cards[0]).toMatchObject({ id: 'card-new', name: 'Card One' })
+      // 2回目(最後)の select 呼び出しの card フィールドが CARDS_SAFE_COLUMNS であることを確認
+      // select() の fields 引数は型上 optional だが、この時点で最低1回は
+      // 呼び出し済み（かつ全呼び出しが明示的に fields を渡す実装）であることが
+      // 保証されているため non-null アサーションで受ける。
+      const lastCall = db.select.mock.calls[db.select.mock.calls.length - 1][0]!
+      expect(lastCall.card).toEqual(CARDS_SAFE_COLUMNS)
+    })
+
+    it('本番未デプロイ8列に該当しないエラーではフォールバックせず null を返す（既存挙動）', async () => {
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [streamersTable, [STREAMER]],
+            [cardsTable, [CARD_OLD, CARD_NEW]],
+          ]),
+          errors: new Map([
+            [streamersTable, [Object.assign(new Error('permission denied'), { code: '42501' })]],
+          ]),
+        },
+        () => getStreamerData('twitch-user-1')
+      )
+
+      expect(pgResult).toBeNull()
+    })
   })
 
   describe('getStreamerDataPaginated', () => {
@@ -481,6 +539,40 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
       expect(postgrestResult).toBeNull()
       expect(pgResult).toBeNull()
     })
+
+    // Issue #685: cards の無指定 select() は本番未デプロイ8列を要求する。
+    // count → cards は逐次実行（Promise.all ではない）のため、エラーキューを
+    // 2件（count 用 1件 + cards 初回試行用 1件）積んでも消費順序は決定的。
+    // count は独自リトライを持たないため 1回目のエラーでそのまま totalCount=0
+    // に落ちる（既存の「count エラー時 0 扱い」と同じ経路）。cards は
+    // isMissingCardsBattleColumnError 判定を通り CARDS_SAFE_COLUMNS で再試行し
+    // 成功する。
+    it('本番未デプロイ8列(hp等)SELECTフォールバック: cardsはCARDS_SAFE_COLUMNSで再試行し成功する', async () => {
+      const { result: pgResult, db } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [streamersTable, [STREAMER]],
+            [cardsTable, [CARD_NEW, CARD_OLD]],
+          ]),
+          errors: new Map([
+            [cardsTable, [missingCardsBattleColumnError(), missingCardsBattleColumnError()]],
+          ]),
+        },
+        () => getStreamerDataPaginated('twitch-user-1', 1, 20)
+      )
+
+      // count 側は1回目のエラーをそのまま消費し、既存の「count エラー時 0 扱い」
+      // に落ちる（本テストの主眼は cards 側のフォールバックのため許容する）。
+      expect((pgResult as any).pagination.total).toBe(0)
+      expect((pgResult as any).cards).toHaveLength(2)
+      expect((pgResult as any).cards[0]).not.toHaveProperty('hp')
+      expect((pgResult as any).cards[0]).toMatchObject({ id: 'card-new' })
+      // select() の fields 引数は型上 optional だが、この時点で最低1回は
+      // 呼び出し済み（かつ全呼び出しが明示的に fields を渡す実装）であることが
+      // 保証されているため non-null アサーションで受ける。
+      const lastCall = db.select.mock.calls[db.select.mock.calls.length - 1][0]!
+      expect(lastCall).toEqual(CARDS_SAFE_COLUMNS)
+    })
   })
 
   describe('getRecentGachaHistory', () => {
@@ -521,6 +613,32 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
           expect(entry.redeemed_at).not.toBeInstanceOf(Date)
         }
       }
+    })
+
+    // Issue #685: cards: cardsTable のネスト select は本番未デプロイ8列を要求する。
+    // 単一クエリ（Promise.all を伴わない）のため、エラーキューの消費順序に
+    // 曖昧さがない。
+    it('本番未デプロイ8列(hp等)SELECTフォールバック: CARDS_SAFE_COLUMNSで再試行し成功する', async () => {
+      const { result: pgResult, db } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [gachaHistoryTable, [HISTORY_NEW, HISTORY_OLD]],
+            [cardsTable, [CARD_OLD, CARD_NEW]],
+          ]),
+          errors: new Map([[gachaHistoryTable, [missingCardsBattleColumnError()]]]),
+        },
+        () => getRecentGachaHistory()
+      )
+
+      expect(pgResult).toHaveLength(2)
+      const entry = (pgResult as any[])[0]
+      expect(entry.cards).not.toHaveProperty('hp')
+      expect(entry.cards).toMatchObject({ id: entry.card_id })
+      // select() の fields 引数は型上 optional だが、この時点で最低1回は
+      // 呼び出し済み（かつ全呼び出しが明示的に fields を渡す実装）であることが
+      // 保証されているため non-null アサーションで受ける。
+      const lastCall = db.select.mock.calls[db.select.mock.calls.length - 1][0]!
+      expect(lastCall.cards).toEqual(CARDS_SAFE_COLUMNS)
     })
   })
 
@@ -612,6 +730,38 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
         pagination: { page: 1, perPage: 20, total: 0, totalPages: 0 },
       })
     })
+
+    // Issue #685: cards: cardsTable のネスト select は本番未デプロイ8列を要求する。
+    // rows と count はどちらも .from(gachaHistoryTable) だが Promise.all で並行実行
+    // されるため、mainTable キー共有のモックのエラーキューを rows/count どちらが
+    // 消費するかは一見曖昧に見える。しかし ECMAScript の配列リテラル評価順序
+    // （[fetchRowsWithFallback(), countPromise] は左から順に同期的に呼び出される）
+    // と withDbRetry が queryFn を即座に呼ぶ実装（追加の非同期ホップなし）により、
+    // rows 側の getDb() 待機が count 側より先にスケジュールされ、決定的に rows が
+    // 先にキューを消費する（本テストで実測確認）。
+    it('本番未デプロイ8列(hp等)SELECTフォールバック: rowsはCARDS_SAFE_COLUMNSで再試行し成功する', async () => {
+      const { result: pgResult, db } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [gachaHistoryTable, [HISTORY_NEW, HISTORY_OLD]],
+            [cardsTable, [CARD_OLD, CARD_NEW]],
+          ]),
+          counts: new Map([[gachaHistoryTable, 42]]),
+          errors: new Map([[gachaHistoryTable, [missingCardsBattleColumnError()]]]),
+        },
+        () => getGachaHistoryForStreamer('streamer-1', { page: 1, perPage: 20 })
+      )
+
+      expect(pgResult.history).toHaveLength(2)
+      expect(pgResult.pagination.total).toBe(42)
+      const entry = (pgResult.history as any[])[0]
+      expect(entry.cards).not.toHaveProperty('hp')
+      // select() の fields 引数は型上 optional だが、この時点で最低1回は
+      // 呼び出し済み（かつ全呼び出しが明示的に fields を渡す実装）であることが
+      // 保証されているため non-null アサーションで受ける。
+      const lastCall = db.select.mock.calls[db.select.mock.calls.length - 1][0]!
+      expect(lastCall.cards).toEqual(CARDS_SAFE_COLUMNS)
+    })
   })
 
   describe('getGachaHistoryForUser', () => {
@@ -657,6 +807,35 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
       expect(Array.isArray(entry.cards)).toBe(false)
       expect(typeof entry.redeemed_at).toBe('string')
     })
+
+    // Issue #685: getGachaHistoryForStreamer と同じ rows/count 並行実行構成
+    // （どちらも .from(gachaHistoryTable)）。配列リテラル評価順序により rows が
+    // 先にエラーキューを消費することを実測確認済み（同パターンで5回連続green）。
+    it('本番未デプロイ8列(hp等)SELECTフォールバック: rowsはCARDS_SAFE_COLUMNSで再試行し成功する', async () => {
+      const { result: pgResult, db } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [gachaHistoryTable, [HISTORY_NEW]],
+            [cardsTable, [CARD_NEW]],
+            [streamersTable, [STREAMER]],
+          ]),
+          counts: new Map([[gachaHistoryTable, 1]]),
+          errors: new Map([[gachaHistoryTable, [missingCardsBattleColumnError()]]]),
+        },
+        () => getGachaHistoryForUser('viewer-1')
+      )
+
+      expect((pgResult as any).history).toHaveLength(1)
+      expect((pgResult as any).pagination.total).toBe(1)
+      const entry = (pgResult as any).history[0]
+      expect(entry.cards).not.toHaveProperty('hp')
+      expect(entry.streamers).toEqual({ twitch_display_name: 'Streamer One' })
+      // select() の fields 引数は型上 optional だが、この時点で最低1回は
+      // 呼び出し済み（かつ全呼び出しが明示的に fields を渡す実装）であることが
+      // 保証されているため non-null アサーションで受ける。
+      const lastCall = db.select.mock.calls[db.select.mock.calls.length - 1][0]!
+      expect(lastCall.cards).toEqual(CARDS_SAFE_COLUMNS)
+    })
   })
 
   describe('getActiveCardsForStreamer', () => {
@@ -676,6 +855,27 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
         expect(typeof card.drop_rate).toBe('number')
         expect(typeof card.created_at).toBe('string')
       }
+    })
+
+    // Issue #685: 無指定 select() は本番未デプロイ8列を要求する。単一クエリ
+    // （Promise.all を伴わない）のため、エラーキューの消費順序に曖昧さがない。
+    it('本番未デプロイ8列(hp等)SELECTフォールバック: CARDS_SAFE_COLUMNSで再試行し成功する', async () => {
+      const { result: pgResult, db } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([[cardsTable, [CARD_NEW, CARD_OLD]]]),
+          errors: new Map([[cardsTable, [missingCardsBattleColumnError()]]]),
+        },
+        () => getActiveCardsForStreamer('streamer-1')
+      )
+
+      expect(pgResult).toHaveLength(2)
+      expect((pgResult as any[])[0]).not.toHaveProperty('hp')
+      expect((pgResult as any[])[0]).not.toHaveProperty('card_number')
+      // select() の fields 引数は型上 optional だが、この時点で最低1回は
+      // 呼び出し済み（かつ全呼び出しが明示的に fields を渡す実装）であることが
+      // 保証されているため non-null アサーションで受ける。
+      const lastCall = db.select.mock.calls[db.select.mock.calls.length - 1][0]!
+      expect(lastCall).toEqual(CARDS_SAFE_COLUMNS)
     })
   })
 
@@ -814,6 +1014,34 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
 
       expect(postgrestResult).toBeNull()
       expect(pgResult).toBeNull()
+    })
+
+    // Issue #685: getTableColumns(cardsTable) のスプレッドは本番未デプロイ8列を
+    // 要求する。card 取得（.from(cardsTable)）は user/count 取得より前に完了する
+    // 逐次ステップのため、エラーキューの消費順序に曖昧さがない。
+    it('本番未デプロイ8列(hp等)SELECTフォールバック: CARDS_SAFE_COLUMNSで再試行し成功する', async () => {
+      const { result: pgResult, db } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [cardsTable, [CARD_NEW]],
+            [streamersTable, [STREAMER]],
+            [usersTable, [USER_ROW]],
+          ]),
+          counts: new Map([[userCardsTable, 2]]),
+          errors: new Map([[cardsTable, [missingCardsBattleColumnError()]]]),
+        },
+        () => getUserCardDetail('viewer-1', 'streamer-1', 'card-new')
+      )
+
+      expect(pgResult).not.toBeNull()
+      expect(pgResult).not.toHaveProperty('hp')
+      expect(pgResult).toMatchObject({ id: 'card-new', streamer: STREAMER, count: 2 })
+      const cardsCalls = db.select.mock.calls.filter((call: any[]) => {
+        const fields = call[0]
+        return fields && 'streamers' in fields
+      })
+      const lastCardsCall = cardsCalls[cardsCalls.length - 1][0]
+      expect(lastCardsCall).toEqual({ ...CARDS_SAFE_COLUMNS, streamers: streamersTable })
     })
 
     it('カードなし（0行）では両経路とも null を返す', async () => {

--- a/tests/unit/dashboard-data-driver-parity.test.ts
+++ b/tests/unit/dashboard-data-driver-parity.test.ts
@@ -235,9 +235,25 @@ function createDrizzleDbMock(config: DrizzleMockConfig = {}) {
         const joins: Array<{ table: Table; on: SQL }> = []
 
         const evaluate = () => {
-          const errorQueue = config.errors?.get(mainTable)
-          if (errorQueue && errorQueue.length > 0) {
-            throw errorQueue.shift()
+          const selection = fields ?? (getTableColumns(mainTable) as Record<string, unknown>)
+          // 集計（count() 等）を含む選択は、実 SQL の SELECT count(*) と同じく
+          // マッチ行数に関わらず常に 1 行を返す
+          const hasAggregate = Object.values(selection).some((f) => is(f, SQL))
+
+          // Issue #685 self-review fix: エラーキューは mainTable 単位だが、rows と
+          // count が同一 mainTable を Promise.all で共有する関数（例:
+          // getGachaHistoryForStreamerPg）では、集計クエリは実列を一切選択しない
+          // ため列欠落エラー（isMissingCardsBattleColumnError 等）を構造的に
+          // 受け取り得ない。集計クエリにだけエラーキューを適用しないことで、
+          // rows/count どちらが先に評価されてもテストが決定的になる
+          // （評価順序への依存を無くす。以前は配列リテラル評価順序 +
+          // withDbRetry の実装により rows が先に消費される前提で書かれていたが、
+          // その前提は実装の些細な変更で崩れうる脆弱な仮定だった）。
+          if (!hasAggregate) {
+            const errorQueue = config.errors?.get(mainTable)
+            if (errorQueue && errorQueue.length > 0) {
+              throw errorQueue.shift()
+            }
           }
 
           // 行コンテキスト: テーブル → その行（LEFT JOIN 不一致は null）
@@ -303,10 +319,9 @@ function createDrizzleDbMock(config: DrizzleMockConfig = {}) {
               })
             )
 
-          const selection = fields ?? (getTableColumns(mainTable) as Record<string, unknown>)
           // 集計（count() 等）を含む選択は、実 SQL の SELECT count(*) と同じく
-          // マッチ行数に関わらず常に 1 行を返す
-          const hasAggregate = Object.values(selection).some((f) => is(f, SQL))
+          // マッチ行数に関わらず常に 1 行を返す（selection/hasAggregate は
+          // 関数先頭で計算済み）
           if (hasAggregate) {
             return [project(selection, new Map())]
           }
@@ -468,9 +483,11 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
       expect((pgResult as any).cards[0]).not.toHaveProperty('card_number')
       expect((pgResult as any).cards[0]).toMatchObject({ id: 'card-new', name: 'Card One' })
       // 2回目(最後)の select 呼び出しの card フィールドが CARDS_SAFE_COLUMNS であることを確認
-      // select() の fields 引数は型上 optional だが、この時点で最低1回は
-      // 呼び出し済み（かつ全呼び出しが明示的に fields を渡す実装）であることが
-      // 保証されているため non-null アサーションで受ける。
+      // select() の fields 引数は型上 optional（引数なし呼び出しも存在する）
+      // だが、直前で db.select.mock.calls が最低1回は記録されていることを
+      // 呼び出し自体で保証しており、かつこのテストが検証したい「最後の」
+      // 呼び出しは実装上必ず fields を明示的に渡す形になっているため、
+      // ここに限り non-null アサーションで受けてよい。
       const lastCall = db.select.mock.calls[db.select.mock.calls.length - 1][0]!
       expect(lastCall.card).toEqual(CARDS_SAFE_COLUMNS)
     })
@@ -541,10 +558,11 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
     })
 
     // Issue #685: cards の無指定 select() は本番未デプロイ8列を要求する。
-    // count → cards は逐次実行（Promise.all ではない）のため、エラーキューを
-    // 2件（count 用 1件 + cards 初回試行用 1件）積んでも消費順序は決定的。
-    // count は独自リトライを持たないため 1回目のエラーでそのまま totalCount=0
-    // に落ちる（既存の「count エラー時 0 扱い」と同じ経路）。cards は
+    // count（{ count: countRows() } のみを選択）は cards の実列を一切選択しない
+    // ため、本番の postgres.js でも列欠落エラーを構造的に受け取り得ない。モック
+    // 側も集計クエリをエラーキュー対象外にしている（createDrizzleDbMock の
+    // hasAggregate 判定）ため、エラーは cards 側の初回試行にのみ適用され、count
+    // は counts フィクスチャの本物の値をそのまま返す。cards は
     // isMissingCardsBattleColumnError 判定を通り CARDS_SAFE_COLUMNS で再試行し
     // 成功する。
     it('本番未デプロイ8列(hp等)SELECTフォールバック: cardsはCARDS_SAFE_COLUMNSで再試行し成功する', async () => {
@@ -554,22 +572,22 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
             [streamersTable, [STREAMER]],
             [cardsTable, [CARD_NEW, CARD_OLD]],
           ]),
-          errors: new Map([
-            [cardsTable, [missingCardsBattleColumnError(), missingCardsBattleColumnError()]],
-          ]),
+          counts: new Map([[cardsTable, 2]]),
+          errors: new Map([[cardsTable, [missingCardsBattleColumnError()]]]),
         },
         () => getStreamerDataPaginated('twitch-user-1', 1, 20)
       )
 
-      // count 側は1回目のエラーをそのまま消費し、既存の「count エラー時 0 扱い」
-      // に落ちる（本テストの主眼は cards 側のフォールバックのため許容する）。
-      expect((pgResult as any).pagination.total).toBe(0)
+      // count は集計クエリのためエラーキューの影響を受けず、常に本物の total を返す
+      expect((pgResult as any).pagination.total).toBe(2)
       expect((pgResult as any).cards).toHaveLength(2)
       expect((pgResult as any).cards[0]).not.toHaveProperty('hp')
       expect((pgResult as any).cards[0]).toMatchObject({ id: 'card-new' })
-      // select() の fields 引数は型上 optional だが、この時点で最低1回は
-      // 呼び出し済み（かつ全呼び出しが明示的に fields を渡す実装）であることが
-      // 保証されているため non-null アサーションで受ける。
+      // select() の fields 引数は型上 optional（引数なし呼び出しも存在する）
+      // だが、直前で db.select.mock.calls が最低1回は記録されていることを
+      // 呼び出し自体で保証しており、かつこのテストが検証したい「最後の」
+      // 呼び出しは実装上必ず fields を明示的に渡す形になっているため、
+      // ここに限り non-null アサーションで受けてよい。
       const lastCall = db.select.mock.calls[db.select.mock.calls.length - 1][0]!
       expect(lastCall).toEqual(CARDS_SAFE_COLUMNS)
     })
@@ -634,9 +652,11 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
       const entry = (pgResult as any[])[0]
       expect(entry.cards).not.toHaveProperty('hp')
       expect(entry.cards).toMatchObject({ id: entry.card_id })
-      // select() の fields 引数は型上 optional だが、この時点で最低1回は
-      // 呼び出し済み（かつ全呼び出しが明示的に fields を渡す実装）であることが
-      // 保証されているため non-null アサーションで受ける。
+      // select() の fields 引数は型上 optional（引数なし呼び出しも存在する）
+      // だが、直前で db.select.mock.calls が最低1回は記録されていることを
+      // 呼び出し自体で保証しており、かつこのテストが検証したい「最後の」
+      // 呼び出しは実装上必ず fields を明示的に渡す形になっているため、
+      // ここに限り non-null アサーションで受けてよい。
       const lastCall = db.select.mock.calls[db.select.mock.calls.length - 1][0]!
       expect(lastCall.cards).toEqual(CARDS_SAFE_COLUMNS)
     })
@@ -732,13 +752,13 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
     })
 
     // Issue #685: cards: cardsTable のネスト select は本番未デプロイ8列を要求する。
-    // rows と count はどちらも .from(gachaHistoryTable) だが Promise.all で並行実行
-    // されるため、mainTable キー共有のモックのエラーキューを rows/count どちらが
-    // 消費するかは一見曖昧に見える。しかし ECMAScript の配列リテラル評価順序
-    // （[fetchRowsWithFallback(), countPromise] は左から順に同期的に呼び出される）
-    // と withDbRetry が queryFn を即座に呼ぶ実装（追加の非同期ホップなし）により、
-    // rows 側の getDb() 待機が count 側より先にスケジュールされ、決定的に rows が
-    // 先にキューを消費する（本テストで実測確認）。
+    // rows と count はどちらも .from(gachaHistoryTable) を使うが、count 側は
+    // { count: countRows() } の集計のみで cards の列を一切選択しないため、
+    // 本番の postgres.js でも列欠落エラー（isMissingCardsBattleColumnError 該当）
+    // を構造的に受け取り得ない。モック側もこれに合わせて集計クエリをエラーキュー
+    // の対象外にしている（createDrizzleDbMock の hasAggregate 判定、上部参照）ため、
+    // rows/count が Promise.all で並行実行されても消費順序に曖昧さはなく、count は
+    // 常に本物の total（42）を返す。
     it('本番未デプロイ8列(hp等)SELECTフォールバック: rowsはCARDS_SAFE_COLUMNSで再試行し成功する', async () => {
       const { result: pgResult, db } = await runPg(
         {
@@ -753,14 +773,42 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
       )
 
       expect(pgResult.history).toHaveLength(2)
+      // count は集計クエリのためエラーキューの影響を受けず、常に本物の total を返す
       expect(pgResult.pagination.total).toBe(42)
       const entry = (pgResult.history as any[])[0]
       expect(entry.cards).not.toHaveProperty('hp')
-      // select() の fields 引数は型上 optional だが、この時点で最低1回は
-      // 呼び出し済み（かつ全呼び出しが明示的に fields を渡す実装）であることが
-      // 保証されているため non-null アサーションで受ける。
+      // select() の fields 引数は型上 optional（引数なし呼び出しも存在する）
+      // だが、直前で db.select.mock.calls が最低1回は記録されていることを
+      // 呼び出し自体で保証しており、かつこのテストが検証したい「最後の」
+      // 呼び出しは実装上必ず fields を明示的に渡す形になっているため、
+      // ここに限り non-null アサーションで受けてよい。
       const lastCall = db.select.mock.calls[db.select.mock.calls.length - 1][0]!
       expect(lastCall.cards).toEqual(CARDS_SAFE_COLUMNS)
+    })
+
+    // Issue #685 self-review fix: rows/count が Promise.all で並行実行される
+    // 構成で、本番未デプロイ8列に該当しないエラーが rows 側で発生した場合に
+    // フォールバックせずそのまま呼び出し元の catch（history: [] 扱い）に
+    // 落ちることを確認する。
+    it('本番未デプロイ8列に該当しないエラーではフォールバックせず空結果を返す', async () => {
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [gachaHistoryTable, [HISTORY_NEW, HISTORY_OLD]],
+            [cardsTable, [CARD_OLD, CARD_NEW]],
+          ]),
+          counts: new Map([[gachaHistoryTable, 42]]),
+          errors: new Map([
+            [gachaHistoryTable, [Object.assign(new Error('permission denied'), { code: '42501' })]],
+          ]),
+        },
+        () => getGachaHistoryForStreamer('streamer-1', { page: 1, perPage: 20 })
+      )
+
+      expect(pgResult).toEqual({
+        history: [],
+        pagination: { page: 1, perPage: 20, total: 0, totalPages: 0 },
+      })
     })
   })
 
@@ -809,8 +857,9 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
     })
 
     // Issue #685: getGachaHistoryForStreamer と同じ rows/count 並行実行構成
-    // （どちらも .from(gachaHistoryTable)）。配列リテラル評価順序により rows が
-    // 先にエラーキューを消費することを実測確認済み（同パターンで5回連続green）。
+    // （どちらも .from(gachaHistoryTable)）。count は集計クエリのためエラー
+    // キュー対象外（上部 createDrizzleDbMock の hasAggregate 判定参照）であり、
+    // 消費順序に曖昧さはない。
     it('本番未デプロイ8列(hp等)SELECTフォールバック: rowsはCARDS_SAFE_COLUMNSで再試行し成功する', async () => {
       const { result: pgResult, db } = await runPg(
         {
@@ -830,11 +879,37 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
       const entry = (pgResult as any).history[0]
       expect(entry.cards).not.toHaveProperty('hp')
       expect(entry.streamers).toEqual({ twitch_display_name: 'Streamer One' })
-      // select() の fields 引数は型上 optional だが、この時点で最低1回は
-      // 呼び出し済み（かつ全呼び出しが明示的に fields を渡す実装）であることが
-      // 保証されているため non-null アサーションで受ける。
+      // select() の fields 引数は型上 optional（引数なし呼び出しも存在する）
+      // だが、直前で db.select.mock.calls が最低1回は記録されていることを
+      // 呼び出し自体で保証しており、かつこのテストが検証したい「最後の」
+      // 呼び出しは実装上必ず fields を明示的に渡す形になっているため、
+      // ここに限り non-null アサーションで受けてよい。
       const lastCall = db.select.mock.calls[db.select.mock.calls.length - 1][0]!
       expect(lastCall.cards).toEqual(CARDS_SAFE_COLUMNS)
+    })
+
+    // Issue #685 self-review fix: getGachaHistoryForStreamer と同様、rows/count
+    // 並行実行構成での「該当しないエラーはフォールバックしない」ことの確認。
+    it('本番未デプロイ8列に該当しないエラーではフォールバックせず空結果を返す', async () => {
+      const { result: pgResult } = await runPg(
+        {
+          tables: new Map<Table, Array<Record<string, unknown>>>([
+            [gachaHistoryTable, [HISTORY_NEW]],
+            [cardsTable, [CARD_NEW]],
+            [streamersTable, [STREAMER]],
+          ]),
+          counts: new Map([[gachaHistoryTable, 1]]),
+          errors: new Map([
+            [gachaHistoryTable, [Object.assign(new Error('permission denied'), { code: '42501' })]],
+          ]),
+        },
+        () => getGachaHistoryForUser('viewer-1')
+      )
+
+      expect(pgResult).toEqual({
+        history: [],
+        pagination: { page: 1, perPage: 20, total: 0, totalPages: 0 },
+      })
     })
   })
 
@@ -871,9 +946,11 @@ describe('dashboard-data: postgrest / pg 経路の形状互換 (#571)', () => {
       expect(pgResult).toHaveLength(2)
       expect((pgResult as any[])[0]).not.toHaveProperty('hp')
       expect((pgResult as any[])[0]).not.toHaveProperty('card_number')
-      // select() の fields 引数は型上 optional だが、この時点で最低1回は
-      // 呼び出し済み（かつ全呼び出しが明示的に fields を渡す実装）であることが
-      // 保証されているため non-null アサーションで受ける。
+      // select() の fields 引数は型上 optional（引数なし呼び出しも存在する）
+      // だが、直前で db.select.mock.calls が最低1回は記録されていることを
+      // 呼び出し自体で保証しており、かつこのテストが検証したい「最後の」
+      // 呼び出しは実装上必ず fields を明示的に渡す形になっているため、
+      // ここに限り non-null アサーションで受けてよい。
       const lastCall = db.select.mock.calls[db.select.mock.calls.length - 1][0]!
       expect(lastCall).toEqual(CARDS_SAFE_COLUMNS)
     })


### PR DESCRIPTION
## Summary

本番 Supabase の `cards` テーブルには battle機能由来のスキーマドリフト（#625）で8列（`card_number`/`hp`/`atk`/`def`/`spd`/`skill_type`/`skill_name`/`skill_power`）が実在しないが、`src/lib/db/schema.ts` の Drizzle スキーマには定義されているため、無指定 `.select()`/`getTableColumns()`/ネスト `{cards: cardsTable}` は本番で42703エラーになる。PR #682 で `src/app/api/cards/route.ts` に導入済みの `CARDS_SAFE_COLUMNS`/`isMissingCardsBattleColumnError` パターン（まず無指定→列欠落エラー検知→明示列リストで再試行）を、同一問題を抱えていた `src/lib/dashboard-data.ts` の残り7箇所に適用した。

対象: `getStreamerDataPg`・`getStreamerDataPaginatedPg`・`getRecentGachaHistoryPg`・`getGachaHistoryForStreamerPg`・`getGachaHistoryForUserPg`・`fetchActiveCardsForStreamerFromDBPg`・`getUserCardDetailPg`

このうち2箇所（`getGachaHistoryForStreamerPg`/`getGachaHistoryForUserPg`）は rows/count クエリが `Promise.all` で同一テーブルを共有する構成のため、テスト用モック（`createDrizzleDbMock`）の `hasAggregate` 判定をエラーキュー消費より前に移動し、集計クエリ（count）を構造的にエラーキュー対象外にする改修も行った（本番の count クエリは cards の実列を一切選択しないため列欠落エラーを受け取ること自体があり得ない、という実際の性質と一致させ、テストの評価順序依存を排除）。

7箇所の共通 try/catch/retry パターンは `src/lib/db/cards-safe-columns.ts` の新規ヘルパー `withCardsBattleColumnFallback` に共通化した。

`DB_DRIVER` 未設定時（postgrest経路）の挙動は無変更。preview環境（8列とも実在）では無指定select/getTableColumnsがそのまま成功するためフォールバック経路には到達せず、既存の全列を返す挙動を維持する。

## レビュープロセス

- fable が利用上限に達したため、実装は統括セッション（sonnet）が直接担当
- 厳格自己レビュー（デフォルトモデル）を実施し、major指摘2件（Promise.allレース条件へのテストの脆弱な依存、count集計クエリの意味論的矛盾）・minor指摘3件（7箇所の重複、否定テスト不足、コメント精度）を全て解消

## Test plan

- [x] `npx vitest run`: 160ファイル / 1947テスト全green
- [x] `npx tsc --noEmit`: 新規エラーゼロ（既存24件ベースライン維持）
- [x] `npm run lint`: エラーゼロ
- [x] `dashboard-data-driver-parity.test.ts` を複数回連続実行しflakinessがないことを確認

---

Co-Authored-By: Claude Sonnet 5

https://claude.ai/code/session_01X58SsjpRRR44xxTbCa6HEV

---
_Generated by [Claude Code](https://claude.ai/code/session_01X58SsjpRRR44xxTbCa6HEV)_