### PR TITLE
fix: retry transient Cloudflare R2 10043 upload errors

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -15,40 +15,121 @@ import { sha256Prefix } from '@/lib/crypto-utils';
 import { getUserPlan, PLAN_MAX_UPLOAD_SIZE } from '@/lib/plan';
 import type { Session } from '@/lib/session';
 
-interface ValidateRequestResult { error?: NextResponse; session?: Session; }
+interface ValidateRequestResult {
+  error?: NextResponse;
+  session?: Session;
+}
 
 async function validateRequest(request: NextRequest): Promise<ValidateRequestResult> {
   const session = await getSession();
+
   const identifier = await getRateLimitIdentifier(request, session?.twitchUserId);
   const rateLimitResult = await checkRateLimit(rateLimits.upload, identifier, 10, 60 * 1000);
+
   if (!rateLimitResult.success) {
-    return { error: NextResponse.json({ error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED, retryAfter: rateLimitResult.reset }, { status: 429, headers: { 'X-RateLimit-Limit': String(rateLimitResult.limit), 'X-RateLimit-Remaining': String(rateLimitResult.remaining), 'X-RateLimit-Reset': String(rateLimitResult.reset) } }) };
+    return {
+      error: NextResponse.json(
+        {
+          error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+          retryAfter: rateLimitResult.reset,
+        },
+        {
+          status: 429,
+          headers: {
+            'X-RateLimit-Limit': String(rateLimitResult.limit),
+            'X-RateLimit-Remaining': String(rateLimitResult.remaining),
+            'X-RateLimit-Reset': String(rateLimitResult.reset),
+          },
+        }
+      ),
+    };
   }
-  if (!session) return { error: NextResponse.json({ error: ERROR_MESSAGES.NOT_AUTHENTICATED }, { status: 401 }) };
+
+  if (!session) {
+    return {
+      error: NextResponse.json({ error: ERROR_MESSAGES.NOT_AUTHENTICATED }, { status: 401 }),
+    };
+  }
+
   return { session };
 }
 
 async function validateFile(file: File | null, maxFileSize?: number): Promise<NextResponse | null> {
-  if (!file) return NextResponse.json({ error: ERROR_MESSAGES.NO_FILE_SELECTED }, { status: 400 });
-  if (!file.name || file.name.trim() === '') return NextResponse.json({ error: ERROR_MESSAGES.FILE_NAME_EMPTY }, { status: 400 });
+  if (!file) {
+    return NextResponse.json({ error: ERROR_MESSAGES.NO_FILE_SELECTED }, { status: 400 });
+  }
+
+  if (!file.name || file.name.trim() === '') {
+    return NextResponse.json({ error: ERROR_MESSAGES.FILE_NAME_EMPTY }, { status: 400 });
+  }
+
+  // プラン別のmaxFileSizeが指定されている場合はそちらを使用
   const validation = validateUpload(file, maxFileSize);
-  if (!validation.valid) return NextResponse.json({ error: getUploadErrorMessage(validation.error!) }, { status: 400 });
+  if (!validation.valid) {
+    return NextResponse.json(
+      { error: getUploadErrorMessage(validation.error!) },
+      { status: 400 }
+    );
+  }
+
   const ext = getFileExtension(file.name);
-  if (!ext || !isValidExtension(ext)) return NextResponse.json({ error: ERROR_MESSAGES.INVALID_FILE_TYPE }, { status: 400 });
+  if (!ext) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.INVALID_FILE_TYPE },
+      { status: 400 }
+    );
+  }
+
+  if (!isValidExtension(ext)) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.INVALID_FILE_TYPE },
+      { status: 400 }
+    );
+  }
+
   return null;
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const csrfValidation = await validateCSRFToken(request)
-  if (!csrfValidation.valid) return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 })
+  if (!csrfValidation.valid) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.FORBIDDEN },
+      { status: 403 }
+    )
+  }
 
   const { error: rateLimitError, session } = await validateRequest(request);
-  if (rateLimitError) return rateLimitError;
+  if (rateLimitError) {
+    return rateLimitError;
+  }
 
