### PR TITLE
fix(db): Drizzleのネストされた列欠落エラーを検知する

### DIFF
--- a/src/lib/card-number-errors.ts
+++ b/src/lib/card-number-errors.ts
@@ -1,3 +1,5 @@
+import { collectErrorSignals } from "@/lib/db/error-signals";
+
 export const CARD_NUMBER_MESSAGES = {
   duplicate: "このカード番号はすでに別のカードで使われています。",
   invalid: "カード番号は1以上の整数で入力してください。",
@@ -5,25 +7,20 @@ export const CARD_NUMBER_MESSAGES = {
 
 export function isCardNumberConflictError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
-  const err = error as { code?: unknown; message?: unknown; details?: unknown };
-  if (err.code !== "23505") return false;
+  const { codes, text } = collectErrorSignals(error);
+  if (!codes.has("23505")) return false;
 
-  const text = `${String(err.message || "")} ${String(err.details || "")}`;
   return text.includes("cards_streamer_card_number_unique") || text.includes("card_number");
 }
 
 export function isMissingCardNumberColumnError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
-  const err = error as { code?: unknown; message?: unknown; details?: unknown; hint?: unknown };
-  const text = [
-    err.message,
-    err.details,
-    err.hint,
-  ].map((value) => String(value || "")).join(" ");
+  const { codes, text } = collectErrorSignals(error);
 
   return text.includes("card_number") && (
     text.includes("schema cache") ||
     text.includes("column") ||
-    err.code === "PGRST204"
+    codes.has("PGRST204") ||
+    codes.has("42703")
   );
 }

--- a/src/lib/db/cards-safe-columns.ts
+++ b/src/lib/db/cards-safe-columns.ts
@@ -24,13 +24,8 @@
 // -----------------------------------------------------------------------------
 
 import { cards as cardsTable } from "@/lib/db/schema";
+import { collectErrorSignals } from "@/lib/db/error-signals";
 
