### PR TITLE
fix(db): migration 00073のdigest()呼び出しをextensionsスキーマ修飾する

### DIFF
--- a/supabase/migrations/00073_add_analysis_dashboard_rpcs.sql
+++ b/supabase/migrations/00073_add_analysis_dashboard_rpcs.sql
@@ -229,8 +229,12 @@ LEFT JOIN card_counts cc ON cc.streamer_id = s.id
 LEFT JOIN users u ON u.twitch_user_id = s.twitch_user_id
 LEFT JOIN streamer_chat_sender_settings css ON css.streamer_id = s.id
 LEFT JOIN twitch_bot_accounts bot ON bot.id = css.custom_bot_account_id
+-- digest() は pgcrypto 由来で、Supabase のデフォルト構成では public ではなく
+-- extensions スキーマにインストールされる。本関数は SET search_path = public
+-- (SECURITY DEFINER の search_path 固定によるインジェクション対策) のため、
+-- search_path を広げる代わりに呼び出し側を extensions.digest(...) と明示修飾する。
 LEFT JOIN storage_usage su
-  ON su.user_prefix = substring(encode(digest(s.twitch_user_id, 'sha256'), 'hex') from 1 for 8)
+  ON su.user_prefix = substring(encode(extensions.digest(s.twitch_user_id, 'sha256'), 'hex') from 1 for 8)
 LEFT JOIN vote_campaign_bonus vcb ON vcb.streamer_id = s.id;
 $$;
 


### PR DESCRIPTION
## 背景

2026-07-08以降、mainへのpush毎に実行される Cloudflare Deploy Support ワークフローの `supabase-migrations` ジョブ（`supabase db push` で実データベースに適用）が継続して失敗していた。

3回連続の失敗を確認 (sha `8b544b42`, `d41b7b68`, `31e18dcc`)。ジョブログ (job_id 86528715981) から実際のエラーを特定:

```
NOTICE (42710): extension "pgcrypto" already exists, skipping
ERROR: function digest(text, unknown) does not exist (SQLSTATE 42883)
```

## 原因

`00073_add_analysis_dashboard_rpcs.sql` の `get_analysis_streamers()` 関数内で `digest()` (pgcrypto由来) を呼んでいるが、この関数は `SECURITY DEFINER` + `SET search_path = public` で定義されている。Supabaseのデフォルト構成では pgcrypto は `public` ではなく `extensions` スキーマにインストールされるため、`public` に固定された search_path からは `digest()` を解決できない。

`CREATE EXTENSION IF NOT EXISTS pgcrypto;` は「既にインストール済み」を報告するだけで、関数呼び出し自体のスキーマ解決は救えない。

## 修正内容

`digest()` の呼び出し箇所を `extensions.digest(...)` と明示スキーマ修飾した。`SET search_path = public` はそのまま維持している(SECURITY DEFINER 関数の search_path 固定はインジェクション対策のベストプラクティスであり、広げるより呼び出し側を明示修飾する方が安全)。

`digest(` の呼び出しはファイル内でこの1箇所のみ(grep で確認済み)。

このファイルはこれまで一度も実データベースへの適用に成功していないため、新規の是正マイグレーションを追加するのではなく、既存ファイルを直接修正する方式を採った(前例: commit `00cc064` — 00071の未適用マイグレーションを直接修正した実績あり)。

## 影響

このバグにより、00073自体だけでなく、その後にマージされた 00074/00075/00076 も含め、mainへの全pushでマイグレーション適用が失敗し続けていた。本修正により、これらが初めて実データベースへ適用可能になる。

#662（Phase 1運用ロールアウト）の開始条件のひとつ「preview deploymentがgreen」がこのバグにより未達だった。本PRはその条件を満たすための前提修正であり、#662自体をcloseするものではない。

## 検証

- `npm run check:migration-order` — OK (65件検証)
- SQLファイルのため型チェック・lintの対象外
- 実データベースへの直接検証は環境上不可能(Supabase接続不可)。pgcryptoがSupabaseで`extensions`スキーマにインストールされるのは公式にドキュメント化されたデフォルト挙動だが、本プロジェクトの実環境での100%確認はできていない旨、Opusレビューで重点確認を依頼する。

Related: #662, #568 (Phase 1)