+  // Check storage limits before processing file
+  // ファイル処理前にストレージ制限をチェック（ボーナス容量も加味）
+  // Web Crypto APIを使用してユーザープレフィックスを生成
   const userPrefix = await sha256Prefix(session!.twitchUserId);
+
   const storageUsage = await getStorageUsage(userPrefix, session!.twitchUserId);
-  if (storageUsage.globalLimitReached) return NextResponse.json({ error: STORAGE_LIMIT_MESSAGES.GLOBAL_LIMIT_REACHED, code: 'GLOBAL_LIMIT_REACHED' }, { status: 507 });
-  if (storageUsage.userLimitReached) return NextResponse.json({ error: STORAGE_LIMIT_MESSAGES.USER_LIMIT_REACHED, code: 'USER_LIMIT_REACHED' }, { status: 507 });
+
+  if (storageUsage.globalLimitReached) {
+    return NextResponse.json(
+      {
+        error: STORAGE_LIMIT_MESSAGES.GLOBAL_LIMIT_REACHED,
+        code: 'GLOBAL_LIMIT_REACHED'
+      },
+      { status: 507 } // Insufficient Storage
+    );
+  }
+
+  if (storageUsage.userLimitReached) {
+    return NextResponse.json(
+      {
+        error: STORAGE_LIMIT_MESSAGES.USER_LIMIT_REACHED,
+        code: 'USER_LIMIT_REACHED'
+      },
+      { status: 507 } // Insufficient Storage
+    );
+  }
 
   let buffer: Buffer | null = null
   let fileName: string | null = null
@@ -56,35 +137,81 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
     const formData = await request.formData();
     const file = formData.get('file') as File | null;
+
+    // プラン別のアップロードサイズ上限を適用
     const plan = await getUserPlan(session!.twitchUserId);
     const maxFileSize = PLAN_MAX_UPLOAD_SIZE[plan];
+
     const fileValidationError = await validateFile(file, maxFileSize);
-    if (fileValidationError) return fileValidationError;
+    if (fileValidationError) {
+      return fileValidationError;
+    }
 
     const ext = getFileExtension(file!.name);
     buffer = Buffer.from(await file!.arrayBuffer());
     const actualType = getFileTypeFromBuffer(buffer);
+
     const expectedType = UPLOAD_CONFIG.EXT_TO_MIME_TYPE[ext as keyof typeof UPLOAD_CONFIG.EXT_TO_MIME_TYPE];
+
     if (actualType !== expectedType) {
       logger.warn(`File content does not match extension. Expected: ${expectedType}, Actual: ${actualType}`);
-      return NextResponse.json({ error: ERROR_MESSAGES.FILE_CONTENT_MISMATCH }, { status: 400 });
+      return NextResponse.json(
+        { error: ERROR_MESSAGES.FILE_CONTENT_MISMATCH },
+        { status: 400 }
+      );
     }
 
+    // User prefix for tracking uploads per user (must match storage-db.ts)
+    // ユーザー別アップロード追跡用プレフィックス（storage-db.tsと一致させる）
+    // Web Crypto APIを使用（Cloudflare Workers互換）
     const userPrefixForFile = await sha256Prefix(session!.twitchUserId);
     const uniqueSuffix = await sha256Prefix(`${session!.twitchUserId}-${Date.now()}`);
+
+    // Format: {userPrefix}_{uniqueSuffix}.{ext}
     fileName = `${userPrefixForFile}_${uniqueSuffix}.${ext}`;
 
-    const uploadResult = await retryCloudflareR2Upload(() => uploadToR2WithRetry(fileName!, buffer!, actualType));
+    // R2にアップロード（Vercel Blobの代わり）
+    const uploadResult = await retryCloudflareR2Upload(
+      () => uploadToR2WithRetry(fileName!, buffer!, actualType)
+    );
+
     if ('error' in uploadResult) {
-      return handleBlobError(new Error(uploadResult.error), "Upload API: Failed to upload to R2", { userId: session!.twitchUserId, fileName, fileSize: buffer.length })
+      return handleBlobError(
+        new Error(uploadResult.error),
+        "Upload API: Failed to upload to R2",
+        { userId: session!.twitchUserId, fileName, fileSize: buffer.length }
+      )
     }
 