-/**
- * 本番 Supabase の cards テーブルに実在しないことが確認済みの8列 (Issue #625,
- * scripts/verify-db-schema.js による実測)。card_number はカード番号採番用、
- * 残り7列は未着手のカードバトル機能用に schema.ts へ定義されているだけで、
- * 対応するマイグレーションが本番に適用されていない。
- */
 export const CARDS_MISSING_IN_PRODUCTION_COLUMNS = [
   "card_number",
   "hp",
@@ -42,14 +37,6 @@ export const CARDS_MISSING_IN_PRODUCTION_COLUMNS = [
   "skill_power",
 ] as const;
 
-/**
- * 上記8列を除いた cards テーブルの明示的な列オブジェクト。
- * Drizzle の `.select({ ... })` / `.returning({ ... })` にそのまま渡せる。
- *
- * rarity_order は GENERATED ALWAYS AS ... STORED の生成カラムで INSERT/UPDATE
- * 対象外だが、SELECT/RETURNING は可能かつ本番に実在するため含める
- * (postgrest 経路の select("*") も返す)。
- */
 export const CARDS_SAFE_COLUMNS = {
   id: cardsTable.id,
   streamer_id: cardsTable.streamer_id,
@@ -67,57 +54,6 @@ export const CARDS_SAFE_COLUMNS = {
   updated_at: cardsTable.updated_at,
 } as const;
 
-type ErrorLike = {
-  code?: unknown;
-  message?: unknown;
-  details?: unknown;
-  hint?: unknown;
-  query?: unknown;
-  cause?: unknown;
-};
-
-/**
- * DrizzleQueryError は PostgreSQL の code/message を `cause` に保持し、外側の
- * message には失敗したSQLだけを含めることがある。循環参照を避けながら cause
- * チェーンを辿り、判定に必要なコードとテキストをまとめる。
- */
-function collectErrorSignals(error: unknown): { codes: Set<string>; text: string } {
-  const codes = new Set<string>();
-  const textParts: string[] = [];
-  const visited = new Set<object>();
-  let current: unknown = error;
-
-  while (current && typeof current === "object" && !visited.has(current)) {
-    visited.add(current);
-    const err = current as ErrorLike;
-
-    if (typeof err.code === "string") codes.add(err.code);
-    for (const value of [err.message, err.details, err.hint, err.query]) {
-      if (value !== undefined && value !== null) textParts.push(String(value));
-    }
-
-    current = err.cause;
-  }
-
-  return { codes, text: textParts.join(" ") };
-}
-
-/**
- * 「cards テーブルの本番未デプロイ8列のいずれかが存在しない」ことによる
- * SELECT/RETURNING 失敗を検知する。card-number-errors.ts の
- * isMissingCardNumberColumnError と同じ判定ロジック（postgrest 由来の
- * "schema cache"/PGRST204、raw postgres 由来の "column ... does not exist"
- * (42703) の両方にマッチする汎用テキスト判定）を、8列全てに拡張したもの。
- *
- * pg (postgres.js) の RETURNING/SELECT は列リストをまとめて評価するため、
- * エラーメッセージには通常「最初に解決できなかった1列」のみが含まれる
- * (例: `column "card_number" of relation "cards" does not exist"`)。
- * DrizzleQueryError では 42703 が `cause.code` に入り、外側の message/query に
- * 対象列を含むSQLが入るため、cause チェーン全体を合わせて判定する (#779)。
- * 8列は本番で常にまとめて欠落している(Issue #625)ため、いずれか1列分の
- * エラーテキストを検知できれば、明示列リストへの再試行で残り7列も含めて
- * 解消される。
- */
 export function isMissingCardsBattleColumnError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
 
@@ -132,16 +68,6 @@ export function isMissingCardsBattleColumnError(error: unknown): boolean {
   return CARDS_MISSING_IN_PRODUCTION_COLUMNS.some((column) => text.includes(column));
 }
 
-/**
- * 「まず無指定/全列で試行 → 列欠落エラー検知 → CARDS_SAFE_COLUMNS で再試行」
- * パターンの共通化 (#685 self-review fix)。src/lib/dashboard-data.ts の7箇所
- * （getStreamerDataPg 等）で同一の try/catch/retry が反復していたため抽出した。
- *
- * attempt(useSafeColumns) は呼び出し側が useSafeColumns の値に応じてクエリの
- * 列指定（無指定 or CARDS_SAFE_COLUMNS 等への差し替え）を切り替える形で実装する。
- * isMissingCardsBattleColumnError に該当しないエラーはそのまま再送出し、
- * 呼び出し側の既存 catch（エラー時の外部挙動パリティ維持）に委ねる。
- */
 export async function withCardsBattleColumnFallback<T>(
   attempt: (useSafeColumns: boolean) => Promise<T>
 ): Promise<T> {

--- a/src/lib/db/cards-safe-columns.ts
+++ b/src/lib/db/cards-safe-columns.ts
@@ -67,6 +67,41 @@ export const CARDS_SAFE_COLUMNS = {
   updated_at: cardsTable.updated_at,
 } as const;
 
+type ErrorLike = {
+  code?: unknown;
+  message?: unknown;
+  details?: unknown;
+  hint?: unknown;
+  query?: unknown;
+  cause?: unknown;
+};
+
+/**
+ * DrizzleQueryError は PostgreSQL の code/message を `cause` に保持し、外側の
+ * message には失敗したSQLだけを含めることがある。循環参照を避けながら cause
+ * チェーンを辿り、判定に必要なコードとテキストをまとめる。
+ */
+function collectErrorSignals(error: unknown): { codes: Set<string>; text: string } {
+  const codes = new Set<string>();
+  const textParts: string[] = [];
+  const visited = new Set<object>();
+  let current: unknown = error;
+
+  while (current && typeof current === "object" && !visited.has(current)) {
+    visited.add(current);
+    const err = current as ErrorLike;
+
+    if (typeof err.code === "string") codes.add(err.code);
+    for (const value of [err.message, err.details, err.hint, err.query]) {
+      if (value !== undefined && value !== null) textParts.push(String(value));
+    }
+
+    current = err.cause;
+  }
+
+  return { codes, text: textParts.join(" ") };
+}
+
 /**
  * 「cards テーブルの本番未デプロイ8列のいずれかが存在しない」ことによる
  * SELECT/RETURNING 失敗を検知する。card-number-errors.ts の
@@ -77,19 +112,21 @@ export const CARDS_SAFE_COLUMNS = {
  * pg (postgres.js) の RETURNING/SELECT は列リストをまとめて評価するため、
  * エラーメッセージには通常「最初に解決できなかった1列」のみが含まれる
  * (例: `column "card_number" of relation "cards" does not exist"`)。
+ * DrizzleQueryError では 42703 が `cause.code` に入り、外側の message/query に
+ * 対象列を含むSQLが入るため、cause チェーン全体を合わせて判定する (#779)。
  * 8列は本番で常にまとめて欠落している(Issue #625)ため、いずれか1列分の
  * エラーテキストを検知できれば、明示列リストへの再試行で残り7列も含めて
  * 解消される。
  */
 export function isMissingCardsBattleColumnError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
-  const err = error as { code?: unknown; message?: unknown; details?: unknown; hint?: unknown };
-  const text = [err.message, err.details, err.hint]
-    .map((value) => String(value || ""))
-    .join(" ");
 
+  const { codes, text } = collectErrorSignals(error);
   const looksLikeSchemaError =
-    text.includes("schema cache") || text.includes("column") || err.code === "PGRST204" || err.code === "42703";
+    text.includes("schema cache") ||
+    text.includes("column") ||
+    codes.has("PGRST204") ||
+    codes.has("42703");
   if (!looksLikeSchemaError) return false;
 
   return CARDS_MISSING_IN_PRODUCTION_COLUMNS.some((column) => text.includes(column));

--- a/src/lib/db/error-signals.ts
+++ b/src/lib/db/error-signals.ts
@@ -1,0 +1,40 @@
+export type ErrorSignals = {
+  codes: Set<string>;
+  text: string;
+};
+
+type ErrorLike = {
+  code?: unknown;
+  message?: unknown;
+  detail?: unknown;
+  details?: unknown;
+  hint?: unknown;
+  query?: unknown;
+  cause?: unknown;
+};
+
+/**
+ * DrizzleQueryError などのラッパーを含む cause チェーンから、判定に必要な
+ * PostgreSQL/PostgREST のコードとテキストを収集する。自己参照・相互参照は
+ * visited で停止し、無限ループを防ぐ。
+ */
+export function collectErrorSignals(error: unknown): ErrorSignals {
+  const codes = new Set<string>();
+  const textParts: string[] = [];
+  const visited = new Set<object>();
+  let current: unknown = error;
+
+  while (current && typeof current === "object" && !visited.has(current)) {
+    visited.add(current);
+    const err = current as ErrorLike;
+
+    if (typeof err.code === "string") codes.add(err.code);
+    for (const value of [err.message, err.detail, err.details, err.hint, err.query]) {
+      if (value !== undefined && value !== null) textParts.push(String(value));
+    }
+
+    current = err.cause;
+  }
+
+  return { codes, text: textParts.join(" ") };
+}

--- a/tests/unit/cards-safe-columns.test.ts
+++ b/tests/unit/cards-safe-columns.test.ts
@@ -5,7 +5,7 @@
  * cards-route-driver-parity.test.ts / dashboard-data-driver-parity.test.ts が
  * 実クエリ経由で間接的に検証しているため、ここでは #685 で新設した
  * withCardsBattleColumnFallback の制御フロー（成功・フォールバック・再送出）
- * のみを、Drizzle モックを介さず直接テストする。
+ * を、Drizzle モックを介さず直接テストする。
  */
 import { describe, it, expect, vi } from 'vitest'
 import { withCardsBattleColumnFallback } from '@/lib/db/cards-safe-columns'
@@ -14,6 +14,20 @@ function missingCardsBattleColumnError(column: string = 'hp') {
   return Object.assign(new Error(`column "${column}" of relation "cards" does not exist`), {
     code: '42703',
   })
+}
+
+function drizzleWrappedMissingColumnError(column: string = 'card_number') {
+  const error = new Error(
+    `Failed query: select "id", "streamer_id", "${column}", "created_at" from "cards"`
+  ) as Error & { cause?: unknown; query?: string }
+  error.query = `select "id", "streamer_id", "${column}", "created_at" from "cards"`
+  error.cause = {
+    code: '42703',
+    severity: 'ERROR',
+    routine: 'errorMissingColumn',
+    position: '27',
+  }
+  return error
 }
 
 describe('withCardsBattleColumnFallback', () => {
@@ -43,6 +57,18 @@ describe('withCardsBattleColumnFallback', () => {
     expect(attempt).toHaveBeenNthCalledWith(2, true)
   })
 
+  it('DrizzleQueryErrorのcauseに42703がある場合も安全列で再試行する (#779)', async () => {
+    const attempt = vi.fn(async (useSafeColumns: boolean) => {
+      if (!useSafeColumns) throw drizzleWrappedMissingColumnError('card_number')
+      return 'safe'
+    })
+
+    await expect(withCardsBattleColumnFallback(attempt)).resolves.toBe('safe')
+    expect(attempt).toHaveBeenCalledTimes(2)
+    expect(attempt).toHaveBeenNthCalledWith(1, false)
+    expect(attempt).toHaveBeenNthCalledWith(2, true)
+  })
+
   it('8列のいずれでもエラーを検知する', async () => {
     const columns = ['card_number', 'hp', 'atk', 'def', 'spd', 'skill_type', 'skill_name', 'skill_power']
     for (const column of columns) {
@@ -62,6 +88,16 @@ describe('withCardsBattleColumnFallback', () => {
 
     await expect(withCardsBattleColumnFallback(attempt)).rejects.toBe(permissionError)
     // 該当しないエラーでは2回目の再試行（useSafeColumns=true）を行わない
+    expect(attempt).toHaveBeenCalledTimes(1)
+  })
+
+  it('無関係な列のDrizzleQueryErrorはフォールバックしない', async () => {
+    const unrelatedError = drizzleWrappedMissingColumnError('unrelated_column')
+    const attempt = vi.fn(async () => {
+      throw unrelatedError
+    })
+
+    await expect(withCardsBattleColumnFallback(attempt)).rejects.toBe(unrelatedError)
     expect(attempt).toHaveBeenCalledTimes(1)
   })
 

--- a/tests/unit/db-error-signals.test.ts
+++ b/tests/unit/db-error-signals.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { collectErrorSignals } from "@/lib/db/error-signals";
+
+describe("collectErrorSignals", () => {
+  it("causeチェーンからcodeとpgのdetailを収集する", () => {
+    const error = Object.assign(new Error("Failed query: select card_number from cards"), {
+      cause: {
+        code: "42703",
+        detail: "column card_number does not exist",
+      },
+    });
+
+    const signals = collectErrorSignals(error);
+    expect(signals.codes.has("42703")).toBe(true);
+    expect(signals.text).toContain("card_number");
+    expect(signals.text).toContain("does not exist");
+  });
+
+  it("自己参照するcauseでも停止する", () => {
+    const error = Object.assign(new Error("schema cache card_number"), {
+      code: "PGRST204",
+      cause: undefined as unknown,
+    });
+    error.cause = error;
+
+    const signals = collectErrorSignals(error);
+    expect(signals.codes.has("PGRST204")).toBe(true);
+    expect(signals.text).toContain("card_number");
+  });
+
+  it("相互参照するcauseでも停止する", () => {
+    const first: { message: string; cause?: unknown } = { message: "outer" };
+    const second: { code: string; detail: string; cause?: unknown } = {
+      code: "42703",
+      detail: "column hp does not exist",
+    };
+    first.cause = second;
+    second.cause = first;
+
+    const signals = collectErrorSignals(first);
+    expect(signals.codes.has("42703")).toBe(true);
+    expect(signals.text).toContain("hp");
+  });
+});


### PR DESCRIPTION
## 終了理由

Issue #779の根本原因は、mainへ直接入ったコミット `773cd5b00869c61508a47844bcc8373857a1c6e1` で、より広い範囲を含めて恒久対応されました。

同コミットでは以下が実施されています。

- Drizzleの`cause`チェーンを循環参照ガード付きで解析
- `cards-safe-columns`、`card-number-errors`、`card-issuance`、`collection-existence`の兄弟判定を統一
- リトライ判定やガチャ系のエラー正規化も同型問題へ対応
- 本番エラーペイロード形状の回帰テストを追加
- 厳格レビュー指摘を反映済み

このPRを再オープンすると、main側の包括修正と重複・競合するため、未マージのまま閉じます。

Superseded by `773cd5b00869c61508a47844bcc8373857a1c6e1`.

Closes #779