### PR TITLE
db: declare gacha history delete grant

### DIFF
--- a/supabase/migrations/20260712211038_explicitly_grant_gacha_history_delete.sql
+++ b/supabase/migrations/20260712211038_explicitly_grant_gacha_history_delete.sql
@@ -1,0 +1,10 @@
+-- Issue #689: both production and preview currently inherit DELETE on
+-- public.gacha_history through Supabase's historical default privileges.
+-- Migration 00047 only documents SELECT/INSERT, so a newly reconstructed
+-- database could diverge from the live environments and break
+-- DELETE /api/gacha-history/[id].  Record the live contract explicitly in a
+-- forward-only migration instead of editing already-applied migration 00047.
+--
+-- GRANT is idempotent in PostgreSQL.  Existing projects keep the same effective
+-- permission; fresh/rebuilt projects no longer depend on provider defaults.
+GRANT DELETE ON TABLE public.gacha_history TO service_role;

--- a/tests/unit/gacha-history-delete-grant-migration.test.ts
+++ b/tests/unit/gacha-history-delete-grant-migration.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, expect, it } from 'vitest'
+
+// Issue #689: service_role の DELETE 権限を暗黙のデフォルト権限へ依存させると、
+// 新規環境の再構築時に DELETE /api/gacha-history/[id] だけが壊れ得る。
+// migration の実行テストはデプロイ側で担保し、ここでは権限・対象テーブル・role の
+// いずれかが将来の編集で欠落する回帰を、既存migrationテストと同じ静的検証で防ぐ。
+describe('gacha_history explicit DELETE grant migration', () => {
+  const migration = readFileSync(
+    resolve(
+      __dirname,
+      '../../supabase/migrations/20260712211038_explicitly_grant_gacha_history_delete.sql'
+    ),
+    'utf-8'
+  )
+
+  it('grants DELETE on public.gacha_history to service_role', () => {
+    expect(migration).toMatch(
+      /GRANT\s+DELETE\s+ON\s+TABLE\s+public\.gacha_history\s+TO\s+service_role\s*;/i
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add a forward-only migration that explicitly grants DELETE on public.gacha_history to service_role
- preserve existing applied migration history instead of rewriting migration 00047

## Preview verification
- preview PR #754 merged
- Supabase preview migration 20260712211038 applied successfully
- service_role DELETE privilege verified with has_table_privilege
- Workers preview deployment succeeded
- preview landing page and Twitch login entry rendered normally

Closes #689