### PR TITLE
fix: preserve concurrent error records

### DIFF
--- a/src/lib/sentry/error-handler.ts
+++ b/src/lib/sentry/error-handler.ts
@@ -58,15 +58,8 @@ function persistedContext(context: Record<string, unknown>): Json {
   // unsupported `undefined` properties before the insert; the cast is safe
   // because JSON.parse can only produce the Json union declared by the schema.
   const serialized = JSON.stringify(sanitizeContext(context))
-  return serialized === undefined ? {} : JSON.parse(serialized) as Json
+  return JSON.parse(serialized) as Json
 }
-
-// Error persistence must never call logger.error: logger.error delegates back to
-// logErrorFromLogger, which would recursively insert another errors row. Track
-// active fingerprints instead of one global boolean so unrelated concurrent
-// requests in the same Cloudflare isolate can still record different errors.
-// The catch path below must use console.warn directly as the primary invariant.
-const activePersistenceKeys = new Set<string>()
 
 async function logErrorToDatabase(
   errorType: string,
@@ -80,13 +73,6 @@ async function logErrorToDatabase(
     return
   }
 
-  const persistenceKey = `${errorType}\u0000${message}\u0000${stackTrace ?? ''}`
-  if (activePersistenceKeys.has(persistenceKey)) {
-    console.warn('[Error Tracking] Recursive error persistence was suppressed')
-    return
-  }
-
-  activePersistenceKeys.add(persistenceKey)
   try {
     // 環境判定: NEXT_PUBLIC_APP_URL に 'preview' が含まれるかで判定
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || ''
@@ -133,9 +119,10 @@ async function logErrorToDatabase(
   } catch (err) {
     // エラーDBへの記録失敗はメインのエラー処理を阻害しない
     // エラー詳細を出力して Cloudflare Workers Observability (wrangler tail) で確認可能にする
+    // logger.error は logErrorFromLogger() を経由してこの関数へ戻るため使用禁止。
+    // console.warn を直接使うことを再帰防止の唯一の仕組みにし、同一isolate内の別
+    // requestで同じエラーが並行発生しても観測データを誤って捨てない。
     console.warn('[Error Tracking] Failed to persist error:', err)
-  } finally {
-    activePersistenceKeys.delete(persistenceKey)
   }
 }
 

--- a/tests/unit/sentry-error-handler.test.ts
+++ b/tests/unit/sentry-error-handler.test.ts
@@ -164,6 +164,19 @@ describe('sentry/error-handler', () => {
       expect(mockFrom).not.toHaveBeenCalled();
     });
 
+    it('DB_DRIVER=pg-readではwriteを従来のPostgREST経路に留める', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg-read');
+
+      await reportError(new Error('read-only rollout'));
+
+      expect(getDb).not.toHaveBeenCalled();
+      expect(mockPgInsert).not.toHaveBeenCalled();
+      expect(mockFrom).toHaveBeenCalledWith('errors');
+      expect(mockInsert).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'read-only rollout',
+      }));
+    });
+
     it('PG insert失敗は呼び出し元へ伝播せずconsole警告へフォールバックする', async () => {
       vi.stubEnv('DB_DRIVER', 'pg');
       mockPgValues.mockRejectedValueOnce(new Error('database unavailable'));
@@ -176,7 +189,7 @@ describe('sentry/error-handler', () => {
       );
     });
 
-    it('失敗後に再入ガードが解除され、次のエラーは記録できる', async () => {
+    it('失敗後も次のエラーは記録できる', async () => {
       vi.stubEnv('DB_DRIVER', 'pg');
       mockPgValues
         .mockRejectedValueOnce(new Error('temporary failure'))
@@ -189,27 +202,22 @@ describe('sentry/error-handler', () => {
       expect(mockPgValues.mock.calls[1][0]).toEqual(expect.objectContaining({ message: 'second' }));
     });
 
-    it('同一エラーの再入だけを抑止し、進行中のinsert完了後にガードを解除する', async () => {
+    it('別requestで並行発生した同一内容のエラーをどちらも記録する', async () => {
       vi.stubEnv('DB_DRIVER', 'pg');
       let releaseInsert!: () => void;
       mockPgValues.mockReturnValueOnce(new Promise<void>((resolve) => {
         releaseInsert = resolve;
       }));
 
-      const first = reportError('recursive');
+      const first = reportError('same incident');
       await waitForMockCalls(mockPgValues, 1);
-      const nested = reportError('recursive');
-      await nested;
+      const concurrent = reportError('same incident');
+      await waitForMockCalls(mockPgValues, 2);
 
-      expect(mockPgValues).toHaveBeenCalledTimes(1);
-      expect(console.warn).toHaveBeenCalledWith(
-        '[Error Tracking] Recursive error persistence was suppressed',
-      );
+      expect(mockPgValues).toHaveBeenCalledTimes(2);
 
       releaseInsert();
-      await first;
-      await reportError('recursive');
-      expect(mockPgValues).toHaveBeenCalledTimes(2);
+      await Promise.all([first, concurrent]);
     });
   });
 


### PR DESCRIPTION
## Summary
- remove content-fingerprint suppression that could drop identical errors from separate concurrent requests
- keep recursion prevention at the console.warn-only persistence failure boundary
- simplify JSON context serialization
- explicitly verify DB_DRIVER=pg-read keeps error writes on PostgREST

## Verification
- sentry error handler: 50/50 passed
- ESLint on changed files passed
- local OpenNext/Workers build completed successfully

Follow-up to #751 and review feedback on #753.