### PR TITLE
feat(channel-points): 非Affiliate配信者のCapability判定・明示的オプトインを実装する (#788)

### DIFF
--- a/config/maintenance-write-surfaces.json
+++ b/config/maintenance-write-surfaces.json
@@ -1,5 +1,17 @@
 [
   {
+    "path": "/api/account/channel-points",
+    "methods": [
+      "POST",
+      "PUT"
+    ],
+    "category": "account",
+    "maintenanceBehavior": "block",
+    "reason": "非Affiliate配信者のChannel Points Capability再判定(POST)・明示的有効化(PUT)。DB書き込み(capability確定状態・channel_points_enabled・streamers UPSERT)を伴う。allowlist未登録のため一律ブロックに従う。",
+    "owner": "azumag",
+    "reviewedAt": "2026-07-23"
+  },
+  {
     "path": "/api/admin/eventsub-replay",
     "methods": [
       "POST"

--- a/messages/en.json
+++ b/messages/en.json
@@ -1356,6 +1356,7 @@
     "capabilityLostWarning": "Channel Points actions require re-authorization or a recheck. Your streaming settings remain accessible.",
     "messages": {
       "enableSuccess": "Streamer features have been enabled.",
+      "enableSuccessSessionPending": "Streamer features have been enabled, but your session could not be refreshed. You may need to log in again for it to fully take effect.",
       "enableFailed": "Failed to enable. Please try again later.",
       "genericError": "An error occurred. Please try again later."
     }

--- a/messages/en.json
+++ b/messages/en.json
@@ -586,7 +586,6 @@
       "mainRewardDesc": "Choose the channel point redemption that triggers card draws, and the card pack it draws from."
     },
     "messages": {
-      "affiliateRequired": "You must be a Twitch Affiliate or Partner to use channel points.",
       "rateLimit": "Too many requests. Please wait and try again.",
       "fetchFailed": "Failed to fetch redemptions. Please log in again.",
       "rewardCreated": "Redemption created",
@@ -596,7 +595,9 @@
       "saveSuccess": "Saved (EventSub registration complete)",
       "eventsubFailed": "Settings saved, but EventSub registration failed. Please verify the URL is accessible externally.",
       "scopeRequired": "To enable the Channel Points integration, please grant Twitch permission to read and manage your channel point redemptions.",
-      "reauthorizeFailed": "Re-authentication failed. Please try again later."
+      "reauthorizeFailed": "Re-authentication failed. Please try again later.",
+      "channelPointsUnavailable": "Channel Points are not currently available on Twitch for this channel. Please check your monetization onboarding and Channel Points settings in the Twitch Creator Dashboard.",
+      "temporarilyUnavailable": "Temporarily unable to check with Twitch. Please try again shortly."
     },
     "form": {
       "selectReward": "Select the channel point redemption that triggers card draws",
@@ -1040,7 +1041,8 @@
     "dashboard": "Dashboard",
     "userSettings": "User Settings",
     "logout": "Logout",
-    "announcements": "Announcements"
+    "announcements": "Announcements",
+    "streamerBadge": "Streamer"
   },
   "accountPage": {
     "title": "User Settings",
@@ -1316,6 +1318,46 @@
       "checkFailed": "Check failed. Please try again later.",
       "reauthorizeFailed": "Re-authorization failed.",
       "networkError": "A network error occurred."
+    }
+  },
+  "channelPointsAccess": {
+    "title": "Channel Points / Streamer Features",
+    "description": "Check whether Channel Points are available on Twitch for your channel, and explicitly enable twica's streamer features even if you're not a Twitch Affiliate.",
+    "loading": "Loading status...",
+    "affiliate": {
+      "message": "You already have access to streamer features as a Twitch Affiliate/Partner."
+    },
+    "reauth": {
+      "message": "Checking Channel Points availability requires additional Twitch permission.",
+      "button": "Re-link with Twitch to check",
+      "buttonLoading": "Redirecting..."
+    },
+    "checking": {
+      "message": "Checking with Twitch..."
+    },
+    "available": {
+      "message": "We confirmed Channel Points are available on Twitch for your channel.",
+      "enableDescription": "Enabling this unlocks card management, overlays, and reward settings.",
+      "enableButton": "Enable streamer features on twica",
+      "enableButtonLoading": "Enabling..."
+    },
+    "enabled": {
+      "message": "Streamer features are enabled.",
+      "settingsLink": "Open streaming settings"
+    },
+    "unavailable": {
+      "message": "Channel Points are not currently available on Twitch for this channel. Please check your monetization onboarding and Channel Points settings in the Twitch Creator Dashboard.",
+      "recheckButton": "Recheck"
+    },
+    "unknown": {
+      "message": "Temporarily unable to check with Twitch. Your saved status has not changed.",
+      "retryButton": "Retry"
+    },
+    "capabilityLostWarning": "Channel Points actions require re-authorization or a recheck. Your streaming settings remain accessible.",
+    "messages": {
+      "enableSuccess": "Streamer features have been enabled.",
+      "enableFailed": "Failed to enable. Please try again later.",
+      "genericError": "An error occurred. Please try again later."
     }
   }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1353,6 +1353,7 @@
     "capabilityLostWarning": "Channel Points操作には再認証・再判定が必要です。配信設定自体は引き続き利用できます。",
     "messages": {
       "enableSuccess": "配信者機能を有効化しました。",
+      "enableSuccessSessionPending": "配信者機能を有効化しました。ただしセッションの更新に失敗したため、反映には再ログインが必要な場合があります。",
       "enableFailed": "有効化に失敗しました。時間をおいて再試行してください。",
       "genericError": "エラーが発生しました。時間をおいて再試行してください。"
     }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -586,7 +586,6 @@
       "mainRewardDesc": "カードの排出につながるチャネルポイント引き換えと、排出対象のカードパックを設定します"
     },
     "messages": {
-      "affiliateRequired": "チャネルポイントを使用するには、Twitchアフィリエイトまたはパートナーである必要があります。",
       "rateLimit": "リクエストが多すぎます。しばらく待ってから再試行してください。",
       "fetchFailed": "チャネルポイント引き換えの取得に失敗しました。再度ログインしてください。",
       "rewardCreated": "チャネルポイント引き換えを作成しました",
@@ -596,7 +595,9 @@
       "saveSuccess": "保存しました（EventSub登録完了）",
       "eventsubFailed": "設定は保存しましたが、EventSub登録に失敗しました。URLが外部からアクセス可能か確認してください。",
       "scopeRequired": "チャネルポイント連携を有効化するには、Twitchでチャネルポイント引き換えの読み取り・管理権限の許可が必要です。",
-      "reauthorizeFailed": "再認証に失敗しました。時間をおいて再度お試しください。"
+      "reauthorizeFailed": "再認証に失敗しました。時間をおいて再度お試しください。",
+      "channelPointsUnavailable": "現在Twitch上でチャネルポイントを利用できません。Twitch Creator Dashboardで収益化オンボーディングとチャネルポイント設定をご確認ください。",
+      "temporarilyUnavailable": "Twitchへの確認に一時的に失敗しました。時間をおいて再試行してください。"
     },
     "form": {
       "selectReward": "カード引き換えのきっかけにするチャネルポイント引き換えを選択",
@@ -1037,7 +1038,8 @@
     "dashboard": "ダッシュボード",
     "userSettings": "ユーザー設定",
     "logout": "ログアウト",
-    "announcements": "お知らせ"
+    "announcements": "お知らせ",
+    "streamerBadge": "配信者"
   },
   "accountPage": {
     "title": "ユーザー設定",
@@ -1313,6 +1315,46 @@
       "checkFailed": "確認に失敗しました。しばらくしてから再試行してください。",
       "reauthorizeFailed": "再認証に失敗しました。",
       "networkError": "ネットワークエラーが発生しました。"
+    }
+  },
+  "channelPointsAccess": {
+    "title": "チャネルポイント / 配信者機能",
+    "description": "Twitch上でチャネルポイントを利用できるかを確認し、非Affiliateでも利用可能な場合はtwicaの配信者機能を明示的に有効化できます。",
+    "loading": "確認状況を読み込み中...",
+    "affiliate": {
+      "message": "Twitchアフィリエイト/パートナーとして、既に配信者機能を利用できます。"
+    },
+    "reauth": {
+      "message": "チャネルポイントの利用可否を確認するには、Twitchでの追加権限の許可が必要です。",
+      "button": "Twitchと再連携して確認",
+      "buttonLoading": "リダイレクト中..."
+    },
+    "checking": {
+      "message": "Twitchへ確認中です..."
+    },
+    "available": {
+      "message": "Twitch上でチャネルポイントを利用できることを確認しました。",
+      "enableDescription": "有効化すると、カード管理・オーバーレイ・報酬設定が利用できるようになります。",
+      "enableButton": "twicaで配信者機能を有効にする",
+      "enableButtonLoading": "有効化中..."
+    },
+    "enabled": {
+      "message": "配信者機能が有効化されています。",
+      "settingsLink": "配信設定を開く"
+    },
+    "unavailable": {
+      "message": "現在Twitch上でチャネルポイントを利用できません。Twitch Creator Dashboardで収益化オンボーディングとチャネルポイント設定をご確認ください。",
+      "recheckButton": "再判定"
+    },
+    "unknown": {
+      "message": "Twitchへの確認に一時的に失敗しました。保存済みの状態は変わっていません。",
+      "retryButton": "再試行"
+    },
+    "capabilityLostWarning": "Channel Points操作には再認証・再判定が必要です。配信設定自体は引き続き利用できます。",
+    "messages": {
+      "enableSuccess": "配信者機能を有効化しました。",
+      "enableFailed": "有効化に失敗しました。時間をおいて再試行してください。",
+      "genericError": "エラーが発生しました。時間をおいて再試行してください。"
     }
   }
 }