-    try { await recordBlobFile(uploadResult.url, userPrefixForFile, buffer.length, 'r2'); }
-    catch (dbError) { logger.warn('Failed to record blob file in DB:', dbError); }
+    // DBにファイル情報を記録（使用量追跡用）
+    try {
+      await recordBlobFile(uploadResult.url, userPrefixForFile, buffer.length, 'r2');
+    } catch (dbError) {
+      // DB記録に失敗しても、アップロードは成功しているので警告ログのみ
+      // 次回の初期化スクリプト実行時に同期される
+      logger.warn('Failed to record blob file in DB:', dbError);
+    }
+
     return NextResponse.json({ url: uploadResult.url });
   } catch (error) {
-    const storageError = error instanceof Error && (error.message.includes('quota') || error.message.includes('limit') || error.message.includes('authentication') || error.message.includes('service unavailable') || error.message.includes('AccessDenied') || error.message.includes('NetworkingError'))
-    if (storageError) return handleBlobError(error, "Upload API: R2 storage error", { userId: session?.twitchUserId, fileName: fileName || 'unknown', fileSize: buffer?.length })
+    // R2またはDB操作でのエラーをハンドリング
+    const storageError = error instanceof Error && (
+      error.message.includes('quota') ||
+      error.message.includes('limit') ||
+      error.message.includes('authentication') ||
+      error.message.includes('service unavailable') ||
+      error.message.includes('AccessDenied') ||
+      error.message.includes('NetworkingError')
+    )
+
+    if (storageError) {
+      return handleBlobError(
+        error,
+        "Upload API: R2 storage error",
+        { userId: session?.twitchUserId, fileName: fileName || 'unknown', fileSize: buffer?.length }
+      )
+    }
+
     return handleApiError(error, "Upload API");
   }
 }

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -8,127 +8,47 @@ import { getFileTypeFromBuffer, getFileExtension, isValidExtension } from '@/lib
 import { logger } from '@/lib/logger';
 import { validateCSRFToken } from '@/lib/csrf';
 import { uploadToR2WithRetry } from '@/lib/r2-client';
+import { retryCloudflareR2Upload } from '@/lib/r2-retry-policy';
 import { recordBlobFile } from '@/lib/storage-db';
 import { getStorageUsage } from '@/lib/storage-usage';
 import { sha256Prefix } from '@/lib/crypto-utils';
 import { getUserPlan, PLAN_MAX_UPLOAD_SIZE } from '@/lib/plan';
 import type { Session } from '@/lib/session';
 
