### PR TITLE
db: gacha_history DELETE権限を明示

### DIFF
--- a/supabase/migrations/20260712211038_explicitly_grant_gacha_history_delete.sql
+++ b/supabase/migrations/20260712211038_explicitly_grant_gacha_history_delete.sql
@@ -1,0 +1,10 @@
+-- Issue #689: both production and preview currently inherit DELETE on
+-- public.gacha_history through Supabase's historical default privileges.
+-- Migration 00047 only documents SELECT/INSERT, so a newly reconstructed
+-- database could diverge from the live environments and break
+-- DELETE /api/gacha-history/[id].  Record the live contract explicitly in a
+-- forward-only migration instead of editing already-applied migration 00047.
+--
+-- GRANT is idempotent in PostgreSQL.  Existing projects keep the same effective
+-- permission; fresh/rebuilt projects no longer depend on provider defaults.
+GRANT DELETE ON TABLE public.gacha_history TO service_role;


### PR DESCRIPTION
## 概要

#689 の実環境GRANT確認結果を、forward-only migrationで明文化します。

## 実環境確認（read-only SQL）

2026-07-13に接続済みSupabaseツールで確認:

- production `TwiCa`: `service_role` に `DELETE` あり
- preview `TwiCa-DEV`: `service_role` に `DELETE` あり

したがって現在のDELETE APIは権限不足の既存バグではなく、ライブ環境がSupabaseの歴史的default privilegesを継承して動作している状態です。

## 変更

- 適用済み `00047` は改変しない
- Supabase CLI `migration new` でforward-only migrationを生成
- `GRANT DELETE ON TABLE public.gacha_history TO service_role` を明示
- GRANTは冪等で、現行環境の実効権限を変更せず、再構築DBのdriftだけを防止

## 検証

- `npm run check:migration-order`: 68 migrations pass
- `git diff --check`: pass

Closes #689.