--- a/src/app/api/account/channel-points/route.ts
+++ b/src/app/api/account/channel-points/route.ts
@@ -1,0 +1,243 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getSession, signSession } from '@/lib/session'
+import { validateCSRFToken } from '@/lib/csrf'
+import { validateContentType } from '@/lib/request-validation'
+import { checkRateLimit, rateLimits, getRateLimitIdentifier } from '@/lib/rate-limit'
+import { handleApiError } from '@/lib/error-handler'
+import { BROADCASTER_TYPE, COOKIE_NAMES, ERROR_MESSAGES, getSessionCookieOptions } from '@/lib/constants'
+import { ADDITIONAL_SCOPES } from '@/lib/twitch/scopes'
+import { hasScope } from '@/lib/twitch/token-manager'
+import { probeChannelPointsCapability, type DefinitiveCapabilityResult } from '@/lib/twitch/channel-points'
+import {
+  enableChannelPointsStreamerAccess,
+  getChannelPointsAccessState,
+  persistChannelPointsCapability,
+} from '@/lib/twitch/channel-points-access'
+import { logger } from '@/lib/logger'
+
+// #788 子C #791: 保存済みcapability確認が「stale」とみなされる猶予期間。
+// これを超えたら/dashboard/accountの初回表示時にUIが自動で再判定(POST)する。
+const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000
+
+async function hasChannelPointsScope(twitchUserId: string): Promise<boolean> {
+  const [hasRead, hasManage] = await Promise.all([
+    hasScope(twitchUserId, ADDITIONAL_SCOPES.CHANNEL_READ_REDEMPTIONS),
+    hasScope(twitchUserId, ADDITIONAL_SCOPES.CHANNEL_MANAGE_REDEMPTIONS),
+  ])
+  return hasRead || hasManage
+}
+
+function isStale(capability: string, checkedAt: string | null): boolean {
+  if (capability === 'unknown' || !checkedAt) return true
+  const checkedAtMs = new Date(checkedAt).getTime()
+  if (Number.isNaN(checkedAtMs)) return true
+  return Date.now() - checkedAtMs > STALE_THRESHOLD_MS
+}
+
+/**
+ * スコープ不足を検出した際に、確定状態としてreauth_requiredを保存する共通処理。
+ * 永続化自体の失敗はレスポンスを巻き込まない（warnログのみ）。
+ */
+async function persistReauthRequired(twitchUserId: string): Promise<void> {
+  const result: DefinitiveCapabilityResult = {
+    capability: 'reauth_required',
+    reason: 'no_access_token',
+    definitive: true,
+  }
+  try {
+    await persistChannelPointsCapability(twitchUserId, result)
+  } catch (error) {
+    logger.warn('Account Channel Points API: failed to persist reauth_required (missing scope)', {
+      twitchUserId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+/**
+ * GET: 副作用なしで保存済みCapability/オプトイン状態と付随情報を返す (#791)。
+ * 認証済みsession必須。canEnableはbroadcasterTypeが空・capabilityがavailable・
+ * 未有効化の場合のみtrueになる（Affiliate/Partnerは対象外）。
+ */
+export async function GET() {
+  try {
+    const session = await getSession()
+    if (!session) {
+      return NextResponse.json({ error: ERROR_MESSAGES.UNAUTHORIZED }, { status: 401 })
+    }
+
+    const [state, hasRequiredScope] = await Promise.all([
+      getChannelPointsAccessState(session.twitchUserId),
+      hasChannelPointsScope(session.twitchUserId),
+    ])
+
+    const capability = state?.capability ?? 'unknown'
+    const capabilityCheckedAt = state?.checkedAt ?? null
+    const enabled = state?.enabled === true
+    const requiresReauth = !hasRequiredScope || capability === 'reauth_required'
+    const stale = isStale(capability, capabilityCheckedAt)
+    const canEnable = session.broadcasterType === BROADCASTER_TYPE.NONE && capability === 'available' && !enabled
+
+    return NextResponse.json({
+      broadcasterType: session.broadcasterType,
+      capability,
+      capabilityCheckedAt,
+      enabled,
+      hasRequiredScope,
+      requiresReauth,
+      stale,
+      canEnable,
+    })
+  } catch (error) {
+    return handleApiError(error, 'Account Channel Points API: GET')
+  }
+}
+
+/**
+ * POST: 明示的な「確認」「再判定」。scope不足ならreauth_requiredを確定保存して返す。
+ * scopeがあればCapability Probeを実行し、definitiveな結果のみDBへ保存する。
+ * 429/5xx/network error等（definitive=false）は保存済みの確定状態を破壊しない。
+ */
+export async function POST(request: NextRequest) {
+  const contentTypeValidation = validateContentType(request, 'application/json')
+  if (contentTypeValidation) return contentTypeValidation
+
+  const csrfValidation = await validateCSRFToken(request)
+  if (!csrfValidation.valid) {
+    return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 })
+  }
+
+  try {
+    const session = await getSession()
+    const identifier = await getRateLimitIdentifier(request, session?.twitchUserId)
+    const rateLimitResult = await checkRateLimit(rateLimits.accountChannelPointsProbe, identifier)
+    if (!rateLimitResult.success) {
+      return NextResponse.json({ error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED }, { status: 429 })
+    }
+
+    if (!session) {
+      return NextResponse.json({ error: ERROR_MESSAGES.UNAUTHORIZED }, { status: 401 })
+    }
+
+    if (!(await hasChannelPointsScope(session.twitchUserId))) {
+      await persistReauthRequired(session.twitchUserId)
+      const state = await getChannelPointsAccessState(session.twitchUserId)
+      return NextResponse.json({
+        code: 'reauth_required',
+        probe: { capability: 'reauth_required', reason: 'no_access_token', definitive: true },
+        persisted: state ? { capability: state.capability, capabilityCheckedAt: state.checkedAt } : null,
+        enabled: state?.enabled === true,
+      })
+    }
+
+    const probeResult = await probeChannelPointsCapability(session.twitchUserId)
+    if (probeResult.definitive) {
+      await persistChannelPointsCapability(session.twitchUserId, probeResult)
+    }
+    const state = await getChannelPointsAccessState(session.twitchUserId)
+
+    return NextResponse.json({
+      code: probeResult.definitive ? probeResult.capability : 'probe_temporarily_failed',
+      probe: probeResult,
+      persisted: state ? { capability: state.capability, capabilityCheckedAt: state.checkedAt } : null,
+      enabled: state?.enabled === true,
+    })
+  } catch (error) {
+    return handleApiError(error, 'Account Channel Points API: POST')
+  }
+}
+
+/**
+ * PUT: 明示的有効化。対象は常にsession本人（bodyから任意のIDを受け付けない）。
+ * Affiliate/Partnerはidempotent success（DB flagは不要にtrue化しない）。
+ * 保存済みavailableを信用せず、必ず新規Probeを実行してから有効化する。
+ * DB更新（RPC）に成功した場合のみsession cookieを再署名する。
+ */
+export async function PUT(request: NextRequest) {
+  // このrouteはbodyを使用しない（有効化対象は常にsession本人）ため、
+  // Content-Type検証は行わない（cards/[id]のPUTと同じ判断）。
+  const csrfValidation = await validateCSRFToken(request)
+  if (!csrfValidation.valid) {
+    return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 })
+  }
+
+  try {
+    const session = await getSession()
+    const identifier = await getRateLimitIdentifier(request, session?.twitchUserId)
+    const rateLimitResult = await checkRateLimit(rateLimits.accountChannelPointsProbe, identifier)
+    if (!rateLimitResult.success) {
+      return NextResponse.json({ error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED }, { status: 429 })
+    }
+
+    if (!session) {
+      return NextResponse.json({ error: ERROR_MESSAGES.UNAUTHORIZED }, { status: 401 })
+    }
+
+    // Affiliate/Partnerは既存アクセス経路を持つため有効化対象ではない。
+    // idempotent successとして返し、DB flagを不要にtrue化しない。
+    if (session.broadcasterType === BROADCASTER_TYPE.AFFILIATE || session.broadcasterType === BROADCASTER_TYPE.PARTNER) {
+      return NextResponse.json({ code: 'already_enabled', enabled: true })
+    }
+
+    if (!(await hasChannelPointsScope(session.twitchUserId))) {
+      await persistReauthRequired(session.twitchUserId)
+      return NextResponse.json({ code: 'reauth_required', enabled: false }, { status: 409 })
+    }
+
+    // 保存済みのavailableを信用せず、必ず新しいProbeで再検証する。
+    const probeResult = await probeChannelPointsCapability(session.twitchUserId)
+    if (probeResult.definitive) {
+      await persistChannelPointsCapability(session.twitchUserId, probeResult)
+    }
+
+    if (probeResult.capability !== 'available') {
+      const code =
+        probeResult.capability === 'reauth_required'
+          ? 'reauth_required'
+          : probeResult.capability === 'unavailable'
+            ? 'channel_points_unavailable'
+            : 'probe_temporarily_failed'
+      return NextResponse.json({ code, enabled: false, probe: probeResult }, { status: 409 })
+    }
+
+    const enableResult = await enableChannelPointsStreamerAccess(session.twitchUserId)
+    if (!enableResult.ok) {
+      const code = enableResult.error === 'capability_not_available' ? 'channel_points_unavailable' : 'user_not_found'
+      return NextResponse.json({ code, enabled: false }, { status: 409 })
+    }
+
+    // DB更新は成功済み。ここから先はsession cookieの再署名のみで、
+    // 失敗してもDBをtrueから巻き戻さない（次回ログインでsession mirrorが復元される）。
+    try {
+      const updatedSessionPayload = {
+        ...session,
+        channelPointsEnabled: true,
+        version: session.version + 1,
+      }
+      const signedSession = await signSession(JSON.stringify(updatedSessionPayload))
+      const response = NextResponse.json({
+        code: 'enabled',
+        enabled: true,
+        streamerId: enableResult.streamerId,
+      })
+      response.cookies.set(COOKIE_NAMES.SESSION, signedSession, getSessionCookieOptions())
+      return response
+    } catch (error) {
+      logger.error('Account Channel Points API: DB enabled but session re-sign failed', {
+        twitchUserId: session.twitchUserId,
+        streamerId: enableResult.streamerId,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return NextResponse.json(
+        {
+          code: 'session_resync_failed',
+          enabled: true,
+          error: 'Enabled successfully, but failed to refresh your session. Please retry or log in again.',
+        },
+        { status: 500 }
+      )
+    }
+  } catch (error) {
+    return handleApiError(error, 'Account Channel Points API: PUT')
+  }
+}

--- a/src/app/api/account/channel-points/route.ts
+++ b/src/app/api/account/channel-points/route.ts
@@ -7,7 +7,11 @@ import { handleApiError } from '@/lib/error-handler'
 import { BROADCASTER_TYPE, COOKIE_NAMES, ERROR_MESSAGES, getSessionCookieOptions } from '@/lib/constants'
 import { ADDITIONAL_SCOPES } from '@/lib/twitch/scopes'
 import { hasScope } from '@/lib/twitch/token-manager'
-import { probeChannelPointsCapability, type DefinitiveCapabilityResult } from '@/lib/twitch/channel-points'
+import {
+  isDefinitiveCapabilityResult,
+  probeChannelPointsCapability,
+  type DefinitiveCapabilityResult,
+} from '@/lib/twitch/channel-points'
 import {
   enableChannelPointsStreamerAccess,
   getChannelPointsAccessState,
@@ -131,7 +135,7 @@ export async function POST(request: NextRequest) {
     }
 
     const probeResult = await probeChannelPointsCapability(session.twitchUserId)
-    if (probeResult.definitive) {
+    if (isDefinitiveCapabilityResult(probeResult)) {
       await persistChannelPointsCapability(session.twitchUserId, probeResult)
     }
     const state = await getChannelPointsAccessState(session.twitchUserId)
@@ -186,7 +190,7 @@ export async function PUT(request: NextRequest) {
 
     // 保存済みのavailableを信用せず、必ず新しいProbeで再検証する。
     const probeResult = await probeChannelPointsCapability(session.twitchUserId)
-    if (probeResult.definitive) {
+    if (isDefinitiveCapabilityResult(probeResult)) {
       await persistChannelPointsCapability(session.twitchUserId, probeResult)
     }
 

--- a/src/app/api/auth/reauth/route.ts
+++ b/src/app/api/auth/reauth/route.ts
@@ -88,9 +88,13 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: ERROR_MESSAGES.UNAUTHORIZED }, { status: 401 })
     }
 
-    // リクエストボディから追加スコープを取得（オプション）
-    // Get additional scopes from request body (optional)
+    // リクエストボディから追加スコープ・returnToを取得（オプション）
+    // Get additional scopes and returnTo from request body (optional)
     let requestedScopes: string[] = []
+    // #788 子C #791: アカウント設定からのstep-up再認証がcallback後に同じページへ
+    // 戻れるよう、任意のreturnToを受け付ける。login/route.tsの既存パターン
+    // （'/'始まり・'//'非始まりの同一origin相対パスのみ許可）を踏襲する。
+    let returnTo: string | undefined
     try {
       const body = await request.json()
       if (body.additionalScopes && Array.isArray(body.additionalScopes)) {
@@ -99,6 +103,13 @@ export async function POST(request: Request) {
         requestedScopes = body.additionalScopes.filter((scope: string) =>
           VALID_ADDITIONAL_SCOPES.includes(scope)
         )
+      }
+      if (
+        typeof body.returnTo === 'string' &&
+        body.returnTo.startsWith('/') &&
+        !body.returnTo.startsWith('//')
+      ) {
+        returnTo = body.returnTo
       }
     } catch {
       // JSONパースエラーは無視（ボディが空の場合も含む）
@@ -168,6 +179,12 @@ export async function POST(request: Request) {
     // callbackで再認証フローを識別するためにstateを保存
     // Store state marker so callback can identify re-auth flow
     response.cookies.set(COOKIE_NAMES.REAUTH_STATE, state, STATE_COOKIE_OPTIONS)
+
+    // #788 子C #791: returnToが指定されていればcallback後の戻り先としてserver-side設定する
+    // （clientがdocument.cookieを直接書く方式は取らない）
+    if (returnTo) {
+      response.cookies.set(COOKIE_NAMES.RETURN_TO, returnTo, STATE_COOKIE_OPTIONS)
+    }
 
     return response
   } catch (error) {

--- a/src/app/api/auth/twitch/callback/route.ts
+++ b/src/app/api/auth/twitch/callback/route.ts
@@ -24,6 +24,8 @@ import { getDb } from '@/lib/db/client'
 import { isPgReadEnabled, isPgWriteEnabled } from '@/lib/db/flags'
 import { withDbRetry } from '@/lib/db/retry'
 import { streamers as streamersTable, users as usersTable } from '@/lib/db/schema'
+import { probeChannelPointsCapability } from '@/lib/twitch/channel-points'
+import { persistChannelPointsCapability } from '@/lib/twitch/channel-points-access'
 
 interface AuthCallbackDriverError {
   code?: string
@@ -180,6 +182,34 @@ async function upsertAuthStreamerPg(payload: {
  * 継続するため、この極めて稀なケース（クエリは成功するが行取得だけ失敗する状況）
  * でのみ挙動が異なる。安全側にしか倒れないため許容する。
  */
+/**
+ * channel_points_enabled フラグ単独読み取りの pg 直結実装 (#788 子C #791)。
+ *
+ * 意図的に users upsert / 他の読み取りから独立させている（Fable設計レビュー
+ * Critical-1）: このフラグ読み取りが users upsert に混ざっていると、
+ * migration未適用のデプロイ窓で列が存在せず upsert 自体が失敗し、
+ * affiliate/partnerを含む全ユーザーのログインが壊れてしまう。呼び出し元は
+ * このクエリのあらゆる失敗（列未適用の42703を含む）を catch し、false へ
+ * フォールバックしてログインを継続させる。
+ */
+async function fetchChannelPointsEnabledFlagPg(twitchUserId: string): Promise<boolean> {
+  const rows = await withDbRetry(
+    async () => {
+      // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+      const { db } = await getDb()
+      return db
+        .select({ channel_points_enabled: usersTable.channel_points_enabled })
+        .from(usersTable)
+        .where(eq(usersTable.twitch_user_id, twitchUserId))
+        .limit(1)
+    },
+    'auth callback(channel points enabled flag)',
+    // 読み取り専用クエリのため冪等（リトライ可）
+    { idempotent: true }
+  )
+  return rows[0]?.channel_points_enabled === true
+}
+
 async function fetchTosAcceptedPg(twitchUserId: string): Promise<{ tos_accepted_at: string | null } | null> {
   const rows = await withDbRetry(
     async () => {
@@ -542,6 +572,54 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    // #788 子C #791: channel_points_enabled フラグを独立読み取りし、セッションへミラーする。
+    // users upsertには混ぜない（Critical-1、fetchChannelPointsEnabledFlagPgのdocコメント参照）。
+    // あらゆる失敗（新列未適用の42703/PGRST204を含む）でfalseへフォールバックし、
+    // ログイン自体は継続する。
+    let channelPointsEnabled = false
+    try {
+      if (isPgReadEnabled()) {
+        channelPointsEnabled = await fetchChannelPointsEnabledFlagPg(twitchUser.id)
+      } else {
+        const { data: cpUser, error: cpError } = await supabaseAdmin
+          .from('users')
+          .select('channel_points_enabled')
+          .eq('twitch_user_id', twitchUser.id)
+          .maybeSingle()
+        if (cpError) throw cpError
+        channelPointsEnabled = cpUser?.channel_points_enabled === true
+      }
+    } catch (error) {
+      logger.warn('Auth callback: Failed to read channel_points_enabled flag (falling back to false)', {
+        twitchUserId: twitchUser.id,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      channelPointsEnabled = false
+    }
+
+    // #788 子C #791: step-up再認証直後（isReauthFlow）でChannel Pointsスコープを
+    // 新たに取得した場合のみCapability Probeを自動実行する。毎ログインでは実行しない
+    // （stale再判定の責務はアカウント設定UIの自動POSTに置く。Fable設計レビュー2回目 Major）。
+    // definitiveな結果のみ保存し、ログイン自体は失敗させない。
+    if (isReauthFlow && tokens.scope) {
+      const hasChannelPointsScope =
+        tokens.scope.includes(ADDITIONAL_SCOPES.CHANNEL_READ_REDEMPTIONS) ||
+        tokens.scope.includes(ADDITIONAL_SCOPES.CHANNEL_MANAGE_REDEMPTIONS)
+      if (hasChannelPointsScope) {
+        try {
+          const probeResult = await probeChannelPointsCapability(twitchUser.id)
+          if (probeResult.definitive) {
+            await persistChannelPointsCapability(twitchUser.id, probeResult)
+          }
+        } catch (error) {
+          logger.warn('Auth callback: Channel Points capability probe failed (ignored, login continues)', {
+            twitchUserId: twitchUser.id,
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+      }
+    }
+
     // Set session cookie with user info only (no tokens - Supabase Auth handles tokens)
     const sessionData = JSON.stringify({
       twitchUserId: twitchUser.id,
@@ -551,6 +629,7 @@ export async function GET(request: NextRequest) {
       broadcasterType: twitchUser.broadcaster_type,
       expiresAt: Date.now() + SESSION_CONFIG.MAX_AGE_MS,
       version: 1,
+      channelPointsEnabled,
     })
 
     // Log session data size for debugging

--- a/src/app/api/auth/twitch/callback/route.ts
+++ b/src/app/api/auth/twitch/callback/route.ts
@@ -24,7 +24,7 @@ import { getDb } from '@/lib/db/client'
 import { isPgReadEnabled, isPgWriteEnabled } from '@/lib/db/flags'
 import { withDbRetry } from '@/lib/db/retry'
 import { streamers as streamersTable, users as usersTable } from '@/lib/db/schema'
-import { probeChannelPointsCapability } from '@/lib/twitch/channel-points'
+import { isDefinitiveCapabilityResult, probeChannelPointsCapability } from '@/lib/twitch/channel-points'
 import { persistChannelPointsCapability } from '@/lib/twitch/channel-points-access'
 
 interface AuthCallbackDriverError {
@@ -608,7 +608,7 @@ export async function GET(request: NextRequest) {
       if (hasChannelPointsScope) {
         try {
           const probeResult = await probeChannelPointsCapability(twitchUser.id)
-          if (probeResult.definitive) {
+          if (isDefinitiveCapabilityResult(probeResult)) {
             await persistChannelPointsCapability(twitchUser.id, probeResult)
           }
         } catch (error) {

--- a/src/app/api/auth/twitch/callback/route.ts
+++ b/src/app/api/auth/twitch/callback/route.ts
@@ -344,6 +344,10 @@ export async function GET(request: NextRequest) {
     }
 
     // Check if user can be a streamer (affiliate or partner)
+    // #788 子E #793: これはAffiliate/Partnerの既存自動プロビジョニング専用の判定であり、
+    // 意図的にbroadcaster_typeのみを見ている。非Affiliateユーザーの明示的オプトインによる
+    // streamers行作成は/api/account/channel-points PUT (enableChannelPointsStreamerAccess)
+    // という別経路で行われ、ここでは変更しない。
     const canBeStreamer = twitchUser.broadcaster_type === 'affiliate' || twitchUser.broadcaster_type === 'partner'
 
     // スコープ復元ガードCookieを確認（login側でDB障害等によりスコープ復元に失敗した場合に設定される）

--- a/src/app/api/twitch/channel-point-bootstrap/route.ts
+++ b/src/app/api/twitch/channel-point-bootstrap/route.ts
@@ -23,7 +23,11 @@ import {
   streamers as streamersTable,
   streamerAdditionalGachaRewards as streamerAdditionalGachaRewardsTable,
 } from "@/lib/db/schema";
-import { getChannelPointsAccessState, recordChannelPointsApiFailure } from "@/lib/twitch/channel-points-access";
+import {
+  getChannelPointsAccessState,
+  persistChannelPointsCapability,
+  recordChannelPointsApiFailure,
+} from "@/lib/twitch/channel-points-access";
 
 const TWITCH_API_URL = "https://api.twitch.tv/helix";
 
@@ -433,7 +437,22 @@ export async function GET(request: NextRequest) {
     if (capabilitySyncStatus) {
       await recordChannelPointsApiFailure(session.twitchUserId, capabilitySyncStatus);
     }
-    const accessState = await getChannelPointsAccessState(session.twitchUserId);
+    let accessState = await getChannelPointsAccessState(session.twitchUserId);
+
+    // #788 子E #793 Fableレビュー Major-2: Twitch APIが実際に200で成功したにもかかわらず、
+    // 保存済みcapabilityが古いunavailable/reauth_required/unknownのままだと、報酬一覧は
+    // 正常に返るのにUIが「利用不可」エラーを表示し続けてしまう（オンボーディング完了後の
+    // 自己回復手段が手動再判定しかない状態）。実際の200成功を根拠にavailableへ回復させる。
+    // 既にavailableなら無駄な書き込みをしない。
+    if (!capabilitySyncStatus && !requiresReauth && !temporarilyUnavailable && accessState?.capability !== "available") {
+      await persistChannelPointsCapability(session.twitchUserId, {
+        capability: "available",
+        reason: "ok",
+        httpStatus: 200,
+        definitive: true,
+      });
+      accessState = await getChannelPointsAccessState(session.twitchUserId);
+    }
 
     const responsePayload: Record<string, unknown> = {
       hasRequiredScope: true,

--- a/src/app/api/twitch/channel-point-bootstrap/route.ts
+++ b/src/app/api/twitch/channel-point-bootstrap/route.ts
@@ -11,6 +11,7 @@ import {
   type EventSubSubscriptionForStatus,
 } from "@/lib/twitch/eventsub-status";
 import { logPerf, perfStart } from "@/lib/perf";
+import { logger } from "@/lib/logger";
 // Issue #690 (#570 パイロット踏襲): pg 直結の読み取り経路。DB_DRIVER=pg-read/pg の
 // ときのみ使われる。getDb() は withDbRetry の queryFn 内で呼ぶ規約
 // (src/lib/db/retry.ts 参照)。フラグ未設定時はこれらのモジュールは一切呼ばれない。
@@ -445,13 +446,24 @@ export async function GET(request: NextRequest) {
     // 自己回復手段が手動再判定しかない状態）。実際の200成功を根拠にavailableへ回復させる。
     // 既にavailableなら無駄な書き込みをしない。
     if (!capabilitySyncStatus && !requiresReauth && !temporarilyUnavailable && accessState?.capability !== "available") {
-      await persistChannelPointsCapability(session.twitchUserId, {
-        capability: "available",
-        reason: "ok",
-        httpStatus: 200,
-        definitive: true,
-      });
-      accessState = await getChannelPointsAccessState(session.twitchUserId);
+      // Fableレビュー Major-B: この自己回復はあくまで補助的な同期であり、
+      // 失敗（デプロイ窓・maintenance中の書き込み不可等）してもTwitchから実際に
+      // 取得できた報酬一覧を返すレスポンス自体を巻き込んではならない
+      // （401/403同期のrecordChannelPointsApiFailureと同じ「握りつぶす」方針に揃える）。
+      try {
+        await persistChannelPointsCapability(session.twitchUserId, {
+          capability: "available",
+          reason: "ok",
+          httpStatus: 200,
+          definitive: true,
+        });
+        accessState = await getChannelPointsAccessState(session.twitchUserId);
+      } catch (error) {
+        logger.warn("Channel Point Bootstrap API: failed to self-heal capability to available (ignored)", {
+          twitchUserId: session.twitchUserId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
 
     const responsePayload: Record<string, unknown> = {

--- a/src/app/api/twitch/channel-point-bootstrap/route.ts
+++ b/src/app/api/twitch/channel-point-bootstrap/route.ts
@@ -23,6 +23,7 @@ import {
   streamers as streamersTable,
   streamerAdditionalGachaRewards as streamerAdditionalGachaRewardsTable,
 } from "@/lib/db/schema";
+import { getChannelPointsAccessState, recordChannelPointsApiFailure } from "@/lib/twitch/channel-points-access";
 
 const TWITCH_API_URL = "https://api.twitch.tv/helix";
 
@@ -45,7 +46,17 @@ function isRaidStateSchemaError(error: { message?: string; code?: string } | nul
     || message.includes("raid_gacha_draw_count");
 }
 
-async function getTwitchRewards(twitchUserId: string): Promise<{ rewards: TwitchReward[]; requiresReauth?: boolean; error?: string }> {
+interface TwitchRewardsResult {
+  rewards: TwitchReward[];
+  requiresReauth?: boolean;
+  // Twitch APIが一時的に失敗した（429/5xx/その他非2xx）ことを示す。
+  // #788: この場合は保存済みcapability確定状態を破壊しない。
+  temporarilyUnavailable?: boolean;
+  // 401/403を受けた場合のみ設定。呼び出し元がDB確定状態を同期するために使う。
+  capabilitySyncStatus?: 401 | 403;
+}
+
+async function getTwitchRewards(twitchUserId: string): Promise<TwitchRewardsResult> {
   const accessToken = await getTwitchAccessToken(twitchUserId);
   if (!accessToken) {
     return { rewards: [], requiresReauth: true };
@@ -62,15 +73,19 @@ async function getTwitchRewards(twitchUserId: string): Promise<{ rewards: Twitch
   );
 
   if (response.status === 401) {
-    return { rewards: [], requiresReauth: true };
+    return { rewards: [], requiresReauth: true, capabilitySyncStatus: 401 };
   }
 
+  // #788: 403を「Affiliateではない」固定文言(旧affiliateRequired契約)ではなく、
+  // Capability状態ベースの契約へ置き換える。呼び出し元がDBのcapabilityを
+  // unavailableへ同期する。
   if (response.status === 403) {
-    return { rewards: [], error: "affiliateRequired" };
+    return { rewards: [], capabilitySyncStatus: 403 };
   }
 
   if (!response.ok) {
-    return { rewards: [], error: "fetchFailed" };
+    // 429/5xx等の一時失敗。DB確定状態は破壊しない。
+    return { rewards: [], temporarilyUnavailable: true };
   }
 
   const data = await response.json();
@@ -402,19 +417,31 @@ export async function GET(request: NextRequest) {
     );
 
     if (!hasRequiredScope) {
+      const accessState = await getChannelPointsAccessState(session.twitchUserId);
       return NextResponse.json({
         hasRequiredScope: false,
         rewards: [],
         requiresReauth: true,
+        capability: accessState?.capability ?? "unknown",
+        capabilityCheckedAt: accessState?.checkedAt ?? null,
       });
     }
 
-    const { rewards, requiresReauth, error } = await getTwitchRewards(session.twitchUserId);
+    const { rewards, requiresReauth, temporarilyUnavailable, capabilitySyncStatus } =
+      await getTwitchRewards(session.twitchUserId);
+
+    if (capabilitySyncStatus) {
+      await recordChannelPointsApiFailure(session.twitchUserId, capabilitySyncStatus);
+    }
+    const accessState = await getChannelPointsAccessState(session.twitchUserId);
+
     const responsePayload: Record<string, unknown> = {
       hasRequiredScope: true,
       rewards,
       requiresReauth,
-      error,
+      temporarilyUnavailable: temporarilyUnavailable === true,
+      capability: accessState?.capability ?? "unknown",
+      capabilityCheckedAt: accessState?.checkedAt ?? null,
     };
 
     if (diagnostics && !requiresReauth) {

--- a/src/app/api/twitch/eventsub/subscribe/route.ts
+++ b/src/app/api/twitch/eventsub/subscribe/route.ts
@@ -11,7 +11,6 @@ import { validateCSRFToken } from "@/lib/csrf";
 // 解消）。このファイルは DB_DRIVER フラグや getDb 等の pg 直結モジュールを直接
 // 参照しない（ヘルパー内部に閉じる）。
 import { getStreamerIdByTwitchUserId } from "@/lib/user-data";
-import { recordChannelPointsApiFailure } from "@/lib/twitch/channel-points-access";
 
 const TWITCH_API_URL = "https://api.twitch.tv/helix";
 
@@ -401,10 +400,15 @@ export async function POST(request: NextRequest) {
     if (!subscribeResponse.ok) {
       const error = await subscribeResponse.json();
 
-      // #788 子E #793: 401/403はDBのcapability確定状態を同期する。
-      if (subscribeResponse.status === 401 || subscribeResponse.status === 403) {
-        await recordChannelPointsApiFailure(session.twitchUserId, subscribeResponse.status);
-      }
+      // #788 子E #793 Fableレビュー Major-1: このEventSub作成呼び出しはapp access
+      // token（getAppAccessToken()、L333）で認証しており、配信者本人のUser Access
+      // Tokenではない。401はアプリ側credentialの問題であって配信者本人のCapabilityとは
+      // 無関係のため、ここでrecordChannelPointsApiFailure()を呼ぶとアプリ障害の瞬間に
+      // subscribeを叩いた全ユーザーの確定'available'状態を誤って破壊してしまう
+      // （親issue #788の中核要件「トークン不整合を恒久的な利用不可と誤判定しない」に反する）。
+      // 403についても「このユーザーがアプリへスコープ許可済みか」という別の意味論であり、
+      // rewards/bootstrap（ユーザートークン直接使用）と単純に同一視できないため、
+      // このrouteではCapability同期を行わない。
 
       // 409 Conflict: サブスクリプションが既に存在する場合
       // 既存のサブスクリプションを取得して返す

--- a/src/app/api/twitch/eventsub/subscribe/route.ts
+++ b/src/app/api/twitch/eventsub/subscribe/route.ts
@@ -11,6 +11,7 @@ import { validateCSRFToken } from "@/lib/csrf";
 // 解消）。このファイルは DB_DRIVER フラグや getDb 等の pg 直結モジュールを直接
 // 参照しない（ヘルパー内部に閉じる）。
 import { getStreamerIdByTwitchUserId } from "@/lib/user-data";
+import { recordChannelPointsApiFailure } from "@/lib/twitch/channel-points-access";
 
 const TWITCH_API_URL = "https://api.twitch.tv/helix";
 
@@ -399,6 +400,11 @@ export async function POST(request: NextRequest) {
 
     if (!subscribeResponse.ok) {
       const error = await subscribeResponse.json();
+
+      // #788 子E #793: 401/403はDBのcapability確定状態を同期する。
+      if (subscribeResponse.status === 401 || subscribeResponse.status === 403) {
+        await recordChannelPointsApiFailure(session.twitchUserId, subscribeResponse.status);
+      }
 
       // 409 Conflict: サブスクリプションが既に存在する場合
       // 既存のサブスクリプションを取得して返す

--- a/src/app/api/twitch/rewards/route.ts
+++ b/src/app/api/twitch/rewards/route.ts
@@ -5,6 +5,17 @@ import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-l
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { getTwitchAccessToken } from "@/lib/twitch/token-manager";
 import { validateCSRFToken } from "@/lib/csrf";
+import { recordChannelPointsApiFailure } from "@/lib/twitch/channel-points-access";
+
+/**
+ * TwitchのChannel Points APIが401/403を返した場合、DBのcapability確定状態を
+ * 同期する (#788 子E #793)。同期自体の失敗は主処理を止めない（helper内でcatch済み）。
+ */
+async function syncCapabilityOnTwitchFailure(twitchUserId: string, status: number): Promise<void> {
+  if (status === 401 || status === 403) {
+    await recordChannelPointsApiFailure(twitchUserId, status);
+  }
+}
 
 const TWITCH_API_URL = "https://api.twitch.tv/helix";
 
@@ -54,6 +65,7 @@ export async function GET(request: Request) {
     );
 
     if (!response.ok) {
+      await syncCapabilityOnTwitchFailure(session.twitchUserId, response.status);
       const error = await response.json();
       return handleApiError(error, "Twitch API rewards fetch");
     }
@@ -126,6 +138,7 @@ export async function POST(request: Request) {
     );
 
     if (!response.ok) {
+      await syncCapabilityOnTwitchFailure(session.twitchUserId, response.status);
       const error = await response.json();
       return handleApiError(error, "Twitch API reward creation");
     }

--- a/src/app/dashboard/account/page.tsx
+++ b/src/app/dashboard/account/page.tsx
@@ -8,6 +8,7 @@ import { LanguageSwitcherSettings } from "@/components/LanguageSwitcher";
 import VoteCampaignReshowSetting from "@/components/VoteCampaignReshowSetting";
 import SupportPlanSection from "@/components/SupportPlanSection";
 import TwitchSubCheckSection from "@/components/TwitchSubCheckSection";
+import ChannelPointsAccessSection from "@/components/ChannelPointsAccessSection";
 
 // Note: Page is automatically dynamic due to cookies() usage in getSession()
 // cookies()使用により自動的に動的ページになるため、force-dynamicは不要
@@ -79,6 +80,12 @@ export default async function AccountSettingsPage() {
         {/* Twitchサブスク確認セクション */}
         <TwitchSubCheckSection
           initialHasSub={twitchSubInfo?.twitch_has_sub === true}
+        />
+
+        {/* Channel Points利用可否確認・非Affiliate向け配信者機能オプトイン (#788) */}
+        <ChannelPointsAccessSection
+          broadcasterType={session.broadcasterType}
+          initialEnabled={session.channelPointsEnabled === true}
         />
       </div>
     </div>

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -159,10 +159,13 @@ export default function ChannelPointSettings({
       }
 
       setNeedsReauth(false);
-      if (data.error === "affiliateRequired") {
-        setError(t("messages.affiliateRequired"));
-      } else if (data.error) {
-        setError(t("messages.fetchFailed"));
+      // #788: 旧affiliateRequired文字列契約をCapability状態ベースの契約へ置き換える。
+      // 403(Twitch側の利用不可)はcapability==="unavailable"、429/5xx等の一時失敗は
+      // temporarilyUnavailableで区別し、それぞれ別の文言・再試行導線を表示する。
+      if (data.capability === "unavailable") {
+        setError(t("messages.channelPointsUnavailable"));
+      } else if (data.temporarilyUnavailable) {
+        setError(t("messages.temporarilyUnavailable"));
       }
       setRewards(Array.isArray(data.rewards) ? data.rewards : []);
 

--- a/src/components/ChannelPointsAccessSection.tsx
+++ b/src/components/ChannelPointsAccessSection.tsx
@@ -197,10 +197,22 @@ export default function ChannelPointsAccessSection({
         credentials: "include",
       });
       const data = await response.json().catch(() => ({}));
-      if (response.ok && data.enabled) {
-        setMessage({ type: "success", text: t("messages.enableSuccess") });
+      // 自動レビュー指摘: response.okだけで成功判定すると、DB更新は成功したが
+      // session cookie再署名だけ失敗したケース（PUT成功時はcode: 'session_resync_failed'
+      // + status 500 + enabled: true を返す設計）を「失敗」と誤表示し、直後のfetchState()で
+      // enabled:trueが表示されて矛盾する。data.enabled===trueを主基準にする。
+      if (data.enabled === true) {
+        setMessage({
+          type: "success",
+          text:
+            data.code === "session_resync_failed"
+              ? t("messages.enableSuccessSessionPending")
+              : t("messages.enableSuccess"),
+        });
         await fetchState();
-        // server component（dashboard layout等のisStreamer判定）へ反映
+        // server component（dashboard layout等のisStreamer判定）へ反映。
+        // session_resync_failed時はCookie未更新のため次回ログインまで完全には
+        // 反映されないが、呼び出し自体は無害なため常に実行する。
         router.refresh();
       } else {
         const maintenanceError = parseMaintenanceError(response, data);

--- a/src/components/ChannelPointsAccessSection.tsx
+++ b/src/components/ChannelPointsAccessSection.tsx
@@ -128,15 +128,18 @@ export default function ChannelPointsAccessSection({
   }, [fetchState, isMaintenanceBlocked, t, tMaintenance]);
 
   // stale時の自動再判定。非Affiliate・スコープ有り・stale・現在probe中でない場合のみ、
-  // mount中に最大1回だけ実行する（無限/重複POST防止）。
+  // mount中に最大1回だけ実行する（無限/重複POST防止）。maintenance中はrunProbe自体が
+  // 拒否してエラーメッセージを出すだけになる（ユーザー操作無しで赤いエラーが出るのは
+  // 体験として不適切）ため、ここで事前にスキップする。guardをautoProbeStarted設定より
+  // 前に置くことで、maintenance解除後の再renderで自動的に再判定を試みられるようにする。
   useEffect(() => {
-    if (loading || autoProbeStarted.current || checking) return;
+    if (loading || autoProbeStarted.current || checking || isMaintenanceBlocked) return;
     const isNonAffiliate = state.broadcasterType === "";
     if (isNonAffiliate && state.hasRequiredScope && state.stale) {
       autoProbeStarted.current = true;
       void runProbe();
     }
-  }, [loading, state, checking, runProbe]);
+  }, [loading, state, checking, runProbe, isMaintenanceBlocked]);
 
   const handleReauthorize = useCallback(async () => {
     if (isMaintenanceBlocked) {

--- a/src/components/ChannelPointsAccessSection.tsx
+++ b/src/components/ChannelPointsAccessSection.tsx
@@ -170,7 +170,10 @@ export default function ChannelPointsAccessSection({
 
       const errorData = await response.json().catch(() => ({}));
       const maintenanceError = parseMaintenanceError(response, errorData);
-      setMessage({ type: "error", text: maintenanceError?.message || errorData.error || t("messages.genericError") });
+      // errorData.errorはAPI契約上は文字列だが、想定外のレスポンス形状
+      // （オブジェクト等）をそのままJSX子要素へ渡すとReactがクラッシュするため防御する。
+      const fallbackText = typeof errorData.error === "string" ? errorData.error : undefined;
+      setMessage({ type: "error", text: maintenanceError?.message || fallbackText || t("messages.genericError") });
       setChecking(false);
     } catch {
       setMessage({ type: "error", text: t("messages.genericError") });

--- a/src/components/ChannelPointsAccessSection.tsx
+++ b/src/components/ChannelPointsAccessSection.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { parseMaintenanceError } from "@/lib/maintenance/client";
+import { useMaintenanceStatus } from "./MaintenanceStatusProvider";
+import { CHANNEL_POINT_SCOPES } from "@/lib/twitch/scopes";
+import { logger } from "@/lib/logger";
+
+interface ChannelPointsAccessSectionProps {
+  broadcasterType: string;
+  initialEnabled: boolean;
+}
+
+type Capability = "available" | "unavailable" | "reauth_required" | "unknown";
+
+interface AccessState {
+  broadcasterType: string;
+  capability: Capability;
+  capabilityCheckedAt: string | null;
+  enabled: boolean;
+  hasRequiredScope: boolean;
+  requiresReauth: boolean;
+  stale: boolean;
+  canEnable: boolean;
+}
+
+/**
+ * 非Affiliateユーザー向けChannel Points利用可否確認・明示的オプトインセクション (#788 子D #792)。
+ * /dashboard/account に配置し、/api/account/channel-points をsource of truthとして
+ * 状態機械（Affiliate/reauth必要/確認中/有効化可能/有効化済み/利用不可/一時失敗）を描画する。
+ */
+export default function ChannelPointsAccessSection({
+  broadcasterType,
+  initialEnabled,
+}: ChannelPointsAccessSectionProps) {
+  const t = useTranslations("channelPointsAccess");
+  const tMaintenance = useTranslations("maintenance");
+  const router = useRouter();
+  const { mode: maintenanceMode } = useMaintenanceStatus();
+  const isMaintenanceBlocked = maintenanceMode !== "off";
+
+  const [loading, setLoading] = useState(true);
+  // 初回GET完了までの仮状態。propsの値のみを反映し、GET結果で必ず上書きされる。
+  const [state, setState] = useState<AccessState>({
+    broadcasterType,
+    capability: "unknown",
+    capabilityCheckedAt: null,
+    enabled: initialEnabled,
+    hasRequiredScope: false,
+    requiresReauth: false,
+    stale: true,
+    canEnable: false,
+  });
+  const [fetchFailed, setFetchFailed] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const [enabling, setEnabling] = useState(false);
+  const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+  // React Strict Modeでのeffect二重実行や再render等で自動probeを複数回発火しないためのガード
+  const autoProbeStarted = useRef(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const fetchState = useCallback(async () => {
+    try {
+      const response = await fetch("/api/account/channel-points", { credentials: "include" });
+      if (!response.ok) {
+        if (mountedRef.current) setFetchFailed(true);
+        return;
+      }
+      const data = (await response.json()) as AccessState;
+      if (mountedRef.current) {
+        setState(data);
+        setFetchFailed(false);
+      }
+    } catch (err) {
+      logger.error("Failed to fetch channel points access state:", err);
+      if (mountedRef.current) setFetchFailed(true);
+    }
+  }, []);
+
+  // 初回マウント時に1回だけGETする。
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      await fetchState();
+      if (mountedRef.current) setLoading(false);
+    })();
+  }, [fetchState]);
+
+  const runProbe = useCallback(async () => {
+    if (isMaintenanceBlocked) {
+      setMessage({ type: "error", text: tMaintenance("writeDisabled") });
+      return;
+    }
+    setChecking(true);
+    setMessage(null);
+    try {
+      const response = await fetch("/api/account/channel-points", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        const maintenanceError = parseMaintenanceError(response, data);
+        if (mountedRef.current) {
+          setMessage({ type: "error", text: maintenanceError?.message || t("messages.genericError") });
+        }
+      }
+    } catch {
+      if (mountedRef.current) {
+        setMessage({ type: "error", text: t("messages.genericError") });
+      }
+    } finally {
+      await fetchState();
+      if (mountedRef.current) setChecking(false);
+    }
+  }, [fetchState, isMaintenanceBlocked, t, tMaintenance]);
+
+  // stale時の自動再判定。非Affiliate・スコープ有り・stale・現在probe中でない場合のみ、
+  // mount中に最大1回だけ実行する（無限/重複POST防止）。
+  useEffect(() => {
+    if (loading || autoProbeStarted.current || checking) return;
+    const isNonAffiliate = state.broadcasterType === "";
+    if (isNonAffiliate && state.hasRequiredScope && state.stale) {
+      autoProbeStarted.current = true;
+      void runProbe();
+    }
+  }, [loading, state, checking, runProbe]);
+
+  const handleReauthorize = useCallback(async () => {
+    if (isMaintenanceBlocked) {
+      setMessage({ type: "error", text: tMaintenance("writeDisabled") });
+      return;
+    }
+    setChecking(true);
+    setMessage(null);
+    try {
+      const response = await fetch("/api/auth/reauth", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          additionalScopes: CHANNEL_POINT_SCOPES,
+          returnTo: "/dashboard/account",
+        }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        if (data.state) {
+          // callbackのstate検証(COOKIE_NAMES.AUTH_STATE)用。reauth APIはこのCookieを
+          // server-sideで設定しないため、既存ChannelPointSettings.handleReauthorizeと
+          // 同じ方式でclient側から設定する。
+          document.cookie = `twitch_auth_state=${data.state}; path=/; max-age=600; secure; samesite=lax`;
+        }
+        window.location.href = data.loginUrl;
+        return;
+      }
+
+      const errorData = await response.json().catch(() => ({}));
+      const maintenanceError = parseMaintenanceError(response, errorData);
+      setMessage({ type: "error", text: maintenanceError?.message || errorData.error || t("messages.genericError") });
+      setChecking(false);
+    } catch {
+      setMessage({ type: "error", text: t("messages.genericError") });
+      setChecking(false);
+    }
+  }, [isMaintenanceBlocked, t, tMaintenance]);
+
+  const handleEnable = useCallback(async () => {
+    if (isMaintenanceBlocked) {
+      setMessage({ type: "error", text: tMaintenance("writeDisabled") });
+      return;
+    }
+    setEnabling(true);
+    setMessage(null);
+    try {
+      const response = await fetch("/api/account/channel-points", {
+        method: "PUT",
+        credentials: "include",
+      });
+      const data = await response.json().catch(() => ({}));
+      if (response.ok && data.enabled) {
+        setMessage({ type: "success", text: t("messages.enableSuccess") });
+        await fetchState();
+        // server component（dashboard layout等のisStreamer判定）へ反映
+        router.refresh();
+      } else {
+        const maintenanceError = parseMaintenanceError(response, data);
+        setMessage({ type: "error", text: maintenanceError?.message || t("messages.enableFailed") });
+        await fetchState();
+      }
+    } catch {
+      if (mountedRef.current) {
+        setMessage({ type: "error", text: t("messages.genericError") });
+      }
+    } finally {
+      if (mountedRef.current) setEnabling(false);
+    }
+  }, [fetchState, isMaintenanceBlocked, router, t, tMaintenance]);
+
+  if (loading) {
+    return (
+      <div className="rounded-xl bg-gray-800 p-6">
+        <h2 className="mb-2 text-xl font-semibold text-white">{t("title")}</h2>
+        <p className="text-sm text-gray-400">{t("loading")}</p>
+      </div>
+    );
+  }
+
+  if (fetchFailed) {
+    return (
+      <div className="rounded-xl bg-gray-800 p-6">
+        <h2 className="mb-2 text-xl font-semibold text-white">{t("title")}</h2>
+        <p className="mb-4 text-sm text-red-300">{t("messages.genericError")}</p>
+        <button
+          onClick={() => fetchState()}
+          className="rounded-lg bg-gray-600 px-4 py-2 text-sm text-white hover:bg-gray-700"
+        >
+          {t("unknown.retryButton")}
+        </button>
+      </div>
+    );
+  }
+
+  const isAffiliateOrPartner = state.broadcasterType === "affiliate" || state.broadcasterType === "partner";
+  const buttonBaseClass =
+    "rounded-lg bg-purple-600 px-4 py-2 text-sm text-white hover:bg-purple-700 disabled:cursor-not-allowed disabled:opacity-50";
+  const secondaryButtonClass =
+    "rounded-lg bg-gray-600 px-4 py-2 text-sm text-white hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50";
+
+  return (
+    <div className="rounded-xl bg-gray-800 p-6">
+      <h2 className="mb-2 text-xl font-semibold text-white">{t("title")}</h2>
+      <p className="mb-4 text-sm text-gray-400">{t("description")}</p>
+
+      {message && (
+        <div
+          role="alert"
+          aria-live="polite"
+          className={`mb-4 rounded-lg p-3 text-sm ${
+            message.type === "success"
+              ? "border border-green-600/50 bg-green-900/30 text-green-300"
+              : "border border-red-600/50 bg-red-900/30 text-red-300"
+          }`}
+        >
+          {message.text}
+        </div>
+      )}
+
+      {isMaintenanceBlocked && <p className="mb-4 text-sm text-yellow-400">{tMaintenance("writeDisabled")}</p>}
+
+      {isAffiliateOrPartner ? (
+        <div>
+          <p className="mb-3 text-sm text-gray-300">{t("affiliate.message")}</p>
+          <Link href="/dashboard/settings" className={`inline-block ${buttonBaseClass}`}>
+            {t("enabled.settingsLink")}
+          </Link>
+        </div>
+      ) : state.enabled ? (
+        <div>
+          <p className="mb-3 text-sm text-green-300">{t("enabled.message")}</p>
+          <Link href="/dashboard/settings" className={`inline-block ${buttonBaseClass}`}>
+            {t("enabled.settingsLink")}
+          </Link>
+          {(state.requiresReauth || state.capability === "unavailable") && (
+            <p className="mt-3 text-sm text-yellow-400">{t("capabilityLostWarning")}</p>
+          )}
+        </div>
+      ) : checking ? (
+        <p className="text-sm text-gray-300" aria-live="polite">
+          {t("checking.message")}
+        </p>
+      ) : state.requiresReauth ? (
+        <div>
+          <p className="mb-3 text-sm text-yellow-300">{t("reauth.message")}</p>
+          <button
+            onClick={handleReauthorize}
+            disabled={checking || isMaintenanceBlocked}
+            title={isMaintenanceBlocked ? tMaintenance("writeDisabled") : undefined}
+            className={buttonBaseClass}
+          >
+            {checking ? t("reauth.buttonLoading") : t("reauth.button")}
+          </button>
+        </div>
+      ) : state.capability === "available" ? (
+        <div>
+          <p className="mb-2 text-sm text-green-300">{t("available.message")}</p>
+          <p className="mb-3 text-sm text-gray-400">{t("available.enableDescription")}</p>
+          <button
+            onClick={handleEnable}
+            disabled={enabling || isMaintenanceBlocked}
+            title={isMaintenanceBlocked ? tMaintenance("writeDisabled") : undefined}
+            className={buttonBaseClass}
+          >
+            {enabling ? t("available.enableButtonLoading") : t("available.enableButton")}
+          </button>
+        </div>
+      ) : state.capability === "unavailable" ? (
+        <div>
+          <p className="mb-3 text-sm text-gray-300">{t("unavailable.message")}</p>
+          <button
+            onClick={runProbe}
+            disabled={isMaintenanceBlocked}
+            title={isMaintenanceBlocked ? tMaintenance("writeDisabled") : undefined}
+            className={secondaryButtonClass}
+          >
+            {t("unavailable.recheckButton")}
+          </button>
+        </div>
+      ) : (
+        <div>
+          <p className="mb-3 text-sm text-gray-300">{t("unknown.message")}</p>
+          <button
+            onClick={runProbe}
+            disabled={isMaintenanceBlocked}
+            title={isMaintenanceBlocked ? tMaintenance("writeDisabled") : undefined}
+            className={secondaryButtonClass}
+          >
+            {t("unknown.retryButton")}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { getTranslations } from "next-intl/server";
-import { getSession } from "@/lib/session";
+import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { LogoutButton } from "@/components/LogoutButton";
 
 interface HeaderProps {
@@ -19,7 +19,9 @@ export default async function Header({ session, unreadAnnouncementsCount = 0 }: 
   const t = await getTranslations("header");
   if (!session) return null;
 
-  const isStreamer = session.broadcasterType === "partner" || session.broadcasterType === "affiliate";
+  // #788: 非Affiliateユーザーが明示的にtwica配信者機能を有効化した場合もisStreamerに含める。
+  // broadcasterTypeの直接比較ではなく、共通判定helperを使う（子E #793監査対象）。
+  const isStreamer = canUseStreamerFeatures(session);
 
   return (
     <header className="border-b border-gray-800 bg-gray-900/95 backdrop-blur">
@@ -49,10 +51,11 @@ export default async function Header({ session, unreadAnnouncementsCount = 0 }: 
             <span className="max-w-[80px] truncate text-sm text-white sm:hidden">
               {session.twitchDisplayName}
             </span>
-            {/* broadcaster type バッジ - PCのみ表示 */}
+            {/* 配信者バッジ - PCのみ表示。broadcasterTypeが空(非Affiliateオプトイン)の
+                場合に空文字を表示しないよう、常にi18n済みラベルを使う。 */}
             {isStreamer && (
               <span className="hidden rounded bg-purple-600 px-2 py-0.5 text-xs text-white sm:inline">
-                {session.broadcasterType}
+                {session.broadcasterType || t("streamerBadge")}
               </span>
             )}
           </div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -613,7 +613,6 @@ export const UI_STRINGS = {
       NONE: '未設定',
     },
     MESSAGES: {
-      AFFILIATE_REQUIRED: 'チャネルポイントを使用するには、Twitchアフィリエイトまたはパートナーである必要があります。',
       RATE_LIMIT: 'リクエストが多すぎます。しばらく待ってから再試行してください。',
       FETCH_FAILED: '報酬の取得に失敗しました。再度ログインしてください。',
       REWARD_CREATED: '報酬を作成しました',

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -165,6 +165,10 @@ export const users = pgTable('users', {
   twitch_sub_verified_at: timestamp('twitch_sub_verified_at', { withTimezone: true, mode: 'string' }),
   // 00023: DDL に NOT NULL は無い（DEFAULT FALSE のみ）
   twitch_has_sub: boolean('twitch_has_sub').default(false),
+  // 20260723150000 (#788): 非Affiliate配信者向けChannel Points Capability判定・オプトイン
+  channel_points_capability: text('channel_points_capability').notNull().default('unknown'),
+  channel_points_capability_checked_at: timestamp('channel_points_capability_checked_at', { withTimezone: true, mode: 'string' }),
+  channel_points_enabled: boolean('channel_points_enabled').notNull().default(false),
   created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
   updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).default(sql`now()`),
 })

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -343,6 +343,10 @@ export const rateLimits = {
   // 認証の運用エンドポイントであり、通常利用者は叩かないため他のadmin系操作と
   // 同水準（分あたり10回）に絞る。
   eventsubReplay: createRatelimit("eventsubReplay", 10, 60 * 1000),
+  // Issue #788: アカウント設定のChannel Points状態確認・再判定・有効化。
+  // 再判定/有効化はTwitch APIへの実疎通(probeChannelPointsCapability)を伴うため、
+  // 過剰な呼び出しを防ぐ専用の低めの制限をPOST/PUT共通で使う。
+  accountChannelPointsProbe: createRatelimit("accountChannelPointsProbe", 10, 60 * 1000),
   // Issue #693: DB接続先（Supabase/PlanetScale）health/diagnosticsエンドポイント。
   // 共有シークレット認証の運用エンドポイントだが、eventsubReplay（書き込みを伴う
   // リプレイ実行）より低リスクな読み取り専用のため、監視ツールからの定期ポーリング

--- a/src/lib/session-cookie.ts
+++ b/src/lib/session-cookie.ts
@@ -10,6 +10,10 @@ export interface SessionPayload {
   expiresAt: number // Unix timestamp (milliseconds)
   csrfTokenHash?: string
   version: number // Optimistic locking
+  // #788: 非Affiliateユーザーがtwica配信者機能を明示的に有効化したかのセッションミラー。
+  // DBが正本、これはアクセス判定用の高速な署名済みミラー。後方互換のためoptional。
+  // 未定義の旧Cookieはfalse相当として扱う（canUseStreamerFeatures参照）。
+  channelPointsEnabled?: boolean
 }
 
 interface VerifySessionOptions {
@@ -84,6 +88,10 @@ export function parseSession(raw: string): SessionPayload {
     }
     if (parsed.version > Number.MAX_SAFE_INTEGER) {
       throw new Error('Invalid session: version exceeds maximum safe integer value')
+    }
+    // channelPointsEnabledはoptional（旧Cookieには存在しない）。存在する場合のみ型検証する。
+    if (parsed.channelPointsEnabled !== undefined && typeof parsed.channelPointsEnabled !== 'boolean') {
+      throw new Error('Invalid session: channelPointsEnabled must be a boolean')
     }
 
     return parsed as SessionPayload

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -70,7 +70,11 @@ export const getSession = cache(async (): Promise<Session | null> => {
 
 export function canUseStreamerFeatures(session: Session | null): boolean {
   if (!session) return false
-  return session.broadcasterType === BROADCASTER_TYPE.AFFILIATE || session.broadcasterType === BROADCASTER_TYPE.PARTNER
+  return session.broadcasterType === BROADCASTER_TYPE.AFFILIATE
+    || session.broadcasterType === BROADCASTER_TYPE.PARTNER
+    // #788: 非Affiliateユーザーが明示的にtwica配信者機能を有効化した場合も配信者扱いにする。
+    // 旧Cookie（フィールド無し）はundefined→falseとなり、既存挙動を維持する。
+    || session.channelPointsEnabled === true
 }
 
 export async function clearSession(): Promise<void> {

--- a/src/lib/twitch/channel-points-access.ts
+++ b/src/lib/twitch/channel-points-access.ts
@@ -3,9 +3,19 @@ import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { getDb } from '@/lib/db/client'
 import { isPgReadEnabled, isPgWriteEnabled } from '@/lib/db/flags'
 import { withDbRetry } from '@/lib/db/retry'
+import { isPgMissingColumnError } from '@/lib/db/errors'
 import { users as usersTable } from '@/lib/db/schema'
 import { logger } from '@/lib/logger'
 import type { ChannelPointsCapability, DefinitiveCapabilityResult } from './channel-points'
+
+// migration未適用のデプロイ窓（列が存在しない）で読み取りが失敗した場合の安全な既定値。
+// 「行が存在しない」場合のnullとは意図的に区別する: ユーザー行自体は存在しうるが
+// 新3列だけ読めない状態なので、DBのDEFAULT値（'unknown'/null/false）と同じ値を返す。
+const DEPLOY_WINDOW_FALLBACK_STATE: ChannelPointsAccessState = {
+  capability: 'unknown',
+  checkedAt: null,
+  enabled: false,
+}
 
 /**
  * users テーブルに永続化されたChannel Points Capability状態のdata layer (#788 子B #790)。
@@ -24,29 +34,45 @@ export interface ChannelPointsAccessState {
 /**
  * 保存済みのCapability/確認日時/オプトイン状態を読み取る。
  * ユーザー行が存在しない場合は null を返す。
+ *
+ * migration未適用のデプロイ窓（新3列が存在しない）では例外を投げず
+ * DEPLOY_WINDOW_FALLBACK_STATE を返す (#788 子E #793 Fableレビュー Major-3)。
+ * これはこの関数のあらゆる呼び出し元（callback、bootstrap、account API）を
+ * 個別に保護する代わりに、data layer側で一元的にデプロイ窓耐性を持たせるための設計判断。
  */
 export async function getChannelPointsAccessState(
   twitchUserId: string
 ): Promise<ChannelPointsAccessState | null> {
   if (isPgReadEnabled()) {
-    const rows = await withDbRetry(
-      async () => {
-        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
-        const { db } = await getDb()
-        return db
-          .select({
-            capability: usersTable.channel_points_capability,
-            checkedAt: usersTable.channel_points_capability_checked_at,
-            enabled: usersTable.channel_points_enabled,
-          })
-          .from(usersTable)
-          .where(eq(usersTable.twitch_user_id, twitchUserId))
-          .limit(1)
-      },
-      'channel-points-access(get state, pg)',
-      // 読み取り専用クエリのため冪等（リトライ可）
-      { idempotent: true }
-    )
+    let rows: { capability: string | null; checkedAt: string | null; enabled: boolean | null }[]
+    try {
+      rows = await withDbRetry(
+        async () => {
+          // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+          const { db } = await getDb()
+          return db
+            .select({
+              capability: usersTable.channel_points_capability,
+              checkedAt: usersTable.channel_points_capability_checked_at,
+              enabled: usersTable.channel_points_enabled,
+            })
+            .from(usersTable)
+            .where(eq(usersTable.twitch_user_id, twitchUserId))
+            .limit(1)
+        },
+        'channel-points-access(get state, pg)',
+        // 読み取り専用クエリのため冪等（リトライ可）
+        { idempotent: true }
+      )
+    } catch (error) {
+      if (isPgMissingColumnError(error)) {
+        logger.warn('[channel-points-access] channel_points_* columns not yet deployed (pg), falling back', {
+          twitchUserId,
+        })
+        return DEPLOY_WINDOW_FALLBACK_STATE
+      }
+      throw error
+    }
     const row = rows[0]
     if (!row) return null
     return {
@@ -63,6 +89,14 @@ export async function getChannelPointsAccessState(
     .maybeSingle()
 
   if (error) {
+    // PGRST204: 列未デプロイ（PostgRESTのスキーマキャッシュ固有のエラーコード）。
+    // pg経路の42703（isPgMissingColumnError）と同じ意味のデプロイ窓フォールバック。
+    if (error.code === 'PGRST204') {
+      logger.warn('[channel-points-access] channel_points_* columns not yet deployed (postgrest), falling back', {
+        twitchUserId,
+      })
+      return DEPLOY_WINDOW_FALLBACK_STATE
+    }
     logger.error('[channel-points-access] getChannelPointsAccessState failed', {
       twitchUserId,
       error: error.message,

--- a/src/lib/twitch/channel-points-access.ts
+++ b/src/lib/twitch/channel-points-access.ts
@@ -129,22 +129,36 @@ export async function persistChannelPointsCapability(
   const checkedAt = new Date().toISOString()
 
   if (isPgWriteEnabled()) {
-    await withDbRetry(
-      async () => {
-        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
-        const { db } = await getDb()
-        return db
-          .update(usersTable)
-          .set({
-            channel_points_capability: result.capability,
-            channel_points_capability_checked_at: checkedAt,
-          })
-          .where(eq(usersTable.twitch_user_id, twitchUserId))
-      },
-      'channel-points-access(persist capability, pg)',
-      // 同じcapability/checkedAtを書くUPDATEのため冪等（リトライ可）
-      { idempotent: true }
-    )
+    try {
+      await withDbRetry(
+        async () => {
+          // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+          const { db } = await getDb()
+          return db
+            .update(usersTable)
+            .set({
+              channel_points_capability: result.capability,
+              channel_points_capability_checked_at: checkedAt,
+            })
+            .where(eq(usersTable.twitch_user_id, twitchUserId))
+        },
+        'channel-points-access(persist capability, pg)',
+        // 同じcapability/checkedAtを書くUPDATEのため冪等（リトライ可）
+        { idempotent: true }
+      )
+    } catch (error) {
+      // 自動レビュー指摘: 読み取り側(getChannelPointsAccessState)と対になる
+      // デプロイ窓フォールバック。列未デプロイ(42703)ではthrowせず、呼び出し元
+      // （account API POST/PUT）を500に巻き込まない。保存は単に「今回はできな
+      // かった」だけで、次回probe時に再試行される。
+      if (isPgMissingColumnError(error)) {
+        logger.warn('[channel-points-access] channel_points_* columns not yet deployed (pg), skipping persist', {
+          twitchUserId,
+        })
+        return
+      }
+      throw error
+    }
     return
   }
 
@@ -157,6 +171,12 @@ export async function persistChannelPointsCapability(
     .eq('twitch_user_id', twitchUserId)
 
   if (error) {
+    if (error.code === 'PGRST204' || error.code === '42703') {
+      logger.warn('[channel-points-access] channel_points_* columns not yet deployed (postgrest), skipping persist', {
+        twitchUserId,
+      })
+      return
+    }
     logger.error('[channel-points-access] persistChannelPointsCapability failed', {
       twitchUserId,
       error: error.message,

--- a/src/lib/twitch/channel-points-access.ts
+++ b/src/lib/twitch/channel-points-access.ts
@@ -89,9 +89,14 @@ export async function getChannelPointsAccessState(
     .maybeSingle()
 
   if (error) {
-    // PGRST204: 列未デプロイ（PostgRESTのスキーマキャッシュ固有のエラーコード）。
-    // pg経路の42703（isPgMissingColumnError）と同じ意味のデプロイ窓フォールバック。
-    if (error.code === 'PGRST204') {
+    // 列未デプロイのデプロイ窓フォールバック（Fableレビュー Major-A修正）。
+    // SELECT/order/filterでの列欠落はPostgreSQLが42703を返し、PGRST204は
+    // insert/update payloadの列欠落専用（PGRST204のみの判定はSELECT系読み取りでは
+    // 実際には作動しない）。本リポジトリの既存前例（collection-existence.ts の
+    // isReadColumnMissingError、token-manager.ts の hasScope コメント、
+    // reauth/route.ts・check-subscription/route.ts の両コード判定）と同じ規約で
+    // 両方を許容する。pg経路の42703（isPgMissingColumnError）と同じ意味。
+    if (error.code === 'PGRST204' || error.code === '42703') {
       logger.warn('[channel-points-access] channel_points_* columns not yet deployed (postgrest), falling back', {
         twitchUserId,
       })

--- a/src/lib/twitch/channel-points-access.ts
+++ b/src/lib/twitch/channel-points-access.ts
@@ -155,9 +155,14 @@ export async function recordChannelPointsApiFailure(
   }
 }
 
+// EnableChannelPointsAccessResultのunionから直接['error']をindexed accessすると、
+// ok:trueメンバーにerrorプロパティが無いためTSエラーになる。判定用の理由型を
+// 独立して名前付けする。
+export type EnableChannelPointsAccessErrorReason = 'capability_not_available' | 'user_not_found'
+
 export type EnableChannelPointsAccessResult =
   | { ok: true; streamerId: string }
-  | { ok: false; error: 'capability_not_available' | 'user_not_found' }
+  | { ok: false; error: EnableChannelPointsAccessErrorReason }
 
 /**
  * enable_channel_points_streamer_access RPC の例外メッセージ（RAISE EXCEPTION の
@@ -165,7 +170,7 @@ export type EnableChannelPointsAccessResult =
  * 両経路ともPostgresのエラーmessageフィールドにRAISE EXCEPTIONの文字列がそのまま
  * 載るため、同一のmessage起点で判定できる（driver parity）。
  */
-function classifyEnableRpcError(message: string): EnableChannelPointsAccessResult['error'] | null {
+function classifyEnableRpcError(message: string): EnableChannelPointsAccessErrorReason | null {
   if (message.includes('CAPABILITY_NOT_AVAILABLE')) return 'capability_not_available'
   if (message.includes('USER_NOT_FOUND')) return 'user_not_found'
   return null

--- a/src/lib/twitch/channel-points-access.ts
+++ b/src/lib/twitch/channel-points-access.ts
@@ -1,0 +1,234 @@
+import { eq } from 'drizzle-orm'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { getDb } from '@/lib/db/client'
+import { isPgReadEnabled, isPgWriteEnabled } from '@/lib/db/flags'
+import { withDbRetry } from '@/lib/db/retry'
+import { users as usersTable } from '@/lib/db/schema'
+import { logger } from '@/lib/logger'
+import type { ChannelPointsCapability, DefinitiveCapabilityResult } from './channel-points'
+
+/**
+ * users テーブルに永続化されたChannel Points Capability状態のdata layer (#788 子B #790)。
+ *
+ * 非Affiliateユーザーは有効化前は streamers 行を持たないため、判定結果・確認日時・
+ * オプトイン状態は users に保存する。DB_DRIVER (postgrest/pg-read/pg) の既存方針に
+ * 従い、読み取りは isPgReadEnabled()、書き込みは isPgWriteEnabled() で分岐する。
+ */
+
+export interface ChannelPointsAccessState {
+  capability: ChannelPointsCapability
+  checkedAt: string | null
+  enabled: boolean
+}
+
+/**
+ * 保存済みのCapability/確認日時/オプトイン状態を読み取る。
+ * ユーザー行が存在しない場合は null を返す。
+ */
+export async function getChannelPointsAccessState(
+  twitchUserId: string
+): Promise<ChannelPointsAccessState | null> {
+  if (isPgReadEnabled()) {
+    const rows = await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .select({
+            capability: usersTable.channel_points_capability,
+            checkedAt: usersTable.channel_points_capability_checked_at,
+            enabled: usersTable.channel_points_enabled,
+          })
+          .from(usersTable)
+          .where(eq(usersTable.twitch_user_id, twitchUserId))
+          .limit(1)
+      },
+      'channel-points-access(get state, pg)',
+      // 読み取り専用クエリのため冪等（リトライ可）
+      { idempotent: true }
+    )
+    const row = rows[0]
+    if (!row) return null
+    return {
+      capability: (row.capability ?? 'unknown') as ChannelPointsCapability,
+      checkedAt: row.checkedAt,
+      enabled: row.enabled === true,
+    }
+  }
+
+  const { data, error } = await getSupabaseAdmin()
+    .from('users')
+    .select('channel_points_capability, channel_points_capability_checked_at, channel_points_enabled')
+    .eq('twitch_user_id', twitchUserId)
+    .maybeSingle()
+
+  if (error) {
+    logger.error('[channel-points-access] getChannelPointsAccessState failed', {
+      twitchUserId,
+      error: error.message,
+    })
+    throw error
+  }
+  if (!data) return null
+  return {
+    capability: (data.channel_points_capability ?? 'unknown') as ChannelPointsCapability,
+    checkedAt: data.channel_points_capability_checked_at,
+    enabled: data.channel_points_enabled === true,
+  }
+}
+
+/**
+ * Capability Probeの「確定」結果 (definitive=true) のみをDBへ保存する。
+ * 引数型 DefinitiveCapabilityResult により、429/5xx/network error等の一時失敗を
+ * 型レベルで渡せなくしている（呼び出し側の分岐漏れで確定状態が破壊される事故を防ぐ）。
+ * checked_at も同時に現在時刻へ更新する。
+ */
+export async function persistChannelPointsCapability(
+  twitchUserId: string,
+  result: DefinitiveCapabilityResult
+): Promise<void> {
+  const checkedAt = new Date().toISOString()
+
+  if (isPgWriteEnabled()) {
+    await withDbRetry(
+      async () => {
+        // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+        const { db } = await getDb()
+        return db
+          .update(usersTable)
+          .set({
+            channel_points_capability: result.capability,
+            channel_points_capability_checked_at: checkedAt,
+          })
+          .where(eq(usersTable.twitch_user_id, twitchUserId))
+      },
+      'channel-points-access(persist capability, pg)',
+      // 同じcapability/checkedAtを書くUPDATEのため冪等（リトライ可）
+      { idempotent: true }
+    )
+    return
+  }
+
+  const { error } = await getSupabaseAdmin()
+    .from('users')
+    .update({
+      channel_points_capability: result.capability,
+      channel_points_capability_checked_at: checkedAt,
+    })
+    .eq('twitch_user_id', twitchUserId)
+
+  if (error) {
+    logger.error('[channel-points-access] persistChannelPointsCapability failed', {
+      twitchUserId,
+      error: error.message,
+    })
+    throw error
+  }
+}
+
+/**
+ * Twitch書き込み系route（reward作成/EventSub登録等）が401/403を受けた際に、
+ * DB確定状態を同期する共通helper (#788 子E #793)。401→reauth_required、
+ * 403→unavailableとして確定保存する。429/5xx等の一時失敗はこのhelperの対象外
+ * （呼び出し元は definitive な401/403のときだけこれを呼ぶ）。
+ *
+ * 同期自体の失敗は呼び出し元の主処理（reward書き込み等のレスポンス）を巻き込まない
+ * よう、例外を投げずwarnログのみに留める。
+ */
+export async function recordChannelPointsApiFailure(
+  twitchUserId: string,
+  httpStatus: 401 | 403
+): Promise<void> {
+  const result: DefinitiveCapabilityResult =
+    httpStatus === 401
+      ? { capability: 'reauth_required', reason: 'unauthorized', httpStatus: 401, definitive: true }
+      : { capability: 'unavailable', reason: 'forbidden', httpStatus: 403, definitive: true }
+
+  try {
+    await persistChannelPointsCapability(twitchUserId, result)
+  } catch (error) {
+    logger.warn('[channel-points-access] recordChannelPointsApiFailure failed to persist', {
+      twitchUserId,
+      httpStatus,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
+export type EnableChannelPointsAccessResult =
+  | { ok: true; streamerId: string }
+  | { ok: false; error: 'capability_not_available' | 'user_not_found' }
+
+/**
+ * enable_channel_points_streamer_access RPC の例外メッセージ（RAISE EXCEPTION の
+ * 文字列そのもの）を、PostgREST/pg直結どちらの経路でも同じtypedエラーへ写像する。
+ * 両経路ともPostgresのエラーmessageフィールドにRAISE EXCEPTIONの文字列がそのまま
+ * 載るため、同一のmessage起点で判定できる（driver parity）。
+ */
+function classifyEnableRpcError(message: string): EnableChannelPointsAccessResult['error'] | null {
+  if (message.includes('CAPABILITY_NOT_AVAILABLE')) return 'capability_not_available'
+  if (message.includes('USER_NOT_FOUND')) return 'user_not_found'
+  return null
+}
+
+/**
+ * 非Affiliateユーザーの明示的オプトインを原子的に処理するRPCを呼ぶ (#788 子B #790)。
+ * DB側で `channel_points_capability = 'available'` を再検証してから
+ * `channel_points_enabled = true` にし、streamers 行をidempotentにUPSERTする
+ * （既存streamer設定は上書きしない）。同時実行・二重送信でも重複作成しない。
+ */
+export async function enableChannelPointsStreamerAccess(
+  twitchUserId: string
+): Promise<EnableChannelPointsAccessResult> {
+  if (isPgWriteEnabled()) {
+    try {
+      const streamerId = await withDbRetry(
+        async () => {
+          // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
+          const { sql } = await getDb()
+          const rows = await sql<{ streamer_id: string | null }[]>`
+            select enable_channel_points_streamer_access(p_twitch_user_id => ${twitchUserId}) as streamer_id
+          `
+          return rows[0]?.streamer_id ?? null
+        },
+        'channel-points-access(enable rpc, pg)',
+        // RPC本体（UPDATE + INSERT...ON CONFLICT DO UPDATE）は同じ入力なら
+        // 何度実行しても同じ終了状態に収束するため冪等（リトライ可）。
+        { idempotent: true }
+      )
+      if (!streamerId) {
+        throw new Error('enable_channel_points_streamer_access returned no streamer_id')
+      }
+      return { ok: true, streamerId }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      const classified = classifyEnableRpcError(message)
+      if (classified) return { ok: false, error: classified }
+      logger.error('[channel-points-access] enableChannelPointsStreamerAccess RPC failed (pg)', {
+        twitchUserId,
+        error: message,
+      })
+      throw error
+    }
+  }
+
+  const { data, error } = await getSupabaseAdmin().rpc('enable_channel_points_streamer_access', {
+    p_twitch_user_id: twitchUserId,
+  })
+
+  if (error) {
+    const classified = classifyEnableRpcError(error.message)
+    if (classified) return { ok: false, error: classified }
+    logger.error('[channel-points-access] enableChannelPointsStreamerAccess RPC failed', {
+      twitchUserId,
+      error: error.message,
+    })
+    throw error
+  }
+
+  if (!data) {
+    throw new Error('enable_channel_points_streamer_access RPC returned no data')
+  }
+
+  return { ok: true, streamerId: data as string }
+}

--- a/src/lib/twitch/channel-points.ts
+++ b/src/lib/twitch/channel-points.ts
@@ -4,6 +4,37 @@ import { logger } from '@/lib/logger'
 
 const TWITCH_API_URL = 'https://api.twitch.tv/helix'
 
+// Twitch APIへの疎通確認が異常に長引いてcallback/API route全体を巻き込んで
+// 遅延させないためのタイムアウト（#788子A #789）。
+const CAPABILITY_PROBE_TIMEOUT_MS = 5000
+
+export type ChannelPointsCapability = 'available' | 'unavailable' | 'reauth_required' | 'unknown'
+
+export type ChannelPointsCapabilityReason =
+  | 'ok'
+  | 'no_access_token'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'rate_limited'
+  | 'twitch_server_error'
+  | 'unexpected_status'
+  | 'network_error'
+
+export interface ChannelPointsCapabilityResult {
+  capability: ChannelPointsCapability
+  reason: ChannelPointsCapabilityReason
+  httpStatus?: number
+  /**
+   * true: 200/401/403相当の確定結果。呼び出し元はDBの確定状態を上書きしてよい。
+   * false: 429/5xx/network error等の一時失敗。呼び出し元は既存の確定状態を
+   *        破壊してはならない（#788親issueの中核要件）。
+   */
+  definitive: boolean
+}
+
+/** definitive=true をリテラル型で強制する。一時失敗の結果を誤って永続化APIへ渡せなくする。 */
+export type DefinitiveCapabilityResult = ChannelPointsCapabilityResult & { definitive: true }
+
 export interface CancelRedemptionParams {
   /** 配信者のTwitchユーザーID（数値ID文字列。EventSub payload の broadcaster_user_id） */
   broadcasterTwitchUserId: string
@@ -101,4 +132,75 @@ export async function cancelRedemption(params: CancelRedemptionParams): Promise<
     })
     return { success: false, reason: 'exception' }
   }
+}
+
+/**
+ * 非Affiliateユーザーを含む配信者本人のChannel Points利用可否を判定する
+ * Capability Probe (#788 子A #789)。
+ *
+ * `GET /helix/channel_points/custom_rewards?broadcaster_id=...&only_manageable_rewards=true`
+ * を呼ぶだけの非破壊・読み取り専用リクエストで、報酬の作成・更新・削除は行わない。
+ * `only_manageable_rewards=true` により、報酬が0件でも利用可能なら200・空配列が
+ * 返るため、報酬件数ではなくHTTPステータスのみで判定する（報酬タイトルや
+ * broadcaster_typeは判定材料にしない）。
+ *
+ * `cancelRedemption`と同じ非throwスタイル: 通常のTwitch拒否（401/403等）では
+ * 例外を投げず、呼び出し元がUI/DB契約へ変換しやすい結果オブジェクトを返す。
+ *
+ * @see https://dev.twitch.tv/docs/api/reference/#get-custom-reward
+ */
+export async function probeChannelPointsCapability(
+  broadcasterTwitchUserId: string
+): Promise<ChannelPointsCapabilityResult> {
+  const accessToken = await getTwitchAccessToken(broadcasterTwitchUserId)
+  if (!accessToken) {
+    return { capability: 'reauth_required', reason: 'no_access_token', definitive: true }
+  }
+
+  const clientId = getEnvVar('NEXT_PUBLIC_TWITCH_CLIENT_ID', true)!
+  const query = new URLSearchParams({
+    broadcaster_id: broadcasterTwitchUserId,
+    only_manageable_rewards: 'true',
+  })
+
+  let response: Response
+  try {
+    response = await fetch(`${TWITCH_API_URL}/channel_points/custom_rewards?${query.toString()}`, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Client-Id': clientId,
+      },
+      signal: AbortSignal.timeout(CAPABILITY_PROBE_TIMEOUT_MS),
+    })
+  } catch (error) {
+    // access token / Authorization headerはログへ出さない。分類済みreasonのみ残す。
+    logger.warn('[probeChannelPointsCapability] Request failed', {
+      broadcasterTwitchUserId,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return { capability: 'unknown', reason: 'network_error', definitive: false }
+  }
+
+  if (response.status === 200) {
+    return { capability: 'available', reason: 'ok', httpStatus: 200, definitive: true }
+  }
+  if (response.status === 401) {
+    return { capability: 'reauth_required', reason: 'unauthorized', httpStatus: 401, definitive: true }
+  }
+  if (response.status === 403) {
+    return { capability: 'unavailable', reason: 'forbidden', httpStatus: 403, definitive: true }
+  }
+  if (response.status === 429) {
+    return { capability: 'unknown', reason: 'rate_limited', httpStatus: 429, definitive: false }
+  }
+  if (response.status >= 500) {
+    return { capability: 'unknown', reason: 'twitch_server_error', httpStatus: response.status, definitive: false }
+  }
+
+  // その他の非2xx。レスポンス本文は機密情報を含み得るためログへ出さない。
+  logger.warn('[probeChannelPointsCapability] Unexpected Twitch API status', {
+    broadcasterTwitchUserId,
+    status: response.status,
+  })
+  return { capability: 'unknown', reason: 'unexpected_status', httpStatus: response.status, definitive: false }
 }

--- a/src/lib/twitch/channel-points.ts
+++ b/src/lib/twitch/channel-points.ts
@@ -35,6 +35,19 @@ export interface ChannelPointsCapabilityResult {
 /** definitive=true をリテラル型で強制する。一時失敗の結果を誤って永続化APIへ渡せなくする。 */
 export type DefinitiveCapabilityResult = ChannelPointsCapabilityResult & { definitive: true }
 
+/**
+ * `result.definitive` の真偽値チェックだけでは、`definitive: boolean` という
+ * プレーンなフィールド宣言のためTypeScriptの制御フロー解析が `DefinitiveCapabilityResult`
+ * への型絞り込みを行わない（呼び出し側で `if (result.definitive)` の中で
+ * `persistChannelPointsCapability(id, result)` を呼ぶと型エラーになる）。
+ * 型ガード関数として定義し、呼び出し側の絞り込みを可能にする。
+ */
+export function isDefinitiveCapabilityResult(
+  result: ChannelPointsCapabilityResult
+): result is DefinitiveCapabilityResult {
+  return result.definitive === true
+}
+
 export interface CancelRedemptionParams {
   /** 配信者のTwitchユーザーID（数値ID文字列。EventSub payload の broadcaster_user_id） */
   broadcasterTwitchUserId: string

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -313,6 +313,10 @@ export interface Database {
           // Twitch API によるサブスク確認のキャッシュ
           twitch_sub_verified_at: string | null
           twitch_has_sub: boolean
+          // 20260723150000 (#788): 非Affiliate配信者向けChannel Points Capability判定・オプトイン
+          channel_points_capability: string
+          channel_points_capability_checked_at: string | null
+          channel_points_enabled: boolean
           created_at: string
           updated_at: string
         }
@@ -326,6 +330,9 @@ export interface Database {
           twitch_scopes?: string[]
           twitch_sub_verified_at?: string | null
           twitch_has_sub?: boolean
+          channel_points_capability?: string
+          channel_points_capability_checked_at?: string | null
+          channel_points_enabled?: boolean
           created_at?: string
           updated_at?: string
         }
@@ -339,6 +346,9 @@ export interface Database {
           twitch_scopes?: string[]
           twitch_sub_verified_at?: string | null
           twitch_has_sub?: boolean
+          channel_points_capability?: string
+          channel_points_capability_checked_at?: string | null
+          channel_points_enabled?: boolean
           created_at?: string
           updated_at?: string
         }

--- a/supabase/migrations/20260723150000_add_channel_points_capability.sql
+++ b/supabase/migrations/20260723150000_add_channel_points_capability.sql
@@ -1,0 +1,81 @@
+-- 非Affiliate配信者向けChannel Points Capability判定・オプトイン基盤 (#788 子B #790)
+--
+-- 背景:
+-- Twitchの「Monetization for All」制度により、Affiliate/Partnerでなくても
+-- Channel Pointsを利用できるユーザーが登場した。twica側は非破壊のCapability
+-- Probe（GET /helix/channel_points/custom_rewards）でTwitch側の利用可否を判定し、
+-- 判定結果とtwica配信者機能への明示的オプトインを users に永続化する。
+--
+-- channel_points_capability: 最後に得た「確定状態」(200/401/403相当)。
+--   429/5xx/network error等の一時失敗はここへ保存しない。
+-- channel_points_capability_checked_at: 確定状態を最後に得た日時。
+-- channel_points_enabled: 非Affiliateユーザーがtwica配信者機能を明示的に
+--   有効化したか。TwitchネイティブのChannel Points設定とは別概念。
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS channel_points_capability TEXT NOT NULL DEFAULT 'unknown',
+  ADD COLUMN IF NOT EXISTS channel_points_capability_checked_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS channel_points_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE users
+  DROP CONSTRAINT IF EXISTS users_channel_points_capability_check;
+ALTER TABLE users
+  ADD CONSTRAINT users_channel_points_capability_check
+  CHECK (channel_points_capability IN ('available', 'unavailable', 'reauth_required', 'unknown'));
+
+-- 明示的有効化 + streamers UPSERT を単一トランザクションで行うRPC。
+-- 00060 (exchange_duplicate_card_for_stones) と同じ SECURITY DEFINER + search_path 固定方針。
+--
+-- 戻り値は streamer_id のみ（INSERT ... ON CONFLICT の結果だけでは「新規作成か
+-- 既存更新か」を安全に判定できず、呼び出し側もその真偽値を使わないため、
+-- 誤りうる判定ロジックを持ち込むより単純化する）。
+--
+-- users 行を FOR UPDATE で行ロックしてから capability を再検証するため、
+-- 同時実行・二重送信でも streamers 行が重複作成されず、capability が
+-- 'available' でなければ有効化されない。
+CREATE OR REPLACE FUNCTION enable_channel_points_streamer_access(p_twitch_user_id TEXT)
+RETURNS UUID AS $$
+DECLARE
+  v_user RECORD;
+  v_streamer_id UUID;
+BEGIN
+  IF p_twitch_user_id IS NULL OR p_twitch_user_id = '' THEN
+    RAISE EXCEPTION 'TWITCH_USER_ID_REQUIRED';
+  END IF;
+
+  SELECT twitch_user_id, twitch_username, twitch_display_name, twitch_profile_image_url,
+         channel_points_capability
+    INTO v_user
+    FROM users
+    WHERE twitch_user_id = p_twitch_user_id
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'USER_NOT_FOUND';
+  END IF;
+
+  IF v_user.channel_points_capability IS DISTINCT FROM 'available' THEN
+    RAISE EXCEPTION 'CAPABILITY_NOT_AVAILABLE';
+  END IF;
+
+  -- updated_atは既存の update_users_updated_at トリガー(00001)が自動更新するため
+  -- ここでは明示的に触らない。
+  UPDATE users SET channel_points_enabled = TRUE
+    WHERE twitch_user_id = p_twitch_user_id;
+
+  -- 既存streamer行がある場合はプロフィール列のみ更新し、reward_id/collection/
+  -- sound/chat設定等の既存カスタマイズを一切上書きしない。
+  INSERT INTO streamers (twitch_user_id, twitch_username, twitch_display_name, twitch_profile_image_url)
+    VALUES (v_user.twitch_user_id, v_user.twitch_username, v_user.twitch_display_name, v_user.twitch_profile_image_url)
+    ON CONFLICT (twitch_user_id) DO UPDATE SET
+      twitch_username = EXCLUDED.twitch_username,
+      twitch_display_name = EXCLUDED.twitch_display_name,
+      twitch_profile_image_url = EXCLUDED.twitch_profile_image_url
+    RETURNING id INTO v_streamer_id;
+
+  RETURN v_streamer_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp;
+
+REVOKE ALL ON FUNCTION enable_channel_points_streamer_access(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION enable_channel_points_streamer_access(TEXT) TO service_role;

--- a/tests/unit/account-channel-points-api.test.ts
+++ b/tests/unit/account-channel-points-api.test.ts
@@ -1,0 +1,744 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest, NextResponse } from 'next/server'
+import { BROADCASTER_TYPE, COOKIE_NAMES, ERROR_MESSAGES } from '@/lib/constants'
+
+// #791: GET/POST/PUT /api/account/channel-points のテスト。
+// tests/unit/channel-point-bootstrap-api.test.ts / tests/unit/streamer-settings-api.test.ts
+// と同じ慣習に従う: 各依存モジュールをvi.mockし、モック設定後にroute moduleを
+// 動的importする（トップレベルでimportすると設定前に評価されてしまうため）。
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('@/lib/session', () => ({
+  getSession: vi.fn(),
+  signSession: vi.fn(),
+}))
+
+vi.mock('@/lib/csrf', () => ({
+  validateCSRFToken: vi.fn(),
+}))
+
+vi.mock('@/lib/request-validation', () => ({
+  validateContentType: vi.fn(),
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn(),
+  getRateLimitIdentifier: vi.fn(),
+  rateLimits: { accountChannelPointsProbe: { windowMs: 60000, max: 10 } },
+}))
+
+// handleApiError: 本物はSentry記録を伴うため、他のroute testと同様に
+// 最小限のNextResponse相当を返すモックに差し替える（このファイルのテストでは
+// GET/POST/PUTのcatchブロックへ到達するケースを意図的に作っていない）。
+vi.mock('@/lib/error-handler', () => ({
+  handleApiError: vi.fn(() => NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })),
+}))
+
+vi.mock('@/lib/twitch/token-manager', () => ({
+  hasScope: vi.fn(),
+}))
+
+vi.mock('@/lib/twitch/channel-points', () => ({
+  probeChannelPointsCapability: vi.fn(),
+}))
+
+vi.mock('@/lib/twitch/channel-points-access', () => ({
+  enableChannelPointsStreamerAccess: vi.fn(),
+  getChannelPointsAccessState: vi.fn(),
+  persistChannelPointsCapability: vi.fn(),
+}))
+
+const session = {
+  twitchUserId: 'twitch-user-1',
+  twitchUsername: 'testuser',
+  twitchDisplayName: 'Test User',
+  twitchProfileImageUrl: '',
+  broadcasterType: BROADCASTER_TYPE.NONE,
+  expiresAt: Date.now() + 60 * 60 * 1000,
+  version: 1,
+}
+
+function makeRequest(method: string, init?: RequestInit) {
+  return new NextRequest('http://localhost:3000/api/account/channel-points', {
+    method,
+    ...init,
+  })
+}
+
+function postRequest(init?: RequestInit) {
+  return makeRequest('POST', {
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  })
+}
+
+function putRequest(init?: RequestInit) {
+  return makeRequest('PUT', init)
+}
+
+describe('/api/account/channel-points', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    const { getSession, signSession } = await import('@/lib/session')
+    const { validateCSRFToken } = await import('@/lib/csrf')
+    const { validateContentType } = await import('@/lib/request-validation')
+    const { checkRateLimit, getRateLimitIdentifier } = await import('@/lib/rate-limit')
+    const { hasScope } = await import('@/lib/twitch/token-manager')
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const { getChannelPointsAccessState, persistChannelPointsCapability, enableChannelPointsStreamerAccess } =
+      await import('@/lib/twitch/channel-points-access')
+
+    // Sensible defaults so tests that don't care about a given dependency
+    // don't have to configure it explicitly. Each test below overrides only
+    // what it needs to exercise.
+    vi.mocked(getSession).mockResolvedValue(session as any)
+    vi.mocked(signSession).mockResolvedValue('signed-session-payload')
+    vi.mocked(validateCSRFToken).mockResolvedValue({ valid: true })
+    vi.mocked(validateContentType).mockReturnValue(null)
+    vi.mocked(checkRateLimit).mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: Date.now() + 60000,
+    })
+    vi.mocked(getRateLimitIdentifier).mockResolvedValue('user:twitch-user-1')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(getChannelPointsAccessState).mockResolvedValue({
+      capability: 'unknown',
+      checkedAt: null,
+      enabled: false,
+    })
+    vi.mocked(persistChannelPointsCapability).mockResolvedValue(undefined)
+    vi.mocked(enableChannelPointsStreamerAccess).mockResolvedValue({ ok: true, streamerId: 'streamer-1' })
+    vi.mocked(probeChannelPointsCapability).mockResolvedValue({
+      capability: 'unknown',
+      reason: 'network_error',
+      definitive: false,
+    })
+  })
+
+  // ==========================================================================
+  // GET
+  // ==========================================================================
+  describe('GET', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('#1 returns 401 when there is no session', async () => {
+      const { getSession } = await import('@/lib/session')
+      vi.mocked(getSession).mockResolvedValue(null)
+
+      const { GET } = await import('@/app/api/account/channel-points/route')
+      const response = await GET()
+
+      expect(response.status).toBe(401)
+      const body = await response.json()
+      expect(body.error).toBe(ERROR_MESSAGES.UNAUTHORIZED)
+    })
+
+    it('#2 flags missing scope + stale + non-enabled for a fresh non-affiliate user', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { getChannelPointsAccessState } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(getChannelPointsAccessState).mockResolvedValue({
+        capability: 'unknown',
+        checkedAt: null,
+        enabled: false,
+      })
+      vi.mocked(hasScope).mockResolvedValue(false)
+
+      const { GET } = await import('@/app/api/account/channel-points/route')
+      const response = await GET()
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body.hasRequiredScope).toBe(false)
+      expect(body.requiresReauth).toBe(true)
+      expect(body.stale).toBe(true)
+      expect(body.canEnable).toBe(false)
+    })
+
+    it('#3 canEnable is true when available + scope present + not enabled + non-affiliate', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { getChannelPointsAccessState } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(getChannelPointsAccessState).mockResolvedValue({
+        capability: 'available',
+        checkedAt: new Date().toISOString(),
+        enabled: false,
+      })
+      vi.mocked(hasScope).mockResolvedValue(true)
+
+      const { GET } = await import('@/app/api/account/channel-points/route')
+      const response = await GET()
+      const body = await response.json()
+
+      expect(body.canEnable).toBe(true)
+    })
+
+    it('#4 canEnable is false when already enabled', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { getChannelPointsAccessState } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(getChannelPointsAccessState).mockResolvedValue({
+        capability: 'available',
+        checkedAt: new Date().toISOString(),
+        enabled: true,
+      })
+      vi.mocked(hasScope).mockResolvedValue(true)
+
+      const { GET } = await import('@/app/api/account/channel-points/route')
+      const response = await GET()
+      const body = await response.json()
+
+      expect(body.canEnable).toBe(false)
+    })
+
+    it('#5 canEnable is false for affiliates even when available and not enabled', async () => {
+      const { getSession } = await import('@/lib/session')
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { getChannelPointsAccessState } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(getSession).mockResolvedValue({ ...session, broadcasterType: BROADCASTER_TYPE.AFFILIATE } as any)
+      vi.mocked(getChannelPointsAccessState).mockResolvedValue({
+        capability: 'available',
+        checkedAt: new Date().toISOString(),
+        enabled: false,
+      })
+      vi.mocked(hasScope).mockResolvedValue(true)
+
+      const { GET } = await import('@/app/api/account/channel-points/route')
+      const response = await GET()
+      const body = await response.json()
+
+      expect(body.canEnable).toBe(false)
+    })
+
+    it('#6a stale is true when capabilityCheckedAt is more than 24h old', async () => {
+      vi.useFakeTimers()
+      const now = new Date('2026-07-23T00:00:00.000Z')
+      vi.setSystemTime(now)
+
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { getChannelPointsAccessState } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(getChannelPointsAccessState).mockResolvedValue({
+        capability: 'available',
+        // Exactly threshold + 1ms ago: Date.now() - checkedAtMs > 24h is true.
+        checkedAt: new Date(now.getTime() - 24 * 60 * 60 * 1000 - 1).toISOString(),
+        enabled: false,
+      })
+
+      const { GET } = await import('@/app/api/account/channel-points/route')
+      const response = await GET()
+      const body = await response.json()
+
+      expect(body.stale).toBe(true)
+    })
+
+    it('#6b stale is false at the exact 24h boundary (isStale uses strictly-greater-than)', async () => {
+      vi.useFakeTimers()
+      const now = new Date('2026-07-23T00:00:00.000Z')
+      vi.setSystemTime(now)
+
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { getChannelPointsAccessState } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(getChannelPointsAccessState).mockResolvedValue({
+        capability: 'available',
+        // Exactly 24h ago: Date.now() - checkedAtMs === 24h, and `>` is strict,
+        // so this boundary is NOT stale per src/app/api/account/channel-points/route.ts isStale().
+        checkedAt: new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString(),
+        enabled: false,
+      })
+
+      const { GET } = await import('@/app/api/account/channel-points/route')
+      const response = await GET()
+      const body = await response.json()
+
+      expect(body.stale).toBe(false)
+    })
+
+    it('#6c stale is false when capabilityCheckedAt is less than 24h old', async () => {
+      vi.useFakeTimers()
+      const now = new Date('2026-07-23T00:00:00.000Z')
+      vi.setSystemTime(now)
+
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { getChannelPointsAccessState } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(getChannelPointsAccessState).mockResolvedValue({
+        capability: 'available',
+        checkedAt: new Date(now.getTime() - 60 * 60 * 1000).toISOString(),
+        enabled: false,
+      })
+
+      const { GET } = await import('@/app/api/account/channel-points/route')
+      const response = await GET()
+      const body = await response.json()
+
+      expect(body.stale).toBe(false)
+    })
+
+    it('#7 requiresReauth is true when capability is reauth_required even if hasRequiredScope is true', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { getChannelPointsAccessState } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(getChannelPointsAccessState).mockResolvedValue({
+        capability: 'reauth_required',
+        checkedAt: new Date().toISOString(),
+        enabled: false,
+      })
+
+      const { GET } = await import('@/app/api/account/channel-points/route')
+      const response = await GET()
+      const body = await response.json()
+
+      expect(body.hasRequiredScope).toBe(true)
+      expect(body.requiresReauth).toBe(true)
+    })
+
+    it('#8 defaults capability to unknown and does not crash when there is no DB row', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { getChannelPointsAccessState } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(getChannelPointsAccessState).mockResolvedValue(null)
+
+      const { GET } = await import('@/app/api/account/channel-points/route')
+      const response = await GET()
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body.capability).toBe('unknown')
+      expect(body.capabilityCheckedAt).toBeNull()
+      expect(body.enabled).toBe(false)
+    })
+  })
+
+  // ==========================================================================
+  // POST
+  // ==========================================================================
+  describe('POST', () => {
+    it('#9 returns 403 and never checks the rate limit when CSRF is invalid', async () => {
+      const { validateCSRFToken } = await import('@/lib/csrf')
+      const { checkRateLimit } = await import('@/lib/rate-limit')
+      vi.mocked(validateCSRFToken).mockResolvedValue({ valid: false })
+
+      const { POST } = await import('@/app/api/account/channel-points/route')
+      const response = await POST(postRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(403)
+      expect(body.error).toBe(ERROR_MESSAGES.FORBIDDEN)
+      expect(checkRateLimit).not.toHaveBeenCalled()
+    })
+
+    it('#10 returns the content-type validation response directly', async () => {
+      const { validateContentType } = await import('@/lib/request-validation')
+      const { validateCSRFToken } = await import('@/lib/csrf')
+      const sentinel = NextResponse.json({ error: 'unsupported media type' }, { status: 415 })
+      vi.mocked(validateContentType).mockReturnValue(sentinel)
+
+      const { POST } = await import('@/app/api/account/channel-points/route')
+      const response = await POST(postRequest())
+
+      expect(response).toBe(sentinel)
+      expect(validateCSRFToken).not.toHaveBeenCalled()
+    })
+
+    it('#11 returns 429 when rate limited', async () => {
+      const { checkRateLimit } = await import('@/lib/rate-limit')
+      vi.mocked(checkRateLimit).mockResolvedValue({
+        success: false,
+        limit: 10,
+        remaining: 0,
+        reset: Date.now() + 60000,
+      })
+
+      const { POST } = await import('@/app/api/account/channel-points/route')
+      const response = await POST(postRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(429)
+      expect(body.error).toBe(ERROR_MESSAGES.RATE_LIMIT_EXCEEDED)
+    })
+
+    it('#12 returns 401 when there is no session', async () => {
+      const { getSession } = await import('@/lib/session')
+      vi.mocked(getSession).mockResolvedValue(null)
+
+      const { POST } = await import('@/app/api/account/channel-points/route')
+      const response = await POST(postRequest())
+
+      expect(response.status).toBe(401)
+    })
+
+    it('#13 persists reauth_required and skips the Twitch probe when scope is missing', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      const { persistChannelPointsCapability, getChannelPointsAccessState } =
+        await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(false)
+      vi.mocked(getChannelPointsAccessState).mockResolvedValue({
+        capability: 'reauth_required',
+        checkedAt: '2026-07-22T00:00:00.000Z',
+        enabled: false,
+      })
+
+      const { POST } = await import('@/app/api/account/channel-points/route')
+      const response = await POST(postRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body.code).toBe('reauth_required')
+      expect(persistChannelPointsCapability).toHaveBeenCalledWith('twitch-user-1', {
+        capability: 'reauth_required',
+        reason: 'no_access_token',
+        definitive: true,
+      })
+      expect(probeChannelPointsCapability).not.toHaveBeenCalled()
+    })
+
+    it('#14 persists a definitive available probe result and echoes the freshly persisted state', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      const { persistChannelPointsCapability, getChannelPointsAccessState } =
+        await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      const probeResult = { capability: 'available', reason: 'ok', httpStatus: 200, definitive: true }
+      vi.mocked(probeChannelPointsCapability).mockResolvedValue(probeResult as any)
+      vi.mocked(getChannelPointsAccessState).mockResolvedValue({
+        capability: 'available',
+        checkedAt: '2026-07-23T00:00:00.000Z',
+        enabled: false,
+      })
+
+      const { POST } = await import('@/app/api/account/channel-points/route')
+      const response = await POST(postRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(persistChannelPointsCapability).toHaveBeenCalledWith('twitch-user-1', probeResult)
+      expect(body.code).toBe('available')
+      expect(body.persisted).toEqual({
+        capability: 'available',
+        capabilityCheckedAt: '2026-07-23T00:00:00.000Z',
+      })
+      expect(body.enabled).toBe(false)
+    })
+
+    it('#15 does not persist a non-definitive probe result and returns the unchanged existing state', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      const { persistChannelPointsCapability, getChannelPointsAccessState } =
+        await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      // A 429 from Twitch: not definitive, must not clobber existing confirmed DB state.
+      const probeResult = { capability: 'unknown', reason: 'rate_limited', httpStatus: 429, definitive: false }
+      vi.mocked(probeChannelPointsCapability).mockResolvedValue(probeResult as any)
+      const existingState = {
+        capability: 'available' as const,
+        checkedAt: '2025-01-01T00:00:00.000Z',
+        enabled: false,
+      }
+      vi.mocked(getChannelPointsAccessState).mockResolvedValue(existingState)
+
+      const { POST } = await import('@/app/api/account/channel-points/route')
+      const response = await POST(postRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(persistChannelPointsCapability).not.toHaveBeenCalled()
+      expect(body.code).toBe('probe_temporarily_failed')
+      // The persisted state reflects the PRE-EXISTING (unchanged) DB row, proving
+      // the transient probe failure did not overwrite it.
+      expect(body.persisted).toEqual({
+        capability: 'available',
+        capabilityCheckedAt: '2025-01-01T00:00:00.000Z',
+      })
+    })
+  })
+
+  // ==========================================================================
+  // PUT
+  // ==========================================================================
+  describe('PUT', () => {
+    it('#16 returns 401 when there is no session', async () => {
+      const { getSession } = await import('@/lib/session')
+      vi.mocked(getSession).mockResolvedValue(null)
+
+      const { PUT } = await import('@/app/api/account/channel-points/route')
+      const response = await PUT(putRequest())
+
+      expect(response.status).toBe(401)
+    })
+
+    it('#17 returns 403 when CSRF is invalid', async () => {
+      const { validateCSRFToken } = await import('@/lib/csrf')
+      vi.mocked(validateCSRFToken).mockResolvedValue({ valid: false })
+
+      const { PUT } = await import('@/app/api/account/channel-points/route')
+      const response = await PUT(putRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(403)
+      expect(body.error).toBe(ERROR_MESSAGES.FORBIDDEN)
+    })
+
+    it('#18 returns 429 when rate limited', async () => {
+      const { checkRateLimit } = await import('@/lib/rate-limit')
+      vi.mocked(checkRateLimit).mockResolvedValue({
+        success: false,
+        limit: 10,
+        remaining: 0,
+        reset: Date.now() + 60000,
+      })
+
+      const { PUT } = await import('@/app/api/account/channel-points/route')
+      const response = await PUT(putRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(429)
+      expect(body.error).toBe(ERROR_MESSAGES.RATE_LIMIT_EXCEEDED)
+    })
+
+    it.each([BROADCASTER_TYPE.AFFILIATE, BROADCASTER_TYPE.PARTNER])(
+      '#19 returns already_enabled immediately for existing %s streamers without probing or enabling',
+      async (broadcasterType) => {
+        const { getSession } = await import('@/lib/session')
+        const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+        const { enableChannelPointsStreamerAccess } = await import('@/lib/twitch/channel-points-access')
+        vi.mocked(getSession).mockResolvedValue({ ...session, broadcasterType } as any)
+
+        const { PUT } = await import('@/app/api/account/channel-points/route')
+        const response = await PUT(putRequest())
+        const body = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(body).toEqual({ code: 'already_enabled', enabled: true })
+        expect(probeChannelPointsCapability).not.toHaveBeenCalled()
+        expect(enableChannelPointsStreamerAccess).not.toHaveBeenCalled()
+      }
+    )
+
+    it('#20 returns reauth_required (409) and persists it without probing or enabling when scope is missing', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      const { persistChannelPointsCapability, enableChannelPointsStreamerAccess } =
+        await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(false)
+
+      const { PUT } = await import('@/app/api/account/channel-points/route')
+      const response = await PUT(putRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(body).toEqual({ code: 'reauth_required', enabled: false })
+      expect(persistChannelPointsCapability).toHaveBeenCalledWith('twitch-user-1', {
+        capability: 'reauth_required',
+        reason: 'no_access_token',
+        definitive: true,
+      })
+      expect(probeChannelPointsCapability).not.toHaveBeenCalled()
+      expect(enableChannelPointsStreamerAccess).not.toHaveBeenCalled()
+    })
+
+    it('#21 returns channel_points_unavailable (409) and does not enable when a fresh probe says unavailable', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      const { enableChannelPointsStreamerAccess } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(probeChannelPointsCapability).mockResolvedValue({
+        capability: 'unavailable',
+        reason: 'forbidden',
+        httpStatus: 403,
+        definitive: true,
+      } as any)
+
+      const { PUT } = await import('@/app/api/account/channel-points/route')
+      const response = await PUT(putRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(body.code).toBe('channel_points_unavailable')
+      expect(body.enabled).toBe(false)
+      expect(enableChannelPointsStreamerAccess).not.toHaveBeenCalled()
+    })
+
+    it('#22 always re-probes rather than trusting a stale DB state: a live "available" probe triggers enable', async () => {
+      // Deliberately do NOT configure getChannelPointsAccessState to say
+      // 'available' here (it defaults to 'unknown' via the shared beforeEach,
+      // and PUT never even reads it) — the fresh probeChannelPointsCapability
+      // mock below is the only thing driving enablement, proving the route
+      // does not trust any possibly-stale DB row.
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      const { enableChannelPointsStreamerAccess } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(probeChannelPointsCapability).mockResolvedValue({
+        capability: 'available',
+        reason: 'ok',
+        httpStatus: 200,
+        definitive: true,
+      } as any)
+      vi.mocked(enableChannelPointsStreamerAccess).mockResolvedValue({ ok: true, streamerId: 'streamer-1' })
+
+      const { PUT } = await import('@/app/api/account/channel-points/route')
+      const response = await PUT(putRequest())
+
+      expect(probeChannelPointsCapability).toHaveBeenCalledWith('twitch-user-1')
+      expect(enableChannelPointsStreamerAccess).toHaveBeenCalledWith('twitch-user-1')
+      expect(response.status).toBe(200)
+    })
+
+    it('#23 sets the session cookie and returns enabled:true when the probe and enable both succeed', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      const { enableChannelPointsStreamerAccess } = await import('@/lib/twitch/channel-points-access')
+      const { signSession } = await import('@/lib/session')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(probeChannelPointsCapability).mockResolvedValue({
+        capability: 'available',
+        reason: 'ok',
+        httpStatus: 200,
+        definitive: true,
+      } as any)
+      vi.mocked(enableChannelPointsStreamerAccess).mockResolvedValue({ ok: true, streamerId: 'uuid-1' })
+      vi.mocked(signSession).mockResolvedValue('signed-cookie-value')
+
+      const { PUT } = await import('@/app/api/account/channel-points/route')
+      const response = await PUT(putRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body).toEqual({ code: 'enabled', enabled: true, streamerId: 'uuid-1' })
+      expect(response.cookies.get(COOKIE_NAMES.SESSION)?.value).toBe('signed-cookie-value')
+    })
+
+    it('#24 returns channel_points_unavailable (409) with no cookie when enable fails with capability_not_available', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      const { enableChannelPointsStreamerAccess } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(probeChannelPointsCapability).mockResolvedValue({
+        capability: 'available',
+        reason: 'ok',
+        httpStatus: 200,
+        definitive: true,
+      } as any)
+      vi.mocked(enableChannelPointsStreamerAccess).mockResolvedValue({
+        ok: false,
+        error: 'capability_not_available',
+      })
+
+      const { PUT } = await import('@/app/api/account/channel-points/route')
+      const response = await PUT(putRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(body).toEqual({ code: 'channel_points_unavailable', enabled: false })
+      expect(response.cookies.get(COOKIE_NAMES.SESSION)).toBeUndefined()
+    })
+
+    it('#25 returns user_not_found (409) with no cookie when enable fails with user_not_found', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      const { enableChannelPointsStreamerAccess } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(probeChannelPointsCapability).mockResolvedValue({
+        capability: 'available',
+        reason: 'ok',
+        httpStatus: 200,
+        definitive: true,
+      } as any)
+      vi.mocked(enableChannelPointsStreamerAccess).mockResolvedValue({
+        ok: false,
+        error: 'user_not_found',
+      })
+
+      const { PUT } = await import('@/app/api/account/channel-points/route')
+      const response = await PUT(putRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(body).toEqual({ code: 'user_not_found', enabled: false })
+      expect(response.cookies.get(COOKIE_NAMES.SESSION)).toBeUndefined()
+    })
+
+    it('#26 double-submit: two sequential successful PUT calls both return the same enabled shape', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      const { enableChannelPointsStreamerAccess } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(probeChannelPointsCapability).mockResolvedValue({
+        capability: 'available',
+        reason: 'ok',
+        httpStatus: 200,
+        definitive: true,
+      } as any)
+      vi.mocked(enableChannelPointsStreamerAccess).mockResolvedValue({ ok: true, streamerId: 'streamer-1' })
+
+      const { PUT } = await import('@/app/api/account/channel-points/route')
+      const first = await PUT(putRequest())
+      const firstBody = await first.json()
+      const second = await PUT(putRequest())
+      const secondBody = await second.json()
+
+      expect(first.status).toBe(200)
+      expect(second.status).toBe(200)
+      expect(firstBody).toEqual({ code: 'enabled', enabled: true, streamerId: 'streamer-1' })
+      expect(secondBody).toEqual({ code: 'enabled', enabled: true, streamerId: 'streamer-1' })
+    })
+
+    it('#27 reports session_resync_failed (500) but still enabled:true when the DB write succeeded but signSession throws', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      const { enableChannelPointsStreamerAccess } = await import('@/lib/twitch/channel-points-access')
+      const { signSession } = await import('@/lib/session')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(probeChannelPointsCapability).mockResolvedValue({
+        capability: 'available',
+        reason: 'ok',
+        httpStatus: 200,
+        definitive: true,
+      } as any)
+      vi.mocked(enableChannelPointsStreamerAccess).mockResolvedValue({ ok: true, streamerId: 'streamer-1' })
+      vi.mocked(signSession).mockRejectedValue(new Error('signing key unavailable'))
+
+      const { PUT } = await import('@/app/api/account/channel-points/route')
+      const response = await PUT(putRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(body.code).toBe('session_resync_failed')
+      // DB write already succeeded, so the client must still be told enabled:true
+      // even though the session cookie could not be refreshed.
+      expect(body.enabled).toBe(true)
+      expect(response.cookies.get(COOKIE_NAMES.SESSION)).toBeUndefined()
+    })
+
+    it('#28 never validates content-type / reads a body — targeting is session-only', async () => {
+      const { validateContentType } = await import('@/lib/request-validation')
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      const { enableChannelPointsStreamerAccess } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(probeChannelPointsCapability).mockResolvedValue({
+        capability: 'available',
+        reason: 'ok',
+        httpStatus: 200,
+        definitive: true,
+      } as any)
+      vi.mocked(enableChannelPointsStreamerAccess).mockResolvedValue({ ok: true, streamerId: 'streamer-1' })
+
+      const { PUT } = await import('@/app/api/account/channel-points/route')
+      // No content-type header and no body at all — this must not trigger a
+      // content-type validation failure, because PUT never calls validateContentType.
+      const response = await PUT(putRequest())
+
+      expect(response.status).toBe(200)
+      expect(validateContentType).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/account-channel-points-api.test.ts
+++ b/tests/unit/account-channel-points-api.test.ts
@@ -43,6 +43,9 @@ vi.mock('@/lib/twitch/token-manager', () => ({
 
 vi.mock('@/lib/twitch/channel-points', () => ({
   probeChannelPointsCapability: vi.fn(),
+  // 実装と同じ判定ロジック（result.definitive === true）。route側の型ガード呼び出しを
+  // モック環境でも動作させる（モジュール全体をvi.mockしているため実関数は使えない）。
+  isDefinitiveCapabilityResult: (result: { definitive: boolean }) => result.definitive === true,
 }))
 
 vi.mock('@/lib/twitch/channel-points-access', () => ({
@@ -61,21 +64,26 @@ const session = {
   version: 1,
 }
 
-function makeRequest(method: string, init?: RequestInit) {
+// signalを除外: lib.dom.d.tsのRequestInit.signalはAbortSignal | nullを許容するが、
+// next/serverのNextRequest内部init型はAbortSignal | undefinedのみを受け付けるため
+// 型不一致になる。このテストではsignalを使わないため型からも除外する。
+type TestRequestInit = Omit<RequestInit, 'signal'>
+
+function makeRequest(method: string, init?: TestRequestInit) {
   return new NextRequest('http://localhost:3000/api/account/channel-points', {
     method,
     ...init,
   })
 }
 
-function postRequest(init?: RequestInit) {
+function postRequest(init?: TestRequestInit) {
   return makeRequest('POST', {
     headers: { 'content-type': 'application/json' },
     ...init,
   })
 }
 
-function putRequest(init?: RequestInit) {
+function putRequest(init?: TestRequestInit) {
   return makeRequest('PUT', init)
 }
 

--- a/tests/unit/account-channel-points-api.test.ts
+++ b/tests/unit/account-channel-points-api.test.ts
@@ -574,6 +574,55 @@ describe('/api/account/channel-points', () => {
       expect(enableChannelPointsStreamerAccess).not.toHaveBeenCalled()
     })
 
+    // 自動レビュー(claude[bot])指摘: #21のunavailableに加え、reauth_required /
+    // probe_temporarily_failed へのcodeマッピングも回帰検知対象にする。
+    it('#21b returns reauth_required (409) and does not enable when a fresh probe says reauth_required', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      const { enableChannelPointsStreamerAccess } = await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(probeChannelPointsCapability).mockResolvedValue({
+        capability: 'reauth_required',
+        reason: 'unauthorized',
+        httpStatus: 401,
+        definitive: true,
+      } as any)
+
+      const { PUT } = await import('@/app/api/account/channel-points/route')
+      const response = await PUT(putRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(body.code).toBe('reauth_required')
+      expect(body.enabled).toBe(false)
+      expect(enableChannelPointsStreamerAccess).not.toHaveBeenCalled()
+    })
+
+    it('#21c returns probe_temporarily_failed (409) and does not enable when a fresh probe is non-definitive (e.g. 429)', async () => {
+      const { hasScope } = await import('@/lib/twitch/token-manager')
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      const { enableChannelPointsStreamerAccess, persistChannelPointsCapability } =
+        await import('@/lib/twitch/channel-points-access')
+      vi.mocked(hasScope).mockResolvedValue(true)
+      vi.mocked(probeChannelPointsCapability).mockResolvedValue({
+        capability: 'unknown',
+        reason: 'rate_limited',
+        httpStatus: 429,
+        definitive: false,
+      } as any)
+
+      const { PUT } = await import('@/app/api/account/channel-points/route')
+      const response = await PUT(putRequest())
+      const body = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(body.code).toBe('probe_temporarily_failed')
+      expect(body.enabled).toBe(false)
+      expect(enableChannelPointsStreamerAccess).not.toHaveBeenCalled()
+      // definitive=falseの結果を確定状態として保存してはならない
+      expect(persistChannelPointsCapability).not.toHaveBeenCalled()
+    })
+
     it('#22 always re-probes rather than trusting a stale DB state: a live "available" probe triggers enable', async () => {
       // Deliberately do NOT configure getChannelPointsAccessState to say
       // 'available' here (it defaults to 'unknown' via the shared beforeEach,

--- a/tests/unit/auth-callback-channel-points.test.ts
+++ b/tests/unit/auth-callback-channel-points.test.ts
@@ -1,0 +1,458 @@
+/**
+ * #788 子C #791: GET /api/auth/twitch/callback の
+ *   1. channel_points_enabled フラグのセッションcookieへのミラーリング
+ *      （postgrest / pg 直結の両経路、列未デプロイ時のフォールバック含む）
+ *   2. step-up再認証（isReauthFlow）直後・channel-pointsスコープ取得時のみ実行される
+ *      Capability Probe の自動実行条件
+ * に絞ったテスト。
+ *
+ * tests/unit/auth-callback-driver-parity.test.ts と同じモック idiom
+ * （next/headers・@/lib/session・@/lib/twitch/auth・rate-limit・
+ * auth-error-handler・logger・url-utils の vi.mock、および pg 経路用の
+ * getDb() スタブ差し替え）を踏襲しつつ、このファイル固有の関心事
+ * （@/lib/twitch/channel-points・@/lib/twitch/channel-points-access のモック）
+ * を追加する。既存ファイルを肥大化させず関心を分離するため、独立ファイルとした。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { getDb } from '@/lib/db/client'
+import { ADDITIONAL_SCOPES } from '@/lib/twitch/scopes'
+import type { ChannelPointsCapabilityResult } from '@/lib/twitch/channel-points'
+
+// next/headers: cookies() mock（driver-parity.test.ts と同一idiom）
+const mockCookieStore = {
+  get: vi.fn(),
+  set: vi.fn(),
+  delete: vi.fn(),
+}
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(() => Promise.resolve(mockCookieStore)),
+}))
+
+vi.mock('@/lib/session', () => ({
+  signSession: (payload: string) => Promise.resolve(payload),
+}))
+
+vi.mock('@/lib/twitch/auth', () => ({
+  getTwitchAuthUrl: vi.fn(() => 'https://twitch.tv/authorize'),
+  exchangeCodeForTokens: vi.fn(),
+  getTwitchUser: vi.fn(),
+  isInvalidAuthorizationCodeError: vi.fn(() => false),
+}))
+
+const mockSaveTwitchScopes = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/twitch/token-manager', () => ({
+  saveTwitchScopes: (...args: unknown[]) => mockSaveTwitchScopes(...args),
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn(() => Promise.resolve({ success: true, limit: 5, remaining: 4, reset: Date.now() + 60000 })),
+  rateLimits: { authCallback: 'authCallback' },
+  getClientIp: vi.fn(() => '127.0.0.1'),
+}))
+
+const mockHandleAuthError = vi.fn((...args: unknown[]) => {
+  const [error, code] = args
+  return {
+    type: 'error',
+    code,
+    error,
+    cookies: { set: vi.fn(), delete: vi.fn() },
+    headers: { get: vi.fn() },
+  }
+})
+vi.mock('@/lib/auth-error-handler', () => ({
+  handleAuthError: (...args: unknown[]) => mockHandleAuthError(...args),
+}))
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('@/lib/url-utils', () => ({
+  getBaseUrl: vi.fn(() => 'http://localhost:3000'),
+}))
+
+// このファイル固有: Capability Probe / 永続化はテスト対象route自体の依存として
+// モックし、呼び出しの有無・引数を直接アサートする。
+const mockProbeChannelPointsCapability = vi.fn()
+vi.mock('@/lib/twitch/channel-points', () => ({
+  probeChannelPointsCapability: (...args: unknown[]) => mockProbeChannelPointsCapability(...args),
+}))
+const mockPersistChannelPointsCapability = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/lib/twitch/channel-points-access', () => ({
+  persistChannelPointsCapability: (...args: unknown[]) => mockPersistChannelPointsCapability(...args),
+}))
+
+/**
+ * pg 直結経路 (Drizzle db) のモック。driver-parity.test.ts の
+ * createDrizzleDbMock は select 呼び出し順(index)でレスポンスを切り替えるが、
+ * このファイルは isReauthFlow の有無で select 呼び出し回数・順序が変わる
+ * （既存スコープ乖離チェックの select が reauth flowでは走らない）ため、
+ * 呼び出し順ではなく select する列名で判定する方が壊れにくい。
+ */
+function createPgDbMock(
+  config: {
+    existingScopes?: string[] | null
+    tosAcceptedAt?: string | null
+    channelPointsEnabled?: boolean | null
+    channelPointsSelectError?: unknown
+  } = {}
+) {
+  const {
+    existingScopes = null,
+    tosAcceptedAt = '2024-01-01',
+    channelPointsEnabled = false,
+    channelPointsSelectError = null,
+  } = config
+
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const keys = Object.keys(fields)
+      const builder: any = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(() => builder),
+        then: (onFulfilled: any, onRejected: any) => {
+          let promise: Promise<unknown[]>
+          if (keys.includes('twitch_scopes')) {
+            promise = Promise.resolve(existingScopes !== null ? [{ twitch_scopes: existingScopes }] : [])
+          } else if (keys.includes('channel_points_enabled')) {
+            promise = channelPointsSelectError
+              ? Promise.reject(channelPointsSelectError)
+              : Promise.resolve(
+                  channelPointsEnabled !== null ? [{ channel_points_enabled: channelPointsEnabled }] : []
+                )
+          } else if (keys.includes('tos_accepted_at')) {
+            promise = Promise.resolve([{ tos_accepted_at: tosAcceptedAt }])
+          } else {
+            promise = Promise.resolve([])
+          }
+          return promise.then(onFulfilled, onRejected)
+        },
+      }
+      return builder
+    }),
+    insert: vi.fn(() => {
+      const builder: any = {
+        values: vi.fn(() => builder),
+        onConflictDoUpdate: vi.fn(() => builder),
+        then: (onFulfilled: any) => Promise.resolve([{}]).then(onFulfilled),
+      }
+      return builder
+    }),
+  }
+  return db
+}
+
+/**
+ * postgrest 経路 (supabase-js) のモック。driver-parity.test.ts の
+ * createSupabaseCallbackMock は select 呼び出し順で判定するが、上記と同じ理由で
+ * select() に渡された列名文字列で判定する方式に変更している。
+ */
+function createSupabaseCallbackMock(
+  options: {
+    existingScopes?: string[] | null
+    tosAcceptedAt?: string | null
+    channelPointsEnabled?: boolean | null
+    channelPointsSelectError?: { code?: string; message: string } | null
+  } = {}
+) {
+  const {
+    existingScopes = null,
+    tosAcceptedAt = '2024-01-01',
+    channelPointsEnabled = false,
+    channelPointsSelectError = null,
+  } = options
+
+  const select = vi.fn((columns: string) => {
+    const eq = vi.fn(() => ({
+      maybeSingle: vi.fn(() => {
+        if (columns.includes('twitch_scopes')) {
+          return Promise.resolve({
+            data: existingScopes !== null ? { twitch_scopes: existingScopes } : null,
+            error: null,
+          })
+        }
+        if (columns.includes('channel_points_enabled')) {
+          if (channelPointsSelectError) {
+            return Promise.resolve({ data: null, error: channelPointsSelectError })
+          }
+          return Promise.resolve({
+            data: channelPointsEnabled !== null ? { channel_points_enabled: channelPointsEnabled } : null,
+            error: null,
+          })
+        }
+        if (columns.includes('tos_accepted_at')) {
+          return Promise.resolve({ data: { tos_accepted_at: tosAcceptedAt }, error: null })
+        }
+        return Promise.resolve({ data: null, error: null })
+      }),
+    }))
+    return { eq }
+  })
+  const upsert = vi.fn().mockResolvedValue({ error: null })
+  return { from: vi.fn(() => ({ select, upsert })) }
+}
+
+describe('GET /api/auth/twitch/callback: channel_points_enabled セッションミラーリング & step-up再認証Capability Probe (#788 子C #791)', () => {
+  let exchangeCodeForTokens: ReturnType<typeof vi.fn>
+  let getTwitchUser: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockSaveTwitchScopes.mockResolvedValue(undefined)
+    mockPersistChannelPointsCapability.mockResolvedValue(undefined)
+
+    const auth = await import('@/lib/twitch/auth')
+    exchangeCodeForTokens = vi.mocked(auth.exchangeCodeForTokens)
+    getTwitchUser = vi.mocked(auth.getTwitchUser)
+
+    // 既定: 通常ログイン（REAUTH_STATEなし）
+    mockCookieStore.get.mockImplementation((name: string) => {
+      if (name === 'twitch_auth_state') return { value: 'test-state-123' }
+      return undefined
+    })
+
+    exchangeCodeForTokens.mockResolvedValue({
+      access_token: 'test-access-token',
+      refresh_token: 'test-refresh-token',
+      expires_in: 3600,
+      token_type: 'bearer',
+      scope: ['user:read:email'],
+    })
+    getTwitchUser.mockResolvedValue({
+      id: 'user123',
+      login: 'testuser',
+      display_name: 'Test User',
+      profile_image_url: 'https://example.com/avatar.png',
+      broadcaster_type: 'affiliate',
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  function createCallbackRequest() {
+    return new NextRequest('http://localhost:3000/api/auth/twitch/callback?code=test-code&state=test-state-123')
+  }
+
+  function setReauthCookies() {
+    mockCookieStore.get.mockImplementation((name: string) => {
+      if (name === 'twitch_auth_state') return { value: 'test-state-123' }
+      if (name === 'twica_reauth_state') return { value: 'test-state-123' }
+      return undefined
+    })
+  }
+
+  async function runAndGetSessionData(response: Response) {
+    const sessionCookie = (response as any).cookies.get('twica_session')
+    expect(sessionCookie).toBeDefined()
+    return JSON.parse(sessionCookie!.value)
+  }
+
+  describe('channel_points_enabled フラグのセッション反映', () => {
+    it('DB_DRIVER=pg: channel_points_enabled列が未デプロイ(42703相当)でもログインは成功し、channelPointsEnabledはfalseにフォールバックする', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+      // 42703 = undefined_column（postgres.js が投げるSQLSTATE形状のエラーを模擬）
+      const missingColumnError = Object.assign(new Error('column "channel_points_enabled" does not exist'), {
+        code: '42703',
+      })
+      const db = createPgDbMock({ channelPointsSelectError: missingColumnError })
+      vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any)
+
+      const { GET } = await import('@/app/api/auth/twitch/callback/route')
+      const response = await GET(createCallbackRequest())
+
+      // ログイン自体は失敗しない（database_errorに落ちていない）
+      expect(mockHandleAuthError).not.toHaveBeenCalled()
+      const sessionData = await runAndGetSessionData(response)
+      expect(sessionData.channelPointsEnabled).toBe(false)
+    })
+
+    it('postgrest経路: channel_points_enabled列が未デプロイ(PGRST204相当)でもログインは成功し、channelPointsEnabledはfalseにフォールバックする', async () => {
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(
+        createSupabaseCallbackMock({
+          channelPointsSelectError: { code: 'PGRST204', message: "column 'channel_points_enabled' does not exist" },
+        }) as any
+      )
+
+      const { GET } = await import('@/app/api/auth/twitch/callback/route')
+      const response = await GET(createCallbackRequest())
+
+      expect(mockHandleAuthError).not.toHaveBeenCalled()
+      const sessionData = await runAndGetSessionData(response)
+      expect(sessionData.channelPointsEnabled).toBe(false)
+    })
+
+    it('DB_DRIVER=pg: channel_points_enabled=trueのとき、セッションのchannelPointsEnabledはtrue', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+      const db = createPgDbMock({ channelPointsEnabled: true })
+      vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any)
+
+      const { GET } = await import('@/app/api/auth/twitch/callback/route')
+      const response = await GET(createCallbackRequest())
+
+      const sessionData = await runAndGetSessionData(response)
+      expect(sessionData.channelPointsEnabled).toBe(true)
+    })
+
+    it('postgrest経路: channel_points_enabled=trueのとき、セッションのchannelPointsEnabledはtrue', async () => {
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(createSupabaseCallbackMock({ channelPointsEnabled: true }) as any)
+
+      const { GET } = await import('@/app/api/auth/twitch/callback/route')
+      const response = await GET(createCallbackRequest())
+
+      const sessionData = await runAndGetSessionData(response)
+      expect(sessionData.channelPointsEnabled).toBe(true)
+    })
+
+    it('postgrest経路: channel_points_enabled=falseのとき、セッションのchannelPointsEnabledはfalse', async () => {
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(createSupabaseCallbackMock({ channelPointsEnabled: false }) as any)
+
+      const { GET } = await import('@/app/api/auth/twitch/callback/route')
+      const response = await GET(createCallbackRequest())
+
+      const sessionData = await runAndGetSessionData(response)
+      expect(sessionData.channelPointsEnabled).toBe(false)
+    })
+  })
+
+  describe('step-up再認証時のCapability Probe自動実行', () => {
+    it('通常ログイン（isReauthFlowがfalse）ではchannel:read:redemptionsスコープがあってもprobeChannelPointsCapabilityは呼ばれない', async () => {
+      // REAUTH_STATE cookieなし（既定のbeforeEach設定のまま）= 通常ログイン
+      exchangeCodeForTokens.mockResolvedValue({
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        expires_in: 3600,
+        token_type: 'bearer',
+        scope: ['user:read:email', ADDITIONAL_SCOPES.CHANNEL_READ_REDEMPTIONS],
+      })
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(createSupabaseCallbackMock() as any)
+
+      const { GET } = await import('@/app/api/auth/twitch/callback/route')
+      await GET(createCallbackRequest())
+
+      expect(mockProbeChannelPointsCapability).not.toHaveBeenCalled()
+    })
+
+    it('step-up再認証（isReauthFlow）かつchannel:read:redemptionsスコープがある場合、probeChannelPointsCapabilityが呼ばれ、definitiveな結果はpersistChannelPointsCapabilityで保存される', async () => {
+      setReauthCookies()
+      exchangeCodeForTokens.mockResolvedValue({
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        expires_in: 3600,
+        token_type: 'bearer',
+        scope: ['user:read:email', ADDITIONAL_SCOPES.CHANNEL_READ_REDEMPTIONS],
+      })
+      const definitiveResult: ChannelPointsCapabilityResult = {
+        capability: 'available',
+        reason: 'ok',
+        httpStatus: 200,
+        definitive: true,
+      }
+      mockProbeChannelPointsCapability.mockResolvedValue(definitiveResult)
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(createSupabaseCallbackMock() as any)
+
+      const { GET } = await import('@/app/api/auth/twitch/callback/route')
+      await GET(createCallbackRequest())
+
+      expect(mockProbeChannelPointsCapability).toHaveBeenCalledWith('user123')
+      expect(mockPersistChannelPointsCapability).toHaveBeenCalledWith('user123', definitiveResult)
+    })
+
+    it('step-up再認証（isReauthFlow）かつchannel:manage:redemptionsスコープがある場合もprobeChannelPointsCapabilityが呼ばれる', async () => {
+      setReauthCookies()
+      exchangeCodeForTokens.mockResolvedValue({
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        expires_in: 3600,
+        token_type: 'bearer',
+        scope: ['user:read:email', ADDITIONAL_SCOPES.CHANNEL_MANAGE_REDEMPTIONS],
+      })
+      mockProbeChannelPointsCapability.mockResolvedValue({
+        capability: 'available',
+        reason: 'ok',
+        httpStatus: 200,
+        definitive: true,
+      })
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(createSupabaseCallbackMock() as any)
+
+      const { GET } = await import('@/app/api/auth/twitch/callback/route')
+      await GET(createCallbackRequest())
+
+      expect(mockProbeChannelPointsCapability).toHaveBeenCalledWith('user123')
+    })
+
+    it('step-up再認証でもchannel points系スコープがなければprobeChannelPointsCapabilityは呼ばれない', async () => {
+      setReauthCookies()
+      exchangeCodeForTokens.mockResolvedValue({
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        expires_in: 3600,
+        token_type: 'bearer',
+        scope: ['user:read:subscriptions'],
+      })
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(createSupabaseCallbackMock() as any)
+
+      const { GET } = await import('@/app/api/auth/twitch/callback/route')
+      await GET(createCallbackRequest())
+
+      expect(mockProbeChannelPointsCapability).not.toHaveBeenCalled()
+    })
+
+    it('probeChannelPointsCapabilityがdefinitive:falseを返した場合、persistChannelPointsCapabilityは呼ばれず、ログインは通常通り成功する', async () => {
+      setReauthCookies()
+      exchangeCodeForTokens.mockResolvedValue({
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        expires_in: 3600,
+        token_type: 'bearer',
+        scope: ['user:read:email', ADDITIONAL_SCOPES.CHANNEL_READ_REDEMPTIONS],
+      })
+      mockProbeChannelPointsCapability.mockResolvedValue({
+        capability: 'unknown',
+        reason: 'rate_limited',
+        httpStatus: 429,
+        definitive: false,
+      })
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(createSupabaseCallbackMock() as any)
+
+      const { GET } = await import('@/app/api/auth/twitch/callback/route')
+      const response = await GET(createCallbackRequest())
+
+      expect(mockProbeChannelPointsCapability).toHaveBeenCalledWith('user123')
+      expect(mockPersistChannelPointsCapability).not.toHaveBeenCalled()
+      expect(mockHandleAuthError).not.toHaveBeenCalled()
+      await runAndGetSessionData(response)
+    })
+
+    it('probeChannelPointsCapabilityが例外を投げても、エラーは握りつぶされてログインは成功する', async () => {
+      setReauthCookies()
+      exchangeCodeForTokens.mockResolvedValue({
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        expires_in: 3600,
+        token_type: 'bearer',
+        scope: ['user:read:email', ADDITIONAL_SCOPES.CHANNEL_READ_REDEMPTIONS],
+      })
+      mockProbeChannelPointsCapability.mockRejectedValue(new Error('network down'))
+      const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+      vi.mocked(getSupabaseAdmin).mockReturnValue(createSupabaseCallbackMock() as any)
+
+      const { GET } = await import('@/app/api/auth/twitch/callback/route')
+      const response = await GET(createCallbackRequest())
+
+      expect(mockPersistChannelPointsCapability).not.toHaveBeenCalled()
+      expect(mockHandleAuthError).not.toHaveBeenCalled()
+      await runAndGetSessionData(response)
+    })
+  })
+})

--- a/tests/unit/auth-callback-channel-points.test.ts
+++ b/tests/unit/auth-callback-channel-points.test.ts
@@ -76,6 +76,9 @@ vi.mock('@/lib/url-utils', () => ({
 const mockProbeChannelPointsCapability = vi.fn()
 vi.mock('@/lib/twitch/channel-points', () => ({
   probeChannelPointsCapability: (...args: unknown[]) => mockProbeChannelPointsCapability(...args),
+  // 実装と同じ判定ロジック（result.definitive === true）。route側の型ガード呼び出しを
+  // モック環境でも動作させる（モジュール全体をvi.mockしているため実関数は使えない）。
+  isDefinitiveCapabilityResult: (result: { definitive: boolean }) => result.definitive === true,
 }))
 const mockPersistChannelPointsCapability = vi.fn().mockResolvedValue(undefined)
 vi.mock('@/lib/twitch/channel-points-access', () => ({

--- a/tests/unit/auth-reauth-scopes.test.ts
+++ b/tests/unit/auth-reauth-scopes.test.ts
@@ -4,6 +4,7 @@ import { POST } from '@/app/api/auth/reauth/route'
 import { getSession } from '@/lib/session'
 import { deleteTwitchTokens } from '@/lib/twitch/token-manager'
 import { validateCSRFToken } from '@/lib/csrf'
+import { COOKIE_NAMES } from '@/lib/constants'
 
 vi.mock('@/lib/session')
 vi.mock('@/lib/csrf', () => ({
@@ -57,6 +58,19 @@ function createRequest(additionalScopes: string[]): NextRequest {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ additionalScopes }),
+  })
+}
+
+// #788 子C #791: returnTo単体、またはadditionalScopesとの組み合わせを
+// リクエストボディで自由に指定するためのヘルパー（上のcreateRequestは
+// additionalScopes専用のため、既存テストへの影響を避けて別関数にする）。
+function createRequestWithBody(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost:3000/api/auth/reauth', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
   })
 }
 
@@ -243,5 +257,92 @@ describe('POST /api/auth/reauth scope merge', () => {
     const { getTwitchAuthUrl } = await import('@/lib/twitch/auth')
     expect(getTwitchAuthUrl).not.toHaveBeenCalled()
     expect(mockDeleteTwitchTokens).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/auth/reauth returnTo cookie (#788 子C #791)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    mockGetSession.mockResolvedValue({
+      twitchUserId: '123456789',
+      twitchUsername: 'test-user',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/avatar.png',
+      broadcasterType: 'affiliate',
+      expiresAt: Date.now() + 60_000,
+      version: 1,
+    })
+    mockDeleteTwitchTokens.mockResolvedValue()
+    mockValidateCSRFToken.mockResolvedValue({ valid: true })
+
+    const { checkRateLimit, getRateLimitIdentifier } = await import('@/lib/rate-limit')
+    vi.mocked(checkRateLimit).mockResolvedValue({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      reset: Date.now() + 60_000,
+    })
+    vi.mocked(getRateLimitIdentifier).mockResolvedValue('user:123456789')
+
+    // 既定: 既存の追加スコープなし（このdescribeの関心はreturnToであり、
+    // スコープ保持ロジックは上のdescribeで既にカバー済みのため単純化する）
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue(
+      mockUserScopesQuery({ data: { twitch_scopes: [] }, error: null }) as any
+    )
+  })
+
+  it('returnToが/で始まる相対パスの場合、RETURN_TOクッキーにその値を設定する', async () => {
+    const response = await POST(createRequestWithBody({ returnTo: '/dashboard/account' }))
+
+    expect(response.status).toBe(200)
+    expect(response.cookies.get(COOKIE_NAMES.RETURN_TO)?.value).toBe('/dashboard/account')
+  })
+
+  it('returnToが絶対URLの場合、RETURN_TOクッキーは設定されない（オープンリダイレクト対策）', async () => {
+    const response = await POST(createRequestWithBody({ returnTo: 'https://evil.example.com/x' }))
+
+    expect(response.status).toBe(200)
+    expect(response.cookies.get(COOKIE_NAMES.RETURN_TO)).toBeUndefined()
+  })
+
+  it('returnToがプロトコル相対URL(//で開始)の場合、RETURN_TOクッキーは設定されない（オープンリダイレクト対策）', async () => {
+    const response = await POST(createRequestWithBody({ returnTo: '//evil.example.com' }))
+
+    expect(response.status).toBe(200)
+    expect(response.cookies.get(COOKIE_NAMES.RETURN_TO)).toBeUndefined()
+  })
+
+  it('returnToを省略した場合、RETURN_TOクッキーは設定されず、既存の挙動のまま完了する', async () => {
+    const response = await POST(createRequest(['user:read:subscriptions']))
+
+    expect(response.status).toBe(200)
+    expect(response.cookies.get(COOKIE_NAMES.RETURN_TO)).toBeUndefined()
+  })
+
+  it('returnToとadditionalScopesを同時に指定した場合、スコープ処理とcookie設定の両方が行われる', async () => {
+    const { getSupabaseAdmin } = await import('@/lib/supabase/admin')
+    vi.mocked(getSupabaseAdmin).mockReturnValue(
+      mockUserScopesQuery({
+        data: { twitch_scopes: ['user:write:chat'] },
+        error: null,
+      }) as any
+    )
+
+    const response = await POST(
+      createRequestWithBody({ additionalScopes: ['user:read:subscriptions'], returnTo: '/dashboard/account' })
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.cookies.get(COOKIE_NAMES.RETURN_TO)?.value).toBe('/dashboard/account')
+
+    const { getTwitchAuthUrl } = await import('@/lib/twitch/auth')
+    expect(getTwitchAuthUrl).toHaveBeenCalledWith(
+      'https://example.com/api/auth/twitch/callback',
+      'fixed-state',
+      ['user:write:chat', 'user:read:subscriptions']
+    )
+    expect(mockDeleteTwitchTokens).toHaveBeenCalledWith('123456789')
   })
 })

--- a/tests/unit/channel-point-bootstrap-api.test.ts
+++ b/tests/unit/channel-point-bootstrap-api.test.ts
@@ -20,6 +20,20 @@ vi.mock('@/lib/twitch/token-manager', () => ({
 vi.mock('@/lib/supabase/admin', () => ({
   getSupabaseAdmin: vi.fn(),
 }))
+// #788: GET ハンドラは早期returnも含め常に getChannelPointsAccessState を呼ぶため、
+// このモジュールをモックしないと未モックの実装（users テーブルへの
+// supabase-js/pgクエリ）が走ってしまい、このファイルが検証したい
+// hasRequiredScope/rewards/diagnostics周りの挙動と無関係な失敗を招く。
+// デフォルトは capability: 'unknown' とし、capability/temporarilyUnavailable の
+// 挙動そのものを検証するテストではケースごとに mockResolvedValueOnce で上書きする。
+vi.mock('@/lib/twitch/channel-points-access', () => ({
+  getChannelPointsAccessState: vi.fn().mockResolvedValue({
+    capability: 'unknown',
+    checkedAt: null,
+    enabled: false,
+  }),
+  recordChannelPointsApiFailure: vi.fn().mockResolvedValue(undefined),
+}))
 
 const session = {
   twitchUserId: 'streamer-1',
@@ -54,6 +68,7 @@ describe('GET /api/twitch/channel-point-bootstrap', () => {
 
   it('scope不足ならTwitch rewardsを呼ばずreauthを返す', async () => {
     const { hasScope } = await import('@/lib/twitch/token-manager')
+    const { getChannelPointsAccessState } = await import('@/lib/twitch/channel-points-access')
     vi.mocked(hasScope).mockResolvedValue(false)
 
     const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
@@ -62,6 +77,10 @@ describe('GET /api/twitch/channel-point-bootstrap', () => {
 
     expect(body).toMatchObject({ hasRequiredScope: false, rewards: [], requiresReauth: true })
     expect(global.fetch).not.toHaveBeenCalled()
+    // #788: scope不足の早期returnでもcapability状態を読み、レスポンスへ含める
+    expect(getChannelPointsAccessState).toHaveBeenCalledWith('streamer-1')
+    expect(body.capability).toBe('unknown')
+    expect(body.capabilityCheckedAt).toBeNull()
   })
 
   it('diagnostics=0ではscope確認とrewards取得だけを返す', async () => {
@@ -135,5 +154,74 @@ describe('GET /api/twitch/channel-point-bootstrap', () => {
     expect(body.raidEventSubStatus).toBe('active')
     expect(body.additionalRewards).toHaveLength(1)
     expect(body.raidGiftDrawCount).toBe(3)
+  })
+
+  // #788: Capability Probe導入に伴い、旧 error: "affiliateRequired" /
+  // "fetchFailed" 契約を廃止し、capability / temporarilyUnavailable ベースの
+  // 契約へ置き換えた（route.ts のgetTwitchRewards・GETハンドラ参照）。
+  // 以下はその新契約の3ケース（403/401/一時失敗）を検証する。
+  it('Twitch 403応答時はrecordChannelPointsApiFailure(403)を呼びcapabilityが最新のDB確定状態を返す（error: affiliateRequiredは返さない）', async () => {
+    const { hasScope, getTwitchAccessToken } = await import('@/lib/twitch/token-manager')
+    const { getChannelPointsAccessState, recordChannelPointsApiFailure } =
+      await import('@/lib/twitch/channel-points-access')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(getTwitchAccessToken).mockResolvedValue('token-1')
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Forbidden' }), { status: 403 }) as any
+    )
+    // recordChannelPointsApiFailure(403)がDBへ永続化した後の状態を模す
+    // （route は recordChannelPointsApiFailure 呼び出し後に再度状態を読み直す）
+    vi.mocked(getChannelPointsAccessState).mockResolvedValueOnce({
+      capability: 'unavailable',
+      checkedAt: '2026-07-23T00:00:00.000Z',
+      enabled: false,
+    })
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    const response = await GET(request())
+    const body = await response.json()
+
+    expect(recordChannelPointsApiFailure).toHaveBeenCalledWith('streamer-1', 403)
+    expect(body.capability).toBe('unavailable')
+    expect(body.capabilityCheckedAt).toBe('2026-07-23T00:00:00.000Z')
+    expect(body.rewards).toEqual([])
+    expect(body.error).toBeUndefined()
+  })
+
+  it('Twitch 401応答時はrecordChannelPointsApiFailure(401)を呼びrequiresReauth:trueを返す', async () => {
+    const { hasScope, getTwitchAccessToken } = await import('@/lib/twitch/token-manager')
+    const { recordChannelPointsApiFailure } = await import('@/lib/twitch/channel-points-access')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(getTwitchAccessToken).mockResolvedValue('token-1')
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Unauthorized' }), { status: 401 }) as any
+    )
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    const response = await GET(request())
+    const body = await response.json()
+
+    expect(recordChannelPointsApiFailure).toHaveBeenCalledWith('streamer-1', 401)
+    expect(body.requiresReauth).toBe(true)
+    expect(body.rewards).toEqual([])
+  })
+
+  it('Twitch 429/5xx等の一時失敗ではtemporarilyUnavailable:trueを返しDB確定状態は破壊しない(recordChannelPointsApiFailure未呼び出し)', async () => {
+    const { hasScope, getTwitchAccessToken } = await import('@/lib/twitch/token-manager')
+    const { recordChannelPointsApiFailure } = await import('@/lib/twitch/channel-points-access')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(getTwitchAccessToken).mockResolvedValue('token-1')
+    // 429/5xxはどちらも「非401/403の非2xx」という同一分岐（!response.ok）を通る
+    // ため、代表として429のみ検証する。
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ message: 'Too Many Requests' }), { status: 429 }) as any
+    )
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    const response = await GET(request())
+    const body = await response.json()
+
+    expect(body.temporarilyUnavailable).toBe(true)
+    expect(recordChannelPointsApiFailure).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/channel-point-bootstrap-api.test.ts
+++ b/tests/unit/channel-point-bootstrap-api.test.ts
@@ -272,4 +272,34 @@ describe('GET /api/twitch/channel-point-bootstrap', () => {
 
     expect(persistChannelPointsCapability).not.toHaveBeenCalled()
   })
+
+  // 最終レビュー Major-B: 自己回復の書き込み自体が失敗（デプロイ窓・maintenance中の
+  // 書き込み不可等）しても、Twitchから実際に取得できた報酬一覧のレスポンスを
+  // 500に巻き込んではならない（401/403同期のrecordChannelPointsApiFailureと同じ
+  // 「握りつぶす」方針）。
+  it('自己回復の書き込みが失敗しても、報酬一覧のレスポンス自体は200のまま返す', async () => {
+    const { hasScope, getTwitchAccessToken } = await import('@/lib/twitch/token-manager')
+    const { getChannelPointsAccessState, persistChannelPointsCapability } =
+      await import('@/lib/twitch/channel-points-access')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(getTwitchAccessToken).mockResolvedValue('token-1')
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: 'reward-1', title: 'Reward', cost: 100, is_enabled: true }] }), { status: 200 }) as any
+    )
+    vi.mocked(getChannelPointsAccessState).mockResolvedValue({
+      capability: 'unavailable',
+      checkedAt: '2026-07-01T00:00:00.000Z',
+      enabled: false,
+    })
+    vi.mocked(persistChannelPointsCapability).mockRejectedValueOnce(
+      new Error('column "channel_points_capability" does not exist')
+    )
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    const response = await GET(request())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.rewards).toHaveLength(1)
+  })
 })

--- a/tests/unit/channel-point-bootstrap-api.test.ts
+++ b/tests/unit/channel-point-bootstrap-api.test.ts
@@ -33,6 +33,7 @@ vi.mock('@/lib/twitch/channel-points-access', () => ({
     enabled: false,
   }),
   recordChannelPointsApiFailure: vi.fn().mockResolvedValue(undefined),
+  persistChannelPointsCapability: vi.fn().mockResolvedValue(undefined),
 }))
 
 const session = {
@@ -223,5 +224,52 @@ describe('GET /api/twitch/channel-point-bootstrap', () => {
 
     expect(body.temporarilyUnavailable).toBe(true)
     expect(recordChannelPointsApiFailure).not.toHaveBeenCalled()
+  })
+
+  // #788 子E #793 Fableレビュー Major-2: Twitchが実際に200で成功したら、staleな
+  // 旧確定状態(unavailable/reauth_required/unknown)をavailableへ自己回復させる。
+  it('Twitch 200成功時、保存済みcapabilityがunavailableならavailableへ自己回復させる', async () => {
+    const { hasScope, getTwitchAccessToken } = await import('@/lib/twitch/token-manager')
+    const { getChannelPointsAccessState, persistChannelPointsCapability } =
+      await import('@/lib/twitch/channel-points-access')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(getTwitchAccessToken).mockResolvedValue('token-1')
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 }) as any
+    )
+    vi.mocked(getChannelPointsAccessState)
+      .mockResolvedValueOnce({ capability: 'unavailable', checkedAt: '2026-07-01T00:00:00.000Z', enabled: false })
+      .mockResolvedValueOnce({ capability: 'available', checkedAt: '2026-07-23T00:00:00.000Z', enabled: false })
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    const response = await GET(request())
+    const body = await response.json()
+
+    expect(persistChannelPointsCapability).toHaveBeenCalledWith(
+      'streamer-1',
+      expect.objectContaining({ capability: 'available', definitive: true })
+    )
+    expect(body.capability).toBe('available')
+  })
+
+  it('Twitch 200成功時、保存済みcapabilityが既にavailableなら無駄な書き込みをしない', async () => {
+    const { hasScope, getTwitchAccessToken } = await import('@/lib/twitch/token-manager')
+    const { getChannelPointsAccessState, persistChannelPointsCapability } =
+      await import('@/lib/twitch/channel-points-access')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(getTwitchAccessToken).mockResolvedValue('token-1')
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 }) as any
+    )
+    vi.mocked(getChannelPointsAccessState).mockResolvedValue({
+      capability: 'available',
+      checkedAt: '2026-07-23T00:00:00.000Z',
+      enabled: false,
+    })
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    await GET(request())
+
+    expect(persistChannelPointsCapability).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/channel-point-bootstrap-driver-parity.test.ts
+++ b/tests/unit/channel-point-bootstrap-driver-parity.test.ts
@@ -70,6 +70,7 @@ vi.mock('@/lib/twitch/channel-points-access', () => ({
     enabled: false,
   }),
   recordChannelPointsApiFailure: vi.fn().mockResolvedValue(undefined),
+  persistChannelPointsCapability: vi.fn().mockResolvedValue(undefined),
 }))
 // handleApiError/handleDatabaseError → logAndRecordError → logErrorFromLogger は
 // 既定で getSupabaseAdmin() 経由の "errors" テーブル書き込みを行う（DB_DRIVER 移行

--- a/tests/unit/channel-point-bootstrap-driver-parity.test.ts
+++ b/tests/unit/channel-point-bootstrap-driver-parity.test.ts
@@ -53,6 +53,24 @@ vi.mock('@/lib/twitch/token-manager', () => ({
 vi.mock('@/lib/supabase/admin', () => ({
   getSupabaseAdmin: vi.fn(),
 }))
+// #788: capability probe の永続化状態を読む/書くヘルパー。このテストファイルは
+// getOwnedStreamer/getAdditionalRewards のドライバ分岐（postgrest vs pg）だけを
+// 検証対象としており、capability state 自体の pg/postgrest 分岐は
+// channel-points-access.ts 側の責務（別途ユニットテストで検証）。ここをモックせず
+// 実装のまま呼ばせると、GET ハンドラが必ず呼ぶ getChannelPointsAccessState が
+// 「users」テーブル/クエリを追加で叩いてしまい、このファイルが検証したい
+// streamers/streamer_additional_gacha_rewards への呼び出し回数・実引数の
+// アサーションを汚染する（db.select 呼び出し回数が streamers/rewards 分の
+// 期待値からズレる等）。モジュール全体を固定値でモックすることでpg/postgrest
+// 分岐を問わず一定の応答を返させ、本来の検証対象に集中させる。
+vi.mock('@/lib/twitch/channel-points-access', () => ({
+  getChannelPointsAccessState: vi.fn().mockResolvedValue({
+    capability: 'unknown',
+    checkedAt: null,
+    enabled: false,
+  }),
+  recordChannelPointsApiFailure: vi.fn().mockResolvedValue(undefined),
+}))
 // handleApiError/handleDatabaseError → logAndRecordError → logErrorFromLogger は
 // 既定で getSupabaseAdmin() 経由の "errors" テーブル書き込みを行う（DB_DRIVER 移行
 // とは無関係な既存のエラーロギング基盤）。ここではその副作用を排除し、

--- a/tests/unit/channel-points-access.test.ts
+++ b/tests/unit/channel-points-access.test.ts
@@ -222,9 +222,28 @@ describe('getChannelPointsAccessState', () => {
       expect(result?.capability).toBe('unknown')
     })
 
-    // #788 子E #793 Fableレビュー Major-3: migration未適用のデプロイ窓(PGRST204)では
+    // #788 子E #793 Fableレビュー Major-3: migration未適用のデプロイ窓では
     // throwせず、unknown/null/falseの安全な既定値を返す(呼び出し元を個別に保護しない)。
-    it('PGRST204(列未デプロイ)ではthrowせずデプロイ窓の既定値を返す', async () => {
+    //
+    // 最終レビュー Major-A: SELECT/order/filterでの列欠落はPostgreSQLが42703を返し、
+    // PGRST204はinsert/update payloadの列欠落専用（このgetXxxはSELECTのみを行う
+    // 読み取り関数のため、本番で実際に発生するのは42703）。PGRST204のみを見ていると
+    // 実際のデプロイ窓で保護されない（src/lib/collections/collection-existence.ts の
+    // 既存コメント参照）。両方をテストする。
+    it('42703(列未デプロイ、SELECT経路で実際に発生するコード)ではthrowせずデプロイ窓の既定値を返す', async () => {
+      const queryBuilder = createMockQueryBuilder()
+      ;(queryBuilder.maybeSingle as any).mockResolvedValue({
+        data: null,
+        error: { code: '42703', message: 'column "channel_points_capability" does not exist' },
+      })
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn(() => queryBuilder) } as any)
+
+      const result = await getChannelPointsAccessState(TWITCH_USER_ID)
+
+      expect(result).toEqual({ capability: 'unknown', checkedAt: null, enabled: false })
+    })
+
+    it('PGRST204(念のための多重防御)でもthrowせずデプロイ窓の既定値を返す', async () => {
       const queryBuilder = createMockQueryBuilder()
       ;(queryBuilder.maybeSingle as any).mockResolvedValue({
         data: null,

--- a/tests/unit/channel-points-access.test.ts
+++ b/tests/unit/channel-points-access.test.ts
@@ -221,6 +221,21 @@ describe('getChannelPointsAccessState', () => {
 
       expect(result?.capability).toBe('unknown')
     })
+
+    // #788 子E #793 Fableレビュー Major-3: migration未適用のデプロイ窓(PGRST204)では
+    // throwせず、unknown/null/falseの安全な既定値を返す(呼び出し元を個別に保護しない)。
+    it('PGRST204(列未デプロイ)ではthrowせずデプロイ窓の既定値を返す', async () => {
+      const queryBuilder = createMockQueryBuilder()
+      ;(queryBuilder.maybeSingle as any).mockResolvedValue({
+        data: null,
+        error: { code: 'PGRST204', message: 'column not found' },
+      })
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn(() => queryBuilder) } as any)
+
+      const result = await getChannelPointsAccessState(TWITCH_USER_ID)
+
+      expect(result).toEqual({ capability: 'unknown', checkedAt: null, enabled: false })
+    })
   })
 
   describe('pg 経路(DB_DRIVER=pg-read)', () => {
@@ -268,6 +283,17 @@ describe('getChannelPointsAccessState', () => {
       const result = await getChannelPointsAccessState(TWITCH_USER_ID)
 
       expect(result?.capability).toBe('unknown')
+    })
+
+    // #788 子E #793 Fableレビュー Major-3: migration未適用のデプロイ窓(42703)では
+    // throwせず、unknown/null/falseの安全な既定値を返す。
+    it('42703(列未デプロイ)ではthrowせずデプロイ窓の既定値を返す', async () => {
+      const { db } = createSelectDbMock([{ reject: pgError('column "channel_points_capability" does not exist', '42703') }])
+      mockGetDb.mockResolvedValue({ db, sql: {} as any })
+
+      const result = await getChannelPointsAccessState(TWITCH_USER_ID)
+
+      expect(result).toEqual({ capability: 'unknown', checkedAt: null, enabled: false })
     })
   })
 })

--- a/tests/unit/channel-points-access.test.ts
+++ b/tests/unit/channel-points-access.test.ts
@@ -1,0 +1,554 @@
+/**
+ * #788 子B #790: src/lib/twitch/channel-points-access.ts (users テーブルへの
+ * Channel Points Capability / opt-in 状態の永続化データレイヤ) の
+ * postgrest 経路 / pg 直結経路 ドライバパリティテスト。
+ *
+ * モックの流儀は既存の driver-parity テスト群を踏襲する:
+ *   - Drizzle select/update ビルダーモック: tests/unit/additional-rewards-driver-parity.test.ts
+ *     (createDrizzleDbMock) / tests/unit/streamer-settings-driver-parity.test.ts
+ *   - 生 sql タグテンプレートモック(RPC呼び出し): tests/unit/gacha-rpc-driver-parity.test.ts
+ *     / tests/unit/write-rpc-driver-parity.test.ts の createSqlMock
+ *
+ * isPgReadEnabled()/isPgWriteEnabled() 自体はモックせず、他の driver-parity
+ * テストと同じく vi.stubEnv('DB_DRIVER', ...) で src/lib/db/flags.ts の実装
+ * (process.env 参照)をそのまま経由させる。理由: フラグ判定ロジック自体の
+ * 正しさ(pg-read は読み取りのみ有効化する等)も一緒に検証できるほうが、
+ * isPgReadEnabled を直接モックするより実体に近い。
+ *
+ * withDbRetry (src/lib/db/retry.ts) もモックしない。エラーに retryable な
+ * code(CONNECTION_CLOSED 等)を含めるかどうかでリトライの有無を制御できるため、
+ * 「idempotent: true が渡されているか」は実際にリトライが起きることで間接的に
+ * 検証する(gacha-rpc-driver-parity.test.ts 等の既存の踏襲パターン)。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { eq } from 'drizzle-orm'
+import { getSupabaseAdmin } from '@/lib/supabase/admin'
+import { getDb } from '@/lib/db/client'
+import { users as usersTable } from '@/lib/db/schema'
+import { logger } from '@/lib/logger'
+import { createMockQueryBuilder } from '../utils/supabase-mock'
+import {
+  getChannelPointsAccessState,
+  persistChannelPointsCapability,
+  recordChannelPointsApiFailure,
+  enableChannelPointsStreamerAccess,
+} from '@/lib/twitch/channel-points-access'
+import type { DefinitiveCapabilityResult } from '@/lib/twitch/channel-points'
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+vi.mock('@/lib/supabase/admin', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/supabase/admin')>()
+  return { ...actual, getSupabaseAdmin: vi.fn() }
+})
+
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin)
+const mockGetDb = vi.mocked(getDb)
+
+const TWITCH_USER_ID = 'twitch-user-1'
+// new Date().toISOString() の形式 (YYYY-MM-DDTHH:mm:ss.sssZ)
+const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+
+const AVAILABLE_RESULT: DefinitiveCapabilityResult = {
+  capability: 'available',
+  reason: 'ok',
+  httpStatus: 200,
+  definitive: true,
+}
+
+/** postgres.js が throw するエラー(err.code に SQLSTATE/ドライバコード)を模す */
+function pgError(message: string, code?: string): Error & { code?: string } {
+  const error = new Error(message) as Error & { code?: string }
+  if (code) error.code = code
+  return error
+}
+
+interface PgResponse {
+  rows?: Array<Record<string, unknown>>
+  reject?: unknown
+}
+
+/**
+ * db.select({...}).from(usersTable).where(...).limit(1) を模す Drizzle ビルダーモック。
+ * additional-rewards-driver-parity.test.ts の createDrizzleDbMock と同じ流儀。
+ */
+function createSelectDbMock(responses: PgResponse[]) {
+  let callIndex = 0
+  const calls: Array<{ where?: unknown }> = []
+  const select = vi.fn((fields: Record<string, unknown>) => {
+    const response = responses[Math.min(callIndex, responses.length - 1)]
+    callIndex += 1
+    const call: { where?: unknown } = {}
+    calls.push(call)
+    const resolve = () =>
+      response.reject !== undefined
+        ? Promise.reject(response.reject)
+        : Promise.resolve(
+            (response.rows ?? []).map((row) =>
+              Object.fromEntries(Object.keys(fields).map((key) => [key, row[key] ?? null]))
+            )
+          )
+    const builder: any = {
+      from: vi.fn(() => builder),
+      where: vi.fn((condition: unknown) => {
+        call.where = condition
+        return builder
+      }),
+      limit: vi.fn(() => builder),
+      then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+    }
+    return builder
+  })
+  return { db: { select } as any, calls }
+}
+
+/** db.update(usersTable).set({...}).where(...) を模す Drizzle ビルダーモック */
+function createUpdateDbMock(responses: PgResponse[]) {
+  let callIndex = 0
+  const calls: Array<{ table?: unknown; set?: unknown; where?: unknown }> = []
+  const update = vi.fn((table: unknown) => {
+    const response = responses[Math.min(callIndex, responses.length - 1)]
+    callIndex += 1
+    const call: { table?: unknown; set?: unknown; where?: unknown } = { table }
+    calls.push(call)
+    const resolve = () =>
+      response.reject !== undefined ? Promise.reject(response.reject) : Promise.resolve(response.rows ?? [])
+    const builder: any = {
+      set: vi.fn((values: unknown) => {
+        call.set = values
+        return builder
+      }),
+      where: vi.fn((condition: unknown) => {
+        call.where = condition
+        return builder
+      }),
+      then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
+    }
+    return builder
+  })
+  return { db: { update } as any, calls }
+}
+
+/**
+ * postgres.js の sql タグ呼び出し(sql`...${v}...`)を模したモック。
+ * gacha-rpc-driver-parity.test.ts / write-rpc-driver-parity.test.ts の
+ * createSqlMock と同じ流儀(呼び出しごとに responses を1つずつ消費)。
+ */
+function createSqlMock(responses: Array<{ rows?: unknown[]; reject?: unknown }>) {
+  let callIndex = 0
+  return vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => {
+    void strings
+    void values
+    const response = responses[Math.min(callIndex, responses.length - 1)]
+    callIndex += 1
+    return response.reject !== undefined ? Promise.reject(response.reject) : Promise.resolve(response.rows ?? [])
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  // 各 describe 内の vi.stubEnv('DB_DRIVER', ...) を確実に元へ戻す
+  // (announcements-driver-parity.test.ts 等の既存パターンと同じ理由)
+  vi.unstubAllEnvs()
+})
+
+// =============================================================================
+// getChannelPointsAccessState
+// =============================================================================
+describe('getChannelPointsAccessState', () => {
+  describe('postgrest 経路(DB_DRIVER未設定)', () => {
+    it('行が見つかれば capability/checkedAt/enabled を正しくマッピングする', async () => {
+      const queryBuilder = createMockQueryBuilder()
+      ;(queryBuilder.maybeSingle as any).mockResolvedValue({
+        data: {
+          channel_points_capability: 'available',
+          channel_points_capability_checked_at: '2026-07-01T00:00:00.000Z',
+          channel_points_enabled: true,
+        },
+        error: null,
+      })
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn(() => queryBuilder) } as any)
+
+      const result = await getChannelPointsAccessState(TWITCH_USER_ID)
+
+      expect(result).toEqual({
+        capability: 'available',
+        checkedAt: '2026-07-01T00:00:00.000Z',
+        enabled: true,
+      })
+      expect(queryBuilder.select).toHaveBeenCalledWith(
+        'channel_points_capability, channel_points_capability_checked_at, channel_points_enabled'
+      )
+      expect(queryBuilder.eq).toHaveBeenCalledWith('twitch_user_id', TWITCH_USER_ID)
+    })
+
+    it('行が無ければ null を返す(maybeSingle: data=null)', async () => {
+      const queryBuilder = createMockQueryBuilder()
+      ;(queryBuilder.maybeSingle as any).mockResolvedValue({ data: null, error: null })
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn(() => queryBuilder) } as any)
+
+      const result = await getChannelPointsAccessState(TWITCH_USER_ID)
+
+      expect(result).toBeNull()
+    })
+
+    it('クエリエラーは握りつぶさず throw する', async () => {
+      const queryError = new Error('connection refused')
+      const queryBuilder = createMockQueryBuilder()
+      ;(queryBuilder.maybeSingle as any).mockResolvedValue({ data: null, error: queryError })
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn(() => queryBuilder) } as any)
+
+      await expect(getChannelPointsAccessState(TWITCH_USER_ID)).rejects.toBe(queryError)
+    })
+
+    it('capability が falsy(null)なら unknown にフォールバックする(防御的分岐)', async () => {
+      const queryBuilder = createMockQueryBuilder()
+      ;(queryBuilder.maybeSingle as any).mockResolvedValue({
+        data: {
+          channel_points_capability: null,
+          channel_points_capability_checked_at: null,
+          channel_points_enabled: false,
+        },
+        error: null,
+      })
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn(() => queryBuilder) } as any)
+
+      const result = await getChannelPointsAccessState(TWITCH_USER_ID)
+
+      expect(result?.capability).toBe('unknown')
+    })
+  })
+
+  describe('pg 経路(DB_DRIVER=pg-read)', () => {
+    beforeEach(() => {
+      vi.stubEnv('DB_DRIVER', 'pg-read')
+    })
+
+    it('行が見つかれば capability/checkedAt/enabled を正しくマッピングする', async () => {
+      const { db, calls } = createSelectDbMock([
+        { rows: [{ capability: 'available', checkedAt: '2026-07-01T00:00:00.000Z', enabled: true }] },
+      ])
+      mockGetDb.mockResolvedValue({ db, sql: {} as any })
+
+      const result = await getChannelPointsAccessState(TWITCH_USER_ID)
+
+      expect(result).toEqual({
+        capability: 'available',
+        checkedAt: '2026-07-01T00:00:00.000Z',
+        enabled: true,
+      })
+      expect(calls[0].where).toEqual(eq(usersTable.twitch_user_id, TWITCH_USER_ID))
+    })
+
+    it('行が無ければ null を返す(空配列)', async () => {
+      const { db } = createSelectDbMock([{ rows: [] }])
+      mockGetDb.mockResolvedValue({ db, sql: {} as any })
+
+      const result = await getChannelPointsAccessState(TWITCH_USER_ID)
+
+      expect(result).toBeNull()
+    })
+
+    it('クエリエラーは握りつぶさず throw する', async () => {
+      const queryError = new Error('connection refused')
+      const { db } = createSelectDbMock([{ reject: queryError }])
+      mockGetDb.mockResolvedValue({ db, sql: {} as any })
+
+      await expect(getChannelPointsAccessState(TWITCH_USER_ID)).rejects.toBe(queryError)
+    })
+
+    it('capability が falsy(null)なら unknown にフォールバックする(防御的分岐)', async () => {
+      const { db } = createSelectDbMock([{ rows: [{ capability: null, checkedAt: null, enabled: false }] }])
+      mockGetDb.mockResolvedValue({ db, sql: {} as any })
+
+      const result = await getChannelPointsAccessState(TWITCH_USER_ID)
+
+      expect(result?.capability).toBe('unknown')
+    })
+  })
+})
+
+// =============================================================================
+// persistChannelPointsCapability
+// =============================================================================
+describe('persistChannelPointsCapability', () => {
+  describe('postgrest 経路(DB_DRIVER未設定)', () => {
+    it('capability + checked_at(ISO文字列) を含むオブジェクトで update する', async () => {
+      const queryBuilder = createMockQueryBuilder()
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn(() => queryBuilder) } as any)
+
+      await persistChannelPointsCapability(TWITCH_USER_ID, AVAILABLE_RESULT)
+
+      expect(queryBuilder.update).toHaveBeenCalledTimes(1)
+      const updateArg = (queryBuilder.update as any).mock.calls[0][0]
+      expect(updateArg.channel_points_capability).toBe('available')
+      expect(updateArg.channel_points_capability_checked_at).toMatch(ISO_TIMESTAMP_RE)
+      expect(queryBuilder.eq).toHaveBeenCalledWith('twitch_user_id', TWITCH_USER_ID)
+    })
+
+    it('update がエラーを返したら throw する', async () => {
+      const updateError = new Error('write failed')
+      const queryBuilder = createMockQueryBuilder()
+      // update()/eq() はどちらも既定で queryBuilder 自身を返すチェイン可能モック
+      // (createMockQueryBuilder)なので、最終的な await の解決値を .then の
+      // 上書きで直接コントロールする(additional-rewards-driver-parity.test.ts の
+      // rewardsQuery.then 上書きパターンと同じ流儀)。
+      ;(queryBuilder as any).then = (resolve: (v: unknown) => void) => {
+        resolve({ error: updateError })
+        return queryBuilder
+      }
+      mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn(() => queryBuilder) } as any)
+
+      await expect(persistChannelPointsCapability(TWITCH_USER_ID, AVAILABLE_RESULT)).rejects.toBe(updateError)
+    })
+  })
+
+  describe('pg 経路(DB_DRIVER=pg)', () => {
+    beforeEach(() => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+    })
+
+    it('update(usersTable).set({capability, checked_at}).where(...) が正しく呼ばれる', async () => {
+      const { db, calls } = createUpdateDbMock([{ rows: [] }])
+      mockGetDb.mockResolvedValue({ db, sql: {} as any })
+
+      await persistChannelPointsCapability(TWITCH_USER_ID, AVAILABLE_RESULT)
+
+      expect(calls).toHaveLength(1)
+      expect(calls[0].table).toBe(usersTable)
+      const setArg = calls[0].set as Record<string, unknown>
+      expect(setArg.channel_points_capability).toBe('available')
+      expect(setArg.channel_points_capability_checked_at).toMatch(ISO_TIMESTAMP_RE)
+      expect(calls[0].where).toEqual(eq(usersTable.twitch_user_id, TWITCH_USER_ID))
+    })
+
+    it('idempotent:true — CONNECTION_CLOSED後にリトライして成功する(withDbRetryへidempotentが渡っている証跡)', async () => {
+      // withDbRetry 自体はモックしていないため、「idempotent:true が渡された場合だけ
+      // 起きるはずの挙動(retryable errorからの自動リトライ)」を実際に発生させることで
+      // 間接的に検証する。idempotent:false(既定)なら1回で即throwし、この呼び出し回数
+      // アサーションが失敗する。
+      const { db, calls } = createUpdateDbMock([
+        { reject: pgError('write CONNECTION_CLOSED', 'CONNECTION_CLOSED') },
+        { rows: [] },
+      ])
+      mockGetDb.mockResolvedValue({ db, sql: {} as any })
+
+      await expect(persistChannelPointsCapability(TWITCH_USER_ID, AVAILABLE_RESULT)).resolves.toBeUndefined()
+      expect(calls).toHaveLength(2)
+    })
+  })
+})
+
+// =============================================================================
+// recordChannelPointsApiFailure
+// =============================================================================
+describe('recordChannelPointsApiFailure', () => {
+  it('401 → capability=reauth_required/reason=unauthorized を永続化する', async () => {
+    const queryBuilder = createMockQueryBuilder()
+    mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn(() => queryBuilder) } as any)
+
+    await recordChannelPointsApiFailure(TWITCH_USER_ID, 401)
+
+    const updateArg = (queryBuilder.update as any).mock.calls[0][0]
+    expect(updateArg.channel_points_capability).toBe('reauth_required')
+  })
+
+  it('403 → capability=unavailable/reason=forbidden を永続化する', async () => {
+    const queryBuilder = createMockQueryBuilder()
+    mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn(() => queryBuilder) } as any)
+
+    await recordChannelPointsApiFailure(TWITCH_USER_ID, 403)
+
+    const updateArg = (queryBuilder.update as any).mock.calls[0][0]
+    expect(updateArg.channel_points_capability).toBe('unavailable')
+  })
+
+  it('永続化(persistChannelPointsCapability)が失敗しても throw せず warn ログのみ残す', async () => {
+    const persistError = new Error('db unreachable')
+    const queryBuilder = createMockQueryBuilder()
+    ;(queryBuilder as any).then = (resolve: (v: unknown) => void) => {
+      resolve({ error: persistError })
+      return queryBuilder
+    }
+    mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn(() => queryBuilder) } as any)
+
+    // reject せず正常に resolve すること自体が「throw しない」ことの証明
+    await expect(recordChannelPointsApiFailure(TWITCH_USER_ID, 401)).resolves.toBeUndefined()
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      '[channel-points-access] recordChannelPointsApiFailure failed to persist',
+      expect.objectContaining({ twitchUserId: TWITCH_USER_ID, httpStatus: 401, error: 'db unreachable' })
+    )
+  })
+})
+
+// =============================================================================
+// enableChannelPointsStreamerAccess
+// =============================================================================
+describe('enableChannelPointsStreamerAccess', () => {
+  describe('postgrest 経路(DB_DRIVER未設定)', () => {
+    it('成功: rpc が返す streamer_id で ok:true になる', async () => {
+      const rpc = vi.fn().mockResolvedValue({ data: 'uuid-postgrest-1', error: null })
+      mockGetSupabaseAdmin.mockReturnValue({ rpc } as any)
+
+      const result = await enableChannelPointsStreamerAccess(TWITCH_USER_ID)
+
+      expect(result).toEqual({ ok: true, streamerId: 'uuid-postgrest-1' })
+      expect(rpc).toHaveBeenCalledWith('enable_channel_points_streamer_access', {
+        p_twitch_user_id: TWITCH_USER_ID,
+      })
+    })
+
+    it('CAPABILITY_NOT_AVAILABLE エラー → ok:false, error:capability_not_available', async () => {
+      const rpc = vi.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'CAPABILITY_NOT_AVAILABLE', code: 'P0001' },
+      })
+      mockGetSupabaseAdmin.mockReturnValue({ rpc } as any)
+
+      const result = await enableChannelPointsStreamerAccess(TWITCH_USER_ID)
+
+      expect(result).toEqual({ ok: false, error: 'capability_not_available' })
+    })
+
+    it('USER_NOT_FOUND エラー → ok:false, error:user_not_found', async () => {
+      const rpc = vi.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'USER_NOT_FOUND', code: 'P0001' },
+      })
+      mockGetSupabaseAdmin.mockReturnValue({ rpc } as any)
+
+      const result = await enableChannelPointsStreamerAccess(TWITCH_USER_ID)
+
+      expect(result).toEqual({ ok: false, error: 'user_not_found' })
+    })
+
+    it('無関係なエラーは分類せず re-throw する(黙って握りつぶさない)', async () => {
+      // DB関数は TWITCH_USER_ID_REQUIRED も RAISE EXCEPTION するが、これは
+      // classifyEnableRpcError が拾わない第三のメッセージ(20260723150000_add_channel_points_capability.sql
+      // 参照)。呼び出し元が独自にハンドリングすべき想定外エラーとして
+      // そのまま伝播することを固定する。
+      const unrelatedError = { message: 'TWITCH_USER_ID_REQUIRED', code: 'P0001' }
+      const rpc = vi.fn().mockResolvedValue({ data: null, error: unrelatedError })
+      mockGetSupabaseAdmin.mockReturnValue({ rpc } as any)
+
+      await expect(enableChannelPointsStreamerAccess(TWITCH_USER_ID)).rejects.toEqual(unrelatedError)
+    })
+  })
+
+  describe('pg 経路(DB_DRIVER=pg)', () => {
+    beforeEach(() => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+    })
+
+    it('成功: sql が返す streamer_id で ok:true になる', async () => {
+      const sqlMock = createSqlMock([{ rows: [{ streamer_id: 'uuid-pg-1' }] }])
+      mockGetDb.mockResolvedValue({ db: {} as any, sql: sqlMock as any })
+
+      const result = await enableChannelPointsStreamerAccess(TWITCH_USER_ID)
+
+      expect(result).toEqual({ ok: true, streamerId: 'uuid-pg-1' })
+      expect(sqlMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('CAPABILITY_NOT_AVAILABLE (RAISE EXCEPTION文字列) → ok:false, error:capability_not_available', async () => {
+      const sqlMock = createSqlMock([{ reject: pgError('CAPABILITY_NOT_AVAILABLE', 'P0001') }])
+      mockGetDb.mockResolvedValue({ db: {} as any, sql: sqlMock as any })
+
+      const result = await enableChannelPointsStreamerAccess(TWITCH_USER_ID)
+
+      expect(result).toEqual({ ok: false, error: 'capability_not_available' })
+    })
+
+    it('USER_NOT_FOUND (RAISE EXCEPTION文字列) → ok:false, error:user_not_found', async () => {
+      const sqlMock = createSqlMock([{ reject: pgError('USER_NOT_FOUND', 'P0001') }])
+      mockGetDb.mockResolvedValue({ db: {} as any, sql: sqlMock as any })
+
+      const result = await enableChannelPointsStreamerAccess(TWITCH_USER_ID)
+
+      expect(result).toEqual({ ok: false, error: 'user_not_found' })
+    })
+
+    it('無関係なエラーは分類せず re-throw する(黙って握りつぶさない)', async () => {
+      const unrelatedError = pgError('TWITCH_USER_ID_REQUIRED', 'P0001')
+      const sqlMock = createSqlMock([{ reject: unrelatedError }])
+      mockGetDb.mockResolvedValue({ db: {} as any, sql: sqlMock as any })
+
+      await expect(enableChannelPointsStreamerAccess(TWITCH_USER_ID)).rejects.toThrow('TWITCH_USER_ID_REQUIRED')
+    })
+
+    it('streamer_id が null(行はある)なら「no streamer_id」エラーで throw する', async () => {
+      const sqlMock = createSqlMock([{ rows: [{ streamer_id: null }] }])
+      mockGetDb.mockResolvedValue({ db: {} as any, sql: sqlMock as any })
+
+      await expect(enableChannelPointsStreamerAccess(TWITCH_USER_ID)).rejects.toThrow(
+        'enable_channel_points_streamer_access returned no streamer_id'
+      )
+    })
+
+    it('rows が空配列なら「no streamer_id」エラーで throw する', async () => {
+      const sqlMock = createSqlMock([{ rows: [] }])
+      mockGetDb.mockResolvedValue({ db: {} as any, sql: sqlMock as any })
+
+      await expect(enableChannelPointsStreamerAccess(TWITCH_USER_ID)).rejects.toThrow(
+        'enable_channel_points_streamer_access returned no streamer_id'
+      )
+    })
+
+    it('冪等性: 同じ入力で2回呼んでも両方成功する(JS層で入力順序やstateに依存しないことの確認)', async () => {
+      // DB側の真の冪等性(ON CONFLICT等)はモックでは検証できないため、ここでは
+      // 「同一モックに対して2回呼んでも呼び出しごとに独立して同じ結果になる」
+      // というJS層でのドキュメント的な確認に留める(タスク仕様の指示どおり)。
+      const sqlMock = createSqlMock([{ rows: [{ streamer_id: 'uuid-pg-1' }] }])
+      mockGetDb.mockResolvedValue({ db: {} as any, sql: sqlMock as any })
+
+      const first = await enableChannelPointsStreamerAccess(TWITCH_USER_ID)
+      const second = await enableChannelPointsStreamerAccess(TWITCH_USER_ID)
+
+      expect(first).toEqual({ ok: true, streamerId: 'uuid-pg-1' })
+      expect(second).toEqual({ ok: true, streamerId: 'uuid-pg-1' })
+    })
+  })
+
+  // Fable厳格レビュー指摘(classifyEnableRpcErrorのコメント参照): PostgREST/pg直結
+  // どちらの経路でも同一のRAISE EXCEPTION文字列から同一の型付きエラーへ写像
+  // されることを、実際に両経路を実行して比較することで固定する。
+  describe('driver parity: classifyEnableRpcError の分類結果が postgrest/pg で一致する', () => {
+    it('CAPABILITY_NOT_AVAILABLE は両経路で同じ分類結果になる', async () => {
+      const rpc = vi.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'CAPABILITY_NOT_AVAILABLE', code: 'P0001' },
+      })
+      mockGetSupabaseAdmin.mockReturnValue({ rpc } as any)
+      const postgrestResult = await enableChannelPointsStreamerAccess(TWITCH_USER_ID)
+
+      vi.stubEnv('DB_DRIVER', 'pg')
+      const sqlMock = createSqlMock([{ reject: pgError('CAPABILITY_NOT_AVAILABLE', 'P0001') }])
+      mockGetDb.mockResolvedValue({ db: {} as any, sql: sqlMock as any })
+      const pgResult = await enableChannelPointsStreamerAccess(TWITCH_USER_ID)
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect(pgResult).toEqual({ ok: false, error: 'capability_not_available' })
+    })
+
+    it('USER_NOT_FOUND は両経路で同じ分類結果になる', async () => {
+      const rpc = vi.fn().mockResolvedValue({
+        data: null,
+        error: { message: 'USER_NOT_FOUND', code: 'P0001' },
+      })
+      mockGetSupabaseAdmin.mockReturnValue({ rpc } as any)
+      const postgrestResult = await enableChannelPointsStreamerAccess(TWITCH_USER_ID)
+
+      vi.stubEnv('DB_DRIVER', 'pg')
+      const sqlMock = createSqlMock([{ reject: pgError('USER_NOT_FOUND', 'P0001') }])
+      mockGetDb.mockResolvedValue({ db: {} as any, sql: sqlMock as any })
+      const pgResult = await enableChannelPointsStreamerAccess(TWITCH_USER_ID)
+
+      expect(pgResult).toEqual(postgrestResult)
+      expect(pgResult).toEqual({ ok: false, error: 'user_not_found' })
+    })
+  })
+})

--- a/tests/unit/channel-points-access.test.ts
+++ b/tests/unit/channel-points-access.test.ts
@@ -350,6 +350,23 @@ describe('persistChannelPointsCapability', () => {
 
       await expect(persistChannelPointsCapability(TWITCH_USER_ID, AVAILABLE_RESULT)).rejects.toBe(updateError)
     })
+
+    // 自動レビュー(claude[bot])指摘 Major-1: 読み取り側(getChannelPointsAccessState)
+    // と対になるデプロイ窓フォールバックが書き込み側に無く、POST/PUT
+    // /api/account/channel-points が列未デプロイの窓で500になっていた。
+    it.each(['PGRST204', '42703'])(
+      '%sではthrowせず、保存をスキップして正常終了する(デプロイ窓フォールバック)',
+      async (code) => {
+        const queryBuilder = createMockQueryBuilder()
+        ;(queryBuilder as any).then = (resolve: (v: unknown) => void) => {
+          resolve({ error: { code, message: 'column not found' } })
+          return queryBuilder
+        }
+        mockGetSupabaseAdmin.mockReturnValue({ from: vi.fn(() => queryBuilder) } as any)
+
+        await expect(persistChannelPointsCapability(TWITCH_USER_ID, AVAILABLE_RESULT)).resolves.toBeUndefined()
+      }
+    )
   })
 
   describe('pg 経路(DB_DRIVER=pg)', () => {
@@ -384,6 +401,14 @@ describe('persistChannelPointsCapability', () => {
 
       await expect(persistChannelPointsCapability(TWITCH_USER_ID, AVAILABLE_RESULT)).resolves.toBeUndefined()
       expect(calls).toHaveLength(2)
+    })
+
+    // 自動レビュー(claude[bot])指摘 Major-1: pg経路でも同様にデプロイ窓を吸収する。
+    it('42703ではthrowせず、保存をスキップして正常終了する(デプロイ窓フォールバック)', async () => {
+      const { db } = createUpdateDbMock([{ reject: pgError('column "channel_points_capability" does not exist', '42703') }])
+      mockGetDb.mockResolvedValue({ db, sql: {} as any })
+
+      await expect(persistChannelPointsCapability(TWITCH_USER_ID, AVAILABLE_RESULT)).resolves.toBeUndefined()
     })
   })
 })

--- a/tests/unit/channel-points-capability-probe.test.ts
+++ b/tests/unit/channel-points-capability-probe.test.ts
@@ -1,0 +1,294 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// #788/#789: probeChannelPointsCapability() は非Affiliate配信者を含む「Channel Points
+// が実際に利用可能か」を、報酬を一切作成しない読み取り専用APIコール
+// (GET /helix/channel_points/custom_rewards) だけで判定する。
+//
+// このテストで検証する契約:
+// 1. アクセストークンが取れない場合はfetchすら呼ばず reauth_required/no_access_token を返す
+// 2. Twitch APIのHTTPステータスを capability/reason/definitive へ正しくマッピングする
+//    - definitive:true  = 401/403/200相当。呼び出し元がDBの確定状態を上書きしてよい
+//    - definitive:false = 429/5xx/unexpected/network error等。既存の確定状態を破壊してはならない
+// 3. 200時のレスポンス本文（報酬件数・内容）は判定に一切影響しない
+// 4. リクエストURL・クエリパラメータ・認証ヘッダーが仕様通りである
+// 5. アクセストークン/Authorizationヘッダーの値がログへ絶対に出力されない
+//    （ソースコードのコメントで明示されている契約）
+
+const mocks = vi.hoisted(() => ({
+  getTwitchAccessToken: vi.fn(),
+}))
+
+vi.mock('@/lib/twitch/token-manager', () => ({
+  getTwitchAccessToken: mocks.getTwitchAccessToken,
+}))
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/env-validation', () => ({
+  getEnvVar: vi.fn().mockReturnValue('test-client-id'),
+}))
+
+const BROADCASTER_ID = 'broadcaster-1'
+// トークン漏洩検知テストで「本当にこの文字列がログに出ていないか」を検証するための
+// 十分ユニークな値（'token' のような一般語だと誤検知しやすいため）。
+const FAKE_ACCESS_TOKEN = 'super-secret-broadcaster-access-token-xyz'
+const EXPECTED_URL =
+  `https://api.twitch.tv/helix/channel_points/custom_rewards?broadcaster_id=${BROADCASTER_ID}&only_manageable_rewards=true`
+
+/** 全てのモック呼び出し引数を文字列化し、指定した秘匿値が一切含まれないことを検証する */
+function expectNoLeak(mockFn: ReturnType<typeof vi.fn>, secret: string) {
+  for (const call of mockFn.mock.calls) {
+    const serialized = JSON.stringify(call)
+    expect(serialized.includes(secret)).toBe(false)
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal('fetch', vi.fn())
+  mocks.getTwitchAccessToken.mockResolvedValue(FAKE_ACCESS_TOKEN)
+})
+
+describe('probeChannelPointsCapability', () => {
+  it('アクセストークンが取得できない場合、fetchを呼ばずreauth_required/no_access_tokenを返す', async () => {
+    mocks.getTwitchAccessToken.mockResolvedValue(null)
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'reauth_required',
+      reason: 'no_access_token',
+      definitive: true,
+    })
+    expect(result.httpStatus).toBeUndefined()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('getTwitchAccessTokenをbroadcasterTwitchUserId単一引数で呼び出す', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ status: 200 } as unknown as Response)
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(mocks.getTwitchAccessToken).toHaveBeenCalledTimes(1)
+    expect(mocks.getTwitchAccessToken).toHaveBeenCalledWith(BROADCASTER_ID)
+  })
+
+  it('200・空のdata配列でavailable/okを返す（報酬0件でも利用可能と判定する）', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({ data: [] }),
+    } as unknown as Response)
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'available',
+      reason: 'ok',
+      httpStatus: 200,
+      definitive: true,
+    })
+  })
+
+  it('200・非空の報酬配列でも同じくavailable/okを返す（報酬件数・内容は判定に影響しない）', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        data: [
+          { id: 'reward-1', title: 'Gacha', cost: 100, is_enabled: true },
+          { id: 'reward-2', title: 'Another Reward', cost: 500, is_enabled: false },
+        ],
+      }),
+    } as unknown as Response)
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'available',
+      reason: 'ok',
+      httpStatus: 200,
+      definitive: true,
+    })
+  })
+
+  it('401でreauth_required/unauthorizedを返す（definitive:true）', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ status: 401 } as unknown as Response)
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'reauth_required',
+      reason: 'unauthorized',
+      httpStatus: 401,
+      definitive: true,
+    })
+  })
+
+  it('403でunavailable/forbiddenを返す（definitive:true。非Affiliateで機能なし確定）', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ status: 403 } as unknown as Response)
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'unavailable',
+      reason: 'forbidden',
+      httpStatus: 403,
+      definitive: true,
+    })
+  })
+
+  it('429でunknown/rate_limitedを返す（definitive:false。既存確定状態を破壊してはならない）', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ status: 429 } as unknown as Response)
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'unknown',
+      reason: 'rate_limited',
+      httpStatus: 429,
+      definitive: false,
+    })
+  })
+
+  it('500でunknown/twitch_server_errorを返す（definitive:false）', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ status: 500 } as unknown as Response)
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'unknown',
+      reason: 'twitch_server_error',
+      httpStatus: 500,
+      definitive: false,
+    })
+  })
+
+  it('503（他の5xx）でもunknown/twitch_server_errorを返す（definitive:false）', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ status: 503 } as unknown as Response)
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'unknown',
+      reason: 'twitch_server_error',
+      httpStatus: 503,
+      definitive: false,
+    })
+  })
+
+  it('401/403/429/5xx以外の非2xx(418)ではunknown/unexpected_statusを返す（definitive:false）', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ status: 418 } as unknown as Response)
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'unknown',
+      reason: 'unexpected_status',
+      httpStatus: 418,
+      definitive: false,
+    })
+  })
+
+  it('fetch自体が例外をthrow/rejectした場合、unknown/network_errorを返す（httpStatusなし）', async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error('network down'))
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'unknown',
+      reason: 'network_error',
+      definitive: false,
+    })
+    expect(result.httpStatus).toBeUndefined()
+  })
+
+  it('リクエストURLがbroadcaster_idとonly_manageable_rewards=trueを含む正しいものである', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ status: 200 } as unknown as Response)
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    const [url] = vi.mocked(global.fetch).mock.calls[0]
+    expect(url).toBe(EXPECTED_URL)
+    expect(String(url)).toContain(`broadcaster_id=${BROADCASTER_ID}`)
+    expect(String(url)).toContain('only_manageable_rewards=true')
+  })
+
+  it('Authorization/Client-Idヘッダーが正しく設定され、タイムアウト用のAbortSignalが渡される', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ status: 200 } as unknown as Response)
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    await probeChannelPointsCapability(BROADCASTER_ID)
+
+    const [, init] = vi.mocked(global.fetch).mock.calls[0]
+    expect(init).toMatchObject({
+      headers: {
+        'Authorization': `Bearer ${FAKE_ACCESS_TOKEN}`,
+        'Client-Id': 'test-client-id',
+      },
+    })
+    // GETのみ・報酬の作成/更新/削除を行わない非破壊リクエストであることの確認
+    // (methodを明示していない = デフォルトのGETである)
+    expect((init as RequestInit).method).toBeUndefined()
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('ネットワークエラー時、logger.warnはエラー分類のみを記録しアクセストークンの値をログへ出力しない', async () => {
+    vi.mocked(global.fetch).mockRejectedValue(new Error('network down'))
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    await probeChannelPointsCapability(BROADCASTER_ID)
+
+    const { logger } = await import('@/lib/logger')
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.error).not.toHaveBeenCalled()
+    expectNoLeak(vi.mocked(logger.warn), FAKE_ACCESS_TOKEN)
+    expectNoLeak(vi.mocked(logger.warn), `Bearer ${FAKE_ACCESS_TOKEN}`)
+  })
+
+  it('想定外ステータス(418)時、logger.warnはstatusのみを記録しアクセストークンの値をログへ出力しない', async () => {
+    vi.mocked(global.fetch).mockResolvedValue({ status: 418 } as unknown as Response)
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    await probeChannelPointsCapability(BROADCASTER_ID)
+
+    const { logger } = await import('@/lib/logger')
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.error).not.toHaveBeenCalled()
+    expectNoLeak(vi.mocked(logger.warn), FAKE_ACCESS_TOKEN)
+    expectNoLeak(vi.mocked(logger.warn), `Bearer ${FAKE_ACCESS_TOKEN}`)
+  })
+
+  it('definitive:trueとなる200/401/403、およびdefinitive:falseの429/5xxでは一切ログを出力しない', async () => {
+    const { logger } = await import('@/lib/logger')
+
+    for (const status of [200, 401, 403, 429, 500, 503]) {
+      vi.clearAllMocks()
+      mocks.getTwitchAccessToken.mockResolvedValue(FAKE_ACCESS_TOKEN)
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status } as unknown as Response))
+
+      const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+      await probeChannelPointsCapability(BROADCASTER_ID)
+
+      expect(logger.warn).not.toHaveBeenCalled()
+      expect(logger.error).not.toHaveBeenCalled()
+    }
+  })
+})