-interface ValidateRequestResult {
-  error?: NextResponse;
-  session?: Session;
-}
+interface ValidateRequestResult { error?: NextResponse; session?: Session; }
 
 async function validateRequest(request: NextRequest): Promise<ValidateRequestResult> {
   const session = await getSession();
-
   const identifier = await getRateLimitIdentifier(request, session?.twitchUserId);
   const rateLimitResult = await checkRateLimit(rateLimits.upload, identifier, 10, 60 * 1000);
-
   if (!rateLimitResult.success) {
-    return {
-      error: NextResponse.json(
-        {
-          error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-          retryAfter: rateLimitResult.reset,
-        },
-        {
-          status: 429,
-          headers: {
-            'X-RateLimit-Limit': String(rateLimitResult.limit),
-            'X-RateLimit-Remaining': String(rateLimitResult.remaining),
-            'X-RateLimit-Reset': String(rateLimitResult.reset),
-          },
-        }
-      ),
-    };
+    return { error: NextResponse.json({ error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED, retryAfter: rateLimitResult.reset }, { status: 429, headers: { 'X-RateLimit-Limit': String(rateLimitResult.limit), 'X-RateLimit-Remaining': String(rateLimitResult.remaining), 'X-RateLimit-Reset': String(rateLimitResult.reset) } }) };
   }
-
-  if (!session) {
-    return {
-      error: NextResponse.json({ error: ERROR_MESSAGES.NOT_AUTHENTICATED }, { status: 401 }),
-    };
-  }
-
+  if (!session) return { error: NextResponse.json({ error: ERROR_MESSAGES.NOT_AUTHENTICATED }, { status: 401 }) };
   return { session };
 }
 
 async function validateFile(file: File | null, maxFileSize?: number): Promise<NextResponse | null> {
-  if (!file) {
-    return NextResponse.json({ error: ERROR_MESSAGES.NO_FILE_SELECTED }, { status: 400 });
-  }
-
-  if (!file.name || file.name.trim() === '') {
-    return NextResponse.json({ error: ERROR_MESSAGES.FILE_NAME_EMPTY }, { status: 400 });
-  }
-
-  // プラン別のmaxFileSizeが指定されている場合はそちらを使用
+  if (!file) return NextResponse.json({ error: ERROR_MESSAGES.NO_FILE_SELECTED }, { status: 400 });
+  if (!file.name || file.name.trim() === '') return NextResponse.json({ error: ERROR_MESSAGES.FILE_NAME_EMPTY }, { status: 400 });
   const validation = validateUpload(file, maxFileSize);
-  if (!validation.valid) {
-    return NextResponse.json(
-      { error: getUploadErrorMessage(validation.error!) },
-      { status: 400 }
-    );
-  }
-
+  if (!validation.valid) return NextResponse.json({ error: getUploadErrorMessage(validation.error!) }, { status: 400 });
   const ext = getFileExtension(file.name);
-  if (!ext) {
-    return NextResponse.json(
-      { error: ERROR_MESSAGES.INVALID_FILE_TYPE },
-      { status: 400 }
-    );
-  }
-
-  if (!isValidExtension(ext)) {
-    return NextResponse.json(
-      { error: ERROR_MESSAGES.INVALID_FILE_TYPE },
-      { status: 400 }
-    );
-  }
-
+  if (!ext || !isValidExtension(ext)) return NextResponse.json({ error: ERROR_MESSAGES.INVALID_FILE_TYPE }, { status: 400 });
   return null;
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const csrfValidation = await validateCSRFToken(request)
-  if (!csrfValidation.valid) {
-    return NextResponse.json(
-      { error: ERROR_MESSAGES.FORBIDDEN },
-      { status: 403 }
-    )
-  }
+  if (!csrfValidation.valid) return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 })
 
   const { error: rateLimitError, session } = await validateRequest(request);
-  if (rateLimitError) {
-    return rateLimitError;
-  }
+  if (rateLimitError) return rateLimitError;
 
-  // Check storage limits before processing file
-  // ファイル処理前にストレージ制限をチェック（ボーナス容量も加味）
-  // Web Crypto APIを使用してユーザープレフィックスを生成
   const userPrefix = await sha256Prefix(session!.twitchUserId);
-
   const storageUsage = await getStorageUsage(userPrefix, session!.twitchUserId);
-
-  if (storageUsage.globalLimitReached) {
-    return NextResponse.json(
-      {
-        error: STORAGE_LIMIT_MESSAGES.GLOBAL_LIMIT_REACHED,
-        code: 'GLOBAL_LIMIT_REACHED'
-      },
-      { status: 507 } // Insufficient Storage
-    );
-  }
-
-  if (storageUsage.userLimitReached) {
-    return NextResponse.json(
-      {
-        error: STORAGE_LIMIT_MESSAGES.USER_LIMIT_REACHED,
-        code: 'USER_LIMIT_REACHED'
-      },
-      { status: 507 } // Insufficient Storage
-    );
-  }
+  if (storageUsage.globalLimitReached) return NextResponse.json({ error: STORAGE_LIMIT_MESSAGES.GLOBAL_LIMIT_REACHED, code: 'GLOBAL_LIMIT_REACHED' }, { status: 507 });
+  if (storageUsage.userLimitReached) return NextResponse.json({ error: STORAGE_LIMIT_MESSAGES.USER_LIMIT_REACHED, code: 'USER_LIMIT_REACHED' }, { status: 507 });
 
   let buffer: Buffer | null = null
   let fileName: string | null = null
@@ -136,79 +56,35 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
     const formData = await request.formData();
     const file = formData.get('file') as File | null;
-
-    // プラン別のアップロードサイズ上限を適用
     const plan = await getUserPlan(session!.twitchUserId);
     const maxFileSize = PLAN_MAX_UPLOAD_SIZE[plan];
