### PR TITLE
ci: preview migration履歴の一回限り修復経路を追加

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -59,6 +59,11 @@ on:
         options:
           - preview
           - production
+      include_all_migrations:
+        description: "Preview only: repair an out-of-order migration history"
+        required: false
+        default: false
+        type: boolean
 
 # Prevent concurrent deployments to the same environment
 # 同一環境への同時デプロイを防止
@@ -100,10 +105,25 @@ jobs:
             echo "::error::Production migrations are only allowed from the main branch"
             exit 1
           fi
-          supabase db push --db-url "$SUPABASE_DB_URL" --yes
+
+          # 00073 was merged to main after preview had already applied 00075/00076.
+          # Supabase correctly rejects that out-of-order history by default.  The
+          # escape hatch is deliberately restricted to a manual preview dispatch:
+          # keeping --include-all on normal pushes would hide future numbering
+          # regressions and could apply an old production migration unexpectedly.
+          if [ "$INCLUDE_ALL_MIGRATIONS" = "true" ]; then
+            if [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ] || [ "$RESOLVED_ENV" != "preview" ]; then
+              echo "::error::include_all_migrations is allowed only for a manual preview deployment"
+              exit 1
+            fi
+            supabase db push --db-url "$SUPABASE_DB_URL" --yes --include-all
+          else
+            supabase db push --db-url "$SUPABASE_DB_URL" --yes
+          fi
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
           RESOLVED_ENV: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.environment) || (github.ref == 'refs/heads/preview' && 'preview') || 'production' }}
+          INCLUDE_ALL_MIGRATIONS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.include_all_migrations || 'false' }}
 
   legacy-app-deploy:
     if: vars.CLOUDFLARE_WORKERS_BUILDS_ENABLED != 'true'


### PR DESCRIPTION
## 概要

preview DB の migration 履歴分岐を一回限りで修復するため、手動 workflow dispatch に `include_all_migrations` 入力を追加します。

## 原因

preview DB は `00075` / `00076` が適用済みですが、後から preview ブランチへ入った `00073_add_analysis_dashboard_rpcs.sql` が未適用です。通常の `supabase db push` は古い migration の差し込みを安全側で拒否するため、preview push の `supabase-migrations` job が継続的に失敗しています。

## 安全策

- `--include-all` は `workflow_dispatch` かつ `environment=preview` の場合だけ許可
- 通常の preview/main push は従来どおり順序違反を拒否
- production では入力を true にしても明示的に失敗
- 修復後は通常の preview push を再実行し、通常モードで成功することを確認する

## 検証

- Ruby YAML parser: pass
- `npm run check:migration-order`: 67 migrations pass
- `git diff --check`: pass

Related to #568 and #662.
