### PR TITLE
fix: retry transient Cloudflare 525 errors

### DIFF
--- a/src/lib/supabase/retry.ts
+++ b/src/lib/supabase/retry.ts
@@ -1,9 +1,9 @@
 /**
  * Supabase Query Retry Utility
- * Supabaseクエリのリトライユーティリティ (Issue #339, #326, #325)
+ * Supabaseクエリのリトライユーティリティ (Issue #339, #326, #325, #646)
  *
- * Supabase PostgREST が一時的に 502/503 を返す場合に指数バックオフでリトライする。
- * Cloudflare Workers 環境でのネットワーク一時障害に対応。
+ * Supabase PostgREST が一時的な5xxを返す場合に指数バックオフでリトライする。
+ * Cloudflare Workers 環境でのネットワーク・SSLハンドシェイク一時障害に対応。
  */
 
 import { logger } from '@/lib/logger'
@@ -16,16 +16,21 @@ interface RetryOptions {
 
 const DEFAULT_DELAYS = [100, 300, 1000]
 
-// 500/502/503 はインフラ一時障害のためリトライ対象
-const RETRYABLE_STATUS_CODES = [500, 502, 503]
+// 500/502/503 は上流インフラ障害、525 はCloudflare SSL handshake失敗のためリトライ対象
+const RETRYABLE_STATUS_CODES = [500, 502, 503, 525]
 
-// Supabase/PostgREST が返すエラーメッセージのテキストパターン
-// ステータスコード数字が含まれない場合（"Bad Gateway" 等）にも対応
-const RETRYABLE_MESSAGE_PATTERNS = ['internal server error', 'bad gateway', 'service unavailable']
+// Supabase/PostgREST/Cloudflare が返すエラーメッセージのテキストパターン
+// ステータスコード数字が含まれない場合にも対応
+const RETRYABLE_MESSAGE_PATTERNS = [
+  'internal server error',
+  'bad gateway',
+  'service unavailable',
+  'ssl handshake failed',
+]
 
 /**
  * Supabase クエリ結果に対するリトライラッパー
- * { data, error } 形式のレスポンスで 502/503 相当のエラーの場合にリトライする。
+ * { data, error } 形式のレスポンスで一時的な5xx相当のエラーの場合にリトライする。
  * ステータスコード数字・テキストメッセージの両方でマッチする。
  *
  * @param queryFn - Supabase クエリを返す関数（await前のPromiseを返す）

--- a/tests/unit/supabase-retry.test.ts
+++ b/tests/unit/supabase-retry.test.ts
@@ -87,6 +87,28 @@ describe('withRetry', () => {
     expect(queryFn).toHaveBeenCalledTimes(2)
   })
 
+  it('Cloudflare 525 のエラーコードをリトライする', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        error: { message: 'error code: 525' },
+      })
+      .mockResolvedValueOnce({ data: 'ok', error: null })
+    const result = await withRetry(queryFn, 'getLicensePlan', { delays: [0, 0, 0] })
+    expect(result.error).toBeNull()
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('SSL handshake failed メッセージをリトライする', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        error: { message: 'SSL handshake failed' },
+      })
+      .mockResolvedValueOnce({ data: 'ok', error: null })
+    const result = await withRetry(queryFn, 'test', { delays: [0, 0, 0] })
+    expect(result.error).toBeNull()
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+
   it('テキストパターン "bad gateway" でもリトライする', async () => {
     const queryFn = vi.fn()
       .mockResolvedValueOnce({


### PR DESCRIPTION
## 概要

Cloudflareの一時的なSSLハンドシェイク失敗（525）をSupabase共通リトライの対象に追加します。

Closes #646

## 選定理由

- `auto-generated` と `bug` の両ラベルが付いたオープンIssue
- 対応中の重複PRなし
- 未完了の依存Issueなし
- 報告メッセージ `error code: 525` が既存の共通リトライ対象から漏れていることを確認
- 変更範囲を共通リトライと単体テストに限定可能

## 変更内容

- `withRetry()` のリトライ対象へHTTP/Cloudflareコード525を追加
- 数値コードがない場合に備え、`SSL handshake failed` メッセージもリトライ対象へ追加
- Issueで報告された `error code: 525` とSSLハンドシェイク文言の回帰テストを追加
- 400などの非一時エラーは従来どおり即時返却

## 検証結果

- 既存のSupabaseリトライ単体テストへ回帰ケースを追加
- GitHub Actionsのtypecheck・unit・integration・lint・migration orderで検証予定

## 未実施事項・リスク

- 525は一時的な上流SSL障害として扱い、既存と同じ最大3回の指数バックオフを適用します。
- 恒常的な証明書設定不備も最大3回試行するため、最終エラー返却まで最大約1.4秒増える可能性があります。
- DBクエリは読み取り系を含む既存の`withRetry()`利用箇所に適用されますが、リトライ回数・バックオフ値は変更していません。
