### PR TITLE
fix: retry transient Cloudflare 522 errors

### DIFF
--- a/src/lib/supabase/retry.ts
+++ b/src/lib/supabase/retry.ts
@@ -1,6 +1,6 @@
 /**
  * Supabase Query Retry Utility
- * Supabaseクエリのリトライユーティリティ (Issue #339, #326, #325, #646)
+ * Supabaseクエリのリトライユーティリティ (Issue #339, #326, #325, #645, #646)
  *
  * Supabase PostgREST が一時的な5xxを返す場合に指数バックオフでリトライする。
  * Cloudflare Workers 環境でのネットワーク・SSLハンドシェイク一時障害に対応。
@@ -16,8 +16,8 @@ interface RetryOptions {
 
 const DEFAULT_DELAYS = [100, 300, 1000]
 
-// 500/502/503 は上流インフラ障害、525 はCloudflare SSL handshake失敗のためリトライ対象
-const RETRYABLE_STATUS_CODES = [500, 502, 503, 525]
+// 500/502/503 は上流インフラ障害、522 は接続タイムアウト、525 はSSL handshake失敗のためリトライ対象
+const RETRYABLE_STATUS_CODES = [500, 502, 503, 522, 525]
 
 // Supabase/PostgREST/Cloudflare が返すエラーメッセージのテキストパターン
 // ステータスコード数字が含まれない場合にも対応
@@ -25,6 +25,7 @@ const RETRYABLE_MESSAGE_PATTERNS = [
   'internal server error',
   'bad gateway',
   'service unavailable',
+  'connection timed out',
   'ssl handshake failed',
 ]
 

--- a/tests/unit/supabase-retry.test.ts
+++ b/tests/unit/supabase-retry.test.ts
@@ -87,6 +87,28 @@ describe('withRetry', () => {
     expect(queryFn).toHaveBeenCalledTimes(2)
   })
 
+  it('Cloudflare 522 のエラーコードをリトライする', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        error: { message: 'error code: 522' },
+      })
+      .mockResolvedValueOnce({ data: 'ok', error: null })
+    const result = await withRetry(queryFn, 'overlayEvents', { delays: [0, 0, 0] })
+    expect(result.error).toBeNull()
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('Connection timed out メッセージをリトライする', async () => {
+    const queryFn = vi.fn()
+      .mockResolvedValueOnce({
+        error: { message: 'Connection timed out' },
+      })
+      .mockResolvedValueOnce({ data: 'ok', error: null })
+    const result = await withRetry(queryFn, 'overlayEvents', { delays: [0, 0, 0] })
+    expect(result.error).toBeNull()
+    expect(queryFn).toHaveBeenCalledTimes(2)
+  })
+
   it('Cloudflare 525 のエラーコードをリトライする', async () => {
     const queryFn = vi.fn()
       .mockResolvedValueOnce({


### PR DESCRIPTION
## 概要

Cloudflareの一時的な接続タイムアウト（522）をSupabase共通リトライの対象に追加します。

Closes #645

## 選定理由

- `auto-generated` と `bug` の両ラベルが付いたオープンIssue
- 対応中の重複PRなし
- 未完了の依存Issueなし
- 2026-07-07にも再発しており、報告メッセージ `error code: 522` が既存の共通リトライ対象から漏れていることを確認
- 変更範囲を共通リトライと単体テストに限定可能

## 変更内容

- `withRetry()` のリトライ対象へCloudflare 522を追加
- 数値コードがない場合に備え、`Connection timed out` メッセージもリトライ対象へ追加
- Issueで報告された `error code: 522` と接続タイムアウト文言の回帰テストを追加
- previewに既に含まれる525対応を維持
- 400などの非一時エラー、リトライ回数、バックオフ値は変更なし

## 検証結果

- 522コードと接続タイムアウト文言の単体テストを追加
- GitHub Actionsのtypecheck・unit・integration・lint・migration orderで検証予定

## 未実施事項・リスク

- 522は一時的な上流接続タイムアウトとして扱い、既存と同じ最大3回の指数バックオフを適用します。
- 恒常的な接続障害でも最大3回試行するため、最終エラー返却まで最大約1.4秒増える可能性があります。
- DBクエリは既存の`withRetry()`利用箇所に適用されますが、リトライ回数・バックオフ値は変更していません。
- ブランチはmainから作成し、previewとの差分を522対応のみに保つため、previewに先行している525対応も同一内容で保持しています。