--- a/tests/unit/components/channel-points-access-section.test.tsx
+++ b/tests/unit/components/channel-points-access-section.test.tsx
@@ -43,6 +43,7 @@ const JA = {
   unavailableMessage:
     "現在Twitch上でチャネルポイントを利用できません。Twitch Creator Dashboardで収益化オンボーディングとチャネルポイント設定をご確認ください。",
   unavailableRecheckButton: "再判定",
+  checkingMessage: "Twitchへ確認中です...",
   unknownMessage: "Twitchへの確認に一時的に失敗しました。保存済みの状態は変わっていません。",
   unknownRetryButton: "再試行",
   capabilityLostWarning: "Channel Points操作には再認証・再判定が必要です。配信設定自体は引き続き利用できます。",
@@ -255,13 +256,19 @@ describe("ChannelPointsAccessSection", () => {
     );
     vi.stubGlobal("fetch", buildFetchMock({ get: getHandler, post: postHandler }));
 
-    renderSection({ mode: "off" });
+    const { rerender } = renderSection({ mode: "off" });
 
     await waitFor(() => expect(postHandler).toHaveBeenCalledTimes(1));
+    // runProbe() は成功後finally節で必ずfetchState()(GET)を呼び直す設計のため、
+    // checking表示が終わって再判定ボタンが戻ってくるまで待つことで、そのGETも
+    // 含めた一連の非同期チェーンが完全に片付いたことを保証する
+    // (afterEachでのfetchモック解除より前に未解決のfetch呼び出しを残さないため)。
+    await screen.findByRole("button", { name: JA.unknownRetryButton });
 
-    // 追加の再render(Strict Modeの二重effect実行相当の懸念)を発生させても
+    // 追加の再render(Strict Modeの二重effect実行相当の懸念)を発生させても、
+    // 同一コンポーネントインスタンスに対するrerenderであるため新規mountは起きず、
     // autoProbeStarted(useRef)ガードにより再発火しないことを確認する。
-    render(buildTree({ mode: "off" }));
+    rerender(buildTree({ mode: "off" }));
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(postHandler).toHaveBeenCalledTimes(1);
   });
