### PR TITLE
chore: promote preview changes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Typecheck
+        # #588: 型エラーの検出漏れ防止のため tsc --noEmit をゲート化する。
+        # 既に依存インストール済みの test job に同居させ、新規 job による
+        # 追加の npm ci / セットアップコストを避ける。
+        run: npm run typecheck
+
       - name: Unit tests
         run: npm run test:unit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: vitest-unit-report
-          path: vitest-report.json
+          path: |
+            vitest-report.json
+            tests/unit/raid-gacha-driver-parity.test.ts
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,18 @@ jobs:
         run: npm run typecheck
 
       - name: Unit tests
-        # 失敗時に大量の成功ログで原因が埋もれないよう、最初の失敗で停止し
-        # compactなdot reporterを使う。ローカルのtest:unitコマンド自体は変更しない。
-        run: npm run test:unit -- --reporter=dot --bail=1
+        # 失敗時に大量の成功ログで原因が埋もれないよう、最初の失敗で停止し、
+        # 機械可読なJSONレポートを生成する。失敗時のみ次のstepでartifact化する。
+        run: npm run test:unit -- --reporter=json --outputFile=vitest-report.json --bail=1
+
+      - name: Upload failed unit test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vitest-unit-report
+          path: vitest-report.json
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Integration tests
         run: npm run test:integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: vitest-unit-report
-          path: |
-            vitest-report.json
-            tests/unit/raid-gacha-driver-parity.test.ts
+          path: vitest-report.json
           if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
         run: npm run typecheck
 
       - name: Unit tests
-        run: npm run test:unit
+        # 失敗時に大量の成功ログで原因が埋もれないよう、最初の失敗で停止し
+        # compactなdot reporterを使う。ローカルのtest:unitコマンド自体は変更しない。
+        run: npm run test:unit -- --reporter=dot --bail=1
 
       - name: Integration tests
         run: npm run test:integration

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",
     "test:all": "vitest run",

--- a/src/app/api/gacha/route.ts
+++ b/src/app/api/gacha/route.ts
@@ -78,7 +78,22 @@ export async function POST(request: NextRequest) {
     }
 
     const gachaService = new GachaService();
