### PR TITLE
fix: ガチャ読み取りをPGドライバへ統一

### DIFF
--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -251,30 +251,48 @@ export class GachaService {
       }> | null
       let cardsError: GachaReadDriverError | null
 
+      // Drizzle側はSupabase SDKの文字列リテラル型推論制約を受けないため、primaryと
+      // max_issuance_count未デプロイ時fallbackで同じpredicate/列定義を共有する。
+      // includeIssuanceLimit=false のときだけ当該列をSQLから外し、呼出側contractは
+      // nullを補って維持する。これにより片側だけpack条件を直し忘れる事故を防ぐ。
+      const loadPgCards = async (includeIssuanceLimit: boolean) => {
+        const { db } = await getDb()
+        const predicates = [
+          eq(cardsTable.streamer_id, streamerId),
+          eq(cardsTable.is_active, true),
+        ]
+        if (collectionName) {
+          predicates.push(collectionName === DEFAULT_PACK_SENTINEL
+            ? isNull(cardsTable.collection_name)
+            : eq(cardsTable.collection_name, collectionName))
+        }
+        const rows = await db.select({
+          id: cardsTable.id,
+          name: cardsTable.name,
+          description: cardsTable.description,
+          image_url: cardsTable.image_url,
+          rarity: cardsTable.rarity,
+          drop_rate: cardsTable.drop_rate,
+          ...(includeIssuanceLimit ? { max_issuance_count: cardsTable.max_issuance_count } : {}),
+          ...(collectionName ? { intra_rarity_weight: cardsTable.intra_rarity_weight } : {}),
+        }).from(cardsTable).where(and(...predicates))
+
+        return rows.map(row => ({
+          ...row,
+          max_issuance_count:
+            includeIssuanceLimit && 'max_issuance_count' in row
+              ? row.max_issuance_count ?? null
+              : null,
+        }))
+      }
+
       if (getGachaDbDriver() === 'pg') {
         try {
-          cards = await withDbRetry(async () => {
-            const { db } = await getDb()
-            const predicates = [
-              eq(cardsTable.streamer_id, streamerId),
-              eq(cardsTable.is_active, true),
-            ]
-            if (collectionName) {
-              predicates.push(collectionName === DEFAULT_PACK_SENTINEL
-                ? isNull(cardsTable.collection_name)
-                : eq(cardsTable.collection_name, collectionName))
-            }
-            return db.select({
-              id: cardsTable.id,
-              name: cardsTable.name,
-              description: cardsTable.description,
-              image_url: cardsTable.image_url,
-              rarity: cardsTable.rarity,
-              drop_rate: cardsTable.drop_rate,
-              max_issuance_count: cardsTable.max_issuance_count,
-              ...(collectionName ? { intra_rarity_weight: cardsTable.intra_rarity_weight } : {}),
-            }).from(cardsTable).where(and(...predicates))
-          }, 'gacha:executeGacha:cards', { idempotent: true })
+          cards = await withDbRetry(
+            () => loadPgCards(true),
+            'gacha:executeGacha:cards',
+            { idempotent: true }
+          )
           cardsError = null
         } catch (error) {
           cards = null
@@ -318,28 +336,11 @@ export class GachaService {
       if (cardsError && isMissingCardIssuanceColumnError(cardsError)) {
         if (getGachaDbDriver() === 'pg') {
           try {
-            const fallbackCards = await withDbRetry(async () => {
-              const { db } = await getDb()
-              const predicates = [
-                eq(cardsTable.streamer_id, streamerId),
-                eq(cardsTable.is_active, true),
-              ]
-              if (collectionName) {
-                predicates.push(collectionName === DEFAULT_PACK_SENTINEL
-                  ? isNull(cardsTable.collection_name)
-                  : eq(cardsTable.collection_name, collectionName))
-              }
-              return db.select({
-                id: cardsTable.id,
-                name: cardsTable.name,
-                description: cardsTable.description,
-                image_url: cardsTable.image_url,
-                rarity: cardsTable.rarity,
-                drop_rate: cardsTable.drop_rate,
-                ...(collectionName ? { intra_rarity_weight: cardsTable.intra_rarity_weight } : {}),
-              }).from(cardsTable).where(and(...predicates))
-            }, 'gacha:executeGacha:cards:fallback', { idempotent: true })
-            cards = fallbackCards.map(card => ({ ...card, max_issuance_count: null }))
+            cards = await withDbRetry(
+              () => loadPgCards(false),
+              'gacha:executeGacha:cards:fallback',
+              { idempotent: true }
+            )
             cardsError = null
           } catch (error) {
             cards = null

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -13,6 +13,13 @@ import { getDb } from '@/lib/db/client'
 import { getGachaDbDriver } from '@/lib/db/flags'
 import { withDbRetry } from '@/lib/db/retry'
 import { isPgFunctionNotFoundError } from '@/lib/db/errors'
+import { and, eq, inArray, isNull } from 'drizzle-orm'
+import {
+  cards as cardsTable,
+  gachaHistory,
+  streamerAdditionalGachaRewards,
+  streamers,
+} from '@/lib/db/schema'
 import { CARD_ISSUANCE_MESSAGES, isMissingCardIssuanceColumnError } from '@/lib/card-issuance'
 import {
   isMissingCollectionNameColumn,
@@ -27,7 +34,10 @@ export interface GachaCard {
   name: string
   description: string | null
   image_url: string | null
-  rarity: 'common' | 'rare' | 'epic' | 'legendary'
+  // migration 00048 で固定 CHECK は撤廃され、配信者定義のカスタムレアリティを
+  // 許可している。PG 経路の schema.ts も text として扱うため、旧4種 union に
+  // 狭めると正しい DB 行を型上だけ拒否してしまう。
+  rarity: string
   drop_rate: number
   max_issuance_count?: number | null
 }
@@ -108,6 +118,20 @@ interface GachaTransactionRpcResult {
 interface GachaRpcDriverError {
   code?: string
   message: string
+}
+
+interface GachaReadDriverError {
+  code?: string
+  message: string
+}
+
+function normalizePgReadError(error: unknown): GachaReadDriverError {
+  return {
+    code: typeof error === 'object' && error !== null && typeof (error as { code?: unknown }).code === 'string'
+      ? (error as { code: string }).code
+      : undefined,
+    message: error instanceof Error ? error.message : String(error),
+  }
 }
 
 /**
@@ -211,8 +235,54 @@ export class GachaService {
       // Row 型を推論するため(変数文字列や三項式を渡すと型が崩れる)、列リストが
       // 異なる分岐ごとに select() 呼び出し自体を分ける。パック未指定クエリの
       // 列リストは従来(main の #108 実装)と完全に同一のまま維持する。
-      let { data: cards, error: cardsError } = await withRetry(
-        () => {
+      // #718: ガチャの読み取りと書き込みは同じ GACHA_DB_DRIVER で切り替える。
+      // DB_DRIVER と分離すると、緊急ロールバック時に抽選プールだけ別 provider を
+      // 読み続ける split-brain が起きるため、課金系クリティカルパスを一つの
+      // rollback unit として扱う。PG 読み取りは冪等なので接続断リトライを許可する。
+      let cards: Array<{
+        id: string
+        name: string
+        description: string | null
+        image_url: string | null
+        rarity: string
+        drop_rate: number
+        max_issuance_count: number | null
+        intra_rarity_weight?: number | null
+      }> | null
+      let cardsError: GachaReadDriverError | null
+
+      if (getGachaDbDriver() === 'pg') {
+        try {
+          cards = await withDbRetry(async () => {
+            const { db } = await getDb()
+            const predicates = [
+              eq(cardsTable.streamer_id, streamerId),
+              eq(cardsTable.is_active, true),
+            ]
+            if (collectionName) {
+              predicates.push(collectionName === DEFAULT_PACK_SENTINEL
+                ? isNull(cardsTable.collection_name)
+                : eq(cardsTable.collection_name, collectionName))
+            }
+            return db.select({
+              id: cardsTable.id,
+              name: cardsTable.name,
+              description: cardsTable.description,
+              image_url: cardsTable.image_url,
+              rarity: cardsTable.rarity,
+              drop_rate: cardsTable.drop_rate,
+              max_issuance_count: cardsTable.max_issuance_count,
+              ...(collectionName ? { intra_rarity_weight: cardsTable.intra_rarity_weight } : {}),
+            }).from(cardsTable).where(and(...predicates))
+          }, 'gacha:executeGacha:cards', { idempotent: true })
+          cardsError = null
+        } catch (error) {
+          cards = null
+          cardsError = normalizePgReadError(error)
+        }
+      } else {
+        const result = await withRetry(
+          () => {
           if (collectionName) {
             let query = this.supabase
               .from('cards')
@@ -239,12 +309,45 @@ export class GachaService {
             .eq('streamer_id', streamerId)
             .eq('is_active', true)
         },
-        'gacha:executeGacha:cards',
-      )
+          'gacha:executeGacha:cards',
+        )
+        cards = result.data
+        cardsError = result.error
+      }
 
       if (cardsError && isMissingCardIssuanceColumnError(cardsError)) {
-        const fallbackResult = await withRetry(
-          () => {
+        if (getGachaDbDriver() === 'pg') {
+          try {
+            const fallbackCards = await withDbRetry(async () => {
+              const { db } = await getDb()
+              const predicates = [
+                eq(cardsTable.streamer_id, streamerId),
+                eq(cardsTable.is_active, true),
+              ]
+              if (collectionName) {
+                predicates.push(collectionName === DEFAULT_PACK_SENTINEL
+                  ? isNull(cardsTable.collection_name)
+                  : eq(cardsTable.collection_name, collectionName))
+              }
+              return db.select({
+                id: cardsTable.id,
+                name: cardsTable.name,
+                description: cardsTable.description,
+                image_url: cardsTable.image_url,
+                rarity: cardsTable.rarity,
+                drop_rate: cardsTable.drop_rate,
+                ...(collectionName ? { intra_rarity_weight: cardsTable.intra_rarity_weight } : {}),
+              }).from(cardsTable).where(and(...predicates))
+            }, 'gacha:executeGacha:cards:fallback', { idempotent: true })
+            cards = fallbackCards.map(card => ({ ...card, max_issuance_count: null }))
+            cardsError = null
+          } catch (error) {
+            cards = null
+            cardsError = normalizePgReadError(error)
+          }
+        } else {
+          const fallbackResult = await withRetry(
+            () => {
             // Issue #579: fallback 側もパック指定時は intra_rarity_weight を含める
             // (含めないと発行上限列のデプロイ窓中だけパック内自動配分が
             // intra=デフォルト1.0 扱いになり配分が静かにズレる)。列リストが
@@ -269,13 +372,14 @@ export class GachaService {
               .eq('streamer_id', streamerId)
               .eq('is_active', true)
           },
-          'gacha:executeGacha:cards:fallback',
-        )
-        cards = fallbackResult.data?.map((card) => ({
-          ...card,
-          max_issuance_count: null,
-        })) ?? null
-        cardsError = fallbackResult.error
+            'gacha:executeGacha:cards:fallback',
+          )
+          cards = fallbackResult.data?.map((card) => ({
+            ...card,
+            max_issuance_count: null,
+          })) ?? null
+          cardsError = fallbackResult.error
+        }
       }
 
       if (cardsError) {
@@ -814,13 +918,32 @@ export class GachaService {
       (_, index) => buildDrawEventId(eventId, index) as string
     )
 
-    const { data, error } = await withRetry(
-      () => this.supabase
-        .from('gacha_history')
-        .select('event_id')
-        .in('event_id', candidateEventIds),
-      'gacha:executeGachaDraws:completedPrefix',
-    )
+    let data: Array<{ event_id: string | null }> | null
+    let error: GachaReadDriverError | null
+    if (getGachaDbDriver() === 'pg') {
+      try {
+        data = await withDbRetry(async () => {
+          const { db } = await getDb()
+          return db.select({ event_id: gachaHistory.event_id })
+            .from(gachaHistory)
+            .where(inArray(gachaHistory.event_id, candidateEventIds))
+        }, 'gacha:executeGachaDraws:completedPrefix', { idempotent: true })
+        error = null
+      } catch (queryError) {
+        data = null
+        error = normalizePgReadError(queryError)
+      }
+    } else {
+      const result = await withRetry(
+        () => this.supabase
+          .from('gacha_history')
+          .select('event_id')
+          .in('event_id', candidateEventIds),
+        'gacha:executeGachaDraws:completedPrefix',
+      )
+      data = result.data
+      error = result.error
+    }
 
     if (error) {
       return err(`Database error: ${error.message}`)
@@ -1070,14 +1193,59 @@ export class GachaService {
       // (#576 フェーズ2) のパック内レアリティ自動配分に使う。
       // default_card_pack_name (migration 00063, Issue #554) は {packName} プレースホルダで
       // デフォルト(未分類)パックの表示名オーバーライドとして使う(Issue #597)。
-      let { data: streamer, error: streamerError } = await withRetry(
-        () => this.supabase
-          .from('streamers')
-          .select('id, channel_point_reward_id, channel_point_collection_name, chat_announcement_enabled, chat_announcement_template, chat_announcement_multi_template, chat_announcement_multi_show_cards, raid_gacha_active_until, rarity_weights, rarity_weights_scope, pack_rarity_weights, default_card_pack_name')
-          .eq('twitch_user_id', event.broadcaster_user_id)
-          .maybeSingle(),
-        'gacha:executeGachaForEventSub:streamer',
-      )
+      let streamer: {
+        id: string
+        channel_point_reward_id: string | null
+        channel_point_collection_name: string | null
+        chat_announcement_enabled: boolean
+        chat_announcement_template: string | null
+        chat_announcement_multi_template: string | null
+        chat_announcement_multi_show_cards: boolean
+        raid_gacha_active_until: string | null
+        rarity_weights: Record<string, number> | null
+        rarity_weights_scope: string | null
+        pack_rarity_weights: Record<string, Record<string, number>> | null
+        default_card_pack_name: string | null
+      } | null
+      let streamerError: GachaReadDriverError | null
+
+      if (getGachaDbDriver() === 'pg') {
+        try {
+          const rows = await withDbRetry(async () => {
+            const { db } = await getDb()
+            return db.select({
+              id: streamers.id,
+              channel_point_reward_id: streamers.channel_point_reward_id,
+              channel_point_collection_name: streamers.channel_point_collection_name,
+              chat_announcement_enabled: streamers.chat_announcement_enabled,
+              chat_announcement_template: streamers.chat_announcement_template,
+              chat_announcement_multi_template: streamers.chat_announcement_multi_template,
+              chat_announcement_multi_show_cards: streamers.chat_announcement_multi_show_cards,
+              raid_gacha_active_until: streamers.raid_gacha_active_until,
+              rarity_weights: streamers.rarity_weights,
+              rarity_weights_scope: streamers.rarity_weights_scope,
+              pack_rarity_weights: streamers.pack_rarity_weights,
+              default_card_pack_name: streamers.default_card_pack_name,
+            }).from(streamers).where(eq(streamers.twitch_user_id, event.broadcaster_user_id)).limit(1)
+          }, 'gacha:executeGachaForEventSub:streamer', { idempotent: true })
+          streamer = rows[0] ?? null
+          streamerError = null
+        } catch (error) {
+          streamer = null
+          streamerError = normalizePgReadError(error)
+        }
+      } else {
+        const result = await withRetry(
+          () => this.supabase
+            .from('streamers')
+            .select('id, channel_point_reward_id, channel_point_collection_name, chat_announcement_enabled, chat_announcement_template, chat_announcement_multi_template, chat_announcement_multi_show_cards, raid_gacha_active_until, rarity_weights, rarity_weights_scope, pack_rarity_weights, default_card_pack_name')
+            .eq('twitch_user_id', event.broadcaster_user_id)
+            .maybeSingle(),
+          'gacha:executeGachaForEventSub:streamer',
+        )
+        streamer = result.data
+        streamerError = result.error
+      }
 
       // Issue #579 (#576 フェーズ2): rarity_weights_scope / pack_rarity_weights は
       // migration 00065(#578)で追加された列で、channel_point_collection_name
@@ -1090,7 +1258,12 @@ export class GachaService {
       // 再取得する。欠落時は rarity_weights_scope=null
       // (resolveRarityWeightsForPool は null/undefined を 'global' として扱う)
       // / pack_rarity_weights=null (パック別上書きなし) を安全側デフォルトとする。
+      // PG フラグは必要 migration の適用確認後にだけ有効化する運用契約のため、
+      // PG 側で 42703 が出た場合に PostgREST へ跨いだ fallback は行わない。
+      // ここで旧経路へ混ぜると Phase 2 の provider 切替後に古い DB を読んで抽選する
+      // 危険がある。PG 経路はエラーとして停止し、GACHA_DB_DRIVER 全体を戻す。
       if (
+        getGachaDbDriver() !== 'pg' &&
         streamerError &&
         (isMissingRarityWeightsScopeColumnError(streamerError) || isMissingPackRarityWeightsColumnError(streamerError))
       ) {
@@ -1120,7 +1293,7 @@ export class GachaService {
       // raid_gacha_active_until. 列が複数欠落していれば後続の広域 fallback が拾う。
       // rarity_weights_scope/pack_rarity_weights はこの分岐に来る時点で確実に
       // 未デプロイ(上のコメント参照)なので選択せず null 固定にする。
-      if (streamerError && isMissingCollectionNameColumn(streamerError)) {
+      if (getGachaDbDriver() !== 'pg' && streamerError && isMissingCollectionNameColumn(streamerError)) {
         const collectionFallback = await withRetry(
           () => this.supabase
             .from('streamers')
@@ -1144,7 +1317,7 @@ export class GachaService {
         streamerError = collectionFallback.error
       }
 
-      if (isStreamerSettingsSchemaError(streamerError)) {
+      if (getGachaDbDriver() !== 'pg' && isStreamerSettingsSchemaError(streamerError)) {
         const fallbackResult = await withRetry(
           () => this.supabase
             .from('streamers')
@@ -1234,21 +1407,52 @@ export class GachaService {
 
       // Check if the reward ID matches any additional reward
       // 追加報酬のいずれかと一致するかチェック
-      let { data: additionalReward, error: additionalError } = await withRetry(
-        () => this.supabase
-          .from('streamer_additional_gacha_rewards')
-          .select('id, draw_count, is_raid_limited, collection_name')
-          .eq('streamer_id', streamer.id)
-          .eq('reward_id', event.reward.id)
-          .maybeSingle(),
-        'gacha:executeGachaForEventSub:additionalReward',
-      )
+      let additionalReward: {
+        id: string
+        draw_count: number
+        is_raid_limited: boolean
+        collection_name: string | null
+      } | null
+      let additionalError: GachaReadDriverError | null
+      if (getGachaDbDriver() === 'pg') {
+        try {
+          const rows = await withDbRetry(async () => {
+            const { db } = await getDb()
+            return db.select({
+              id: streamerAdditionalGachaRewards.id,
+              draw_count: streamerAdditionalGachaRewards.draw_count,
+              is_raid_limited: streamerAdditionalGachaRewards.is_raid_limited,
+              collection_name: streamerAdditionalGachaRewards.collection_name,
+            }).from(streamerAdditionalGachaRewards).where(and(
+              eq(streamerAdditionalGachaRewards.streamer_id, streamer.id),
+              eq(streamerAdditionalGachaRewards.reward_id, event.reward.id),
+            )).limit(1)
+          }, 'gacha:executeGachaForEventSub:additionalReward', { idempotent: true })
+          additionalReward = rows[0] ?? null
+          additionalError = null
+        } catch (error) {
+          additionalReward = null
+          additionalError = normalizePgReadError(error)
+        }
+      } else {
+        const result = await withRetry(
+          () => this.supabase
+            .from('streamer_additional_gacha_rewards')
+            .select('id, draw_count, is_raid_limited, collection_name')
+            .eq('streamer_id', streamer.id)
+            .eq('reward_id', event.reward.id)
+            .maybeSingle(),
+          'gacha:executeGachaForEventSub:additionalReward',
+        )
+        additionalReward = result.data
+        additionalError = result.error
+      }
 
       // Deploy-window fallback: only the collection_name column is missing.
       // Handled separately from raid-option errors so we don't needlessly block
       // the additional reward gacha (it just falls back to "all cards").
       // collection_name 列のみ未デプロイなら null fallback（追加報酬ガチャは止めない）。
-      if (additionalError && isMissingCollectionNameColumn(additionalError)) {
+      if (getGachaDbDriver() !== 'pg' && additionalError && isMissingCollectionNameColumn(additionalError)) {
         const fallbackResult = await withRetry(
           () => this.supabase
             .from('streamer_additional_gacha_rewards')
@@ -1314,13 +1518,48 @@ export class GachaService {
     eventId?: string
   ): Promise<Result<GachaResult>> {
     try {
-      let { data: streamer, error: streamerError } = await this.supabase
-        .from('streamers')
-        .select('id, chat_announcement_enabled, chat_announcement_template, chat_announcement_multi_template, chat_announcement_multi_show_cards, raid_gacha_draw_count')
-        .eq('twitch_user_id', event.to_broadcaster_user_id)
-        .maybeSingle()
+      let streamer: {
+        id: string
+        chat_announcement_enabled: boolean
+        chat_announcement_template: string | null
+        chat_announcement_multi_template: string | null
+        chat_announcement_multi_show_cards: boolean
+        raid_gacha_draw_count: number
+      } | null
+      let streamerError: GachaReadDriverError | null
+      if (getGachaDbDriver() === 'pg') {
+        try {
+          const rows = await withDbRetry(async () => {
+            const { db } = await getDb()
+            return db.select({
+              id: streamers.id,
+              chat_announcement_enabled: streamers.chat_announcement_enabled,
+              chat_announcement_template: streamers.chat_announcement_template,
+              chat_announcement_multi_template: streamers.chat_announcement_multi_template,
+              chat_announcement_multi_show_cards: streamers.chat_announcement_multi_show_cards,
+              raid_gacha_draw_count: streamers.raid_gacha_draw_count,
+            }).from(streamers).where(eq(streamers.twitch_user_id, event.to_broadcaster_user_id)).limit(1)
+          }, 'gacha:executeGachaForRaidEvent:streamer', { idempotent: true })
+          streamer = rows[0] ?? null
+          streamerError = null
+        } catch (error) {
+          streamer = null
+          streamerError = normalizePgReadError(error)
+        }
+      } else {
+        const result = await withRetry(
+          () => this.supabase
+            .from('streamers')
+            .select('id, chat_announcement_enabled, chat_announcement_template, chat_announcement_multi_template, chat_announcement_multi_show_cards, raid_gacha_draw_count')
+            .eq('twitch_user_id', event.to_broadcaster_user_id)
+            .maybeSingle(),
+          'gacha:executeGachaForRaidEvent:streamer',
+        )
+        streamer = result.data
+        streamerError = result.error
+      }
 
-      if (isStreamerSettingsSchemaError(streamerError)) {
+      if (getGachaDbDriver() !== 'pg' && isStreamerSettingsSchemaError(streamerError)) {
         const fallbackResult = await this.supabase
           .from('streamers')
           .select('id, chat_announcement_enabled, chat_announcement_template')

--- a/tests/unit/gacha-rpc-driver-parity.test.ts
+++ b/tests/unit/gacha-rpc-driver-parity.test.ts
@@ -44,6 +44,10 @@ const limitedTestCards = [
   { id: 'available-card', name: 'Available', description: null, image_url: null, rarity: 'common', drop_rate: 1, max_issuance_count: null },
 ]
 
+// 各テストが setupSupabase に渡した抽選プールを、同じテスト内の PG 読み取り
+// mock でも共有する。これにより driver 切替前後で入力カードだけは完全に一致する。
+let currentTestCards: Array<Record<string, unknown>> = testCards
+
 /** cards クエリの thenable モック(gacha-service.test.ts と同じ流儀) */
 function createCardsQuery<T extends Record<string, unknown>>(cards: T[]) {
   const q = createMockQueryBuilder()
@@ -90,9 +94,18 @@ function renderSqlCall(sqlMock: ReturnType<typeof vi.fn>, index: number) {
   return { text: strings.join('$'), values }
 }
 
-function setupPgSql(responses: Array<{ rows?: unknown[]; reject?: unknown }>) {
+function setupPgSql(
+  responses: Array<{ rows?: unknown[]; reject?: unknown }>,
+  cards: Array<Record<string, unknown>> = currentTestCards,
+) {
   const sqlMock = createSqlMock(responses)
-  vi.mocked(getDb).mockResolvedValue({ db: {} as never, sql: sqlMock as never })
+  // #718 で PG 経路は RPC 書き込みだけでなく、抽選プールの cards 読み取りも
+  // Drizzle に統一された。where() の Promise だけで実装の await 形状を再現し、
+  // SQL タグ用 responses の消費順序を変えず既存 RPC アサーションを保つ。
+  const where = vi.fn().mockResolvedValue(cards)
+  const from = vi.fn().mockReturnValue({ where })
+  const select = vi.fn().mockReturnValue({ from })
+  vi.mocked(getDb).mockResolvedValue({ db: { select } as never, sql: sqlMock as never })
   return sqlMock
 }
 
@@ -105,7 +118,8 @@ function setupSupabase(options?: {
   rpc?: ReturnType<typeof vi.fn>
   tables?: Record<string, unknown>
 }) {
-  const cardsQuery = createCardsQuery(options?.cards ?? testCards)
+  currentTestCards = options?.cards ?? testCards
+  const cardsQuery = createCardsQuery(currentTestCards)
   const rpc = options?.rpc ?? vi.fn()
   const fromMock = vi.fn((table: string) => {
     if (table === 'cards') return cardsQuery
@@ -122,6 +136,7 @@ function setupSupabase(options?: {
 describe('ガチャ RPC ドライバパリティ (#573)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    currentTestCards = testCards
   })
 
   // 環境変数は vi.stubEnv + vi.unstubAllEnvs で確実に復元する

--- a/tests/unit/gacha-rpc-driver-parity.test.ts
+++ b/tests/unit/gacha-rpc-driver-parity.test.ts
@@ -110,8 +110,9 @@ function setupPgSql(
 }
 
 /**
- * supabase-js クライアントモック。cards 読み取りは #573 の対象外(常に postgrest)
- * なので、pg 経路のテストでも必ず必要になる。
+ * supabase-js クライアントモック。PG経路ではcardsをDrizzleから読むが、
+ * 42883時のlegacy fallbackやdriver間の入力カード共有も検証するため保持する。
+ * PG readそのものとPostgREST不使用はgacha-service.test.tsで明示的に固定する。
  */
 function setupSupabase(options?: {
   cards?: Array<Record<string, unknown>>

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -4,18 +4,156 @@ import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { createMockQueryBuilder } from '../utils/supabase-mock'
 import { DEFAULT_PACK_SENTINEL } from '@/lib/validation/collection-name'
 import { CARD_ISSUANCE_MESSAGES } from '@/lib/card-issuance'
+import { getDb } from '@/lib/db/client'
 
 vi.mock('@/lib/supabase/admin', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/supabase/admin')>()
   return { ...actual, getSupabaseAdmin: vi.fn() }
+})
+
+/**
+ * Issue #718: GACHA_DB_DRIVER=pg で追加した課金系read pathを、実際の
+ * GachaService公開メソッド経由で通す回帰テスト。単にgetDbを呼ぶだけでなく、
+ * 選択列を固定し、Supabase table queryへ混在しないことも検証する。
+ */
+describe('GachaService PG read paths (Issue #718)', () => {
+  function limitQuery(rows: unknown[]) {
+    return {
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+      }),
+    }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('GACHA_DB_DRIVER', 'pg')
+    mockGetSupabaseAdmin.mockReturnValue({
+      from: vi.fn(),
+      rpc: vi.fn(),
+    } as unknown as ReturnType<typeof getSupabaseAdmin>)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('EventSub streamerと追加報酬をPGで読み、未一致を安全に拒否する', async () => {
+    const select = vi.fn()
+      .mockReturnValueOnce(limitQuery([{
+        id: 'streamer-1',
+        channel_point_reward_id: 'main-reward',
+        channel_point_collection_name: null,
+        chat_announcement_enabled: false,
+        chat_announcement_template: null,
+        chat_announcement_multi_template: null,
+        chat_announcement_multi_show_cards: true,
+        raid_gacha_active_until: null,
+        rarity_weights: null,
+        rarity_weights_scope: null,
+        pack_rarity_weights: null,
+        default_card_pack_name: null,
+      }]))
+      .mockReturnValueOnce(limitQuery([]))
+    mockGetDb.mockResolvedValue({ db: { select } as never, sql: vi.fn() as never })
+
+    const result = await new GachaService().executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'unknown-reward', cost: 100 },
+    }, 'event-pg-read')
+
+    expect(result).toEqual({ success: false, error: 'Reward ID mismatch' })
+    expect(select).toHaveBeenCalledTimes(2)
+    expect(Object.keys(select.mock.calls[0][0])).toEqual(expect.arrayContaining([
+      'id', 'channel_point_reward_id', 'rarity_weights_scope', 'pack_rarity_weights',
+    ]))
+    expect(Object.keys(select.mock.calls[1][0])).toEqual([
+      'id', 'draw_count', 'is_raid_limited', 'collection_name',
+    ])
+    expect(mockGetSupabaseAdmin.mock.results[0].value.from).not.toHaveBeenCalled()
+  })
+
+  it('raid streamerをPGで読み、無効設定ならカード発行前に停止する', async () => {
+    const select = vi.fn().mockReturnValueOnce(limitQuery([{
+      id: 'streamer-1',
+      chat_announcement_enabled: false,
+      chat_announcement_template: null,
+      chat_announcement_multi_template: null,
+      chat_announcement_multi_show_cards: true,
+      raid_gacha_draw_count: 0,
+    }]))
+    mockGetDb.mockResolvedValue({ db: { select } as never, sql: vi.fn() as never })
+
+    const result = await new GachaService().executeGachaForRaidEvent({
+      to_broadcaster_user_id: 'broadcaster-1',
+      from_broadcaster_user_id: 'raider-1',
+    }, 'raid-event-pg-read')
+
+    expect(result.success).toBe(false)
+    expect(select).toHaveBeenCalledTimes(1)
+    expect(Object.keys(select.mock.calls[0][0])).toEqual(expect.arrayContaining([
+      'id', 'raid_gacha_draw_count', 'chat_announcement_multi_show_cards',
+    ]))
+    expect(mockGetSupabaseAdmin.mock.results[0].value.from).not.toHaveBeenCalled()
+  })
+
+  it('N連再開判定でgacha_historyをPG読取し、権限エラーを発行前に返す', async () => {
+    const permissionError = Object.assign(new Error('permission denied'), { code: '42501' })
+    const select = vi.fn()
+      .mockReturnValueOnce(limitQuery([{
+        id: 'streamer-1',
+        channel_point_reward_id: 'main-reward',
+        channel_point_collection_name: null,
+        chat_announcement_enabled: false,
+        chat_announcement_template: null,
+        chat_announcement_multi_template: null,
+        chat_announcement_multi_show_cards: true,
+        raid_gacha_active_until: null,
+        rarity_weights: null,
+        rarity_weights_scope: null,
+        pack_rarity_weights: null,
+        default_card_pack_name: null,
+      }]))
+      .mockReturnValueOnce(limitQuery([{
+        id: 'additional-1',
+        draw_count: 2,
+        is_raid_limited: false,
+        collection_name: null,
+      }]))
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockRejectedValue(permissionError) }),
+      })
+    mockGetDb.mockResolvedValue({ db: { select } as never, sql: vi.fn() as never })
+
+    const result = await new GachaService().executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'additional-reward', cost: 100 },
+    }, 'event-prefix-pg-read')
+
+    expect(result.success).toBe(false)
+    expect(select).toHaveBeenCalledTimes(3)
+    expect(Object.keys(select.mock.calls[2][0])).toEqual(['event_id'])
+    expect(mockGetSupabaseAdmin.mock.results[0].value.from).not.toHaveBeenCalled()
+  })
 })
 vi.mock('@/lib/sentry/error-handler', () => ({
   reportError: vi.fn(),
   reportApiError: vi.fn(),
   logErrorFromLogger: vi.fn(),
 }))
+vi.mock('@/lib/db/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/db/client')>()
+  return { ...actual, getDb: vi.fn() }
+})
 
 const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin)
+const mockGetDb = vi.mocked(getDb)
 
 // テスト用カードデータ
 const testCards = [

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -93,6 +93,35 @@ describe('GachaService PG read paths (Issue #718)', () => {
     expect(mockGetSupabaseAdmin.mock.results[0].value.from).not.toHaveBeenCalledWith('cards')
   })
 
+  it('streamer列欠落時はPostgRESTへ跨がずfail-closedする', async () => {
+    const missingColumn = Object.assign(
+      new Error('column rarity_weights_scope does not exist'),
+      { code: '42703' }
+    )
+    const select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockRejectedValue(missingColumn) }),
+      }),
+    })
+    mockGetDb.mockResolvedValue({ db: { select } as never, sql: vi.fn() as never })
+
+    const result = await new GachaService().executeGachaForEventSub({
+      broadcaster_user_id: 'broadcaster-1',
+      user_id: 'user-1',
+      user_login: 'viewer',
+      user_name: 'Viewer',
+      reward: { id: 'reward-1', cost: 100 },
+    }, 'event-schema-not-ready')
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Database error fetching streamer: column rarity_weights_scope does not exist',
+    })
+    expect(select).toHaveBeenCalledTimes(1)
+    // 異なるproviderへ跨ぐfallbackは抽選プールのsplit-brainを起こすため禁止する。
+    expect(mockGetSupabaseAdmin.mock.results[0].value.from).not.toHaveBeenCalled()
+  })
+
   it('EventSub streamerと追加報酬をPGで読み、未一致を安全に拒否する', async () => {
     const select = vi.fn()
       .mockReturnValueOnce(limitQuery([{

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -38,6 +38,61 @@ describe('GachaService PG read paths (Issue #718)', () => {
     vi.unstubAllEnvs()
   })
 
+  it('executeGachaのcardsをPGで読み、PostgRESTのcards tableへ触れない', async () => {
+    const where = vi.fn().mockResolvedValue(testCards)
+    const select = vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({ where }),
+    })
+    const sql = vi.fn().mockResolvedValue([{
+      result: { is_duplicate: false, limit_reached: false, history_id: 'history-pg-read' },
+    }])
+    mockGetDb.mockResolvedValue({ db: { select } as never, sql: sql as never })
+
+    const result = await new GachaService().executeGacha(
+      'streamer-1', 'user-1', 'Viewer', 'event-cards-pg-read'
+    )
+
+    expect(result.success).toBe(true)
+    expect(select).toHaveBeenCalledTimes(1)
+    expect(Object.keys(select.mock.calls[0][0])).toContain('max_issuance_count')
+    expect(mockGetSupabaseAdmin.mock.results[0].value.from).not.toHaveBeenCalledWith('cards')
+  })
+
+  it('max_issuance_count未デプロイ時はPG内で列なし再読取しnullを補う', async () => {
+    const missingColumn = Object.assign(
+      new Error('column max_issuance_count does not exist'),
+      { code: '42703' }
+    )
+    const select = vi.fn()
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockRejectedValue(missingColumn) }),
+      })
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(testCards.map(card => {
+          const { max_issuance_count: _omitted, ...withoutLimit } = card
+          void _omitted
+          return withoutLimit
+        })) }),
+      })
+    const sql = vi.fn().mockResolvedValue([{
+      result: { is_duplicate: false, limit_reached: false, history_id: 'history-pg-fallback' },
+    }])
+    mockGetDb.mockResolvedValue({ db: { select } as never, sql: sql as never })
+
+    const result = await new GachaService().executeGacha(
+      'streamer-1', 'user-1', 'Viewer', 'event-cards-pg-fallback'
+    )
+
+    expect(result.success).toBe(true)
+    expect(select).toHaveBeenCalledTimes(2)
+    expect(Object.keys(select.mock.calls[0][0])).toContain('max_issuance_count')
+    expect(Object.keys(select.mock.calls[1][0])).not.toContain('max_issuance_count')
+    if (result.success) {
+      expect(result.data.card.max_issuance_count).toBeNull()
+    }
+    expect(mockGetSupabaseAdmin.mock.results[0].value.from).not.toHaveBeenCalledWith('cards')
+  })
+
   it('EventSub streamerと追加報酬をPGで読み、未一致を安全に拒否する', async () => {
     const select = vi.fn()
       .mockReturnValueOnce(limitQuery([{


### PR DESCRIPTION
## 概要

preview で検証済みの #718 対応を main へ反映します。

- `GACHA_DB_DRIVER=pg` 時にガチャ抽選前の直接読み取りも Drizzle/Hyperdrive 経路へ統一
- `cards`, `streamers`, `streamer_additional_gacha_rewards`, `gacha_history` の5論理操作を移行
- PG経路の読み取りは冪等リトライを使用し、schema不一致時は別providerへ跨がず fail-closed
- migration 00048 の実態に合わせ、カスタムレアリティを `string` として扱う

## preview 検証

- preview PR #747 merge済み
- preview migration履歴分岐をPR #748 + manual run `29207824450` で修復
- 修復用一時workflowはPR #749で削除済み
- 通常 Supabase migration run `29208102352`: success
- Workers Build (preview SHA `18eebba4`): success
- CI run `29208102347`: typecheck / unit / integration success
- `https://twica-preview.tsubasa-azumagakito.workers.dev/`: 表示正常
- `/`, `/guide`, `/releases`: HTTP 200
- ブラウザconsole warning/error: 0
- 実ガチャ付与はpreviewデータを汚すため実施せず、unit driver parityで検証

## 本番反映後

- 非破壊HTTPスモークチェック
- Workers Build / production migrations / auxiliary worker結果確認
- `wrangler tail` でエラーを一定時間監視
- 実ガチャなど本番データを書き換えるテストは行わない

Closes #718
