### PR TITLE
fix: lazy-load gacha Supabase client

### DIFF
--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -187,7 +187,16 @@ function buildDrawEventId(eventId: string | undefined, index: number): string | 
 }
 
 export class GachaService {
-  private supabase = getSupabaseAdmin()
+  /**
+   * PostgREST経路を実際に使う時だけSupabase admin clientを生成する。
+   * GACHA_DB_DRIVER=pg では全read/writeをHyperdriveへ揃えているため、class fieldで
+   * eagerly生成すると、Phase 4でSupabase環境変数を削除した後もconstructorだけで
+   * throwしてPG経路へ到達できない。getSupabaseAdmin()自体がsingletonなので、
+   * getter化してもPostgREST経路でclientを繰り返し生成するコストは発生しない。
+   */
+  private get supabase() {
+    return getSupabaseAdmin()
+  }
 
   async executeGacha(
     streamerId: string,

--- a/tests/unit/gacha-rpc-driver-parity.test.ts
+++ b/tests/unit/gacha-rpc-driver-parity.test.ts
@@ -200,7 +200,11 @@ describe('ガチャ RPC ドライバパリティ (#573)', () => {
     })
 
     it('正常系: 名前付き引数の SQL が実行され ok(card) が返る(supabase rpc は不呼出)', async () => {
-      const { rpc } = setupSupabase()
+      // Phase 4でSupabase env/clientが存在しなくてもPG経路がconstructorから完走する
+      // ことを固定する。単なるfrom()未呼出ではeager client生成の退行を検知できない。
+      mockGetSupabaseAdmin.mockImplementation(() => {
+        throw new Error('Supabase environment must not be required in PG mode')
+      })
       const sqlMock = setupPgSql([
         { rows: [{ result: { is_duplicate: false, limit_reached: false, history_id: 'h-pg-1' } }] },
       ])
@@ -227,8 +231,8 @@ describe('ガチャ RPC ドライバパリティ (#573)', () => {
       expect(text).toContain('p_reward_id => $')
       expect(values).toEqual(['event-1', 'user-1', 'testuser', 'card-1', 'streamer-1', null, null])
 
-      // 書き込み RPC が postgrest 経路へ流れていないこと
-      expect(rpc).not.toHaveBeenCalled()
+      // client生成を含め、PostgREST経路へ一切触れていないこと
+      expect(mockGetSupabaseAdmin).not.toHaveBeenCalled()
     })
 
     it('rewardCost / rewardId は bind 値としてそのまま渡される', async () => {

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -55,7 +55,7 @@ describe('GachaService PG read paths (Issue #718)', () => {
     expect(result.success).toBe(true)
     expect(select).toHaveBeenCalledTimes(1)
     expect(Object.keys(select.mock.calls[0][0])).toContain('max_issuance_count')
-    expect(mockGetSupabaseAdmin.mock.results[0].value.from).not.toHaveBeenCalledWith('cards')
+    expect(mockGetSupabaseAdmin).not.toHaveBeenCalled()
   })
 
   it('max_issuance_count未デプロイ時はPG内で列なし再読取しnullを補う', async () => {
@@ -90,7 +90,7 @@ describe('GachaService PG read paths (Issue #718)', () => {
     if (result.success) {
       expect(result.data.card.max_issuance_count).toBeNull()
     }
-    expect(mockGetSupabaseAdmin.mock.results[0].value.from).not.toHaveBeenCalledWith('cards')
+    expect(mockGetSupabaseAdmin).not.toHaveBeenCalled()
   })
 
   it('streamer列欠落時はPostgRESTへ跨がずfail-closedする', async () => {
@@ -119,7 +119,7 @@ describe('GachaService PG read paths (Issue #718)', () => {
     })
     expect(select).toHaveBeenCalledTimes(1)
     // 異なるproviderへ跨ぐfallbackは抽選プールのsplit-brainを起こすため禁止する。
-    expect(mockGetSupabaseAdmin.mock.results[0].value.from).not.toHaveBeenCalled()
+    expect(mockGetSupabaseAdmin).not.toHaveBeenCalled()
   })
 
   it('EventSub streamerと追加報酬をPGで読み、未一致を安全に拒否する', async () => {
@@ -157,7 +157,7 @@ describe('GachaService PG read paths (Issue #718)', () => {
     expect(Object.keys(select.mock.calls[1][0])).toEqual([
       'id', 'draw_count', 'is_raid_limited', 'collection_name',
     ])
-    expect(mockGetSupabaseAdmin.mock.results[0].value.from).not.toHaveBeenCalled()
+    expect(mockGetSupabaseAdmin).not.toHaveBeenCalled()
   })
 
   it('raid streamerをPGで読み、無効設定ならカード発行前に停止する', async () => {
@@ -181,7 +181,7 @@ describe('GachaService PG read paths (Issue #718)', () => {
     expect(Object.keys(select.mock.calls[0][0])).toEqual(expect.arrayContaining([
       'id', 'raid_gacha_draw_count', 'chat_announcement_multi_show_cards',
     ]))
-    expect(mockGetSupabaseAdmin.mock.results[0].value.from).not.toHaveBeenCalled()
+    expect(mockGetSupabaseAdmin).not.toHaveBeenCalled()
   })
 
   it('N連再開判定でgacha_historyをPG読取し、権限エラーを発行前に返す', async () => {
@@ -223,7 +223,7 @@ describe('GachaService PG read paths (Issue #718)', () => {
     expect(result.success).toBe(false)
     expect(select).toHaveBeenCalledTimes(3)
     expect(Object.keys(select.mock.calls[2][0])).toEqual(['event_id'])
-    expect(mockGetSupabaseAdmin.mock.results[0].value.from).not.toHaveBeenCalled()
+    expect(mockGetSupabaseAdmin).not.toHaveBeenCalled()
   })
 })
 vi.mock('@/lib/sentry/error-handler', () => ({


### PR DESCRIPTION
## Summary
- create the Supabase admin client only when a PostgREST gacha branch actually uses it
- allow GACHA_DB_DRIVER=pg to construct and execute GachaService without Supabase environment variables
- strengthen PG-path tests to require zero admin-client construction

## Verification
- focused gacha suites: 72/72 passed
- typecheck passed
- ESLint: 0 errors
- diff check passed

Partial progress for #687; follow-up to #718.