### PR TITLE
fix: promote overlay streamer ID validation to main

### DIFF
--- a/src/lib/overlay-route-validation.ts
+++ b/src/lib/overlay-route-validation.ts
@@ -1,0 +1,22 @@
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const OVERLAY_EVENTS_PATH_PATTERN = /^\/api\/overlay\/([^/]+)\/events\/?$/
+
+/**
+ * Overlay events API の動的 streamerId がUUIDとして不正かを判定する。
+ *
+ * 対象外のパスは false を返す。対象パスでURLデコード不能、またはUUID形式で
+ * ない場合だけ true を返し、middlewareでDBアクセス前に400へ変換する。
+ */
+export function hasInvalidOverlayEventsStreamerId(pathname: string): boolean {
+  const match = pathname.match(OVERLAY_EVENTS_PATH_PATTERN)
+  if (!match) return false
+
+  let streamerId: string
+  try {
+    streamerId = decodeURIComponent(match[1])
+  } catch {
+    return true
+  }
+
+  return !UUID_PATTERN.test(streamerId)
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,6 +3,7 @@ import { updateSession } from '@/lib/supabase/middleware'
 import { checkRateLimit, rateLimits, getClientIp } from '@/lib/rate-limit'
 import { setSecurityHeaders } from '@/lib/security-headers'
 import { ERROR_MESSAGES } from '@/lib/constants'
+import { hasInvalidOverlayEventsStreamerId } from '@/lib/overlay-route-validation'
 import { defaultLocale, locales, LOCALE_COOKIE_NAME, type Locale } from '@/i18n/config'
 
 // Next.js 16 recommends proxy.ts, but Proxy always builds as Node.js runtime
@@ -77,6 +78,17 @@ const RATE_LIMIT_EXCLUDED_PATHS = [
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
+
+  // Issue #657: 不正な streamerId をDBクエリへ渡す前に拒否する。
+  // OBSブラウザソース等のURL末尾に文字列が混入しても、PostgreSQLの22P02を
+  // 継続発生させず、入力エラーとして400を返す。
+  if (hasInvalidOverlayEventsStreamerId(pathname)) {
+    const errorResponse = NextResponse.json(
+      { error: 'Invalid streamer ID' },
+      { status: 400 }
+    )
+    return setSecurityHeaders(errorResponse, pathname)
+  }
 
   const response = await updateSession(request)
   // パスに基づいて適切なセキュリティヘッダーを設定

--- a/tests/unit/overlay-route-validation.test.ts
+++ b/tests/unit/overlay-route-validation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { hasInvalidOverlayEventsStreamerId } from "@/lib/overlay-route-validation";
+
+describe("hasInvalidOverlayEventsStreamerId", () => {
+  const validStreamerId = "94cb6927-8733-4f1c-8e7e-0afb89773daa";
+
+  it("accepts a canonical UUID on the overlay events API path", () => {
+    expect(
+      hasInvalidOverlayEventsStreamerId(
+        `/api/overlay/${validStreamerId}/events`
+      )
+    ).toBe(false);
+  });
+
+  it("accepts a trailing slash", () => {
+    expect(
+      hasInvalidOverlayEventsStreamerId(
+        `/api/overlay/${validStreamerId}/events/`
+      )
+    ).toBe(false);
+  });
+
+  it("rejects a UUID with an appended string (Issue #657)", () => {
+    expect(
+      hasInvalidOverlayEventsStreamerId(
+        `/api/overlay/${validStreamerId}source/events`
+      )
+    ).toBe(true);
+  });
+
+  it("rejects a non-UUID streamer ID", () => {
+    expect(
+      hasInvalidOverlayEventsStreamerId("/api/overlay/streamer-1/events")
+    ).toBe(true);
+  });
+
+  it("does not validate unrelated paths", () => {
+    expect(
+      hasInvalidOverlayEventsStreamerId(
+        `/overlay/${validStreamerId}`
+      )
+    ).toBe(false);
+    expect(
+      hasInvalidOverlayEventsStreamerId(
+        `/api/overlay/${validStreamerId}/events/extra`
+      )
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

previewで検証済みのIssue #657修正をmainへ昇格します。

Closes #657

## 含まれる変更

- #744 `fix: reject invalid overlay streamer IDs before DB access`
- `/api/overlay/[streamerId]/events` の不正UUIDをDBアクセス前に400で拒否
- Issueで報告されたUUID末尾への `source` 混入を含む回帰テスト

## 検証結果

最新head `b124de00` で以下を確認済みです。

- Typecheck: success
- Unit tests: success
- Integration tests: success
- Lint: success
- Migration order check: success
- Build: Cloudflare Workers Builds有効のためworkflow条件によりskip
- Cloudflare `twica-preview` deployment: success

## リスク

- 発生元URLの利用者設定自体は変更せず、不正入力を400へ変換してDBエラーの連続発生を防ぐ修正です。
- mainへマージすると、リポジトリのhead branch自動削除設定により`preview`が削除される可能性があります。マージ時は自動削除設定またはマージ後のpreview再作成を確認してください。