@@ -323,10 +330,14 @@ describe("ChannelPointsAccessSection", () => {
     fireEvent.click(enableButton);
 
     await waitFor(() => expect(putHandler).toHaveBeenCalledTimes(1));
+    // 実装は setMessage(成功) → await fetchState()(GET) → router.refresh() の順で
+    // 実行される。成功メッセージの描画はfetchState/refreshより先に起こりうるため、
+    // 「メッセージが見える」ことをもって後続処理の完了を仮定せず、
+    // router.refresh呼び出しとGET再取得の両方を個別にwaitForで待つ
+    // (afterEachでfetchモックが解除される前に非同期チェーンを完全に片付けるため)。
     await waitFor(() => expect(screen.getByText(JA.enableSuccess)).toBeInTheDocument());
-    expect(routerMocks.refresh).toHaveBeenCalledTimes(1);
-    // 初回GET + PUT成功後の再取得で計2回
-    expect(getHandler).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(getHandler).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(routerMocks.refresh).toHaveBeenCalledTimes(1));
   });
 
   it("unavailable状態では案内メッセージ(Twitch Creator Dashboard誘導)と再判定ボタンを表示し、クリックでPOSTが呼ばれる", async () => {
@@ -355,6 +366,11 @@ describe("ChannelPointsAccessSection", () => {
     fireEvent.click(recheckButton);
 
     await waitFor(() => expect(postHandler).toHaveBeenCalledTimes(1));
+    // runProbe()はfinally節で必ずfetchState()(GET)を呼び直してからchecking状態を
+    // 解除する。再判定ボタンが復帰するまで待つことで、そのGETも含めた一連の
+    // 非同期チェーンが完全に片付いたことを保証する
+    // (afterEachでのfetchモック解除より前に未解決のfetch呼び出しを残さないため)。
+    await screen.findByRole("button", { name: JA.unavailableRecheckButton });
   });
 
   it("自動probeが一時失敗しても、直前の確定状態(capabilityCheckedAt)を消さずunknown/再試行を表示する", async () => {
@@ -441,17 +457,14 @@ describe("ChannelPointsAccessSection", () => {
     // handleEnable の失敗パスは data.error を一切参照せず、常に
     // t("messages.enableFailed") (またはparseMaintenanceErrorのmessage)に
     // フォールバックする実装になっている。data.errorがオブジェクト形状でも
-    // 无視されるため、フォールバック文言が安全に描画されることを確認する。
+    // 無視されるため、フォールバック文言が安全に描画されることを確認する。
+    const getHandler = vi.fn(() =>
+      jsonResponse(makeState({ capability: "available", enabled: false, hasRequiredScope: true }))
+    );
     const putHandler = vi.fn(() =>
       jsonResponse({ error: { code: "some_code", message: "Something failed" }, enabled: false }, 200)
     );
-    vi.stubGlobal(
-      "fetch",
-      buildFetchMock({
-        get: () => jsonResponse(makeState({ capability: "available", enabled: false, hasRequiredScope: true })),
-        put: putHandler,
-      })
-    );
+    vi.stubGlobal("fetch", buildFetchMock({ get: getHandler, put: putHandler }));
 
     renderSection({ mode: "off" });
 
@@ -462,6 +475,10 @@ describe("ChannelPointsAccessSection", () => {
     const alert = await screen.findByRole("alert");
     expect(alert.textContent).not.toContain("[object Object]");
     expect(alert.textContent).not.toContain("object Object");
+    // 失敗パスもfinally節で必ずfetchState()(GET)を呼び直してから完了する。
+    // それを待つことで、afterEachでのfetchモック解除より前に未解決のfetch呼び出しを
+    // 残さないようにする。
+    await waitFor(() => expect(getHandler).toHaveBeenCalledTimes(2));
   });
 
   describe("channelPointsAccess i18n キーの ja/en 両対応 (コンポーネントが実際に t() で参照するキーのみ)", () => {

--- a/tests/unit/components/channel-points-access-section.test.tsx
+++ b/tests/unit/components/channel-points-access-section.test.tsx
@@ -48,6 +48,9 @@ const JA = {
   unknownRetryButton: "再試行",
   capabilityLostWarning: "Channel Points操作には再認証・再判定が必要です。配信設定自体は引き続き利用できます。",
   enableSuccess: "配信者機能を有効化しました。",
+  enableSuccessSessionPending:
+    "配信者機能を有効化しました。ただしセッションの更新に失敗したため、反映には再ログインが必要な場合があります。",
+  enableFailed: "有効化に失敗しました。時間をおいて再試行してください。",
   genericError: "エラーが発生しました。時間をおいて再試行してください。",
   maintenanceWriteDisabled: "メンテナンス中は操作できません",
 } as const;
@@ -340,6 +343,39 @@ describe("ChannelPointsAccessSection", () => {
     await waitFor(() => expect(routerMocks.refresh).toHaveBeenCalledTimes(1));
   });
 
+  // 自動レビュー(claude[bot])指摘 Major-2: PUTがDB更新成功だがsession cookie再署名に
+  // 失敗した場合、サーバーはstatus 500 + { code: 'session_resync_failed', enabled: true }
+  // を返す。response.okだけで成功判定すると「失敗」と誤表示され、直後のGETで
+  // enabled:trueが表示されて矛盾する。data.enabled===trueを見て成功扱いすることを確認する。
+  it("PUTがsession_resync_failed(500だがenabled:true)を返した場合も成功として表示し、GET再取得・router.refreshを行う", async () => {
+    let getCallCount = 0;
+    const getHandler = vi.fn(() => {
+      getCallCount += 1;
+      if (getCallCount === 1) {
+        return jsonResponse(
+          makeState({ capability: "available", enabled: false, hasRequiredScope: true, canEnable: true })
+        );
+      }
+      return jsonResponse(makeState({ capability: "available", enabled: true, hasRequiredScope: true }));
+    });
+    const putHandler = vi.fn(() =>
+      jsonResponse({ code: "session_resync_failed", enabled: true, error: "..." }, 500)
+    );
+    vi.stubGlobal("fetch", buildFetchMock({ get: getHandler, put: putHandler }));
+
+    renderSection({ mode: "off" });
+
+    const enableButton = await screen.findByRole("button", { name: JA.availableEnableButton });
+    fireEvent.click(enableButton);
+
+    await waitFor(() => expect(putHandler).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByText(JA.enableSuccessSessionPending)).toBeInTheDocument());
+    // 「有効化に失敗しました」という矛盾したエラー文言は表示されない
+    expect(screen.queryByText(JA.enableFailed)).not.toBeInTheDocument();
+    await waitFor(() => expect(getHandler).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(routerMocks.refresh).toHaveBeenCalledTimes(1));
+  });
+
   it("unavailable状態では案内メッセージ(Twitch Creator Dashboard誘導)と再判定ボタンを表示し、クリックでPOSTが呼ばれる", async () => {
     const postHandler = vi.fn(() => jsonResponse({}));
     vi.stubGlobal(
@@ -506,6 +542,7 @@ describe("ChannelPointsAccessSection", () => {
       "unknown.retryButton",
       "capabilityLostWarning",
       "messages.enableSuccess",
+      "messages.enableSuccessSessionPending",
       "messages.enableFailed",
       "messages.genericError",
     ];

--- a/tests/unit/components/channel-points-access-section.test.tsx
+++ b/tests/unit/components/channel-points-access-section.test.tsx
@@ -1,0 +1,539 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import ChannelPointsAccessSection from "@/components/ChannelPointsAccessSection";
+import { MaintenanceStatusContext } from "@/components/MaintenanceStatusProvider";
+import type { MaintenanceStatusResponse } from "@/lib/maintenance/client";
+import { CHANNEL_POINT_SCOPES } from "@/lib/twitch/scopes";
+import jaMessages from "../../../messages/ja.json";
+import enMessages from "../../../messages/en.json";
+
+// GitHub issue #788/#792: 非Affiliate配信者向けChannel Points利用可否確認・
+// 明示的オプトインセクション (src/components/ChannelPointsAccessSection.tsx) の単体テスト。
+//
+// 既存の類似コンポーネントテストと同じ規約に揃えている:
+//   - tests/unit/components/twitch-sub-check-section-maintenance.test.tsx
+//     (fetchベースの状態管理・maintenanceゲーティング・再認証フローの型)
+//   - tests/unit/components/channel-point-settings-maintenance.test.tsx
+//     (URLディスパッチ式のfetchモックパターン)
+// アサーションは messages/ja.json の実翻訳文字列をハードコードして使う
+// （上記2ファイルの慣例。next-intlの補間・改行等の差異による誤検知を避けるため、
+// 独自に組み立てた偽文字列ではなく実ファイルの値をそのままコピーしている）。
+
+// useRouter().refresh を呼び出しごとに検証したいため、vi.hoisted で
+// モジュール全体から参照できる単一のモック関数を用意する。
+// （vi.mock ファクトリはファイル先頭にホイストされるため、参照する変数も
+// vi.hoisted で包む必要がある。同じパターンを本リポジトリの他テストでも使用）
+const routerMocks = vi.hoisted(() => ({ refresh: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerMocks,
+}));
+
+// 実際に画面へ表示される日本語文言。messages/ja.json の channelPointsAccess キー
+// (末尾付近) からそのままコピーしたもの。ja.json が変更されたら要追随。
+const JA = {
+  loading: "確認状況を読み込み中...",
+  affiliateMessage: "Twitchアフィリエイト/パートナーとして、既に配信者機能を利用できます。",
+  reauthMessage: "チャネルポイントの利用可否を確認するには、Twitchでの追加権限の許可が必要です。",
+  reauthButton: "Twitchと再連携して確認",
+  availableMessage: "Twitch上でチャネルポイントを利用できることを確認しました。",
+  availableEnableButton: "twicaで配信者機能を有効にする",
+  enabledMessage: "配信者機能が有効化されています。",
+  enabledSettingsLink: "配信設定を開く",
+  unavailableMessage:
+    "現在Twitch上でチャネルポイントを利用できません。Twitch Creator Dashboardで収益化オンボーディングとチャネルポイント設定をご確認ください。",
+  unavailableRecheckButton: "再判定",
+  unknownMessage: "Twitchへの確認に一時的に失敗しました。保存済みの状態は変わっていません。",
+  unknownRetryButton: "再試行",
+  capabilityLostWarning: "Channel Points操作には再認証・再判定が必要です。配信設定自体は引き続き利用できます。",
+  enableSuccess: "配信者機能を有効化しました。",
+  genericError: "エラーが発生しました。時間をおいて再試行してください。",
+  maintenanceWriteDisabled: "メンテナンス中は操作できません",
+} as const;
+
+// GET /api/account/channel-points のレスポンス形状。コンポーネント本体は
+// このinterfaceをexportしていないため、テスト側で最小限を複製する。
+type Capability = "available" | "unavailable" | "reauth_required" | "unknown";
+interface AccessState {
+  broadcasterType: string;
+  capability: Capability;
+  capabilityCheckedAt: string | null;
+  enabled: boolean;
+  hasRequiredScope: boolean;
+  requiresReauth: boolean;
+  stale: boolean;
+  canEnable: boolean;
+}
+
+function makeState(overrides: Partial<AccessState> = {}): AccessState {
+  return {
+    broadcasterType: "",
+    capability: "unknown",
+    capabilityCheckedAt: null,
+    enabled: false,
+    hasRequiredScope: false,
+    requiresReauth: false,
+    stale: false,
+    canEnable: false,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// GET/POST/PUT (/api/account/channel-points) と POST /api/auth/reauth を
+// URL・methodで振り分けるfetchモック。未指定のハンドラはchannel-point-settings-
+// maintenance.test.tsx と同様、素の200 `{}` を返す。
+function buildFetchMock(handlers: {
+  get?: () => Response | Promise<Response>;
+  post?: (init?: RequestInit) => Response | Promise<Response>;
+  put?: (init?: RequestInit) => Response | Promise<Response>;
+  reauth?: (init?: RequestInit) => Response | Promise<Response>;
+}) {
+  return vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (url.includes("/api/account/channel-points")) {
+      if (method === "GET") {
+        return Promise.resolve((handlers.get ?? (() => jsonResponse(makeState())))());
+      }
+      if (method === "POST" && handlers.post) {
+        return Promise.resolve(handlers.post(init));
+      }
+      if (method === "PUT" && handlers.put) {
+        return Promise.resolve(handlers.put(init));
+      }
+    }
+    if (url.includes("/api/auth/reauth") && handlers.reauth) {
+      return Promise.resolve(handlers.reauth(init));
+    }
+    return Promise.resolve(jsonResponse({}));
+  });
+}
+
+function buildTree(
+  status: MaintenanceStatusResponse,
+  props: { broadcasterType?: string; initialEnabled?: boolean } = {}
+) {
+  return (
+    <NextIntlClientProvider locale="ja" messages={jaMessages}>
+      <MaintenanceStatusContext.Provider value={status}>
+        <ChannelPointsAccessSection
+          broadcasterType={props.broadcasterType ?? ""}
+          initialEnabled={props.initialEnabled ?? false}
+        />
+      </MaintenanceStatusContext.Provider>
+    </NextIntlClientProvider>
+  );
+}
+
+function renderSection(
+  status: MaintenanceStatusResponse,
+  props: { broadcasterType?: string; initialEnabled?: boolean } = {}
+) {
+  return render(buildTree(status, props));
+}
+
+// happy-dom の window.location をテスト間で安全に差し替え/復元するための元の参照。
+// #569 (overlay-page.test.tsx) と同じ方針: hrefはgetter/setterではなく
+// プレーンなプロパティを持つ差し替えオブジェクトにするため、代入(`location.href = x`)
+// をそのまま観測できる。
+const ORIGINAL_LOCATION = window.location;
+
+function stubLocationHref() {
+  const current = window.location;
+  Object.defineProperty(window, "location", {
+    value: {
+      hash: current.hash,
+      host: current.host,
+      hostname: current.hostname,
+      href: current.href,
+      origin: current.origin,
+      pathname: current.pathname,
+      port: current.port,
+      protocol: current.protocol,
+      search: current.search,
+    },
+    configurable: true,
+  });
+}
+
+describe("ChannelPointsAccessSection", () => {
+  beforeEach(() => {
+    routerMocks.refresh.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    // stubLocationHref() を使ったテストが失敗して復元処理まで到達しなかった
+    // 場合でも、以降のテストに影響を残さないよう毎回無条件に復元する。
+    Object.defineProperty(window, "location", { value: ORIGINAL_LOCATION, configurable: true });
+  });
+
+  it("初回GET解決前はローディング表示のみで、アクションボタンは描画されない", async () => {
+    let resolveGet!: (value: Response) => void;
+    const pendingGet = new Promise<Response>((resolve) => {
+      resolveGet = resolve;
+    });
+    vi.stubGlobal("fetch", buildFetchMock({ get: () => pendingGet }));
+
+    renderSection({ mode: "off" });
+
+    expect(screen.getByText(JA.loading)).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+
+    // pending中のPromiseを残したままテストを終えるとactの外での警告や後続テストへの
+    // 汚染につながるため、明示的に解決してから終える。
+    resolveGet(jsonResponse(makeState({ capability: "available", hasRequiredScope: true })));
+    await waitFor(() => expect(screen.queryByText(JA.loading)).not.toBeInTheDocument());
+  });
+
+  it.each(["affiliate", "partner"] as const)(
+    "broadcasterType=%s の場合はAffiliateメッセージと設定リンクのみを表示し、有効化ボタンは出さない",
+    async (broadcasterType) => {
+      vi.stubGlobal(
+        "fetch",
+        buildFetchMock({
+          get: () =>
+            jsonResponse(
+              makeState({ broadcasterType, enabled: false, hasRequiredScope: true, capability: "unknown" })
+            ),
+        })
+      );
+
+      renderSection({ mode: "off" }, { broadcasterType });
+
+      expect(await screen.findByText(JA.affiliateMessage)).toBeInTheDocument();
+      const link = screen.getByRole("link", { name: JA.enabledSettingsLink });
+      expect(link).toHaveAttribute("href", "/dashboard/settings");
+      // Affiliate分岐にはボタン要素が一切存在しない(リンクのみ)ことを確認する
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    }
+  );
+
+  it("スコープ不足/要再認証の場合は再認証メッセージとボタンを表示し、クリックでPOST /api/auth/reauthを正しいbodyで呼ぶ", async () => {
+    stubLocationHref();
+    const reauthHandler = vi.fn((init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      expect(body).toEqual({
+        additionalScopes: CHANNEL_POINT_SCOPES,
+        returnTo: "/dashboard/account",
+      });
+      return jsonResponse({ loginUrl: "https://id.twitch.tv/oauth2/authorize?mock=1", state: "abc123" });
+    });
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock({
+        get: () => jsonResponse(makeState({ hasRequiredScope: false, requiresReauth: true, stale: false })),
+        reauth: reauthHandler,
+      })
+    );
+
+    renderSection({ mode: "off" });
+
+    expect(await screen.findByText(JA.reauthMessage)).toBeInTheDocument();
+    const button = screen.getByRole("button", { name: JA.reauthButton });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(reauthHandler).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(window.location.href).toBe("https://id.twitch.tv/oauth2/authorize?mock=1")
+    );
+  });
+
+  it("non-affiliate + スコープ有 + stale の場合、ユーザー操作なしで自動的に1回だけPOST /api/account/channel-pointsが発火する", async () => {
+    const postHandler = vi.fn(() => jsonResponse({}));
+    const getHandler = vi.fn(() =>
+      jsonResponse(makeState({ hasRequiredScope: true, stale: true, capability: "unknown" }))
+    );
+    vi.stubGlobal("fetch", buildFetchMock({ get: getHandler, post: postHandler }));
+
+    renderSection({ mode: "off" });
+
+    await waitFor(() => expect(postHandler).toHaveBeenCalledTimes(1));
+
+    // 追加の再render(Strict Modeの二重effect実行相当の懸念)を発生させても
+    // autoProbeStarted(useRef)ガードにより再発火しないことを確認する。
+    render(buildTree({ mode: "off" }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(postHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("stale:false の場合は自動POSTが発火しない", async () => {
+    const postHandler = vi.fn(() => jsonResponse({}));
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock({
+        get: () => jsonResponse(makeState({ hasRequiredScope: true, stale: false, capability: "unknown" })),
+        post: postHandler,
+      })
+    );
+
+    renderSection({ mode: "off" });
+
+    await screen.findByText(JA.unknownMessage);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(postHandler).not.toHaveBeenCalled();
+  });
+
+  it("Affiliateの場合はstale:trueでも自動POSTが発火しない(コンポーネント側ガードの防御的検証)", async () => {
+    const postHandler = vi.fn(() => jsonResponse({}));
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock({
+        get: () =>
+          jsonResponse(
+            makeState({ broadcasterType: "affiliate", hasRequiredScope: true, stale: true })
+          ),
+        post: postHandler,
+      })
+    );
+
+    renderSection({ mode: "off" }, { broadcasterType: "affiliate" });
+
+    await screen.findByText(JA.affiliateMessage);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(postHandler).not.toHaveBeenCalled();
+  });
+
+  it("available状態で有効化ボタンをクリックするとPUTを呼び、成功メッセージ・router.refresh・GET再取得を行う", async () => {
+    let getCallCount = 0;
+    const getHandler = vi.fn(() => {
+      getCallCount += 1;
+      if (getCallCount === 1) {
+        return jsonResponse(
+          makeState({ capability: "available", enabled: false, hasRequiredScope: true, canEnable: true })
+        );
+      }
+      return jsonResponse(makeState({ capability: "available", enabled: true, hasRequiredScope: true }));
+    });
+    const putHandler = vi.fn(() => jsonResponse({ code: "enabled", enabled: true, streamerId: "uuid-1" }));
+    vi.stubGlobal("fetch", buildFetchMock({ get: getHandler, put: putHandler }));
+
+    renderSection({ mode: "off" });
+
+    const enableButton = await screen.findByRole("button", { name: JA.availableEnableButton });
+    fireEvent.click(enableButton);
+
+    await waitFor(() => expect(putHandler).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByText(JA.enableSuccess)).toBeInTheDocument());
+    expect(routerMocks.refresh).toHaveBeenCalledTimes(1);
+    // 初回GET + PUT成功後の再取得で計2回
+    expect(getHandler).toHaveBeenCalledTimes(2);
+  });
+
+  it("unavailable状態では案内メッセージ(Twitch Creator Dashboard誘導)と再判定ボタンを表示し、クリックでPOSTが呼ばれる", async () => {
+    const postHandler = vi.fn(() => jsonResponse({}));
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock({
+        get: () =>
+          jsonResponse(
+            makeState({ capability: "unavailable", enabled: false, hasRequiredScope: true, stale: false })
+          ),
+        post: postHandler,
+      })
+    );
+
+    renderSection({ mode: "off" });
+
+    const message = await screen.findByText(JA.unavailableMessage);
+    expect(message).toBeInTheDocument();
+    // 撤去済みのはずの旧文言("Affiliate required"等)が復活していないことの防御的確認。
+    // 実文言はTwitch Creator Dashboardでのオンボーディング確認を案内する内容である。
+    expect(message.textContent).not.toMatch(/Affiliate required/i);
+    expect(message.textContent).toContain("Creator Dashboard");
+
+    const recheckButton = screen.getByRole("button", { name: JA.unavailableRecheckButton });
+    fireEvent.click(recheckButton);
+
+    await waitFor(() => expect(postHandler).toHaveBeenCalledTimes(1));
+  });
+
+  it("自動probeが一時失敗しても、直前の確定状態(capabilityCheckedAt)を消さずunknown/再試行を表示する", async () => {
+    const CHECKED_AT = "2026-01-01T00:00:00Z";
+    // POSTのレスポンスbody自体はコンポーネントの実装上は使われず(finally節で
+    // 常にfetchStateを呼び直す設計)、その後のGETが返す「persisted」な状態が
+    // 画面表示を決定する。よってGET側に一時失敗後も保持されるはずの
+    // capability:'unknown' + capabilityCheckedAt(非null)を返させる。
+    const getHandler = vi.fn(() =>
+      jsonResponse(
+        makeState({
+          hasRequiredScope: true,
+          stale: true,
+          capability: "unknown",
+          capabilityCheckedAt: CHECKED_AT,
+        })
+      )
+    );
+    const postHandler = vi.fn(() =>
+      jsonResponse({
+        code: "probe_temporarily_failed",
+        probe: { definitive: false },
+        persisted: { capability: "unknown", capabilityCheckedAt: CHECKED_AT },
+      })
+    );
+    vi.stubGlobal("fetch", buildFetchMock({ get: getHandler, post: postHandler }));
+
+    renderSection({ mode: "off" });
+
+    await waitFor(() => expect(postHandler).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText(JA.unknownMessage)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: JA.unknownRetryButton })).toBeInTheDocument();
+    expect(screen.queryByText(JA.unavailableMessage)).not.toBeInTheDocument();
+  });
+
+  it.each([
+    { requiresReauth: true, capability: "unknown" as const },
+    { requiresReauth: false, capability: "unavailable" as const },
+  ])(
+    "有効化済み(enabled:true)でcapabilityを喪失した場合、設定リンクと再認証/再判定案内を両方表示する (requiresReauth=$requiresReauth, capability=$capability)",
+    async ({ requiresReauth, capability }) => {
+      vi.stubGlobal(
+        "fetch",
+        buildFetchMock({
+          get: () =>
+            jsonResponse(
+              makeState({ enabled: true, requiresReauth, capability, hasRequiredScope: !requiresReauth })
+            ),
+        })
+      );
+
+      renderSection({ mode: "off" }, { initialEnabled: true });
+
+      expect(await screen.findByText(JA.enabledMessage)).toBeInTheDocument();
+      // ユーザーがロックアウトされないこと(設定リンクは引き続き表示される)
+      expect(screen.getByRole("link", { name: JA.enabledSettingsLink })).toBeInTheDocument();
+      // かつ再認証/再判定が必要という警告も同時に表示される(どちらか一方ではない)
+      expect(screen.getByText(JA.capabilityLostWarning)).toBeInTheDocument();
+    }
+  );
+
+  it("メンテナンス中は有効化ボタンがdisabledになり、クリックしてもPUTは呼ばれない(UI無効化 + handler側ガードの多重防御)", async () => {
+    const putHandler = vi.fn(() => jsonResponse({ code: "enabled", enabled: true, streamerId: "uuid-1" }));
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock({
+        get: () => jsonResponse(makeState({ capability: "available", enabled: false, hasRequiredScope: true })),
+        put: putHandler,
+      })
+    );
+
+    renderSection({ mode: "read-only" });
+
+    const enableButton = await screen.findByRole("button", { name: JA.availableEnableButton });
+    expect(enableButton).toBeDisabled();
+    expect(screen.getByText(JA.maintenanceWriteDisabled)).toBeInTheDocument();
+
+    fireEvent.click(enableButton);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(putHandler).not.toHaveBeenCalled();
+  });
+
+  it("有効化(PUT)がobject形状のerrorボディで失敗しても、[object Object]という文字列を描画せず翻訳済みの汎用エラーにフォールバックする", async () => {
+    // handleEnable の失敗パスは data.error を一切参照せず、常に
+    // t("messages.enableFailed") (またはparseMaintenanceErrorのmessage)に
+    // フォールバックする実装になっている。data.errorがオブジェクト形状でも
+    // 无視されるため、フォールバック文言が安全に描画されることを確認する。
+    const putHandler = vi.fn(() =>
+      jsonResponse({ error: { code: "some_code", message: "Something failed" }, enabled: false }, 200)
+    );
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock({
+        get: () => jsonResponse(makeState({ capability: "available", enabled: false, hasRequiredScope: true })),
+        put: putHandler,
+      })
+    );
+
+    renderSection({ mode: "off" });
+
+    const enableButton = await screen.findByRole("button", { name: JA.availableEnableButton });
+    fireEvent.click(enableButton);
+
+    await waitFor(() => expect(putHandler).toHaveBeenCalledTimes(1));
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).not.toContain("[object Object]");
+    expect(alert.textContent).not.toContain("object Object");
+  });
+
+  describe("channelPointsAccess i18n キーの ja/en 両対応 (コンポーネントが実際に t() で参照するキーのみ)", () => {
+    // src/components/ChannelPointsAccessSection.tsx を grep して収集した、
+    // useTranslations("channelPointsAccess") 経由で呼ばれる全キーパス。
+    // キーを追加/削除した場合はこの配列も追随させること。
+    const CHANNEL_POINTS_ACCESS_KEYS = [
+      "title",
+      "loading",
+      "description",
+      "affiliate.message",
+      "reauth.message",
+      "reauth.button",
+      "reauth.buttonLoading",
+      "checking.message",
+      "available.message",
+      "available.enableDescription",
+      "available.enableButton",
+      "available.enableButtonLoading",
+      "enabled.message",
+      "enabled.settingsLink",
+      "unavailable.message",
+      "unavailable.recheckButton",
+      "unknown.message",
+      "unknown.retryButton",
+      "capabilityLostWarning",
+      "messages.enableSuccess",
+      "messages.enableFailed",
+      "messages.genericError",
+    ];
+
+    function getByPath(obj: unknown, path: string): unknown {
+      return path.split(".").reduce<unknown>((acc, key) => {
+        if (typeof acc !== "object" || acc === null) return undefined;
+        return (acc as Record<string, unknown>)[key];
+      }, obj);
+    }
+
+    it.each(CHANNEL_POINTS_ACCESS_KEYS)("ja/en 両方に channelPointsAccess.%s が非空文字列として存在する", (key) => {
+      const jaValue = getByPath((jaMessages as { channelPointsAccess: unknown }).channelPointsAccess, key);
+      const enValue = getByPath((enMessages as { channelPointsAccess: unknown }).channelPointsAccess, key);
+
+      expect(typeof jaValue).toBe("string");
+      expect((jaValue as string).length).toBeGreaterThan(0);
+      expect(typeof enValue).toBe("string");
+      expect((enValue as string).length).toBeGreaterThan(0);
+    });
+
+    // tMaintenance("writeDisabled") もコンポーネントが実際に呼ぶキー
+    it("ja/en 両方に maintenance.writeDisabled が非空文字列として存在する", () => {
+      expect(jaMessages.maintenance.writeDisabled.length).toBeGreaterThan(0);
+      expect(enMessages.maintenance.writeDisabled.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("fetch未解決中にunmountしても、アンマウント後のReact state更新警告を出さない", async () => {
+    let resolveGet!: (value: Response) => void;
+    const pendingGet = new Promise<Response>((resolve) => {
+      resolveGet = resolve;
+    });
+    vi.stubGlobal("fetch", buildFetchMock({ get: () => pendingGet }));
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { unmount } = renderSection({ mode: "off" });
+    unmount();
+    resolveGet(jsonResponse(makeState({ capability: "available", hasRequiredScope: true })));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const unmountedWarnings = consoleErrorSpy.mock.calls.filter(
+      ([msg]) => typeof msg === "string" && msg.includes("unmounted component")
+    );
+    expect(unmountedWarnings).toHaveLength(0);
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/tests/unit/session.test.ts
+++ b/tests/unit/session.test.ts
@@ -169,6 +169,98 @@ describe('parseSession', () => {
     const session = parseSession(JSON.stringify(validSession))
     expect(session.version).toBe(Number.MAX_SAFE_INTEGER)
   })
+
+  it('should parse successfully when channelPointsEnabled is absent (legacy cookie) and leave it undefined', () => {
+    const legacySession = {
+      twitchUserId: '12345',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/image.png',
+      broadcasterType: 'affiliate',
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      version: 1
+    }
+
+    const session = parseSession(JSON.stringify(legacySession))
+    expect(session.channelPointsEnabled).toBeUndefined()
+  })
+
+  it('should preserve channelPointsEnabled: true', () => {
+    const validSession = {
+      twitchUserId: '12345',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/image.png',
+      broadcasterType: '',
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      version: 1,
+      channelPointsEnabled: true
+    }
+
+    const session = parseSession(JSON.stringify(validSession))
+    expect(session.channelPointsEnabled).toBe(true)
+  })
+
+  it('should preserve channelPointsEnabled: false', () => {
+    const validSession = {
+      twitchUserId: '12345',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/image.png',
+      broadcasterType: '',
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      version: 1,
+      channelPointsEnabled: false
+    }
+
+    const session = parseSession(JSON.stringify(validSession))
+    expect(session.channelPointsEnabled).toBe(false)
+  })
+
+  it('should throw error if channelPointsEnabled is a string instead of a boolean', () => {
+    const invalidSession = {
+      twitchUserId: '12345',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/image.png',
+      broadcasterType: '',
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      version: 1,
+      channelPointsEnabled: 'true'
+    }
+
+    expect(() => parseSession(JSON.stringify(invalidSession))).toThrow('channelPointsEnabled must be a boolean')
+  })
+
+  it('should throw error if channelPointsEnabled is a number instead of a boolean', () => {
+    const invalidSession = {
+      twitchUserId: '12345',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/image.png',
+      broadcasterType: '',
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      version: 1,
+      channelPointsEnabled: 1
+    }
+
+    expect(() => parseSession(JSON.stringify(invalidSession))).toThrow('channelPointsEnabled must be a boolean')
+  })
+
+  it('should throw error if channelPointsEnabled is null', () => {
+    const invalidSession = {
+      twitchUserId: '12345',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/image.png',
+      broadcasterType: '',
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      version: 1,
+      channelPointsEnabled: null
+    }
+
+    expect(() => parseSession(JSON.stringify(invalidSession))).toThrow('channelPointsEnabled must be a boolean')
+  })
 })
 
 describe('canUseStreamerFeatures', () => {
@@ -216,6 +308,80 @@ describe('canUseStreamerFeatures', () => {
 
   it('should return false for null session', () => {
     expect(canUseStreamerFeatures(null)).toBe(false)
+  })
+
+  it('should return true for affiliate broadcaster even when channelPointsEnabled is false', () => {
+    const session: Session = {
+      twitchUserId: '12345',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/image.png',
+      broadcasterType: 'affiliate',
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      version: 1,
+      channelPointsEnabled: false
+    }
+
+    expect(canUseStreamerFeatures(session)).toBe(true)
+  })
+
+  it('should return true for partner broadcaster even when channelPointsEnabled is false', () => {
+    const session: Session = {
+      twitchUserId: '12345',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/image.png',
+      broadcasterType: 'partner',
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      version: 1,
+      channelPointsEnabled: false
+    }
+
+    expect(canUseStreamerFeatures(session)).toBe(true)
+  })
+
+  it('should return true for non-affiliate broadcaster who explicitly opted in via channelPointsEnabled', () => {
+    const session: Session = {
+      twitchUserId: '12345',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/image.png',
+      broadcasterType: '',
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      version: 1,
+      channelPointsEnabled: true
+    }
+
+    expect(canUseStreamerFeatures(session)).toBe(true)
+  })
+
+  it('should return false for non-affiliate broadcaster with channelPointsEnabled explicitly false', () => {
+    const session: Session = {
+      twitchUserId: '12345',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/image.png',
+      broadcasterType: '',
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      version: 1,
+      channelPointsEnabled: false
+    }
+
+    expect(canUseStreamerFeatures(session)).toBe(false)
+  })
+
+  it('should return false for non-affiliate broadcaster with channelPointsEnabled omitted (legacy session)', () => {
+    const session: Session = {
+      twitchUserId: '12345',
+      twitchUsername: 'testuser',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/image.png',
+      broadcasterType: '',
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      version: 1
+    }
+
+    expect(canUseStreamerFeatures(session)).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

Twitchの新制度「Monetization for All」により、Affiliate/Partnerでなくても収益化オンボーディング済みでChannel Pointsを利用できる配信者が登場した。本PRはissue #788（親issue、子issue #789〜#793）を実装し、非破壊のCapability Probeによる利用可否判定と、本人の明示的オプトインによるtwica配信者機能の有効化を追加する。

- **#789**: `probeChannelPointsCapability()` — 読み取り専用Twitch API呼び出しでの利用可否判定（200/401/403/429/5xx/network errorを`available`/`reauth_required`/`unavailable`/`unknown`(一時失敗)へ分類）
- **#790**: `users`テーブルへの`channel_points_capability`/`channel_points_capability_checked_at`/`channel_points_enabled`列追加migration、原子的な有効化+`streamers` UPSERT用RPC、session cookieへの`channelPointsEnabled`ミラーリング、`canUseStreamerFeatures()`拡張
- **#791**: `/api/account/channel-points`（GET/POST/PUT）、OAuth callbackのstep-up時自動判定、`/api/auth/reauth`の`returnTo`対応
- **#792**: `/dashboard/account`にChannel Points状態確認・明示的有効化セクションを追加（9状態機械、自動再判定、i18n）
- **#793**: 既存経路（Header、`channel-point-bootstrap`、`ChannelPointSettings`、rewards、eventsub/subscribe）のCapability契約への移行、`affiliateRequired`固定文言の撤去

## マイグレーションに関する重要な注意

- 新規migration: `supabase/migrations/20260723150000_add_channel_points_capability.sql`（`ALTER TABLE users ADD COLUMN ...` + `enable_channel_points_streamer_access` RPC、いずれも再実行安全）。
- **本番DBは本日(#699)PlanetScaleへcutover済みだが、現行CIの`supabase-migrations`ジョブは`supabase db push`のみを実行しPlanetScaleへは自動適用されない。** 本番反映時は `DATABASE_URL="<PlanetScale prod>" node scripts/db-migrate.js apply --provider=planetscale` を別途手動実行する必要がある（本PRの実行環境ではPlanetScaleの接続情報を保有していないため、この手順はオーナー側での実施が必要）。
- migration未適用のデプロイ窓（列未追加の状態でコードだけ先行デプロイされる短い期間）でも、OAuth callback・`channel-point-bootstrap`・`/api/account/channel-points` GETのいずれも既存ログイン・既存Affiliate/Partnerの操作を壊さないようフォールバック実装済み（対応テストあり）。

## レビュー

CLAUDE.mdの規約に従い、fableエージェントによる設計レビュー3回（全てGO）・成果物レビュー2回（Critical 0、指摘したMajor 5件は全て修正・再レビュー済み）を実施した。fableモデルの利用上限到達時のみ、直前2件のMajor修正の妥当性確認という限定的な最終確認を代替モデル(opus)で実施（結論: GO）。

## Test plan

- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx eslint`（変更ファイル27件） — エラーなし（既存の無関係な警告1件のみ）
- [x] `npx vitest run` — preview基準で2972件全成功（main基準では3375件全成功）
- [x] `npm run check:migration-order -- --base=origin/preview` — OK
- [x] `npm run check:maintenance-surfaces` — OK（新規write route `/api/account/channel-points` 登録済み）
- [x] 新規/既存テスト: Capability Probe(16)、data layer(31、postgrest/pg driver parity込み)、session/canUseStreamerFeatures(11追加)、OAuth callback(12、デプロイ窓フォールバック・step-up限定probe含む)、reauth returnTo(5)、account API(31、GET/POST/PUT)、bootstrap API/driver-parity(自己回復ロジック含む)、UIコンポーネント(38、9状態機械・maintenance連携・i18nパリティ含む)
- [ ] preview環境での実機検証（マージ後に実施）

---
_Generated by [Claude Code](https://claude.ai/code/session_01Af2MDpxrEM3SRitmadVTKg)_