-
     const fileValidationError = await validateFile(file, maxFileSize);
-    if (fileValidationError) {
-      return fileValidationError;
-    }
+    if (fileValidationError) return fileValidationError;
 
     const ext = getFileExtension(file!.name);
     buffer = Buffer.from(await file!.arrayBuffer());
     const actualType = getFileTypeFromBuffer(buffer);
-
     const expectedType = UPLOAD_CONFIG.EXT_TO_MIME_TYPE[ext as keyof typeof UPLOAD_CONFIG.EXT_TO_MIME_TYPE];
-
     if (actualType !== expectedType) {
       logger.warn(`File content does not match extension. Expected: ${expectedType}, Actual: ${actualType}`);
-      return NextResponse.json(
-        { error: ERROR_MESSAGES.FILE_CONTENT_MISMATCH },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: ERROR_MESSAGES.FILE_CONTENT_MISMATCH }, { status: 400 });
     }
 
-    // User prefix for tracking uploads per user (must match storage-db.ts)
-    // ユーザー別アップロード追跡用プレフィックス（storage-db.tsと一致させる）
-    // Web Crypto APIを使用（Cloudflare Workers互換）
     const userPrefixForFile = await sha256Prefix(session!.twitchUserId);
     const uniqueSuffix = await sha256Prefix(`${session!.twitchUserId}-${Date.now()}`);
-
-    // Format: {userPrefix}_{uniqueSuffix}.{ext}
     fileName = `${userPrefixForFile}_${uniqueSuffix}.${ext}`;
 
-    // R2にアップロード（Vercel Blobの代わり）
-    const uploadResult = await uploadToR2WithRetry(fileName, buffer, actualType);
-
+    const uploadResult = await retryCloudflareR2Upload(() => uploadToR2WithRetry(fileName!, buffer!, actualType));
     if ('error' in uploadResult) {
-      return handleBlobError(
-        new Error(uploadResult.error),
-        "Upload API: Failed to upload to R2",
-        { userId: session!.twitchUserId, fileName, fileSize: buffer.length }
-      )
+      return handleBlobError(new Error(uploadResult.error), "Upload API: Failed to upload to R2", { userId: session!.twitchUserId, fileName, fileSize: buffer.length })
     }
 
-    // DBにファイル情報を記録（使用量追跡用）
-    try {
-      await recordBlobFile(uploadResult.url, userPrefixForFile, buffer.length, 'r2');
-    } catch (dbError) {
-      // DB記録に失敗しても、アップロードは成功しているので警告ログのみ
-      // 次回の初期化スクリプト実行時に同期される
-      logger.warn('Failed to record blob file in DB:', dbError);
-    }
-
+    try { await recordBlobFile(uploadResult.url, userPrefixForFile, buffer.length, 'r2'); }
+    catch (dbError) { logger.warn('Failed to record blob file in DB:', dbError); }
     return NextResponse.json({ url: uploadResult.url });
   } catch (error) {
-    // R2またはDB操作でのエラーをハンドリング
-    const storageError = error instanceof Error && (
-      error.message.includes('quota') ||
-      error.message.includes('limit') ||
-      error.message.includes('authentication') ||
-      error.message.includes('service unavailable') ||
-      error.message.includes('AccessDenied') ||
-      error.message.includes('NetworkingError')
-    )
-
-    if (storageError) {
-      return handleBlobError(
-        error,
-        "Upload API: R2 storage error",
-        { userId: session?.twitchUserId, fileName: fileName || 'unknown', fileSize: buffer?.length }
-      )
-    }
-
+    const storageError = error instanceof Error && (error.message.includes('quota') || error.message.includes('limit') || error.message.includes('authentication') || error.message.includes('service unavailable') || error.message.includes('AccessDenied') || error.message.includes('NetworkingError'))
+    if (storageError) return handleBlobError(error, "Upload API: R2 storage error", { userId: session?.twitchUserId, fileName: fileName || 'unknown', fileSize: buffer?.length })
     return handleApiError(error, "Upload API");
   }
 }

