### PR TITLE
fix(cards): PlanetScale切替後の確率再計算でDB参照先を統一する (#794)

### DIFF
--- a/src/app/api/cards/batch-update/route.ts
+++ b/src/app/api/cards/batch-update/route.ts
@@ -8,7 +8,12 @@ import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
 import { recalculateIfAutoMode, executeBatchUpdateCardDropRatesRpcPg } from "@/lib/recalculate-drop-rates";
 import { logger } from "@/lib/logger";
+import { and, eq, inArray } from "drizzle-orm";
+import { getDb } from "@/lib/db/client";
 import { isPgWriteEnabled } from "@/lib/db/flags";
+import { withDbRetry } from "@/lib/db/retry";
+import { cards as cardsTable, streamers as streamersTable } from "@/lib/db/schema";
+import { CARDS_SAFE_COLUMNS } from "@/lib/db/cards-safe-columns";
 import type { ApiRateLimitResponse } from "@/types/api";
 
 /**
@@ -19,6 +24,102 @@ interface DropRateUpdate {
   id: string;
   dropRate: number;
   intraRarityWeight?: number;
+}
+
+interface StreamerForBatchUpdate {
+  id: string;
+  rarity_weights: Record<string, number> | null;
+}
+
+/**
+ * Issue #794: DB_DRIVER=pg のとき、所有権確認も更新RPCと同じPlanetScaleで行う。
+ * 既存PostgREST経路はエラーを明示処理せず data=null → 403 に倒すため、
+ * pg経路も取得失敗時はnullを返して外部挙動を揃える。
+ */
+async function fetchStreamerForBatchUpdatePg(
+  streamerId: string,
+  twitchUserId: string
+): Promise<StreamerForBatchUpdate | null> {
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({
+            id: streamersTable.id,
+            rarity_weights: streamersTable.rarity_weights,
+          })
+          .from(streamersTable)
+          .where(
+            and(
+              eq(streamersTable.id, streamerId),
+              eq(streamersTable.twitch_user_id, twitchUserId)
+            )
+          )
+          .limit(1);
+      },
+      "Cards Batch Update API: streamer ownership check(pg)",
+      { idempotent: true }
+    );
+    return rows[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Issue #794: 更新対象カードの存在確認もPlanetScale上の同じスナップショットで行う。
+ */
+async function fetchExistingCardsForBatchUpdatePg(
+  streamerId: string,
+  cardIds: string[]
+): Promise<Array<{ id: string }> | null> {
+  try {
+    return await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({ id: cardsTable.id })
+          .from(cardsTable)
+          .where(
+            and(
+              eq(cardsTable.streamer_id, streamerId),
+              inArray(cardsTable.id, cardIds)
+            )
+          );
+      },
+      "Cards Batch Update API: existing cards check(pg)",
+      { idempotent: true }
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Issue #794: 更新後レスポンスもPlanetScaleから取得する。
+ * 無指定selectは本番未デプロイ列を要求しうるためCARDS_SAFE_COLUMNSを使う。
+ */
+async function fetchUpdatedCardsForBatchUpdatePg(
+  streamerId: string,
+  cardIds: string[]
+) {
+  return withDbRetry(
+    async () => {
+      const { db } = await getDb();
+      return db
+        .select(CARDS_SAFE_COLUMNS)
+        .from(cardsTable)
+        .where(
+          and(
+            eq(cardsTable.streamer_id, streamerId),
+            inArray(cardsTable.id, cardIds)
+          )
+        );
+    },
+    "Cards Batch Update API: fetch updated cards(pg)",
+    { idempotent: true }
+  );
 }
 
 /**
@@ -104,14 +205,24 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Issue #794: 読み取り・RPC更新・更新後取得を同じDBへ揃える。
+    // pg-read は書き込みがPostgRESTのままなので従来経路を維持する。
+    const pgWriteEnabled = isPgWriteEnabled();
+
     // Verify streamer owns this streamer profile
     // 配信者がこのstreamerプロフィールを所有しているか確認
-    const { data: streamer } = await supabaseAdmin
-      .from("streamers")
-      .select("id, rarity_weights")
-      .eq("id", streamerId)
-      .eq("twitch_user_id", session.twitchUserId)
-      .maybeSingle();
+    let streamer: StreamerForBatchUpdate | null;
+    if (pgWriteEnabled) {
+      streamer = await fetchStreamerForBatchUpdatePg(streamerId, session.twitchUserId);
+    } else {
+      const result = await supabaseAdmin
+        .from("streamers")
+        .select("id, rarity_weights")
+        .eq("id", streamerId)
+        .eq("twitch_user_id", session.twitchUserId)
+        .maybeSingle();
+      streamer = result.data as StreamerForBatchUpdate | null;
+    }
 
     if (!streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
@@ -156,11 +267,18 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
-    const { data: existingCards } = await supabaseAdmin
-      .from("cards")
-      .select("id")
-      .eq("streamer_id", streamerId)
-      .in("id", cardIds);
+
+    let existingCards: Array<{ id: string }> | null;
+    if (pgWriteEnabled) {
+      existingCards = await fetchExistingCardsForBatchUpdatePg(streamerId, cardIds);
+    } else {
+      const result = await supabaseAdmin
+        .from("cards")
+        .select("id")
+        .eq("streamer_id", streamerId)
+        .in("id", cardIds);
+      existingCards = result.data as Array<{ id: string }> | null;
+    }
 
     if (!existingCards || existingCards.length !== cardIds.length) {
       return NextResponse.json(
@@ -183,7 +301,7 @@ export async function POST(request: NextRequest) {
     // #573: isPgWriteEnabled() のときだけ pg 直結経路へ分岐する。pg 側の { data, error }
     // 正規化は recalculate-drop-rates.ts の executeBatchUpdateCardDropRatesRpcPg を
     // 共有する(同じ RPC を呼ぶ実装を2箇所に重複させない。doc コメント参照)。
-    const { data: rpcResult, error: rpcError } = isPgWriteEnabled()
+    const { data: rpcResult, error: rpcError } = pgWriteEnabled
       ? await executeBatchUpdateCardDropRatesRpcPg(streamerId, rpcPayload)
       : await supabaseAdmin.rpc(
           "batch_update_card_drop_rates",
@@ -224,14 +342,24 @@ export async function POST(request: NextRequest) {
 
     // 更新後のカードデータを取得して返す
     // 再計算済みの場合はそちらを優先
-    const { data: updatedCards, error: fetchError } = await supabaseAdmin
-      .from("cards")
-      .select()
-      .eq("streamer_id", streamerId)
-      .in("id", cardIds);
+    let updatedCards;
+    if (pgWriteEnabled) {
+      try {
+        updatedCards = await fetchUpdatedCardsForBatchUpdatePg(streamerId, cardIds);
+      } catch (fetchError) {
+        return handleDatabaseError(fetchError, "Cards Batch Update API: Failed to fetch updated cards");
+      }
+    } else {
+      const { data, error: fetchError } = await supabaseAdmin
+        .from("cards")
+        .select()
+        .eq("streamer_id", streamerId)
+        .in("id", cardIds);
 
-    if (fetchError) {
-      return handleDatabaseError(fetchError, "Cards Batch Update API: Failed to fetch updated cards");
+      if (fetchError) {
+        return handleDatabaseError(fetchError, "Cards Batch Update API: Failed to fetch updated cards");
+      }
+      updatedCards = data;
     }
 
     return NextResponse.json({

--- a/src/lib/recalculate-drop-rates.ts
+++ b/src/lib/recalculate-drop-rates.ts
@@ -9,9 +9,12 @@ import { logger } from "@/lib/logger";
 // ため、import が存在するだけでは挙動に影響しない(#570 の設計。tests/setup.ts の
 // getDb throw スタブが「postgrest 経路で getDb が呼ばれない」ことを構造的に保証)。
 // ---------------------------------------------------------------------------
+import { and, eq, inArray } from "drizzle-orm";
 import { getDb } from "@/lib/db/client";
 import { isPgWriteEnabled } from "@/lib/db/flags";
 import { withDbRetry } from "@/lib/db/retry";
+import { cards as cardsTable } from "@/lib/db/schema";
+import { CARDS_SAFE_COLUMNS } from "@/lib/db/cards-safe-columns";
 
 /**
  * batch_update_card_drop_rates RPC の pg 直結エラーを PostgREST .rpc() の error と
@@ -103,6 +106,76 @@ export async function executeBatchUpdateCardDropRatesRpcPg(
   }
 }
 
+type RecalculationCard = Pick<
+  Card,
+  "id" | "rarity" | "is_active" | "intra_rarity_weight"
+>;
+
+/**
+ * Issue #794: DB_DRIVER=pg では再計算対象も PlanetScale から取得する。
+ *
+ * 以前は更新RPCだけが pg 直結で、前後の SELECT は Supabase のままだったため、
+ * cutover後に PlanetScale へ追加されたカードが再計算対象から漏れていた。
+ * 読み書き混在処理は isPgWriteEnabled() で処理全体を同じDBへ揃える。
+ */
+async function fetchActiveCardsForRecalculationPg(
+  streamerId: string
+): Promise<RecalculationCard[]> {
+  const rows = await withDbRetry(
+    async () => {
+      const { db } = await getDb();
+      return db
+        .select({
+          id: cardsTable.id,
+          rarity: cardsTable.rarity,
+          is_active: cardsTable.is_active,
+          intra_rarity_weight: cardsTable.intra_rarity_weight,
+        })
+        .from(cardsTable)
+        .where(
+          and(
+            eq(cardsTable.streamer_id, streamerId),
+            eq(cardsTable.is_active, true)
+          )
+        );
+    },
+    "recalculateIfAutoMode: active cards(pg)",
+    { idempotent: true }
+  );
+
+  // is_active=true で絞っているため、この処理内では nullable なDB型を
+  // calculateDropRates が要求する boolean として安全に扱える。
+  return rows as RecalculationCard[];
+}
+
+/**
+ * Issue #794: pg更新後のカードも同じ PlanetScale 接続から取得する。
+ * cards の無指定 select は本番未デプロイ列を要求しうるため、安全列を明示する。
+ */
+async function fetchRecalculatedCardsPg(
+  streamerId: string,
+  updatedCardIds: string[]
+): Promise<Card[]> {
+  const rows = await withDbRetry(
+    async () => {
+      const { db } = await getDb();
+      return db
+        .select(CARDS_SAFE_COLUMNS)
+        .from(cardsTable)
+        .where(
+          and(
+            eq(cardsTable.streamer_id, streamerId),
+            inArray(cardsTable.id, updatedCardIds)
+          )
+        );
+    },
+    "recalculateIfAutoMode: recalculated cards(pg)",
+    { idempotent: true }
+  );
+
+  return normalizeDropRate(rows as Card[]);
+}
+
 /**
  * Recalculate active cards drop_rate when rarity auto mode is enabled.
  * Returns updated active cards, [] when no active cards exist, or null when auto mode is disabled.
@@ -117,17 +190,27 @@ export async function recalculateIfAutoMode(
     return null;
   }
 
-  const { data: activeCards, error: activeCardsError } = await supabaseAdmin
-    .from("cards")
-    .select("id, rarity, is_active, intra_rarity_weight")
-    .eq("streamer_id", streamerId)
-    .eq("is_active", true);
+  // Issue #794: 一連の再計算中に参照先を混在させないため、分岐値を1回だけ確定する。
+  // pg-read は書き込みがPostgRESTのままなので、読み取りも従来側へ揃える。
+  const pgWriteEnabled = isPgWriteEnabled();
 
-  if (activeCardsError) {
-    throw activeCardsError;
+  let activeCards: RecalculationCard[];
+  if (pgWriteEnabled) {
+    activeCards = await fetchActiveCardsForRecalculationPg(streamerId);
+  } else {
+    const { data, error } = await supabaseAdmin
+      .from("cards")
+      .select("id, rarity, is_active, intra_rarity_weight")
+      .eq("streamer_id", streamerId)
+      .eq("is_active", true);
+
+    if (error) {
+      throw error;
+    }
+    activeCards = (data || []) as RecalculationCard[];
   }
 
-  const updates = calculateDropRates(activeCards || [], rarityWeights);
+  const updates = calculateDropRates(activeCards, rarityWeights);
   if (updates.length === 0) {
     return [];
   }
@@ -140,11 +223,8 @@ export async function recalculateIfAutoMode(
   }));
 
   // #573: isPgWriteEnabled() のときだけ pg 直結(postgres.js)経路へ分岐する。
-  // pg 側は PostgREST .rpc() と同一の { data, error } 形状へ正規化して返す
-  // (executeBatchUpdateCardDropRatesRpcPg の doc コメント参照)ため、直後の
-  // 既存エラー分岐(rpcError → throw)とカウント照合ログはそのまま両経路で
-  // 共有される。フラグ未設定時は下の既存 supabase-js 実装が無変更のまま実行される。
-  const { data: rpcResult, error: rpcError } = isPgWriteEnabled()
+  // Issue #794: pgWriteEnabled は上の SELECT と共通で、同じ処理中にDBをまたがない。
+  const { data: rpcResult, error: rpcError } = pgWriteEnabled
     ? await executeBatchUpdateCardDropRatesRpcPg(streamerId, rpcPayload)
     : await supabaseAdmin.rpc(
         "batch_update_card_drop_rates",
@@ -168,6 +248,10 @@ export async function recalculateIfAutoMode(
   }
 
   const updatedCardIds = updates.map((update) => update.id);
+  if (pgWriteEnabled) {
+    return fetchRecalculatedCardsPg(streamerId, updatedCardIds);
+  }
+
   const { data: recalculatedCards, error: recalculatedCardsError } = await supabaseAdmin
     .from("cards")
     .select("*")

--- a/src/lib/recalculate-drop-rates.ts
+++ b/src/lib/recalculate-drop-rates.ts
@@ -14,7 +14,10 @@ import { getDb } from "@/lib/db/client";
 import { isPgWriteEnabled } from "@/lib/db/flags";
 import { withDbRetry } from "@/lib/db/retry";
 import { cards as cardsTable } from "@/lib/db/schema";
-import { CARDS_SAFE_COLUMNS } from "@/lib/db/cards-safe-columns";
+import {
+  CARDS_SAFE_COLUMNS,
+  withCardsBattleColumnFallback,
+} from "@/lib/db/cards-safe-columns";
 
 /**
  * batch_update_card_drop_rates RPC の pg 直結エラーを PostgREST .rpc() の error と
@@ -156,24 +159,29 @@ async function fetchRecalculatedCardsPg(
   streamerId: string,
   updatedCardIds: string[]
 ): Promise<Card[]> {
-  const rows = await withDbRetry(
-    async () => {
-      const { db } = await getDb();
-      return db
-        .select(CARDS_SAFE_COLUMNS)
-        .from(cardsTable)
-        .where(
-          and(
-            eq(cardsTable.streamer_id, streamerId),
-            inArray(cardsTable.id, updatedCardIds)
-          )
-        );
-    },
-    "recalculateIfAutoMode: recalculated cards(pg)",
-    { idempotent: true }
-  );
+  async function selectCards(useSafeColumns: boolean) {
+    return withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        const query = useSafeColumns
+          ? db.select(CARDS_SAFE_COLUMNS)
+          : db.select();
+        return query
+          .from(cardsTable)
+          .where(
+            and(
+              eq(cardsTable.streamer_id, streamerId),
+              inArray(cardsTable.id, updatedCardIds)
+            )
+          );
+      },
+      "recalculateIfAutoMode: recalculated cards(pg)",
+      { idempotent: true }
+    );
+  }
 
-  return normalizeDropRate(rows as Card[]);
+  const rows = await withCardsBattleColumnFallback(selectCards);
+  return normalizeDropRate(rows as unknown as Card[]);
 }
 
 /**

--- a/tests/unit/api/cards-batch-update-driver-consistency.test.ts
+++ b/tests/unit/api/cards-batch-update-driver-consistency.test.ts
@@ -1,0 +1,210 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { POST } from "@/app/api/cards/batch-update/route";
+import { getDb } from "@/lib/db/client";
+import { getSession, canUseStreamerFeatures } from "@/lib/session";
+import { checkRateLimit, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { validateCSRFToken } from "@/lib/csrf";
+import { validateContentType } from "@/lib/request-validation";
+import { getSupabaseAdmin } from "@/lib/supabase/admin";
+
+vi.mock("@/lib/session");
+vi.mock("@/lib/rate-limit");
+vi.mock("@/lib/csrf");
+vi.mock("@/lib/request-validation");
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const mockGetSession = vi.mocked(getSession);
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures);
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+const mockGetRateLimitIdentifier = vi.mocked(getRateLimitIdentifier);
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken);
+const mockValidateContentType = vi.mocked(validateContentType);
+const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin);
+
+function createPgSelectMock(responses: unknown[][]) {
+  let responseIndex = 0;
+  const select = vi.fn(() => {
+    const rows = responses[responseIndex] ?? [];
+    responseIndex += 1;
+
+    const builder: Record<string, unknown> = {};
+    builder.from = vi.fn(() => builder);
+    builder.where = vi.fn(() => builder);
+    builder.limit = vi.fn(() => builder);
+    builder.then = (
+      resolve: (value: unknown[]) => unknown,
+      reject: (reason: unknown) => unknown
+    ) => Promise.resolve(rows).then(resolve, reject);
+    return builder;
+  });
+
+  return { db: { select }, select };
+}
+
+function createSqlMock(results: Array<{ updated_count: number }>) {
+  let resultIndex = 0;
+  return vi.fn((_strings: TemplateStringsArray, ..._values: unknown[]) => {
+    const result = results[resultIndex] ?? results[results.length - 1];
+    resultIndex += 1;
+    return Promise.resolve([{ result }]);
+  });
+}
+
+function createRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/cards/batch-update", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      streamerId: "streamer-1",
+      updates: [
+        {
+          id: "card-after-cutover",
+          dropRate: 0.25,
+          intraRarityWeight: 2,
+        },
+      ],
+    }),
+  });
+}
+
+describe("POST /api/cards/batch-update DB driver consistency (#794)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("DB_DRIVER", "pg");
+
+    mockGetSession.mockResolvedValue({
+      twitchUserId: "twitch-user-1",
+      twitchUsername: "streamer",
+      twitchDisplayName: "Streamer",
+      twitchProfileImageUrl: "",
+      broadcasterType: "affiliate",
+      expiresAt: Date.now() + 60_000,
+      version: 1,
+    });
+    mockCanUseStreamerFeatures.mockReturnValue(true);
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: Math.floor(Date.now() / 1000) + 60,
+    });
+    mockGetRateLimitIdentifier.mockResolvedValue("user:twitch-user-1");
+    mockValidateCSRFToken.mockResolvedValue({ valid: true });
+    mockValidateContentType.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses PlanetScale for ownership, card validation, recalculation, and response reads", async () => {
+    const streamerRow = {
+      id: "streamer-1",
+      rarity_weights: { common: 100 },
+    };
+    const activeCards = [
+      {
+        id: "card-old",
+        rarity: "common",
+        is_active: true,
+        intra_rarity_weight: 1,
+      },
+      {
+        id: "card-after-cutover",
+        rarity: "common",
+        is_active: true,
+        intra_rarity_weight: 2,
+      },
+    ];
+    const recalculatedCards = [
+      {
+        id: "card-old",
+        streamer_id: "streamer-1",
+        rarity: "common",
+        drop_rate: 0.3333,
+        intra_rarity_weight: 1,
+        is_active: true,
+      },
+      {
+        id: "card-after-cutover",
+        streamer_id: "streamer-1",
+        rarity: "common",
+        drop_rate: 0.6667,
+        intra_rarity_weight: 2,
+        is_active: true,
+      },
+    ];
+    const updatedCards = [recalculatedCards[1]];
+
+    const pg = createPgSelectMock([
+      [streamerRow],
+      [{ id: "card-after-cutover" }],
+      activeCards,
+      recalculatedCards,
+      updatedCards,
+    ]);
+    const sql = createSqlMock([
+      { updated_count: 1 },
+      { updated_count: 2 },
+    ]);
+    vi.mocked(getDb).mockResolvedValue({
+      db: pg.db,
+      sql,
+    } as never);
+
+    const supabaseAdmin = {
+      from: vi.fn(() => {
+        throw new Error("Supabase read must not run in pg mode");
+      }),
+      rpc: vi.fn(() => {
+        throw new Error("Supabase RPC must not run in pg mode");
+      }),
+    };
+    mockGetSupabaseAdmin.mockReturnValue(supabaseAdmin as never);
+
+    const response = await POST(createRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      updated: 1,
+      cards: updatedCards,
+      recalculatedCards,
+    });
+    expect(pg.select).toHaveBeenCalledTimes(5);
+    expect(supabaseAdmin.from).not.toHaveBeenCalled();
+    expect(supabaseAdmin.rpc).not.toHaveBeenCalled();
+    expect(sql).toHaveBeenCalledTimes(2);
+
+    const firstSqlValues = (sql.mock.calls[0] as [
+      TemplateStringsArray,
+      ...unknown[],
+    ]).slice(1);
+    expect(firstSqlValues).toEqual([
+      "streamer-1",
+      JSON.stringify([
+        {
+          id: "card-after-cutover",
+          drop_rate: 0.25,
+          intra_rarity_weight: 2,
+        },
+      ]),
+    ]);
+
+    const secondSqlValues = (sql.mock.calls[1] as [
+      TemplateStringsArray,
+      ...unknown[],
+    ]).slice(1);
+    expect(secondSqlValues).toEqual([
+      "streamer-1",
+      JSON.stringify([
+        { id: "card-old", drop_rate: 0.3333 },
+        { id: "card-after-cutover", drop_rate: 0.6667 },
+      ]),
+    ]);
+  });
+});

--- a/tests/unit/recalculate-drop-rates-driver-consistency.test.ts
+++ b/tests/unit/recalculate-drop-rates-driver-consistency.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDb } from "@/lib/db/client";
+import { recalculateIfAutoMode } from "@/lib/recalculate-drop-rates";
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+function createPgSelectMock(responses: unknown[][]) {
+  let responseIndex = 0;
+  const select = vi.fn(() => {
+    const rows = responses[responseIndex] ?? [];
+    responseIndex += 1;
+
+    const builder: Record<string, unknown> = {};
+    builder.from = vi.fn(() => builder);
+    builder.where = vi.fn(() => builder);
+    builder.limit = vi.fn(() => builder);
+    builder.then = (
+      resolve: (value: unknown[]) => unknown,
+      reject: (reason: unknown) => unknown
+    ) => Promise.resolve(rows).then(resolve, reject);
+    return builder;
+  });
+
+  return { db: { select }, select };
+}
+
+function createSqlMock(results: Array<{ updated_count: number }>) {
+  let resultIndex = 0;
+  return vi.fn((_strings: TemplateStringsArray, ..._values: unknown[]) => {
+    const result = results[resultIndex] ?? results[results.length - 1];
+    resultIndex += 1;
+    return Promise.resolve([{ result }]);
+  });
+}
+
+function createPostgrestCardsMock(
+  activeCards: unknown[],
+  recalculatedCards: unknown[]
+) {
+  let cardsCallIndex = 0;
+  const from = vi.fn((table: string) => {
+    expect(table).toBe("cards");
+    const result =
+      cardsCallIndex === 0
+        ? { data: activeCards, error: null }
+        : { data: recalculatedCards, error: null };
+    cardsCallIndex += 1;
+
+    const builder: Record<string, unknown> = {};
+    builder.select = vi.fn(() => builder);
+    builder.eq = vi.fn(() => builder);
+    builder.in = vi.fn(() => builder);
+    builder.then = (
+      resolve: (value: typeof result) => unknown,
+      reject: (reason: unknown) => unknown
+    ) => Promise.resolve(result).then(resolve, reject);
+    return builder;
+  });
+
+  return {
+    from,
+    rpc: vi.fn().mockResolvedValue({
+      data: { updated_count: activeCards.length },
+      error: null,
+    }),
+  };
+}
+
+describe("recalculateIfAutoMode DB driver consistency (#794)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("postgrest mode keeps all reads and the update RPC on Supabase", async () => {
+    const activeCards = [
+      {
+        id: "card-old",
+        rarity: "common",
+        is_active: true,
+        intra_rarity_weight: 1,
+      },
+      {
+        id: "card-new",
+        rarity: "common",
+        is_active: true,
+        intra_rarity_weight: 1,
+      },
+    ];
+    const recalculatedCards = [
+      { id: "card-old", drop_rate: 0.5 },
+      { id: "card-new", drop_rate: 0.5 },
+    ];
+    const supabaseAdmin = createPostgrestCardsMock(
+      activeCards,
+      recalculatedCards
+    );
+
+    const result = await recalculateIfAutoMode(
+      supabaseAdmin as never,
+      "streamer-1",
+      { common: 100 }
+    );
+
+    expect(result).toEqual(recalculatedCards);
+    expect(supabaseAdmin.from).toHaveBeenCalledTimes(2);
+    expect(supabaseAdmin.rpc).toHaveBeenCalledWith(
+      "batch_update_card_drop_rates",
+      {
+        p_streamer_id: "streamer-1",
+        p_updates: [
+          { id: "card-old", drop_rate: 0.5 },
+          { id: "card-new", drop_rate: 0.5 },
+        ],
+      }
+    );
+    expect(getDb).not.toHaveBeenCalled();
+  });
+
+  it("pg mode reads, updates, and re-reads cards only from PlanetScale", async () => {
+    vi.stubEnv("DB_DRIVER", "pg");
+
+    const activeCards = [
+      {
+        id: "card-old",
+        rarity: "common",
+        is_active: true,
+        intra_rarity_weight: 1,
+      },
+      {
+        id: "card-after-cutover",
+        rarity: "common",
+        is_active: true,
+        intra_rarity_weight: 1,
+      },
+    ];
+    const recalculatedCards = [
+      { id: "card-old", drop_rate: 0.5 },
+      { id: "card-after-cutover", drop_rate: 0.5 },
+    ];
+    const pg = createPgSelectMock([activeCards, recalculatedCards]);
+    const sql = createSqlMock([{ updated_count: 2 }]);
+    vi.mocked(getDb).mockResolvedValue({
+      db: pg.db,
+      sql,
+    } as never);
+
+    const supabaseAdmin = {
+      from: vi.fn(() => {
+        throw new Error("Supabase cards read must not run in pg mode");
+      }),
+      rpc: vi.fn(() => {
+        throw new Error("Supabase RPC must not run in pg mode");
+      }),
+    };
+
+    const result = await recalculateIfAutoMode(
+      supabaseAdmin as never,
+      "streamer-1",
+      { common: 100 }
+    );
+
+    expect(result).toEqual(recalculatedCards);
+    expect(pg.select).toHaveBeenCalledTimes(2);
+    expect(supabaseAdmin.from).not.toHaveBeenCalled();
+    expect(supabaseAdmin.rpc).not.toHaveBeenCalled();
+    expect(sql).toHaveBeenCalledTimes(1);
+
+    const [, ...values] = sql.mock.calls[0] as [
+      TemplateStringsArray,
+      ...unknown[],
+    ];
+    expect(values).toEqual([
+      "streamer-1",
+      JSON.stringify([
+        { id: "card-old", drop_rate: 0.5 },
+        { id: "card-after-cutover", drop_rate: 0.5 },
+      ]),
+    ]);
+  });
+});

--- a/tests/unit/write-rpc-driver-parity.test.ts
+++ b/tests/unit/write-rpc-driver-parity.test.ts
@@ -106,6 +106,35 @@ function primePgDb(sqlMock: ReturnType<typeof createSqlMock>) {
   vi.mocked(getDb).mockResolvedValue({ db: {} as never, sql: sqlMock as never })
 }
 
+/**
+ * Issue #794: pg経路でSELECTを含む処理向けの最小Drizzleモック。
+ * responsesをSELECT呼び出し順に返し、from/where/limitのチェインを再現する。
+ */
+function primePgDbWithSelectResponses(
+  sqlMock: ReturnType<typeof createSqlMock>,
+  responses: unknown[][]
+) {
+  let callIndex = 0
+  const select = vi.fn(() => {
+    const rows = responses[Math.min(callIndex, responses.length - 1)] ?? []
+    callIndex += 1
+    const builder: Record<string, unknown> = {}
+    builder.from = vi.fn(() => builder)
+    builder.where = vi.fn(() => builder)
+    builder.limit = vi.fn(() => builder)
+    builder.then = (
+      resolve: (value: unknown[]) => unknown,
+      reject: (reason: unknown) => unknown
+    ) => Promise.resolve(rows).then(resolve, reject)
+    return builder
+  })
+  vi.mocked(getDb).mockResolvedValue({
+    db: { select } as never,
+    sql: sqlMock as never,
+  })
+  return select
+}
+
 function setDefaultAuthMocks() {
   mockGetSession.mockResolvedValue(SESSION as any)
   mockCanUseStreamerFeatures.mockReturnValue(true)
@@ -218,14 +247,16 @@ describe('batch_update_card_drop_rates (#573)', () => {
       const rpc = vi.fn()
       const supabaseAdmin = createSupabaseAdminMock(rpc)
       const sqlMock = createSqlMock([{ rows: [{ result: { updated_count: 1 } }] }])
-      primePgDb(sqlMock)
+      const selectMock = primePgDbWithSelectResponses(sqlMock, [ACTIVE_CARDS, RECALCULATED_CARDS])
 
       const result = await recalculateIfAutoMode(supabaseAdmin as any, 'streamer-1', RARITY_WEIGHTS)
 
       expect(result).toEqual(RECALCULATED_CARDS)
+      expect(selectMock).toHaveBeenCalledTimes(2)
       expect(sqlMock).toHaveBeenCalledTimes(1)
       const { values } = renderSqlCall(sqlMock, 0)
       expect(values).toEqual(['streamer-1', JSON.stringify([{ id: 'card-1', drop_rate: 1 }])])
+      expect(supabaseAdmin.from).not.toHaveBeenCalled()
       expect(rpc).not.toHaveBeenCalled()
     })
   })
@@ -289,9 +320,13 @@ describe('batch_update_card_drop_rates (#573)', () => {
     it('pg 経路(DB_DRIVER=pg): 名前付き引数の SQL が実行され、レスポンス形状が postgrest 経路と一致する', async () => {
       vi.stubEnv('DB_DRIVER', 'pg')
       const rpc = vi.fn()
-      createBatchUpdateSupabaseMock({ rpc, updatedCards: [{ id: 'card-1', drop_rate: 0.5 }] })
+      const { from } = createBatchUpdateSupabaseMock({ rpc, updatedCards: [{ id: 'card-1', drop_rate: 0.5 }] })
       const sqlMock = createSqlMock([{ rows: [{ result: { updated_count: 1 } }] }])
-      primePgDb(sqlMock)
+      const selectMock = primePgDbWithSelectResponses(sqlMock, [
+        [{ id: 'streamer-1', rarity_weights: null }],
+        [{ id: 'card-1' }],
+        [{ id: 'card-1', drop_rate: 0.5 }],
+      ])
 
       const response = await batchUpdatePost(
         createRequest({ streamerId: 'streamer-1', updates: [{ id: 'card-1', dropRate: 0.5 }] })
@@ -300,24 +335,31 @@ describe('batch_update_card_drop_rates (#573)', () => {
       expect(response.status).toBe(200)
       const body = await response.json()
       expect(body).toMatchObject({ success: true, updated: 1 })
+      expect(selectMock).toHaveBeenCalledTimes(3)
       expect(sqlMock).toHaveBeenCalledTimes(1)
       const { text } = renderSqlCall(sqlMock, 0)
       expect(text).toContain('batch_update_card_drop_rates')
-      // 書き込み RPC が postgrest 経路(rpc)へ流れていないこと
+      // 読み取り・書き込みのいずれも postgrest 経路へ流れていないこと
+      expect(from).not.toHaveBeenCalled()
       expect(rpc).not.toHaveBeenCalled()
     })
 
     it('pg 経路で RPC エラー: 既存と同じ 500 (handleDatabaseError) を返す', async () => {
       vi.stubEnv('DB_DRIVER', 'pg')
-      createBatchUpdateSupabaseMock({})
+      const { from } = createBatchUpdateSupabaseMock({})
       const sqlMock = createSqlMock([{ reject: pgError('XX000', 'unexpected database error') }])
-      primePgDb(sqlMock)
+      const selectMock = primePgDbWithSelectResponses(sqlMock, [
+        [{ id: 'streamer-1', rarity_weights: null }],
+        [{ id: 'card-1' }],
+      ])
 
       const response = await batchUpdatePost(
         createRequest({ streamerId: 'streamer-1', updates: [{ id: 'card-1', dropRate: 0.5 }] })
       )
 
       expect(response.status).toBe(500)
+      expect(selectMock).toHaveBeenCalledTimes(2)
+      expect(from).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## 概要

Issue #794 の、カード管理一覧と「カードごとの調整」で表示確率が食い違う問題を修正します。

`DB_DRIVER=pg` 時に、確率再計算の更新RPCだけがPlanetScaleを使い、再計算前後のカード取得が旧Supabaseを参照していました。PlanetScale切替後に追加されたカードは旧Supabaseに存在しないため、再計算対象から漏れて作成時の `drop_rate` が残っていました。

Fixes #794

## 変更内容

- `recalculateIfAutoMode()` のDB分岐を処理単位で固定
  - `DB_DRIVER=pg`: 対象カード取得、更新RPC、更新後取得をすべてpg/PlanetScale経路に統一
  - `postgrest` / `pg-read`: 従来どおりSupabase/PostgREST経路を維持
- `/api/cards/batch-update` の所有権確認、対象カード確認、更新後取得も、`DB_DRIVER=pg` 時はpg経路に統一
- 本番未デプロイ列を要求しないよう、pg経路のカード応答には既存の安全列セットを使用
- 切替後にPlanetScaleだけに存在するカードを含む回帰テストを追加

## 既存データについて

- 一括再計算、バックフィル、データ修正SQL、マイグレーションは含めていません
- PRのデプロイだけでは既存の `drop_rate` を書き換えません
- 今後の通常のカード作成・更新等で既存の再計算処理が呼ばれた場合は、その操作の一部としてPlanetScale上の正しいカード集合を使います

## テスト

- `recalculateIfAutoMode` がpgモードでSupabaseへアクセスせず、PlanetScale上の切替後カードを再計算対象へ含めること
- `/api/cards/batch-update` がpgモードで所有権確認、対象確認、再計算、応答取得までSupabaseへアクセスしないこと
- PostgRESTモードの従来経路が維持されること