-    const result = await gachaService.executeGacha(streamerId, session.twitchUserId, session.twitchUsername);
+    // Issue #661: execute_gacha_transaction RPC は p_event_id (Twitch EventSub の
+    // messageId) を唯一の重複防止キーとして使う (gacha_history.event_id の
+    // UNIQUE制約 + ON CONFLICT DO NOTHING)。このエンドポイントは EventSub を
+    // 経由しないため元々 eventId を渡しておらず、RPCへは p_event_id=null が
+    // 渡っていた。NULL同士はUNIQUE制約上「重複」とみなされないため、
+    // RPC側はNULLでの呼び出しを明示的に拒否するようになった(migration
+    // 00076)。ここで毎回一意な合成IDを渡すことで、この手動ドローAPIの
+    // 既存挙動(呼ぶたびに新しい抽選として成功する)を変えずにNULL拒否と
+    // 両立させる。
+    const manualDrawEventId = `manual:${crypto.randomUUID()}`;
+    const result = await gachaService.executeGacha(
+      streamerId,
+      session.twitchUserId,
+      session.twitchUsername,
+      manualDrawEventId
+    );
 
     if (!result.success) {
       // Map GachaService errors to standardized error messages

--- a/src/app/api/streamer/additional-rewards/route.ts
+++ b/src/app/api/streamer/additional-rewards/route.ts
@@ -180,9 +180,10 @@ export async function POST(request: NextRequest) {
     }
 
     const normalizedDrawCount = drawCount === undefined ? 1 : Number(drawCount);
-    if (!Number.isInteger(normalizedDrawCount) || normalizedDrawCount < 1 || normalizedDrawCount > 10) {
+    // Issue #641: upper bound raised from 10 to 15 (fixed limit, confirmed by owner).
+    if (!Number.isInteger(normalizedDrawCount) || normalizedDrawCount < 1 || normalizedDrawCount > 15) {
       return NextResponse.json(
-        { error: "drawCount must be an integer between 1 and 10" },
+        { error: "drawCount must be an integer between 1 and 15" },
         { status: 400 }
       );
     }

--- a/src/app/api/streamer/raid-gacha/route.ts
+++ b/src/app/api/streamer/raid-gacha/route.ts
@@ -119,9 +119,10 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const requestedDrawCount = body.drawCount === undefined ? 0 : Number(body.drawCount);
 
-    if (!Number.isInteger(requestedDrawCount) || requestedDrawCount < 0 || requestedDrawCount > 10) {
+    // Issue #641: upper bound raised from 10 to 15 (fixed limit, confirmed by owner).
+    if (!Number.isInteger(requestedDrawCount) || requestedDrawCount < 0 || requestedDrawCount > 15) {
       return NextResponse.json(
-        { error: "drawCount must be an integer between 0 and 10" },
+        { error: "drawCount must be an integer between 0 and 15" },
         { status: 400 },
       );
     }

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -168,7 +168,8 @@ export default function ChannelPointSettings({
           logger.info("[AdditionalRewards] Bootstrapped additional rewards", { count: data.additionalRewards.length });
         }
         if (typeof data.raidGiftDrawCount !== "undefined") {
-          setRaidGiftDrawCount(Math.min(10, Math.max(0, Number(data.raidGiftDrawCount ?? 0))));
+          // Issue #641: upper bound raised from 10 to 15 (fixed limit, confirmed by owner).
+          setRaidGiftDrawCount(Math.min(15, Math.max(0, Number(data.raidGiftDrawCount ?? 0))));
         }
       }
     } catch (err) {
@@ -250,7 +251,8 @@ export default function ChannelPointSettings({
       });
       if (response.ok) {
         const data = await response.json();
-        setRaidGiftDrawCount(Math.min(10, Math.max(0, Number(data.drawCount ?? 0))));
+        // Issue #641: upper bound raised from 10 to 15 (fixed limit, confirmed by owner).
+        setRaidGiftDrawCount(Math.min(15, Math.max(0, Number(data.drawCount ?? 0))));
       }
     } catch {
       logger.error("Failed to fetch raid gacha status");
@@ -275,7 +277,8 @@ export default function ChannelPointSettings({
         return;
       }
 
-      setRaidGiftDrawCount(Math.min(10, Math.max(0, Number(data.drawCount ?? 0))));
+      // Issue #641: upper bound raised from 10 to 15 (fixed limit, confirmed by owner).
+      setRaidGiftDrawCount(Math.min(15, Math.max(0, Number(data.drawCount ?? 0))));
       setMessage(t("additionalRewards.raidGiftSaved"));
     } catch {
       setMessage(t("additionalRewards.raidStatusFailed"));
@@ -1327,9 +1330,12 @@ export default function ChannelPointSettings({
                    <input
                      type="number"
                      min={1}
-                     max={10}
+                     max={15}
                      value={additionalDrawCount}
-                     onChange={(e) => setAdditionalDrawCount(Math.min(10, Math.max(1, Number(e.target.value) || 1)))}
+                     // Issue #641: onChange clamp must match the `max` attribute above,
+                     // otherwise keyboard-entered values beyond the old 10 cap would be
+                     // silently truncated back down (max alone doesn't block typed input).
+                     onChange={(e) => setAdditionalDrawCount(Math.min(15, Math.max(1, Number(e.target.value) || 1)))}
                      className="h-7 w-12 rounded bg-gray-800 px-2 text-sm text-gray-100 focus:outline-none"
                    />
                  </label>
@@ -1370,10 +1376,13 @@ export default function ChannelPointSettings({
                  <input
                    type="number"
                    min={0}
-                   max={10}
+                   max={15}
                    aria-label={t("additionalRewards.raidGiftCountLabel")}
                    value={raidGiftDrawCount}
-                   onChange={(e) => setRaidGiftDrawCount(Math.min(10, Math.max(0, Number(e.target.value) || 0)))}
+                   // Issue #641: onChange clamp must match the `max` attribute above,
+                   // otherwise keyboard-entered values beyond the old 10 cap would be
+                   // silently truncated back down (max alone doesn't block typed input).
+                   onChange={(e) => setRaidGiftDrawCount(Math.min(15, Math.max(0, Number(e.target.value) || 0)))}
                    className="h-9 w-16 rounded-md border border-gray-600 bg-gray-700 px-2 text-sm text-gray-100 transition-colors hover:border-gray-500 focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500/40"
                  />
                  <button

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -1282,7 +1282,8 @@ export class GachaService {
 
         // Additional reward matched, execute gacha
         // 追加報酬が一致したのでガチャを実行
-        const drawCount = Math.min(Math.max(Number(additionalReward.draw_count ?? 1), 1), 10)
+        // Issue #641: upper bound raised from 10 to 15 (fixed limit, confirmed by owner).
+        const drawCount = Math.min(Math.max(Number(additionalReward.draw_count ?? 1), 1), 15)
         logger.info(`Gacha triggered by additional reward: rewardId=${event.reward.id}, streamerId=${streamer.id}, drawCount=${drawCount}, raidLimited=${Boolean(additionalReward.is_raid_limited)}, collectionName=${additionalReward.collection_name ?? 'all'}`)
         // Issue #393: 追加報酬に紐付くパックで抽選対象を絞る
         return await executeAndAttachStreamer(drawCount, additionalReward.collection_name)
@@ -1331,7 +1332,8 @@ export class GachaService {
         return err('Streamer not found')
       }
 
-      const drawCount = Math.min(Math.max(Number(streamer.raid_gacha_draw_count ?? 0), 0), 10)
+      // Issue #641: upper bound raised from 10 to 15 (fixed limit, confirmed by owner).
+      const drawCount = Math.min(Math.max(Number(streamer.raid_gacha_draw_count ?? 0), 0), 15)
       if (drawCount < 1) {
         return err('Raid gacha disabled')
       }

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -496,13 +496,22 @@ export class GachaService {
    *   is_duplicate:true は「初回が実はコミットされていた」ケースを含むが、これは
    *   EventSub 再送と同じ err('Duplicate event') 扱いが正しい(カードは初回実行分が
    *   既に付与済みで、二重付与も未付与も起きない)。
-   * - demo ガチャ(src/app/api/gacha/route.ts、eventId=null)は冪等キーが無く、
-   *   再実行のたびに新しい履歴行+カード付与が発生するためリトライ禁止
-   *   (withDbRetry の既定 idempotent:false は接続断=「コミット済みか不明」を
-   *   二重排出させないための安全側動作。src/lib/db/retry.ts 参照)。既存 postgrest
-   *   経路の withRetry は eventId に関わらず 502/503 をリトライするが、あちらは
-   *   HTTP ゲートウェイ層のエラー分類であり、pg 直結では接続断の結果不明性を
-   *   優先して非冪等時はリトライしない(意図的な安全側の差)。
+   * - Issue #661 (migration 00076) 以降、RPC 自体が p_event_id=NULL を
+   *   RAISE EXCEPTION で拒否するため、eventId=null での呼び出しは(このメソッドに
+   *   到達する前段の呼び出し元がすべて非 null を渡す設計であることも合わせ、
+   *   下記参照)構造的に発生しない。手動ドローAPI(src/app/api/gacha/route.ts)は
+   *   #661 対応で `manual:${crypto.randomUUID()}` という毎回一意な合成 event_id を
+   *   渡すよう修正済みで、これも ON CONFLICT (event_id) DO NOTHING により冪等
+   *   (=リトライ安全)になった。したがって現状、`executeGacha` の全呼び出し元
+   *   (route.ts の手動ドロー、executeGachaDraws 経由の EventSub/raid N連)が
+   *   非 null の一意な event_id を渡すため `idempotent: eventId !== null` は
+   *   実質的に常に true として評価される。型シグネチャ上 `eventId: string | null`
+   *   を維持しているのは、将来この不変条件が崩れた場合にも
+   *   (a) RPC 側の NULL 拒否、(b) ここでの idempotent:false によるリトライ抑止、
+   *   の二重防御を残すため(意図的な安全側の設計。片方だけに依存しない)。
+   *   既存 postgrest 経路の withRetry は eventId に関わらず 502/503 をリトライ
+   *   するが、あちらは HTTP ゲートウェイ層のエラー分類であり、pg 直結では
+   *   接続断の結果不明性を優先して非冪等時はリトライしない(意図的な安全側の差)。
    * - リトライ回数・バックオフは既存 withRetry と同一の既定値
    *   ([100,300,1000]ms・最大3回)で、冪等時のリトライ特性は両経路で揃う。
    */

--- a/supabase/migrations/00075_raise_draw_count_limit_to_15.sql
+++ b/supabase/migrations/00075_raise_draw_count_limit_to_15.sql
@@ -1,0 +1,31 @@
+-- Issue #641: Raise the connected-gacha draw count ceiling from 10 to 15.
+--
+-- Two independent draw-count settings share the same fixed upper bound:
+--   1. streamer_additional_gacha_rewards.draw_count (per-reward N-draw gacha)
+--   2. streamers.raid_gacha_draw_count (auto gacha gift granted on incoming raid)
+--
+-- The owner explicitly confirmed a fixed limit of 15 is sufficient (issue
+-- comment: "15固定でいい") rather than a per-streamer configurable cap, so
+-- this migration only relaxes the two CHECK constraints introduced in
+-- 00041_add_raid_gacha_reward_options.sql and 00043_add_raid_gacha_draw_count.sql.
+-- Existing values (1-10 / 0-10) already satisfy the widened range, so no
+-- data backfill is required.
+
+ALTER TABLE streamer_additional_gacha_rewards
+  DROP CONSTRAINT IF EXISTS streamer_additional_gacha_rewards_draw_count_check;
+
+ALTER TABLE streamer_additional_gacha_rewards
+  ADD CONSTRAINT streamer_additional_gacha_rewards_draw_count_check
+  CHECK (draw_count BETWEEN 1 AND 15);
+
+ALTER TABLE streamers
+  DROP CONSTRAINT IF EXISTS streamers_raid_gacha_draw_count_check;
+
+ALTER TABLE streamers
+  ADD CONSTRAINT streamers_raid_gacha_draw_count_check
+  CHECK (raid_gacha_draw_count BETWEEN 0 AND 15);
+
+-- Refresh the column doc comment from 00041 so it doesn't keep advertising
+-- the old "10 max" ceiling now that the CHECK constraint allows up to 15.
+COMMENT ON COLUMN streamer_additional_gacha_rewards.draw_count IS
+  'Number of cards granted by this additional channel point reward. 1 = normal gacha, 15 max.';

--- a/supabase/migrations/00076_reject_null_gacha_event_id.sql
+++ b/supabase/migrations/00076_reject_null_gacha_event_id.sql
@@ -1,0 +1,114 @@
+-- Issue #661: execute_gacha_transaction RPC の唯一の重複防止機構は、
+-- gacha_history.event_id の UNIQUE 制約 + `ON CONFLICT (event_id) DO NOTHING`
+-- (00070_add_gacha_history_reward_id.sql 内の本関数定義を参照)である。
+-- PostgreSQL の UNIQUE 制約は NULL 同士を「異なる値」として扱うため、
+-- p_event_id = NULL で呼び出すと ON CONFLICT が一切発火せず、この関数の
+-- 重複検知が丸ごと無効化される — 呼び出しをリトライすると
+-- gacha_history / user_cards への書き込みが際限なく重複しうる。
+--
+-- 本番の Twitch EventSub 経路 (messageId を event_id として渡す) は常に
+-- 非NULLのため現状で実害はないが、テスト・手動実行・将来追加されるかもしれない
+-- 呼び出し元が NULL を渡すと、この防御が無言で無効化されたまま気づかれない
+-- リスクがある。呼び出し規約として「event_id は必須」を明示的に強制するため、
+-- 関数の先頭で NULL を拒否する (Issue #661 の案1)。
+--
+-- 実装時の追加調査: 本リポジトリには `p_event_id` を意図的に NULL のまま渡す
+-- 既存の呼び出し元が実在した (src/app/api/gacha/route.ts の「実際にガチャを引く」
+-- 手動ドローAPI。GachaService.executeGacha の eventId 引数を省略して呼んでいた)。
+-- この関数を NULL 拒否にするだけでは当該エンドポイントが即座に例外で壊れるため、
+-- 本 migration と同一PR内で当該呼び出し元も修正し、毎回一意な合成 event_id
+-- (crypto.randomUUID()) を明示的に渡すように変更している (src/app/api/gacha/route.ts
+-- の manualDrawEventId)。これにより「同じカードを何度でも引ける」という
+-- 手動ドローの既存挙動は変えずに、NULL 拒否と両立させている。
+--
+-- デプロイ順序の注意 (docs/cloudflare-workers-builds.md, Issue #536 参照):
+-- 本番デプロイは GitHub Actions の Supabase migration 適用と Cloudflare
+-- Workers Builds のアプリデプロイが「同じ main への push」から独立に
+-- トリガーされる非同期パイプラインであり、順序保証がない。したがって
+-- このRPC変更はアプリ側の呼び出し規約を変更する(00070のような
+-- 「引数追加」ではなく「既存引数の許容値の変更」)ため、本migrationが
+-- アプリコード(上記route.ts修正)より先に本番へ適用された場合、
+-- Cloudflare側のデプロイが追いつくまでの間(数分程度になりうる)
+-- /api/gacha はRAISE EXCEPTIONに起因する500エラーを返しうる
+-- (RAISE EXCEPTIONはPostgRESTの42883フォールバックの対象外のため、
+-- gacha.ts の legacy フォールバックは吸収しない)。
+-- 影響範囲: RAISE EXCEPTIONは関数の最初の文であり、FOR UPDATEロックや
+-- INSERTより前に発生するため書き込みは一切発生しない。ユーザーへの影響は
+-- 「ガチャを引くボタンが失敗し、再試行すれば成功する」に留まり、
+-- 課金/データ不整合や二重付与は起きない。
+-- ロールバック時の注意: 本migrationは他のマイグレーション同様
+-- forward-only (CREATE OR REPLACE のみ、down-migration無し)。仮に
+-- アプリコード側(route.ts の manualDrawEventId 変更)だけを本migration適用後に
+-- ロールバックすると、/api/gacha は上記と同じ500エラーを恒久的に返し続ける
+-- (自然回復しない)。オンコールは route.ts 側を再度適用するまで
+-- 本migrationをロールバックしないこと(forward-onlyのため、
+-- 対症療法として新しいmigrationで戻すこと自体は可能だが、
+-- まずアプリコード側の復旧を優先する)。
+CREATE OR REPLACE FUNCTION execute_gacha_transaction(
+  p_event_id TEXT,
+  p_user_twitch_id TEXT,
+  p_user_twitch_username TEXT,
+  p_card_id UUID,
+  p_streamer_id UUID,
+  p_reward_cost INTEGER DEFAULT NULL,
+  p_reward_id TEXT DEFAULT NULL
+) RETURNS JSONB AS $$
+DECLARE
+  v_user_id UUID;
+  v_history_id UUID;
+  v_max_issuance_count INTEGER;
+  v_issued_count INTEGER;
+BEGIN
+  IF p_event_id IS NULL THEN
+    RAISE EXCEPTION 'event_id must not be null';
+  END IF;
+
+  -- Lock the selected card row so concurrent draws cannot exceed its issuance limit.
+  SELECT max_issuance_count
+    INTO v_max_issuance_count
+    FROM cards
+    WHERE id = p_card_id
+      AND streamer_id = p_streamer_id
+      AND is_active = true
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('is_duplicate', false, 'limit_reached', true);
+  END IF;
+
+  IF v_max_issuance_count IS NOT NULL THEN
+    SELECT COUNT(*) INTO v_issued_count
+      FROM user_cards
+      WHERE card_id = p_card_id;
+
+    IF v_issued_count >= v_max_issuance_count THEN
+      RETURN jsonb_build_object('is_duplicate', false, 'limit_reached', true);
+    END IF;
+  END IF;
+
+  INSERT INTO gacha_history (event_id, user_twitch_id, user_twitch_username, card_id, streamer_id, reward_cost, reward_id)
+  VALUES (p_event_id, p_user_twitch_id, p_user_twitch_username, p_card_id, p_streamer_id, p_reward_cost, p_reward_id)
+  ON CONFLICT (event_id) DO NOTHING
+  RETURNING id INTO v_history_id;
+
+  IF v_history_id IS NULL AND p_event_id IS NOT NULL THEN
+    RETURN jsonb_build_object('is_duplicate', true);
+  END IF;
+
+  INSERT INTO users (twitch_user_id, twitch_username, twitch_display_name)
+  VALUES (p_user_twitch_id, p_user_twitch_username, p_user_twitch_username)
+  ON CONFLICT (twitch_user_id) DO NOTHING;
+
+  SELECT id INTO v_user_id FROM users WHERE twitch_user_id = p_user_twitch_id;
+
+  IF v_user_id IS NOT NULL THEN
+    INSERT INTO user_cards (user_id, card_id, obtained_at)
+    VALUES (v_user_id, p_card_id, NOW());
+  END IF;
+
+  RETURN jsonb_build_object('is_duplicate', false, 'limit_reached', false, 'history_id', v_history_id);
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION execute_gacha_transaction(TEXT, TEXT, TEXT, UUID, UUID, INTEGER, TEXT) IS
+  'ガチャのDB操作を1トランザクションで実行し、カード発行可能枚数の上限検証と報酬ID(reward_id)の記録を同時に行う(Issue #591)。p_event_idはNULL禁止(Issue #661: NULLだとgacha_history.event_idのUNIQUE制約によるON CONFLICT重複検知が無効化されるため)。';

--- a/tests/unit/additional-rewards-api.test.ts
+++ b/tests/unit/additional-rewards-api.test.ts
@@ -392,7 +392,7 @@ describe('/api/streamer/additional-rewards raid options', () => {
 
     expect(response.status).toBe(400)
     await expect(response.json()).resolves.toEqual({
-      error: 'drawCount must be an integer between 1 and 10',
+      error: 'drawCount must be an integer between 1 and 15',
     })
   })
 

--- a/tests/unit/additional-rewards-api.test.ts
+++ b/tests/unit/additional-rewards-api.test.ts
@@ -42,7 +42,10 @@ describe('/api/streamer/additional-rewards raid options', () => {
       twitchUserId: 'streamer-twitch-1',
       twitchUsername: 'streamer',
       twitchDisplayName: 'Streamer',
-      twitchProfileImageUrl: null,
+      // SessionPayload.twitchProfileImageUrl は string 必須（null 非許容）。
+      // 実際のセッション生成元(callback route)でも Twitch API の profile_image_url を
+      // そのまま格納するため、他のテストと同様にプレースホルダURL文字列を使う。
+      twitchProfileImageUrl: 'https://example.com/avatar.png',
       broadcasterType: 'affiliate',
       expiresAt: Date.now() + 60_000,
       version: 1,

--- a/tests/unit/api/gacha-route.test.ts
+++ b/tests/unit/api/gacha-route.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "@/app/api/gacha/route";
+import { GachaService } from "@/lib/services/gacha";
+import { getSession } from "@/lib/session";
+import { checkRateLimit, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { validateCSRFToken } from "@/lib/csrf";
+import { validateContentType } from "@/lib/request-validation";
+import { broadcastGachaResult } from "@/lib/realtime";
+
+vi.mock("@/lib/session");
+vi.mock("@/lib/rate-limit");
+vi.mock("@/lib/csrf");
+vi.mock("@/lib/request-validation");
+vi.mock("@/lib/realtime");
+vi.mock("@/lib/services/gacha");
+
+const mockGetSession = vi.mocked(getSession);
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+const mockGetRateLimitIdentifier = vi.mocked(getRateLimitIdentifier);
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken);
+const mockValidateContentType = vi.mocked(validateContentType);
+const mockBroadcastGachaResult = vi.mocked(broadcastGachaResult);
+const MockGachaService = vi.mocked(GachaService);
+
+function makeRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/gacha", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const sampleCard = {
+  id: "card-1",
+  name: "Test Card",
+  description: "desc",
+  image_url: "https://example.com/card.png",
+  rarity: "common",
+};
+
+describe("POST /api/gacha", () => {
+  let executeGachaMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({
+      twitchUserId: "twitch-1",
+      twitchUsername: "user1",
+      broadcasterType: "affiliate",
+    } as Awaited<ReturnType<typeof getSession>>);
+    mockGetRateLimitIdentifier.mockResolvedValue("identifier");
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: Date.now() + 60_000,
+    });
+    mockValidateCSRFToken.mockResolvedValue({ valid: true });
+    mockValidateContentType.mockReturnValue(null);
+    mockBroadcastGachaResult.mockResolvedValue(undefined);
+
+    executeGachaMock = vi.fn().mockResolvedValue({
+      success: true,
+      data: { card: sampleCard, userTwitchUsername: "user1" },
+    });
+    MockGachaService.mockImplementation(() => ({
+      executeGacha: executeGachaMock,
+    }) as unknown as GachaService);
+  });
+
+  // Issue #661: execute_gacha_transaction RPC (migration 00076) now rejects
+  // p_event_id = NULL. This route previously called executeGacha without an
+  // eventId at all, which propagated as NULL all the way to the RPC. It must
+  // now always supply a non-null, per-request-unique synthetic event id so
+  // the manual "draw a real gacha" flow keeps working.
+  it("passes a non-null, non-empty eventId to GachaService.executeGacha", async () => {
+    const res = await POST(makeRequest({ streamerId: "streamer-1" }));
+
+    expect(res.status).toBe(200);
+    expect(executeGachaMock).toHaveBeenCalledTimes(1);
+    const eventIdArg = executeGachaMock.mock.calls[0][3];
+    expect(eventIdArg).toBeTruthy();
+    expect(typeof eventIdArg).toBe("string");
+  });
+
+  it("generates a distinct eventId on every call (no accidental dedup across separate draws)", async () => {
+    await POST(makeRequest({ streamerId: "streamer-1" }));
+    await POST(makeRequest({ streamerId: "streamer-1" }));
+
+    const firstEventId = executeGachaMock.mock.calls[0][3];
+    const secondEventId = executeGachaMock.mock.calls[1][3];
+    expect(firstEventId).not.toBe(secondEventId);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await POST(makeRequest({ streamerId: "streamer-1" }));
+    expect(res.status).toBe(401);
+    expect(executeGachaMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the CSRF token is invalid", async () => {
+    mockValidateCSRFToken.mockResolvedValue({ valid: false });
+    const res = await POST(makeRequest({ streamerId: "streamer-1" }));
+    expect(res.status).toBe(403);
+    expect(executeGachaMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when GachaService.executeGacha fails (e.g. the RPC rejects a NULL event_id)", async () => {
+    executeGachaMock.mockResolvedValue({
+      success: false,
+      error: "Failed to execute gacha transaction: event_id must not be null",
+    });
+    const res = await POST(makeRequest({ streamerId: "streamer-1" }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/unit/auth-scope-preservation.test.ts
+++ b/tests/unit/auth-scope-preservation.test.ts
@@ -67,14 +67,18 @@ vi.mock('@/lib/supabase/admin', () => ({
 }))
 
 // twitch auth
-const mockIsInvalidAuthorizationCodeError = vi.fn(() => false)
+// 実関数 isInvalidAuthorizationCodeError(error: unknown) と同じ引数個数で宣言する。
+// vi.fn の型はコールバック引数から推論されるため、0引数のままだと
+// モックするモジュールの型 (error: unknown) => boolean と合わずコンパイルエラーになる。
+const mockIsInvalidAuthorizationCodeError = vi.fn((_error: unknown) => false)
 vi.mock('@/lib/twitch/auth', () => ({
   getTwitchAuthUrl: vi.fn((_redirectUri: string, _state: string, additionalScopes?: string[]) =>
     `https://twitch.tv/authorize?scopes=${(additionalScopes ?? []).join(',')}`
   ),
   exchangeCodeForTokens: vi.fn(),
   getTwitchUser: vi.fn(),
-  isInvalidAuthorizationCodeError: (...args: unknown[]) => mockIsInvalidAuthorizationCodeError(...args),
+  // mock自体の引数型が実関数と一致しているため、spreadラッパーを介さず直接割り当てる
+  isInvalidAuthorizationCodeError: mockIsInvalidAuthorizationCodeError,
 }))
 
 // token-manager
@@ -91,7 +95,9 @@ vi.mock('@/lib/rate-limit', () => ({
 }))
 
 // error handlers and sentry
-const mockHandleAuthError = vi.fn((_err: unknown, code: string) => ({
+// 実関数 handleAuthError(error, errorType, context?, options?) と同じ引数個数で宣言する。
+// 2引数のままだとモックするモジュールの型(4引数)と合わずコンパイルエラーになる。
+const mockHandleAuthError = vi.fn((_err: unknown, code: string, _context?: Record<string, unknown>, _options?: { returnJson?: boolean; baseUrl?: string }) => ({
   type: 'error',
   code,
   cookies: {
@@ -103,7 +109,8 @@ const mockHandleAuthError = vi.fn((_err: unknown, code: string) => ({
   },
 }))
 vi.mock('@/lib/auth-error-handler', () => ({
-  handleAuthError: (...args: unknown[]) => mockHandleAuthError(...args),
+  // 同上: mock自体の引数型が実関数と一致しているため直接割り当てる
+  handleAuthError: mockHandleAuthError,
 }))
 vi.mock('@/lib/sentry/error-handler', () => ({
   reportAuthError: vi.fn(),

--- a/tests/unit/battle.test.ts
+++ b/tests/unit/battle.test.ts
@@ -109,6 +109,8 @@ describe('toBattleCard', () => {
       image_url: 'https://example.com/image.jpg',
       rarity: 'rare',
       card_number: null,
+      // Card.max_issuance_count は `number | null` 必須フィールド。
+      max_issuance_count: null,
       collection_name: null,
       drop_rate: 0.1,
       intra_rarity_weight: 1.0,
@@ -390,6 +392,10 @@ describe('generateCPUOpponent', () => {
     image_url: 'https://example.com/image.jpg',
     rarity: 'common',
     card_number: null,
+    // Card.max_issuance_count は `number | null`(undefined 非許容)。overrides のみに
+    // 委ねると Partial<Card> 由来で `undefined` を許容してしまい型不一致になるため、
+    // ベースオブジェクト側で明示的にデフォルト値を持たせる。
+    max_issuance_count: null,
     collection_name: null,
     drop_rate: 0.1,
     intra_rarity_weight: 1.0,

--- a/tests/unit/cards-get-api.test.ts
+++ b/tests/unit/cards-get-api.test.ts
@@ -69,7 +69,7 @@ function setupCardsMock(options: {
   }
   // PostgREST returns result via implicit await (thenable)
   // PostgRESTは暗黙のawait（thenable）で結果を返す
-  ;(cardsQuery as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
+  ;(cardsQuery as unknown as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
     resolve(cardsResponse)
     return cardsQuery
   }
@@ -77,10 +77,8 @@ function setupCardsMock(options: {
   // Issue #542: 発行済み枚数集計用のuser_cardsクエリビルダー（暗黙のawaitに対応）
   // user_cards query builder for the issued_count aggregation (implicit await)
   const userCardsQuery = createMockQueryBuilder()
-  // Note: 既存の cardsQuery 等は `as Record<string, unknown>` で直接キャストしているが、
-  // MockQueryBuilder<unknown> と Record<string, unknown> は型として十分重ならず
-  // TS2352になる（tsc baseline比較のため、新規コードではここだけ `as unknown` を
-  // 経由してこのエラーパターンを増やさないようにする）。
+  // MockQueryBuilder<unknown> と Record<string, unknown> は型として十分重ならないため
+  // 直接キャストは TS2352 になる。`unknown` を経由して安全にキャストする。
   ;(userCardsQuery as unknown as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
     resolve({ data: options.userCards ?? [], error: options.userCardsError ?? null })
     return userCardsQuery
@@ -97,7 +95,9 @@ function setupCardsMock(options: {
     return createMockQueryBuilder()
   })
 
-  mockGetSupabaseAdmin.mockReturnValue({ from } as ReturnType<typeof getSupabaseAdmin>)
+  // モックの `{ from }` は SupabaseClient の一部プロパティしか持たないため、
+  // `unknown` を経由してキャストする(既存テストで確立されたパターンに合わせる)。
+  mockGetSupabaseAdmin.mockReturnValue({ from } as unknown as ReturnType<typeof getSupabaseAdmin>)
 
   return { streamerQuery, cardsQuery, userCardsQuery, from }
 }
@@ -113,13 +113,13 @@ function setupCardsMockWithRetry(options: {
   )
 
   const firstCardsQuery = createMockQueryBuilder()
-  ;(firstCardsQuery as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
+  ;(firstCardsQuery as unknown as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
     resolve({ data: null, error: options.firstCardsError, count: null })
     return firstCardsQuery
   }
 
   const retryCardsQuery = createMockQueryBuilder()
-  ;(retryCardsQuery as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
+  ;(retryCardsQuery as unknown as Record<string, unknown>).then = (resolve: (value: unknown) => void) => {
     resolve({
       data: options.retryCards ?? [],
       error: null,
@@ -140,7 +140,7 @@ function setupCardsMockWithRetry(options: {
 
   mockGetSupabaseAdmin.mockReturnValue({
     from,
-  } as ReturnType<typeof getSupabaseAdmin>)
+  } as unknown as ReturnType<typeof getSupabaseAdmin>)
 
   return { firstCardsQuery, retryCardsQuery }
 }
@@ -154,12 +154,16 @@ function createRequest(params: Record<string, string> = {}): NextRequest {
 describe('GET /api/cards', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // `issuedAt` は SessionPayload に存在しないフィールド(本番コードでも未参照)のため削除し、
+    // 他のテストと同じ形で必須フィールドを揃える。
     mockGetSession.mockResolvedValue({
       twitchUserId: 'user123',
       twitchUsername: 'testuser',
       twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/avatar.png',
       broadcasterType: 'affiliate',
-      issuedAt: Date.now(),
+      expiresAt: Date.now() + 60_000,
+      version: 1,
     })
     mockCheckRateLimit.mockResolvedValue({
       success: true,

--- a/tests/unit/components/collection-pack-filter.test.tsx
+++ b/tests/unit/components/collection-pack-filter.test.tsx
@@ -20,6 +20,10 @@ const baseCard = (overrides: Partial<StreamerCollectionCard>): StreamerCollectio
   image_url: null,
   rarity: 'common',
   card_number: null,
+  // StreamerCollectionCard.max_issuance_count は `number | null`(undefined 非許容)。
+  // overrides のみに委ねると Partial<> 由来で `undefined` を許容してしまい型不一致に
+  // なるため、ベースオブジェクト側で明示的にデフォルト値を持たせる。
+  max_issuance_count: null,
   collection_name: null,
   drop_rate: 25,
   intra_rarity_weight: 1,

--- a/tests/unit/components/sorted-card-grid.test.tsx
+++ b/tests/unit/components/sorted-card-grid.test.tsx
@@ -18,6 +18,10 @@ const baseCard = (overrides: Partial<Card>): Card => ({
   image_url: 'https://example.com/card-a.png',
   rarity: 'common',
   card_number: null,
+  // Card.max_issuance_count は `number | null`(undefined 非許容)。overrides のみに
+  // 委ねると Partial<Card> 由来で `undefined` を許容してしまい型不一致になるため、
+  // ベースオブジェクト側で明示的にデフォルト値を持たせる。
+  max_issuance_count: null,
   collection_name: null,
   drop_rate: 25,
   intra_rarity_weight: 1,

--- a/tests/unit/gacha-null-event-id-migration.test.ts
+++ b/tests/unit/gacha-null-event-id-migration.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+// Issue #661: p_event_id = NULL のとき、gacha_history.event_id の UNIQUE
+// 制約 + ON CONFLICT (event_id) DO NOTHING による重複検知が (NULL同士は
+// UNIQUE制約上「重複」とみなされないため) 一切機能しなくなる。RPCの先頭で
+// NULLを明示的に拒否するようにした migration の内容を、
+// gacha-history-reward-id-migration.test.ts (00070) と同じく
+// SQLテキストへの静的正規表現アサーションで検証する(実DB実行はしない)。
+describe('reject null gacha event_id migration (00076)', () => {
+  const migration = readFileSync(
+    resolve(__dirname, '../../supabase/migrations/00076_reject_null_gacha_event_id.sql'),
+    'utf-8'
+  )
+
+  it('rejects a NULL p_event_id with a RAISE EXCEPTION', () => {
+    expect(migration).toMatch(/IF p_event_id IS NULL THEN\s*\n\s*RAISE EXCEPTION/i)
+  })
+
+  it('performs the NULL check before any write (INSERT) so the guard has zero side effects', () => {
+    const nullCheckIndex = migration.indexOf('IF p_event_id IS NULL THEN')
+    const firstInsertIndex = migration.indexOf('INSERT INTO')
+
+    expect(nullCheckIndex).toBeGreaterThan(-1)
+    expect(firstInsertIndex).toBeGreaterThan(nullCheckIndex)
+  })
+
+  it('keeps the 00070 7-arg signature unchanged (no DROP FUNCTION needed, no new params)', () => {
+    // シグネチャ(引数リスト)は変更しないため、00070のようなDROP FUNCTIONは不要
+    expect(migration).not.toMatch(/DROP FUNCTION/i)
+    expect(migration).toMatch(
+      /CREATE OR REPLACE FUNCTION execute_gacha_transaction\(\s*p_event_id TEXT,\s*p_user_twitch_id TEXT,\s*p_user_twitch_username TEXT,\s*p_card_id UUID,\s*p_streamer_id UUID,\s*p_reward_cost INTEGER DEFAULT NULL,\s*p_reward_id TEXT DEFAULT NULL\s*\) RETURNS JSONB/i
+    )
+  })
+
+  it('preserves the existing event_id duplicate-detection and issuance-limit logic from 00070', () => {
+    expect(migration).toContain('ON CONFLICT (event_id) DO NOTHING')
+    expect(migration).toContain("'is_duplicate', true")
+    expect(migration).toContain("'limit_reached', true")
+    expect(migration).toContain('FOR UPDATE')
+  })
+
+  it('documents why the NULL check exists', () => {
+    expect(migration).toMatch(/UNIQUE制約/)
+    expect(migration).toMatch(/ON CONFLICT/)
+  })
+})

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -334,9 +334,9 @@ describe('GachaService.executeGacha', () => {
 
   it('発行上限に達したカードを抽選候補から除外する', async () => {
     const cardsQuery = createCardsQuery([
-      { id: 'sold-out-card', name: 'Sold Out', description: null, image_url: null, rarity: 'legendary', drop_rate: 100, max_issuance_count: 1 },
-      { id: 'available-card', name: 'Available', description: null, image_url: null, rarity: 'common', drop_rate: 1, max_issuance_count: null },
-    ] as typeof testCards)
+      { id: 'sold-out-card', name: 'Sold Out', description: 'desc', image_url: null, rarity: 'legendary', collection_name: 'standard', drop_rate: 100, max_issuance_count: 1 },
+      { id: 'available-card', name: 'Available', description: 'desc', image_url: null, rarity: 'common', collection_name: 'standard', drop_rate: 1, max_issuance_count: null },
+    ])
     const mockRpc = createRpcMock({
       issuedCounts: { 'sold-out-card': 1 },
       transactionResponses: [{ data: { is_duplicate: false, limit_reached: false, history_id: 'h-1' }, error: null }],
@@ -358,9 +358,9 @@ describe('GachaService.executeGacha', () => {
 
   it('発行枚数チェックRPCは limitedCards のIDのみに絞り込む（無制限カードIDを含まない）', async () => {
     const cardsQuery = createCardsQuery([
-      { id: 'unlimited-card', name: 'Unlimited', description: null, image_url: null, rarity: 'common', drop_rate: 1, max_issuance_count: null },
-      { id: 'limited-card', name: 'Limited', description: null, image_url: null, rarity: 'rare', drop_rate: 1, max_issuance_count: 5 },
-    ] as typeof testCards)
+      { id: 'unlimited-card', name: 'Unlimited', description: 'desc', image_url: null, rarity: 'common', collection_name: 'standard', drop_rate: 1, max_issuance_count: null },
+      { id: 'limited-card', name: 'Limited', description: 'desc', image_url: null, rarity: 'rare', collection_name: 'standard', drop_rate: 1, max_issuance_count: 5 },
+    ])
     const mockRpc = createRpcMock({
       transactionResponses: [{ data: { is_duplicate: false, history_id: 'h-1' }, error: null }],
     })
@@ -378,8 +378,8 @@ describe('GachaService.executeGacha', () => {
 
   it('全カードが発行上限に達している場合はエラーを返す', async () => {
     const cardsQuery = createCardsQuery([
-      { id: 'sold-out-card', name: 'Sold Out', description: null, image_url: null, rarity: 'legendary', drop_rate: 100, max_issuance_count: 1 },
-    ] as typeof testCards)
+      { id: 'sold-out-card', name: 'Sold Out', description: 'desc', image_url: null, rarity: 'legendary', collection_name: 'standard', drop_rate: 100, max_issuance_count: 1 },
+    ])
     const mockRpc = createRpcMock({
       issuedCounts: { 'sold-out-card': 1 },
       transactionResponses: [],

--- a/tests/unit/open-next-config.test.ts
+++ b/tests/unit/open-next-config.test.ts
@@ -4,17 +4,32 @@ import config from "../../open-next.config";
 
 describe("open-next.config", () => {
   it("uses the Cloudflare config helper while preserving existing runtime overrides", () => {
-    expect(config.default.override.wrapper).toBe("cloudflare-node");
-    expect(config.default.override.converter).toBe("edge");
-    expect(config.default.override.proxyExternalRequest).toBe("fetch");
-    expect(config.default.override.incrementalCache).toBe("dummy");
-    expect(config.default.override.tagCache).toBe("dummy");
-    expect(config.default.override.queue).toBe("direct");
+    // `FunctionOptions.override` は optional なため `config.default.override` は
+    // `OverrideOptions | undefined` 型になる。non-null assertion(!)ではなく、
+    // 未定義なら即座にテスト失敗として扱う型ガードで安全に絞り込む。
+    const defaultOverride = config.default.override;
+    if (!defaultOverride) {
+      throw new Error("config.default.override should be defined by defineCloudflareConfig");
+    }
+    expect(defaultOverride.wrapper).toBe("cloudflare-node");
+    expect(defaultOverride.converter).toBe("edge");
+    expect(defaultOverride.proxyExternalRequest).toBe("fetch");
+    expect(defaultOverride.incrementalCache).toBe("dummy");
+    expect(defaultOverride.tagCache).toBe("dummy");
+    expect(defaultOverride.queue).toBe("direct");
 
     expect(config.edgeExternals).toContain("node:crypto");
-    expect(config.middleware?.external).toBe(true);
-    expect(config.middleware?.override?.wrapper).toBe("cloudflare-edge");
-    expect(config.middleware?.override?.queue).toBe("direct");
+
+    // `config.middleware` は `ExternalMiddlewareConfig | InternalMiddlewareConfig` の
+    // 判別共用体で、`override` は `external: true` 側(ExternalMiddlewareConfig)にしか
+    // 存在しない。`external` の真偽値で絞り込むことで `override` へ安全にアクセスする。
+    const middleware = config.middleware;
+    if (!middleware || !middleware.external) {
+      throw new Error("config.middleware should be configured as external middleware");
+    }
+    expect(middleware.external).toBe(true);
+    expect(middleware.override?.wrapper).toBe("cloudflare-edge");
+    expect(middleware.override?.queue).toBe("direct");
     expect(config.cloudflare?.useWorkerdCondition).toBe(true);
   });
 });

--- a/tests/unit/raid-gacha-api.test.ts
+++ b/tests/unit/raid-gacha-api.test.ts
@@ -44,7 +44,7 @@ describe('/api/streamer/raid-gacha drawCount boundary validation', () => {
       twitchUserId: 'streamer-twitch-1',
       twitchUsername: 'streamer',
       twitchDisplayName: 'Streamer',
-      twitchProfileImageUrl: null,
+      twitchProfileImageUrl: 'https://example.com/avatar.png',
       broadcasterType: 'affiliate',
       expiresAt: Date.now() + 60_000,
       version: 1,

--- a/tests/unit/raid-gacha-api.test.ts
+++ b/tests/unit/raid-gacha-api.test.ts
@@ -1,0 +1,152 @@
+// Issue #641: 連ガチャ上限を10枚から15枚に引き上げ。
+// raid-gacha ルート(streamers.raid_gacha_draw_count)には元々このバリデーションの
+// 境界値テストが存在しなかった(実装プランで既存カバレッジの欠落として指摘済み)ため、
+// additional-rewards-api.test.ts の起こしパターンに倣って新規に追加する。
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST } from '@/app/api/streamer/raid-gacha/route'
+import { getSession, canUseStreamerFeatures } from '@/lib/session'
+import { checkRateLimit } from '@/lib/rate-limit'
+import { validateCSRFToken } from '@/lib/csrf'
+import { validateContentType } from '@/lib/request-validation'
+import { createMockQueryBuilder } from '../utils/supabase-mock'
+
+vi.mock('@/lib/session')
+vi.mock('@/lib/rate-limit')
+vi.mock('@/lib/csrf')
+vi.mock('@/lib/request-validation')
+vi.mock('@/lib/supabase/admin', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/supabase/admin')>()
+  return {
+    ...actual,
+    getSupabaseAdmin: vi.fn(),
+  }
+})
+
+const mockGetSession = vi.mocked(getSession)
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)
+const mockCheckRateLimit = vi.mocked(checkRateLimit)
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken)
+const mockValidateContentType = vi.mocked(validateContentType)
+
+function postRequest(drawCount: unknown) {
+  return new NextRequest('http://localhost/api/streamer/raid-gacha', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ drawCount }),
+  })
+}
+
+describe('/api/streamer/raid-gacha drawCount boundary validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'streamer-twitch-1',
+      twitchUsername: 'streamer',
+      twitchDisplayName: 'Streamer',
+      twitchProfileImageUrl: null,
+      broadcasterType: 'affiliate',
+      expiresAt: Date.now() + 60_000,
+      version: 1,
+    })
+    mockCanUseStreamerFeatures.mockReturnValue(true)
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: Date.now() + 60_000,
+    })
+    mockValidateCSRFToken.mockResolvedValue({ valid: true })
+    mockValidateContentType.mockReturnValue(null)
+  })
+
+  it('rejects a drawCount above the new upper bound (16 > 15) with a 400 and updated error message', async () => {
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from: vi.fn() } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const response = await POST(postRequest(16))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'drawCount must be an integer between 0 and 15',
+    })
+  })
+
+  it('rejects a negative drawCount with a 400', async () => {
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from: vi.fn() } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const response = await POST(postRequest(-1))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'drawCount must be an integer between 0 and 15',
+    })
+  })
+
+  it('accepts the new upper boundary value (15) and persists it', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: 'streamer-1', raid_gacha_active_until: null, raid_gacha_draw_count: 10 },
+      error: null,
+    })
+    const updateQuery = createMockQueryBuilder()
+    ;(updateQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { raid_gacha_active_until: null, raid_gacha_draw_count: 15 },
+      error: null,
+    })
+    // getOwnedStreamer does a SELECT (streamerQuery); POST then does an
+    // UPDATE (updateQuery) on the same table, so `from('streamers')` must
+    // be called twice and return the right builder each time.
+    let streamersCallCount = 0
+    const fromMock = vi.fn((table: string) => {
+      if (table === 'streamers') {
+        streamersCallCount += 1
+        return streamersCallCount === 1 ? streamerQuery : updateQuery
+      }
+      return createMockQueryBuilder()
+    })
+
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    const response = await POST(postRequest(15))
+
+    expect(response.status).toBe(200)
+    expect(updateQuery.update).toHaveBeenCalledWith({ raid_gacha_draw_count: 15 })
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({ success: true, drawCount: 15 })
+    )
+  })
+
+  it('rejects the old upper boundary plus one (11) only if it exceeds the configured limit (non-regression: 11-15 now valid)', async () => {
+    const streamerQuery = createMockQueryBuilder()
+    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { id: 'streamer-1', raid_gacha_active_until: null, raid_gacha_draw_count: 0 },
+      error: null,
+    })
+    const updateQuery = createMockQueryBuilder()
+    ;(updateQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+      data: { raid_gacha_active_until: null, raid_gacha_draw_count: 11 },
+      error: null,
+    })
+    let streamersCallCount = 0
+    const fromMock = vi.fn((table: string) => {
+      if (table === 'streamers') {
+        streamersCallCount += 1
+        return streamersCallCount === 1 ? streamerQuery : updateQuery
+      }
+      return createMockQueryBuilder()
+    })
+
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof getSupabaseAdmin>)
+
+    // 11 was rejected under the old (<=10) limit; issue #641 raises the cap to 15,
+    // so this value (previously invalid) must now be accepted end to end.
+    const response = await POST(postRequest(11))
+
+    expect(response.status).toBe(200)
+    expect(updateQuery.update).toHaveBeenCalledWith({ raid_gacha_draw_count: 11 })
+  })
+})

--- a/tests/unit/raid-gacha-driver-parity.test.ts
+++ b/tests/unit/raid-gacha-driver-parity.test.ts
@@ -270,7 +270,7 @@ describe("streamer/raid-gacha: postgrest / pg 経路の互換 (#663)", () => {
     it("postgrest 経路: drawCount が範囲外なら400", async () => {
       vi.stubEnv("DB_DRIVER", undefined);
       const { POST } = await loadRoute();
-      const response = await POST(postRequest({ drawCount: 11 }));
+      const response = await POST(postRequest({ drawCount: 16 }));
       expect(response.status).toBe(400);
     });
 


### PR DESCRIPTION
## 概要

previewで検証・マージ済みの変更をmainへ昇格します。

## 含まれるPR

- #677 feat(gacha): 連ガチャ上限を15枚へ引き上げ
- #679 fix(types): 型エラー解消とCI typecheckゲート追加
- #712 fix(types): raid-gacha-apiテストの型回帰修正
- #678 fix(gacha): RPCでevent_id=NULLを拒否

## 背景

previewとmainが分岐していたため、mainをpreviewへマージして履歴を統合しました。これにより、以後のpreview向けPRはIssue固有の差分として扱えます。

## 統合時の修正

- main側で追加された `raid-gacha-driver-parity.test.ts` が旧上限10を前提に `drawCount: 11` を範囲外としていたため、上限15の仕様に合わせて境界外値を `16` に更新
- unit test失敗時に原因を取得しやすいよう、VitestのJSONレポートを失敗時artifactとして7日間保存

## 検証

- previewのCloudflareデプロイ成功を確認済み
- typecheck / lint / migration-order checkは成功済み
- 最新head `cb625f1` でunit / integration testを再確認中

## リスク

- CIログ形式をcompactなJSON reporterへ変更しているため、成功時の詳細ログは従来より少なくなります。失敗時の詳細はartifactから確認できます。