--- a/src/lib/r2-retry-policy.ts
+++ b/src/lib/r2-retry-policy.ts
@@ -1,0 +1,34 @@
+export interface R2UploadResult {
+  url?: string
+  error?: string
+}
+
+const CLOUDFLARE_R2_TRANSIENT_MARKERS = [
+  '(10043)',
+  'cloudflarestatus.com',
+  'contact customer support',
+]
+
+export function isTransientCloudflareR2Error(message: string): boolean {
+  const normalized = message.toLowerCase()
+  return CLOUDFLARE_R2_TRANSIENT_MARKERS.some((marker) => normalized.includes(marker))
+}
+
+export async function retryCloudflareR2Upload<T extends R2UploadResult>(
+  upload: () => Promise<T>,
+  maxRetries = 2,
+  sleep: (ms: number) => Promise<void> = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+): Promise<T> {
+  let result = await upload()
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    if (!result.error || !isTransientCloudflareR2Error(result.error)) {
+      return result
+    }
+
+    await sleep(2 ** attempt * 500)
+    result = await upload()
+  }
+
+  return result
+}

--- a/tests/unit/r2-retry-policy.test.ts
+++ b/tests/unit/r2-retry-policy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest'
+import { isTransientCloudflareR2Error, retryCloudflareR2Upload } from '@/lib/r2-retry-policy'
+
+describe('R2 retry policy', () => {
+  it('Cloudflare R2 error 10043を一時障害として扱う', () => {
+    expect(isTransientCloudflareR2Error('put: Please look at https://www.cloudflarestatus.com for issues or contact customer support. (10043)')).toBe(true)
+  })
+
+  it('認証エラーなど恒久障害は再試行対象にしない', () => {
+    expect(isTransientCloudflareR2Error('AccessDenied: invalid credentials')).toBe(false)
+  })
+
+  it('10043の後に成功した場合は再実行する', async () => {
+    const upload = vi.fn<() => Promise<{ url?: string; error?: string }>>()
+      .mockResolvedValueOnce({ error: 'put failed (10043)' })
+      .mockResolvedValueOnce({ url: 'https://example.test/image.png' })
+    const sleep = vi.fn().mockResolvedValue(undefined)
+
+    await expect(retryCloudflareR2Upload(upload, 2, sleep)).resolves.toEqual({ url: 'https://example.test/image.png' })
+    expect(upload).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledWith(500)
+  })
+
+  it('非一時エラーは再試行しない', async () => {
+    const upload = vi.fn().mockResolvedValue({ error: 'AccessDenied' })
+    const sleep = vi.fn().mockResolvedValue(undefined)
+
+    await expect(retryCloudflareR2Upload(upload, 2, sleep)).resolves.toEqual({ error: 'AccessDenied' })
+    expect(upload).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 選定理由

- `auto-generated` / `bug` の両ラベルが付いた Issue #680 と、同一障害を別レイヤーで記録した Issue #681 を対象にしました。
- 既存のオープンPRによる対応、未完了の依存Issueはありません。
- Cloudflare R2の一時障害コード `10043` が既存のリトライ対象外で、影響範囲を画像アップロード経路に限定して安全に修正できます。

Closes #680
Closes #681

## 変更内容

- Cloudflare R2の `10043`、`cloudflarestatus.com`、サポート問い合わせ案内を一時障害として判定する共通ポリシーを追加
- 画像アップロードAPIで、既存のR2リトライ後に10043が返った場合のみ最大2回追加再試行
- 500ms、1000msの指数バックオフを使用
- 同一ファイルキーへのR2 `put` 再送なので、応答喪失後の再実行でも上書きとして扱われます
- 非一時エラーは従来どおり即時返却
- 既存のコメント・改行・書式を維持し、機能変更以外の差分を除去

## 検証

- `10043`の判定テスト
- 10043後に成功する再試行テスト
- 非一時エラーを再試行しないテスト
- 最新headでtypecheck・unit・integration・lint・migration orderをCI確認

## 未実施事項・リスク

- Cloudflare側の恒常障害でも最大2回追加再試行するため、最終エラー返却まで最大1.5秒増えます。
- 効果音アップロード経路は今回のIssue対象外で、既存処理を変更していません。
- 実環境の10043は再現困難なため、エラーメッセージを使った回帰テストで検証します。