### PR TITLE
ci(deploy): PlanetScale本番migrationをdeploy時に自動適用する

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -24,22 +24,19 @@
 # `.github/workflows/planetscale-migrate.yml` が
 # `scripts/db-migrate.js apply --provider=planetscale` を自動実行する
 # （production・main ブランチのみ。preview はまだ PlanetScale 未cutoverのため対象外）。
-# このworkflowとは別ファイルに分離している理由は同ファイルのコメント参照
-# （このworkflow全体の`concurrency: cancel-in-progress: true`に本番migration実行中の
-# ジョブが巻き込まれてキャンセルされる事故を、ファイル分離によって構造的に防ぐため）。
-# 初回有効化前に一度だけ手動での bootstrap 登録が必要。詳細・手順は
-# `docs/planetscale-schema-baseline.md` の「issue #788・CI自動化に伴う追記」節を参照。
+# このworkflowとは別ファイルに分離している（なぜ別ファイルかの理由も含め）詳細は
+# `planetscale-migrate.yml` 冒頭のコメントを参照。初回有効化前に一度だけ手動での
+# bootstrap 登録が必要。詳細・手順は `docs/planetscale-schema-baseline.md` の
+# 「issue #788・CI自動化に伴う追記」節を参照。
 #
 # Production's live DB was cut over from Supabase to PlanetScale (Postgres-compatible)
 # in issue #699, so `supabase db push` now only reaches the retained (rollback-only)
 # legacy Supabase production DB. A separate workflow file,
 # `.github/workflows/planetscale-migrate.yml`, applies
 # `scripts/db-migrate.js apply --provider=planetscale` against the actual production
-# DB on every push to main (preview is not yet cut over, so it's excluded). It lives in
-# its own file (see that file's comments) specifically so this workflow's
-# `concurrency: cancel-in-progress: true` can never cancel an in-progress production
-# migration. A one-time manual bootstrap registration is required before first use —
-# see `docs/planetscale-schema-baseline.md`.
+# DB on every push to main (preview is not yet cut over, so it's excluded). See that
+# file's header comment for why it's kept separate. A one-time manual bootstrap
+# registration is required before first use — see `docs/planetscale-schema-baseline.md`.
 #
 # - preview branch → twica-preview Worker (preview environment)
 # - main branch    → twica Worker (production environment)

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -151,6 +151,24 @@ jobs:
     permissions:
       contents: read
     environment: production
+    # workflow全体のconcurrencyグループ（cancel-in-progress: true）に巻き込まれると、
+    # main連続pushで実行中の本番migrationジョブごとキャンセルされうる（claude-reviewの
+    # 指摘）。job単位のconcurrencyを別グループで指定するとworkflowレベルの設定を
+    # このジョブに限り上書きできる。cancel-in-progress: false により、後続runは
+    # 先行のmigrationジョブが完走するまでキューで待つ（キャンセルしない）。
+    # required(トランザクション内)なmigrationはキャンセルされてもコネクション切断で
+    # 自動rollbackされ安全だが、将来 forbidden(CREATE INDEX CONCURRENTLY等、
+    # トランザクション外実行が必須)なmigrationが追加された場合、中断は
+    # INVALIDなオブジェクトの残留・手動復旧を要する半端な状態を招きうるため。
+    concurrency:
+      group: planetscale-migrate-${{ github.ref }}
+      cancel-in-progress: false
+    # pg_advisory_lock（scripts/db-migrate.js）はロック取得までブロックする。
+    # 手動bootstrap作業との時間的重複等でロックが解放されない場合に備え、
+    # GitHub Actionsのデフォルトタイムアウト(6時間)に張り付き続けないよう上限を設ける
+    # （claude-reviewの指摘）。通常のDDL適用は数秒〜数分で完了する想定のため、
+    # 10分は十分に余裕を持たせた値。
+    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -144,7 +144,7 @@ jobs:
   # 初回有効化前に一度だけ、既存migrationを「実行せず履歴登録のみ」する手動bootstrapが
   # 必要（docs/planetscale-schema-baseline.md 参照）。未実施のままだと、history table
   # 不在 + pending件数過多で db-migrate.js 自身の安全ガード（shouldBlockFreshApply）が
-  # 働き、データ破壊なく exit 1 する（＝赤くなり続けるだけで、73件が誤実行されることはない）。
+  # 働き、データ破壊なく exit 1 する（＝赤くなり続けるだけで、74件が誤実行されることはない）。
   planetscale-migrations:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -20,19 +20,26 @@
 #
 # Production の実DBは issue #699 で PlanetScale (Postgres互換) へ cutover 済みのため、
 # `supabase db push` は rollback用に温存している旧Supabase本番へのみ適用される。実際に
-# アプリが読み書きする本番PlanetScaleへは、下記 `planetscale-migrations` ジョブが
+# アプリが読み書きする本番PlanetScaleへは、別ファイル
+# `.github/workflows/planetscale-migrate.yml` が
 # `scripts/db-migrate.js apply --provider=planetscale` を自動実行する
 # （production・main ブランチのみ。preview はまだ PlanetScale 未cutoverのため対象外）。
+# このworkflowとは別ファイルに分離している理由は同ファイルのコメント参照
+# （このworkflow全体の`concurrency: cancel-in-progress: true`に本番migration実行中の
+# ジョブが巻き込まれてキャンセルされる事故を、ファイル分離によって構造的に防ぐため）。
 # 初回有効化前に一度だけ手動での bootstrap 登録が必要。詳細・手順は
 # `docs/planetscale-schema-baseline.md` の「issue #788・CI自動化に伴う追記」節を参照。
 #
 # Production's live DB was cut over from Supabase to PlanetScale (Postgres-compatible)
 # in issue #699, so `supabase db push` now only reaches the retained (rollback-only)
-# legacy Supabase production DB. The `planetscale-migrations` job below applies
+# legacy Supabase production DB. A separate workflow file,
+# `.github/workflows/planetscale-migrate.yml`, applies
 # `scripts/db-migrate.js apply --provider=planetscale` against the actual production
-# DB on every push to main (preview is not yet cut over, so it's excluded). A one-time
-# manual bootstrap registration is required before first use — see
-# `docs/planetscale-schema-baseline.md`.
+# DB on every push to main (preview is not yet cut over, so it's excluded). It lives in
+# its own file (see that file's comments) specifically so this workflow's
+# `concurrency: cancel-in-progress: true` can never cancel an in-progress production
+# migration. A one-time manual bootstrap registration is required before first use —
+# see `docs/planetscale-schema-baseline.md`.
 #
 # - preview branch → twica-preview Worker (preview environment)
 # - main branch    → twica Worker (production environment)
@@ -126,79 +133,6 @@ jobs:
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
           RESOLVED_ENV: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.environment) || (github.ref == 'refs/heads/preview' && 'preview') || 'production' }}
-
-  # 本番の実DB（PlanetScale、issue #699でcutover済み）へ scripts/db-migrate.js で
-  # migrationを自動適用する。production・main ブランチのみが対象（preview はまだ
-  # PlanetScale 未cutoverのため対象外。cutoverしたら preview 向けの同種ジョブを追加する）。
-  #
-  # legacy-app-deploy / auxiliary-workers からは意図的に needs で依存させない
-  # （このジョブが失敗してもブロックしない独立ジョブとする）。理由:
-  # - CLOUDFLARE_WORKERS_BUILDS_ENABLED=true の場合、実アプリデプロイは Cloudflare の
-  #   Git連携がこの workflow と無関係に進む。ここでブロックしても実効性が薄い。
-  # - アプリ側は列欠落（migration未適用）を検知してもクラッシュせず機能を無効化した
-  #   状態へ縮退する設計（deploy-window fallback、issue #788）を前提にしている。
-  # 失敗時の可視化は通常のコミットステータスチェック（および対象PR/コミットの
-  # デフォルトのGitHub通知）に委ねる。required check化やSlack通知等の追加アラートは
-  # 現時点ではYAGNIと判断し導入していない（必要になれば別途追加する）。
-  #
-  # 初回有効化前に一度だけ、既存migrationを「実行せず履歴登録のみ」する手動bootstrapが
-  # 必要（docs/planetscale-schema-baseline.md 参照）。未実施のままだと、history table
-  # 不在 + pending件数過多で db-migrate.js 自身の安全ガード（shouldBlockFreshApply）が
-  # 働き、データ破壊なく exit 1 する（＝赤くなり続けるだけで、74件が誤実行されることはない）。
-  planetscale-migrations:
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    environment: production
-    # workflow全体のconcurrencyグループ（cancel-in-progress: true）に巻き込まれると、
-    # main連続pushで実行中の本番migrationジョブごとキャンセルされうる（claude-reviewの
-    # 指摘）。job単位のconcurrencyを別グループで指定するとworkflowレベルの設定を
-    # このジョブに限り上書きできる。cancel-in-progress: false により、後続runは
-    # 先行のmigrationジョブが完走するまでキューで待つ（キャンセルしない）。
-    # required(トランザクション内)なmigrationはキャンセルされてもコネクション切断で
-    # 自動rollbackされ安全だが、将来 forbidden(CREATE INDEX CONCURRENTLY等、
-    # トランザクション外実行が必須)なmigrationが追加された場合、中断は
-    # INVALIDなオブジェクトの残留・手動復旧を要する半端な状態を招きうるため。
-    concurrency:
-      group: planetscale-migrate-${{ github.ref }}
-      cancel-in-progress: false
-    # pg_advisory_lock（scripts/db-migrate.js）はロック取得までブロックする。
-    # 手動bootstrap作業との時間的重複等でロックが解放されない場合に備え、
-    # GitHub Actionsのデフォルトタイムアウト(6時間)に張り付き続けないよう上限を設ける
-    # （claude-reviewの指摘）。通常のDDL適用は数秒〜数分で完了する想定のため、
-    # 10分は十分に余裕を持たせた値。
-    timeout-minutes: 10
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      # ジョブ自体は if: で production (main push または workflow_dispatch の
-      # environment=production 選択) にのみ限定しているが、Supabase migrations の
-      # 既存ステップと同様、workflow_dispatch 経路で非 main ブランチから production を
-      # 選択した場合に備えた実行時ガードも二重に入れる（if: 条件の書き間違い・将来の
-      # 変更に対する多層防御。本番DBへのmigration適用はerror-reporter再デプロイ等より
-      # 破壊的なため、単一の防御層に頼らない）。
-      - name: Apply PlanetScale migrations
-        run: |
-          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
-            echo "::error::PlanetScale production migrations are only allowed from the main branch"
-            exit 1
-          fi
-          node scripts/db-migrate.js apply --provider=planetscale
-        env:
-          DATABASE_URL: ${{ secrets.PLANETSCALE_DATABASE_URL }}
-          MIGRATION_APPLIED_BY: github-actions[${{ github.run_id }}]
 
   legacy-app-deploy:
     if: vars.CLOUDFLARE_WORKERS_BUILDS_ENABLED != 'true'

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -18,6 +18,22 @@
 # Supabase マイグレーションは `supabase db push --db-url` でビルド前に自動適用される。
 # 各 GitHub Environment に SUPABASE_DB_URL を設定すること。
 #
+# Production の実DBは issue #699 で PlanetScale (Postgres互換) へ cutover 済みのため、
+# `supabase db push` は rollback用に温存している旧Supabase本番へのみ適用される。実際に
+# アプリが読み書きする本番PlanetScaleへは、下記 `planetscale-migrations` ジョブが
+# `scripts/db-migrate.js apply --provider=planetscale` を自動実行する
+# （production・main ブランチのみ。preview はまだ PlanetScale 未cutoverのため対象外）。
+# 初回有効化前に一度だけ手動での bootstrap 登録が必要。詳細・手順は
+# `docs/planetscale-schema-baseline.md` の「issue #788・CI自動化に伴う追記」節を参照。
+#
+# Production's live DB was cut over from Supabase to PlanetScale (Postgres-compatible)
+# in issue #699, so `supabase db push` now only reaches the retained (rollback-only)
+# legacy Supabase production DB. The `planetscale-migrations` job below applies
+# `scripts/db-migrate.js apply --provider=planetscale` against the actual production
+# DB on every push to main (preview is not yet cut over, so it's excluded). A one-time
+# manual bootstrap registration is required before first use — see
+# `docs/planetscale-schema-baseline.md`.
+#
 # - preview branch → twica-preview Worker (preview environment)
 # - main branch    → twica Worker (production environment)
 #
@@ -37,6 +53,12 @@
 #    - NEXT_PUBLIC_SUPABASE_URL
 #    - NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
 #    - NEXT_PUBLIC_TWITCH_CLIENT_ID
+#
+# 3. "production" environment only, additionally:
+#    "production" environment のみ、追加で以下の Secret を設定:
+#    - PLANETSCALE_DATABASE_URL: PlanetScale本番Postgresへの直接接続文字列
+#      (migration専用。Hyperdrive経由のアプリ実行時接続とは別物。
+#      db/planetscale/bootstrap.sql 等の手動適用と同じ接続文字列を使うこと)
 
 name: Cloudflare Deploy Support
 
@@ -104,6 +126,61 @@ jobs:
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
           RESOLVED_ENV: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.environment) || (github.ref == 'refs/heads/preview' && 'preview') || 'production' }}
+
+  # 本番の実DB（PlanetScale、issue #699でcutover済み）へ scripts/db-migrate.js で
+  # migrationを自動適用する。production・main ブランチのみが対象（preview はまだ
+  # PlanetScale 未cutoverのため対象外。cutoverしたら preview 向けの同種ジョブを追加する）。
+  #
+  # legacy-app-deploy / auxiliary-workers からは意図的に needs で依存させない
+  # （このジョブが失敗してもブロックしない独立ジョブとする）。理由:
+  # - CLOUDFLARE_WORKERS_BUILDS_ENABLED=true の場合、実アプリデプロイは Cloudflare の
+  #   Git連携がこの workflow と無関係に進む。ここでブロックしても実効性が薄い。
+  # - アプリ側は列欠落（migration未適用）を検知してもクラッシュせず機能を無効化した
+  #   状態へ縮退する設計（deploy-window fallback、issue #788）を前提にしている。
+  # 失敗時の可視化は通常のコミットステータスチェック（および対象PR/コミットの
+  # デフォルトのGitHub通知）に委ねる。required check化やSlack通知等の追加アラートは
+  # 現時点ではYAGNIと判断し導入していない（必要になれば別途追加する）。
+  #
+  # 初回有効化前に一度だけ、既存migrationを「実行せず履歴登録のみ」する手動bootstrapが
+  # 必要（docs/planetscale-schema-baseline.md 参照）。未実施のままだと、history table
+  # 不在 + pending件数過多で db-migrate.js 自身の安全ガード（shouldBlockFreshApply）が
+  # 働き、データ破壊なく exit 1 する（＝赤くなり続けるだけで、73件が誤実行されることはない）。
+  planetscale-migrations:
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ジョブ自体は if: で production (main push または workflow_dispatch の
+      # environment=production 選択) にのみ限定しているが、Supabase migrations の
+      # 既存ステップと同様、workflow_dispatch 経路で非 main ブランチから production を
+      # 選択した場合に備えた実行時ガードも二重に入れる（if: 条件の書き間違い・将来の
+      # 変更に対する多層防御。本番DBへのmigration適用はerror-reporter再デプロイ等より
+      # 破壊的なため、単一の防御層に頼らない）。
+      - name: Apply PlanetScale migrations
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::PlanetScale production migrations are only allowed from the main branch"
+            exit 1
+          fi
+          node scripts/db-migrate.js apply --provider=planetscale
+        env:
+          DATABASE_URL: ${{ secrets.PLANETSCALE_DATABASE_URL }}
+          MIGRATION_APPLIED_BY: github-actions[${{ github.run_id }}]
 
   legacy-app-deploy:
     if: vars.CLOUDFLARE_WORKERS_BUILDS_ENABLED != 'true'

--- a/.github/workflows/planetscale-migrate.yml
+++ b/.github/workflows/planetscale-migrate.yml
@@ -54,6 +54,21 @@
 # デフォルトのGitHub通知）に委ねる。required check化やSlack通知等の追加アラートは
 # 現時点ではYAGNIと判断し導入していない（必要になれば別途追加する）。
 #
+# 【運用制約: このパイプラインで自動適用してよいのは additive なmigrationのみ
+# （claude-reviewで指摘、必ず読むこと）】
+# 上記のdeploy-window fallback前提（列欠落時に機能を無効化して縮退する設計）は、
+# 「列追加」のような加法的(additive)な変更にしか成り立たない。`DROP COLUMN`・
+# `RENAME COLUMN`・型変更のような非加法的(non-additive)な変更を含むmigrationを
+# このパイプラインでそのまま自動適用すると、Cloudflare Workers Builds経由の
+# アプリデプロイ（本workflowとは非同期・順序保証なしで進行する）との兼ね合いで、
+# 新アプリコードが未適用スキーマを読む、または旧アプリコードが削除済みカラムを
+# 読むといった本番障害に直結しうる（industry-standardなexpand/contractパターンで
+# いう「contract」フェーズを無条件に自動化してしまうことに相当）。
+# `scripts/db-migrate.js`にはmigrationの加法性を判定する仕組みが無いため、
+# 非加法的な変更を含むmigrationについては、このworkflowでの自動適用に任せず、
+# デプロイ順序を人間が管理した上で手動適用すること（例: 新コードのデプロイ完了を
+# 確認してから該当migrationを個別に`apply`する）。
+#
 # Prerequisites / 前提条件:
 # - GitHub Environment "production" に Secret `PLANETSCALE_DATABASE_URL`
 #   （PlanetScale本番Postgresへの直接接続文字列。migration専用、Hyperdrive経由の

--- a/.github/workflows/planetscale-migrate.yml
+++ b/.github/workflows/planetscale-migrate.yml
@@ -67,7 +67,9 @@
 # `scripts/db-migrate.js`にはmigrationの加法性を判定する仕組みが無いため、
 # 非加法的な変更を含むmigrationについては、このworkflowでの自動適用に任せず、
 # デプロイ順序を人間が管理した上で手動適用すること（例: 新コードのデプロイ完了を
-# 確認してから該当migrationを個別に`apply`する）。
+# 確認してから該当migrationを個別に`apply`する）。この制約を機械的に強制する
+# （非加法的DDLを検知したら明示フラグ無しではブロックする）フォローアップは
+# issue #800 で追跡している。
 #
 # Prerequisites / 前提条件:
 # - GitHub Environment "production" に Secret `PLANETSCALE_DATABASE_URL`

--- a/.github/workflows/planetscale-migrate.yml
+++ b/.github/workflows/planetscale-migrate.yml
@@ -1,0 +1,120 @@
+# PlanetScale Production Migration Workflow
+# PlanetScale本番マイグレーションWorkflow
+#
+# 本番の実DB（PlanetScale、issue #699でcutover済み）へ scripts/db-migrate.js で
+# migrationを自動適用する。production・main ブランチのみが対象（preview はまだ
+# PlanetScale 未cutoverのため対象外。cutoverしたら preview 向けの同種workflowを追加する）。
+#
+# 【なぜ deploy-cloudflare.yml に同居させず、別ファイルに分離しているか（重要）】
+# GitHub Actionsのconcurrencyは「同じgroup名を持つ別runが来たら、そのrun全体をキャンセルする」
+# という run 単位の仕組みであり、job単位で別groupを指定しても、そのjobが属するrun自体が
+# workflowレベルのconcurrencyでキャンセルされる動作からは守れない（公式ドキュメントに
+# 明示的な反証が無く、コミュニティでも同様の報告が複数ある。job-level concurrencyは
+# 「別runの同名jobどうしの調停」であって「自runがキャンセルされることへの盾」ではない）。
+# `deploy-cloudflare.yml` は `concurrency: { group: deploy-${{ github.ref }},
+# cancel-in-progress: true }` を持つため、本番migrationジョブを同じファイル内に置くと、
+# main への連続pushで実行中のmigrationジョブごと強制終了されうる（claude-reviewで
+# 実際に指摘された）。本番PlanetScaleへ書き込み中のプロセスが中断されると、
+# 通常のトランザクション内migrationはコネクション切断で自動rollbackされ安全だが、
+# 将来 `migration-transaction: forbidden`（`CREATE INDEX CONCURRENTLY`等、
+# トランザクション外実行が必須）なmigrationが追加された場合、INVALIDなオブジェクトの
+# 残留・手動復旧を要する半端な状態を招きうる。ファイルを分離すれば、このworkflow自身の
+# concurrencyグループがdeploy-cloudflare.ymlのそれと完全に独立するため、この事故は
+# 構造的に発生しなくなる。
+#
+# Applies `scripts/db-migrate.js apply --provider=planetscale` against production's
+# live DB (PlanetScale, cut over in issue #699) on every push to main. Preview is
+# excluded (not yet cut over).
+#
+# Kept in its own file rather than as a job in deploy-cloudflare.yml because GitHub
+# Actions concurrency cancellation operates at the run level: a workflow-level
+# `cancel-in-progress: true` group cancels an entire in-progress run — including any
+# job inside it that declares its own, differently-named job-level concurrency group.
+# Job-level concurrency only arbitrates between same-named jobs across different runs;
+# it provides no protection against the enclosing run itself being cancelled. Since
+# `deploy-cloudflare.yml` has `concurrency: { group: deploy-${{ github.ref }},
+# cancel-in-progress: true }`, co-locating this job there would let rapid consecutive
+# pushes to main kill an in-progress production migration mid-flight (flagged by
+# claude-review). A separate file gives this workflow its own independent concurrency
+# scope, eliminating that risk structurally.
+#
+# 初回有効化前に一度だけ、既存migrationを「実行せず履歴登録のみ」する手動bootstrapが
+# 必要。詳細・手順は `docs/planetscale-schema-baseline.md` の
+# 「issue #788・CI自動化に伴う追記」節を参照。未実施のままだと、history table
+# 不在 + pending件数過多で db-migrate.js 自身の安全ガード（shouldBlockFreshApply）が
+# 働き、データ破壊なく exit 1 する（＝赤くなり続けるだけで、全件が誤実行されることはない）。
+#
+# legacy-app-deploy / auxiliary-workers（deploy-cloudflare.yml側）からは意図的に
+# 依存させない（このworkflowが失敗してもアプリデプロイをブロックしない）。理由:
+# - CLOUDFLARE_WORKERS_BUILDS_ENABLED=true の場合、実アプリデプロイは Cloudflare の
+#   Git連携がこの workflow と無関係に進む。ここでブロックしても実効性が薄い。
+# - アプリ側は列欠落（migration未適用）を検知してもクラッシュせず機能を無効化した
+#   状態へ縮退する設計（deploy-window fallback、issue #788）を前提にしている。
+# 失敗時の可視化は通常のコミットステータスチェック（および対象コミットの
+# デフォルトのGitHub通知）に委ねる。required check化やSlack通知等の追加アラートは
+# 現時点ではYAGNIと判断し導入していない（必要になれば別途追加する）。
+#
+# Prerequisites / 前提条件:
+# - GitHub Environment "production" に Secret `PLANETSCALE_DATABASE_URL`
+#   （PlanetScale本番Postgresへの直接接続文字列。migration専用、Hyperdrive経由の
+#   アプリ実行時接続とは別物）を設定すること。
+
+name: PlanetScale Production Migrations
+
+on:
+  push:
+    branches: [main]
+
+  # 手動再実行用（例: 一時的な接続エラーからのリトライ）。
+  # このworkflowは常にproduction/mainのみを対象とするため、
+  # deploy-cloudflare.ymlのような環境選択インプットは不要。
+  workflow_dispatch: {}
+
+# このworkflow専用の独立したconcurrencyグループ。cancel-in-progress: false により、
+# main への連続pushがあっても、先行のmigration runが完走するまで後続はキューで待つ
+# （キャンセルしない）。deploy-cloudflare.ymlのconcurrencyグループとは名前・スコープとも
+# 完全に独立している（ファイル冒頭コメント参照）。
+concurrency:
+  group: planetscale-migrate-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  planetscale-migrations:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: production
+    # pg_advisory_lock（scripts/db-migrate.js）はロック取得までブロックする。
+    # 手動bootstrap作業との時間的重複等でロックが解放されない場合に備え、
+    # GitHub Actionsのデフォルトタイムアウト(6時間)に張り付き続けないよう上限を設ける。
+    # 通常のDDL適用は数秒〜数分で完了する想定のため、10分は十分に余裕を持たせた値。
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # push トリガーは branches: [main] で既に限定されているが、workflow_dispatch は
+      # GitHub UI上で任意のブランチ/refを選んで手動実行できてしまうため、既存の
+      # Supabase migrations ステップ（deploy-cloudflare.yml）と同じ流儀で実行時ガードも
+      # 入れる（本番DBへのmigration適用はerror-reporter再デプロイ等より破壊的なため、
+      # trigger設定という単一の防御層に頼らない）。
+      - name: Apply PlanetScale migrations
+        run: |
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "::error::PlanetScale production migrations are only allowed from the main branch"
+            exit 1
+          fi
+          node scripts/db-migrate.js apply --provider=planetscale
+        env:
+          DATABASE_URL: ${{ secrets.PLANETSCALE_DATABASE_URL }}
+          MIGRATION_APPLIED_BY: github-actions[${{ github.run_id }}]

--- a/docs/db-phase2-runbook.md
+++ b/docs/db-phase2-runbook.md
@@ -835,13 +835,18 @@ Supabase 側に対して非破壊的な読み取りのみのため、Supabase �
         provider指定が固定される用途では専用の環境変数より既存フラグの再利用が
         シンプルなため）
       - **実装済み（2026-07-23）**: `scripts/db-migrate.js apply --provider=planetscale`
-        を実行する独立ジョブ`planetscale-migrations`を`deploy-cloudflare.yml`に追加した。
+        を実行する新規workflow `.github/workflows/planetscale-migrate.yml`を追加した。
         production・mainブランチのみが対象（preview はまだ PlanetScale 未cutoverのため
-        対象外。cutover後にpreview向けの同種ジョブを追加する）。既存の
-        `legacy-app-deploy`/`auxiliary-workers`はブロックしない独立ジョブとした
-        （Cloudflare Workers Builds有効時、実アプリデプロイはこのworkflowと無関係に
-        進むため、ここでブロックしても実効性が薄い。かつアプリ側は既にmigration遅延への
-        耐性＝deploy-window fallbackを実装済みのため）。
+        対象外。cutover後にpreview向けの同種workflowを追加する）。既存の
+        `legacy-app-deploy`/`auxiliary-workers`（`deploy-cloudflare.yml`側）はブロック
+        しない独立workflowとした（Cloudflare Workers Builds有効時、実アプリデプロイは
+        この一連のworkflowと無関係に進むため、ここでブロックしても実効性が薄い。かつ
+        アプリ側は既にmigration遅延への耐性＝deploy-window fallbackを実装済みのため）。
+        `deploy-cloudflare.yml`に同居させず別ファイルにしたのは、GitHub Actionsの
+        concurrencyがrun単位で効くため（job単位で別groupを指定しても、そのjobが属する
+        run自体がworkflowレベルのconcurrency＝`deploy-cloudflare.yml`の
+        `cancel-in-progress: true`でキャンセルされる動作からは守れない。claude-reviewの
+        指摘を受けてファイル分離に変更）。
         初回有効化前に一度だけ、既存migrationの手動bootstrap登録が必要
         （`docs/planetscale-schema-baseline.md`「issue #788・CI自動化に伴う追記」節参照）。
         新規secret `PLANETSCALE_DATABASE_URL`をGitHub Environment "production"に

--- a/docs/db-phase2-runbook.md
+++ b/docs/db-phase2-runbook.md
@@ -842,11 +842,9 @@ Supabase 側に対して非破壊的な読み取りのみのため、Supabase �
         しない独立workflowとした（Cloudflare Workers Builds有効時、実アプリデプロイは
         この一連のworkflowと無関係に進むため、ここでブロックしても実効性が薄い。かつ
         アプリ側は既にmigration遅延への耐性＝deploy-window fallbackを実装済みのため）。
-        `deploy-cloudflare.yml`に同居させず別ファイルにしたのは、GitHub Actionsの
-        concurrencyがrun単位で効くため（job単位で別groupを指定しても、そのjobが属する
-        run自体がworkflowレベルのconcurrency＝`deploy-cloudflare.yml`の
-        `cancel-in-progress: true`でキャンセルされる動作からは守れない。claude-reviewの
-        指摘を受けてファイル分離に変更）。
+        `deploy-cloudflare.yml`に同居させず別ファイルにした理由は
+        `planetscale-migrate.yml`冒頭のコメント参照（claude-reviewの指摘を受けて
+        ファイル分離に変更した）。
         初回有効化前に一度だけ、既存migrationの手動bootstrap登録が必要
         （`docs/planetscale-schema-baseline.md`「issue #788・CI自動化に伴う追記」節参照）。
         新規secret `PLANETSCALE_DATABASE_URL`をGitHub Environment "production"に

--- a/docs/db-phase2-runbook.md
+++ b/docs/db-phase2-runbook.md
@@ -814,7 +814,7 @@ Supabase 側に対して非破壊的な読み取りのみのため、Supabase �
       新規経常コストが生じうる、運用複雑さの増加が個人開発の運用体制に見合わない）。
       **2026-07-19、オーナー承認済み。数分停止方式（pg_dump/restore）で確定。
       #667/#696はこの判断によりクローズしてよい**
-- [ ] **切替後の migration 適用手段と migration 履歴の移送**: 2026-07-19、
+- [x] **切替後の migration 適用手段と migration 履歴の移送**: 2026-07-19、
       設計調査完了（`docs/planetscale-migration-audit.md` 6.3節）。推奨方針:
       - `supabase_migrations.schema_migrations`（履歴テーブル）は**移送しない**
         （スキーマ指定なしのpg_dumpだと`twica_app`が権限を持たないスキーマに
@@ -826,11 +826,26 @@ Supabase 側に対して非破壊的な読み取りのみのため、Supabase �
         `00051_add_card_owner_stats.sql`の`SET LOCAL statement_timeout`問題を
         自然に回避）を推奨。Flyway等の確立ツールは既存71ファイルの命名規則変更が
         必須になり導入コストが見合わないため見送り
-      - `.github/workflows/deploy-cloudflare.yml`は新規環境変数`MIGRATION_TARGET`
+      - ~~`.github/workflows/deploy-cloudflare.yml`は新規環境変数`MIGRATION_TARGET`
         （`supabase`|`planetscale`、未設定時は安全側`supabase`）でステップ内
-        分岐する設計を推奨。preview→productionの順で段階的に切替可能
-      - **未実装**（別途スクリプト実装・CI変更のPRが必要）。**この設計方針で
-        実装を進めてよいかオーナー確認をお願いします**
+        分岐する設計を推奨。preview→productionの順で段階的に切替可能~~
+        （**実装時に更新**: 実際には`MIGRATION_TARGET`ではなく、Issue #692で
+        実装済みの provider-neutral runner `scripts/db-migrate.js`の
+        `--provider=planetscale`フラグをそのまま使う設計に変更した。DBごとに
+        provider指定が固定される用途では専用の環境変数より既存フラグの再利用が
+        シンプルなため）
+      - **実装済み（2026-07-23）**: `scripts/db-migrate.js apply --provider=planetscale`
+        を実行する独立ジョブ`planetscale-migrations`を`deploy-cloudflare.yml`に追加した。
+        production・mainブランチのみが対象（preview はまだ PlanetScale 未cutoverのため
+        対象外。cutover後にpreview向けの同種ジョブを追加する）。既存の
+        `legacy-app-deploy`/`auxiliary-workers`はブロックしない独立ジョブとした
+        （Cloudflare Workers Builds有効時、実アプリデプロイはこのworkflowと無関係に
+        進むため、ここでブロックしても実効性が薄い。かつアプリ側は既にmigration遅延への
+        耐性＝deploy-window fallbackを実装済みのため）。
+        初回有効化前に一度だけ、既存migrationの手動bootstrap登録が必要
+        （`docs/planetscale-schema-baseline.md`「issue #788・CI自動化に伴う追記」節参照）。
+        新規secret `PLANETSCALE_DATABASE_URL`をGitHub Environment "production"に
+        追加するオーナー作業が別途必要（このセッションからは追加不可）。
 - [ ] **ロールバック時の差分データの扱い方針**: 7章で指摘した「切替後に
       PlanetScale側にのみ書き込まれたデータ」の扱いは未確定。数分停止方式
       採用（上記）により発生確率は低い想定だが、方針自体はオーナー判断が必要

--- a/docs/planetscale-schema-baseline.md
+++ b/docs/planetscale-schema-baseline.md
@@ -155,6 +155,47 @@ migrationがある状態でも確認なしに通常applyを実行してよい」
 以降、PlanetScale向けの新規migrationは通常の `apply --provider=planetscale`
 （`--bootstrap` 無し）で追加していける。
 
+**重要（issue #788・CI自動化に伴う追記、本番未実施の場合は必ず読むこと）**:
+本節の「73件」は本ドキュメント執筆時点（Chunk 1〜2）の`supabase/migrations/`ファイル数
+（71件）+ bootstrap + baseline の合計である。その後 issue #788 で
+`supabase/migrations/20260723150000_add_channel_points_capability.sql` が追加されたため、
+現在の `--provider=planetscale` pending件数は **74件**（既存73 + 新規1件）になっている。
+
+**`--bootstrap` は「実DBが既にその内容を反映済み」のmigrationにのみ使ってよい
+（SQLを実行せず履歴にのみ登録するため）。`20260723150000_add_channel_points_capability.sql`
+は本番PlanetScaleにまだ一度も適用されていない、実行が必要な真に新規のmigrationのため、
+このファイルを`--bootstrap`で登録してはならない**。誤って含めてしまうと、
+「履歴上は適用済み」なのに実際にはALTER TABLE/CREATE FUNCTIONが未実行という状態になり、
+`src/lib/twitch/channel-points-access.ts`のdeploy-windowフォールバック
+（列欠落を`capability: 'unknown'`へ静かに縮退させる設計）と組み合わさって、
+**CIも赤くならず気付かれないまま該当機能が本番で恒久的に無効化される**事故につながる
+（設計レビューで指摘されたCritical項目）。
+
+本番でまだ一度も`--bootstrap`を実行していない場合、正しい手順は以下の2段階:
+
+```bash
+# 1. 20260723150000_add_channel_points_capability.sql を含まないコミット
+#    （#788昇格前のmainブランチ等）を checkout し、既存73件のみをbootstrap登録する。
+git checkout main   # #788がまだ昇格されていないコミット
+DATABASE_URL="$PLANETSCALE_DATABASE_URL" node scripts/db-migrate.js apply --bootstrap --provider=planetscale
+
+# 2. 上記の後、20260723150000_add_channel_points_capability.sql を含むコミットで、
+#    この1件だけを実際に適用する（--bootstrap を付けない通常の apply）。
+git checkout <#788を含むコミット>
+DATABASE_URL="$PLANETSCALE_DATABASE_URL" node scripts/db-migrate.js apply --provider=planetscale
+```
+
+既に（誤って）#788を含む状態で`--bootstrap`を実行してしまった場合は、
+`twica_meta.schema_migrations`から該当versionの行を手動DELETEしてから
+`apply --provider=planetscale`を再実行することで復旧できる
+（`--bootstrap`は履歴登録のみでSQL実行を伴わないため、この復旧操作自体に副作用は無い）。
+
+**CI自動化について**: `.github/workflows/deploy-cloudflare.yml`の`planetscale-migrations`
+ジョブ（production環境・mainブランチのみ、`legacy-app-deploy`/`auxiliary-workers`はブロック
+しない独立ジョブ）が、`main`へのpush毎に`apply --provider=planetscale`（`--bootstrap`無し）
+を自動実行する。上記のワンタイムbootstrapが完了していれば、以降の新規migrationはこの
+ジョブが自動適用する。`--bootstrap`はワンタイム作業のためCIには含めない。
+
 **「pending 73件」の成立条件について（N-7、Fableレビュー2回目で明記）**: 上記の「73件」は
 既存71ファイル（`00001`〜`20260718140000`）+ bootstrap + baseline の合計だが、この73件を
 **まっさらなDBへ`--bootstrap`無しの素の`apply --provider=planetscale`で実行することはできない**。

--- a/docs/planetscale-schema-baseline.md
+++ b/docs/planetscale-schema-baseline.md
@@ -188,12 +188,18 @@ migrationがある状態でも確認なしに通常applyを実行してよい」
 `20260723150000`を含む別のツリーへ切り替えてから行うこと。
 
 ```bash
-# 1. bootstrap対象のツリーに20260723150000がまだ存在しないことを、
-#    「ブランチ名」ではなく実ファイルの有無で機械的に確認してから実行する
-#    （ブランチ名は将来のマージで指す内容が変わるため信用しない）。
-#    (`git checkout origin/main` は detached HEAD になるが、ここではファイルを
-#    読むだけで何もcommitしないため問題ない)
-git fetch origin main && git checkout origin/main
+# 1. bootstrap対象のツリーを、ブランチ名（例: origin/main）ではなく固定コミットSHAで
+#    明示的に指定する。ブランチ名は本PRのマージ後さらに main が進むと指す内容が
+#    変わってしまうため、「今」#788を含まないことが確認済みの固定点を使う
+#    （claude-reviewで指摘: ブランチ名指定は将来のmain進行に対して脆弱）。
+#    2026-07-23時点でorigin/mainの最新コミットは 9066070dc7405e7b7b44eb153fa3558b4c3e1083
+#    であり、これは#788を含まないことを確認済み（このコミット以前のどのmainコミットでもよい）。
+git fetch origin main
+git checkout 9066070dc7405e7b7b44eb153fa3558b4c3e1083
+# 上記SHAが古くなっていた場合、または別のコミットを使う場合に備え、
+# 実ファイルの有無による機械的な確認も必ず行う（ブランチ名同様、SHA直指定であっても
+# 「この手順を書いた時点の情報が古いまま放置される」リスクは残るため、
+# 最終防御としてコマンドで検証する）。
 test -f supabase/migrations/20260723150000_add_channel_points_capability.sql && \
   { echo "NG: このツリーには#788のmigrationが既に含まれている。bootstrapしないこと"; exit 1; }
 DATABASE_URL="$PLANETSCALE_DATABASE_URL" node scripts/db-migrate.js apply --bootstrap --provider=planetscale

--- a/docs/planetscale-schema-baseline.md
+++ b/docs/planetscale-schema-baseline.md
@@ -210,7 +210,7 @@ DATABASE_URL="$PLANETSCALE_DATABASE_URL" node scripts/db-migrate.js status --pro
 
 検証を通過すれば、以降は`20260723150000_add_channel_points_capability.sql`のみが
 未適用として残る。この1件は、#788昇格PRをmainへマージした後の最初の本番デプロイで
-`planetscale-migrations`ジョブが自動的に適用する（下記「CI自動化について」参照）。
+`.github/workflows/planetscale-migrate.yml`が自動的に適用する（下記「CI自動化について」参照）。
 今すぐ手動で適用したい場合は、#788を含むツリーのまま
 `DATABASE_URL="$PLANETSCALE_DATABASE_URL" node scripts/db-migrate.js apply --provider=planetscale`
 を追加実行してもよいが、CIジョブと同じ処理を先取りするだけなので必須ではない。
@@ -221,11 +221,14 @@ DATABASE_URL="$PLANETSCALE_DATABASE_URL" node scripts/db-migrate.js status --pro
 再実行することで復旧できる（`--bootstrap`は履歴登録のみでSQL実行を伴わないため、
 この復旧操作自体に副作用は無い）。
 
-**CI自動化について**: `.github/workflows/deploy-cloudflare.yml`の`planetscale-migrations`
-ジョブ（production環境・mainブランチのみ、`legacy-app-deploy`/`auxiliary-workers`はブロック
-しない独立ジョブ）が、`main`へのpush毎に`apply --provider=planetscale`（`--bootstrap`無し）
-を自動実行する。上記のワンタイムbootstrapが完了していれば、以降の新規migrationはこの
-ジョブが自動適用する。`--bootstrap`はワンタイム作業のためCIには含めない。
+**CI自動化について**: `.github/workflows/planetscale-migrate.yml`（production環境・
+mainブランチのみが対象の独立workflow）が、`main`へのpush毎に`apply --provider=planetscale`
+（`--bootstrap`無し）を自動実行する。上記のワンタイムbootstrapが完了していれば、以降の
+新規migrationはこのworkflowが自動適用する。`--bootstrap`はワンタイム作業のためCIには
+含めない。`deploy-cloudflare.yml`とは意図的に別ファイルに分離している
+（理由は`planetscale-migrate.yml`冒頭コメント参照。要約: `deploy-cloudflare.yml`の
+`concurrency: cancel-in-progress: true`に本番migration実行中のジョブが巻き込まれて
+キャンセルされる事故を、ファイル分離により構造的に防ぐため）。
 
 **「pending 73件」の成立条件について（N-7、Fableレビュー2回目で明記）**: 上記の「73件」は
 既存71ファイル（`00001`〜`20260718140000`）+ bootstrap + baseline の合計だが、この73件を

--- a/docs/planetscale-schema-baseline.md
+++ b/docs/planetscale-schema-baseline.md
@@ -155,6 +155,12 @@ migrationがある状態でも確認なしに通常applyを実行してよい」
 以降、PlanetScale向けの新規migrationは通常の `apply --provider=planetscale`
 （`--bootstrap` 無し）で追加していける。
 
+**注意**: 上記「未適用0件」はChunk 1〜2検証当時、対象ツリーに73件しか存在しなかった
+（＝#788のmigrationファイルがまだ無かった）ために到達した状態である。下記の追記時点では
+ツリーに74件目（#788分）が存在するため、「未適用0件」の意味が逆転する
+（もはや「全件bootstrap完了」ではなく「#788まで誤ってbootstrapに巻き込んでしまった」
+ことを意味する）。両者は矛盾ではなく、対象ツリーのファイル数が異なることによる違いである。
+
 **重要（issue #788・CI自動化に伴う追記、本番未実施の場合は必ず読むこと）**:
 本節の「73件」は本ドキュメント執筆時点（Chunk 1〜2）の`supabase/migrations/`ファイル数
 （71件）+ bootstrap + baseline の合計である。その後 issue #788 で
@@ -171,37 +177,49 @@ migrationがある状態でも確認なしに通常applyを実行してよい」
 **CIも赤くならず気付かれないまま該当機能が本番で恒久的に無効化される**事故につながる
 （設計レビューで指摘されたCritical項目）。
 
-本番でまだ一度も`--bootstrap`を実行していない場合、**推奨手順は「#788昇格PRをmainへ
-マージする前に」以下を実行することである**（`git checkout main`と書くだけでは、実行の
-タイミングによって「main」が指す内容が変わってしまい危険なため、日付ではなく
-「マージ前」というタイミングそのものを基準にする）:
+本番でまだ一度も`--bootstrap`を実行していない場合、以下の手順で行う。
+
+**重要（2回目のレビューで判明した罠の回避）**: bootstrap実行と検証を同じツリー
+（同じ`git checkout`）で行ってはならない。`status`はその時点で**作業ツリーに存在する
+ファイルしか見ない**ため、bootstrapを「`20260723150000`が存在しないツリー」で実行した後、
+**同じツリーのまま**`status`を見ても「未適用0件」にしかならず、これは
+`--bootstrap`が正しく73件だけを登録できた場合と、誤って#788を含むツリーで実行してしまい
+74件登録してしまった場合の**両方で同じ表示になり、区別できない**。検証は必ず
+`20260723150000`を含む別のツリーへ切り替えてから行うこと。
 
 ```bash
-# 1. #788昇格PR（issue #788のmigrationファイル + 本CI自動化を含むPR）をまだ
-#    mainへマージしていない時点の origin/main を checkout し、
-#    既存73件のみをbootstrap登録する。
+# 1. bootstrap対象のツリーに20260723150000がまだ存在しないことを、
+#    「ブランチ名」ではなく実ファイルの有無で機械的に確認してから実行する
+#    （ブランチ名は将来のマージで指す内容が変わるため信用しない）。
+#    (`git checkout origin/main` は detached HEAD になるが、ここではファイルを
+#    読むだけで何もcommitしないため問題ない)
 git fetch origin main && git checkout origin/main
+test -f supabase/migrations/20260723150000_add_channel_points_capability.sql && \
+  { echo "NG: このツリーには#788のmigrationが既に含まれている。bootstrapしないこと"; exit 1; }
 DATABASE_URL="$PLANETSCALE_DATABASE_URL" node scripts/db-migrate.js apply --bootstrap --provider=planetscale
 
-# 2. 【必須】bootstrap直後に必ず status で検証する。
-#    「未適用: 0件」ならこの時点のmainに20260723150000が含まれてしまっている
-#    （＝#788昇格PRが既にマージ済みの状態でこの手順を実行してしまった）ということなので、
-#    続行せず本節末尾の復旧手順（DELETE）に進むこと。
-#    「未適用: 1件（20260723150000_add_channel_points_capability）」であることを
-#    確認できて初めて成功。
+# 2. 【必須】検証は #788 のmigrationファイルを含む別ツリー
+#    （本CI自動化ブランチ、または#788昇格PRマージ後のmain）へ checkout し直してから行う。
+git checkout <#788のmigrationファイルを含むコミット>  # 例: このブランチ、または昇格後のmain
 DATABASE_URL="$PLANETSCALE_DATABASE_URL" node scripts/db-migrate.js status --provider=planetscale
+#  -> 「未適用: 1件（20260723150000_add_channel_points_capability）」なら成功
+#     （bootstrapが正しく73件のみを登録し、#788は真に未適用のまま残っている）。
+#  -> 「未適用: 0件」なら失敗（#788が誤ってbootstrap時に巻き込まれている）。
+#     続行せず、下記の復旧手順（DELETE）へ進むこと。
 ```
 
-上記のstep 2の検証を通過すれば、以降は`20260723150000_add_channel_points_capability.sql`
-のみが未適用として残る。この1件は、#788昇格PRをmainへマージした後の最初の本番デプロイで
+検証を通過すれば、以降は`20260723150000_add_channel_points_capability.sql`のみが
+未適用として残る。この1件は、#788昇格PRをmainへマージした後の最初の本番デプロイで
 `planetscale-migrations`ジョブが自動的に適用する（下記「CI自動化について」参照）。
-今すぐ手動で適用したい場合は`DATABASE_URL="$PLANETSCALE_DATABASE_URL" node scripts/db-migrate.js apply --provider=planetscale`
+今すぐ手動で適用したい場合は、#788を含むツリーのまま
+`DATABASE_URL="$PLANETSCALE_DATABASE_URL" node scripts/db-migrate.js apply --provider=planetscale`
 を追加実行してもよいが、CIジョブと同じ処理を先取りするだけなので必須ではない。
 
-もし既にマージ後の`main`（#788を含む状態）に対して誤って`--bootstrap`を実行してしまった
-場合は、`twica_meta.schema_migrations`から`20260723150000`のversion行を手動DELETEしてから
-`apply --provider=planetscale`を再実行することで復旧できる
-（`--bootstrap`は履歴登録のみでSQL実行を伴わないため、この復旧操作自体に副作用は無い）。
+もし既にマージ後の`main`（#788を含む状態）に対して誤って`--bootstrap`を実行してしまい、
+上記step 2の検証で「未適用: 0件」（失敗）と判明した場合は、`twica_meta.schema_migrations`
+から`20260723150000`のversion行を手動DELETEしてから`apply --provider=planetscale`を
+再実行することで復旧できる（`--bootstrap`は履歴登録のみでSQL実行を伴わないため、
+この復旧操作自体に副作用は無い）。
 
 **CI自動化について**: `.github/workflows/deploy-cloudflare.yml`の`planetscale-migrations`
 ジョブ（production環境・mainブランチのみ、`legacy-app-deploy`/`auxiliary-workers`はブロック

--- a/docs/planetscale-schema-baseline.md
+++ b/docs/planetscale-schema-baseline.md
@@ -226,9 +226,7 @@ mainブランチのみが対象の独立workflow）が、`main`へのpush毎に`
 （`--bootstrap`無し）を自動実行する。上記のワンタイムbootstrapが完了していれば、以降の
 新規migrationはこのworkflowが自動適用する。`--bootstrap`はワンタイム作業のためCIには
 含めない。`deploy-cloudflare.yml`とは意図的に別ファイルに分離している
-（理由は`planetscale-migrate.yml`冒頭コメント参照。要約: `deploy-cloudflare.yml`の
-`concurrency: cancel-in-progress: true`に本番migration実行中のジョブが巻き込まれて
-キャンセルされる事故を、ファイル分離により構造的に防ぐため）。
+（理由は`planetscale-migrate.yml`冒頭コメント参照）。
 
 **「pending 73件」の成立条件について（N-7、Fableレビュー2回目で明記）**: 上記の「73件」は
 既存71ファイル（`00001`〜`20260718140000`）+ bootstrap + baseline の合計だが、この73件を

--- a/docs/planetscale-schema-baseline.md
+++ b/docs/planetscale-schema-baseline.md
@@ -171,22 +171,35 @@ migrationがある状態でも確認なしに通常applyを実行してよい」
 **CIも赤くならず気付かれないまま該当機能が本番で恒久的に無効化される**事故につながる
 （設計レビューで指摘されたCritical項目）。
 
-本番でまだ一度も`--bootstrap`を実行していない場合、正しい手順は以下の2段階:
+本番でまだ一度も`--bootstrap`を実行していない場合、**推奨手順は「#788昇格PRをmainへ
+マージする前に」以下を実行することである**（`git checkout main`と書くだけでは、実行の
+タイミングによって「main」が指す内容が変わってしまい危険なため、日付ではなく
+「マージ前」というタイミングそのものを基準にする）:
 
 ```bash
-# 1. 20260723150000_add_channel_points_capability.sql を含まないコミット
-#    （#788昇格前のmainブランチ等）を checkout し、既存73件のみをbootstrap登録する。
-git checkout main   # #788がまだ昇格されていないコミット
+# 1. #788昇格PR（issue #788のmigrationファイル + 本CI自動化を含むPR）をまだ
+#    mainへマージしていない時点の origin/main を checkout し、
+#    既存73件のみをbootstrap登録する。
+git fetch origin main && git checkout origin/main
 DATABASE_URL="$PLANETSCALE_DATABASE_URL" node scripts/db-migrate.js apply --bootstrap --provider=planetscale
 
-# 2. 上記の後、20260723150000_add_channel_points_capability.sql を含むコミットで、
-#    この1件だけを実際に適用する（--bootstrap を付けない通常の apply）。
-git checkout <#788を含むコミット>
-DATABASE_URL="$PLANETSCALE_DATABASE_URL" node scripts/db-migrate.js apply --provider=planetscale
+# 2. 【必須】bootstrap直後に必ず status で検証する。
+#    「未適用: 0件」ならこの時点のmainに20260723150000が含まれてしまっている
+#    （＝#788昇格PRが既にマージ済みの状態でこの手順を実行してしまった）ということなので、
+#    続行せず本節末尾の復旧手順（DELETE）に進むこと。
+#    「未適用: 1件（20260723150000_add_channel_points_capability）」であることを
+#    確認できて初めて成功。
+DATABASE_URL="$PLANETSCALE_DATABASE_URL" node scripts/db-migrate.js status --provider=planetscale
 ```
 
-既に（誤って）#788を含む状態で`--bootstrap`を実行してしまった場合は、
-`twica_meta.schema_migrations`から該当versionの行を手動DELETEしてから
+上記のstep 2の検証を通過すれば、以降は`20260723150000_add_channel_points_capability.sql`
+のみが未適用として残る。この1件は、#788昇格PRをmainへマージした後の最初の本番デプロイで
+`planetscale-migrations`ジョブが自動的に適用する（下記「CI自動化について」参照）。
+今すぐ手動で適用したい場合は`DATABASE_URL="$PLANETSCALE_DATABASE_URL" node scripts/db-migrate.js apply --provider=planetscale`
+を追加実行してもよいが、CIジョブと同じ処理を先取りするだけなので必須ではない。
+
+もし既にマージ後の`main`（#788を含む状態）に対して誤って`--bootstrap`を実行してしまった
+場合は、`twica_meta.schema_migrations`から`20260723150000`のversion行を手動DELETEしてから
 `apply --provider=planetscale`を再実行することで復旧できる
 （`--bootstrap`は履歴登録のみでSQL実行を伴わないため、この復旧操作自体に副作用は無い）。
 


### PR DESCRIPTION
## Summary

issue #699で本番DBがSupabaseからPlanetScale(Postgres互換)へcutoverされたが、既存CI(`deploy-cloudflare.yml`の`supabase-migrations`ジョブ)は`supabase db push`のみを実行し、PlanetScaleへは自動適用されない状態だった(`docs/db-phase2-runbook.md`のチェックリストでも「未実装」として記録済みの既知ギャップ)。

ユーザーから「デプロイ時に自動マイグレーションするようにしてほしい」との明示的要望があったため、新規workflow`.github/workflows/planetscale-migrate.yml`を追加し、`scripts/db-migrate.js apply --provider=planetscale`をproduction・mainブランチへのpush毎に自動実行するようにした。

- production環境・mainブランチのみが対象(pushトリガー自体をmain限定 + step内runtimeガードの二重防御)
- `deploy-cloudflare.yml`とは意図的に別ファイルに分離した。GitHub Actionsのconcurrencyキャンセルはrun単位で効くため、job-level concurrencyだけでは、そのjobが属するrun自体が`deploy-cloudflare.yml`の`concurrency: cancel-in-progress: true`でキャンセルされる動作から守れない(claude-reviewで指摘・修正)。ファイル分離により、本番migration workflowが完全に独立したconcurrencyスコープを持つ
- `legacy-app-deploy`/`auxiliary-workers`(deploy-cloudflare.yml側)には依存させない独立workflowとした(Cloudflare Workers Builds有効時、実アプリデプロイはこれらのworkflowと無関係に進むため。かつアプリ側はmigration遅延への耐性=deploy-window fallbackを既に実装済み)
- 失敗時の可視化は通常のコミットステータスチェック+GitHubデフォルト通知に委ね、required-check化やSlack通知等の追加インフラはYAGNIとして見送った

## ⚠️ マージ前にオーナーが必ず実施すること(重要)

本番PlanetScaleの`twica_meta.schema_migrations`(migration適用履歴テーブル)は、このセッションでの実機確認によりまだ存在しないことが判明している。つまり、既存73件(`00001`〜PlanetScale baseline)の「実行せず履歴登録のみ」というワンタイムbootstrap作業が本番に対して一度も行われていない。

**この自動化を有効化する前に、`docs/planetscale-schema-baseline.md`の「issue #788・CI自動化に伴う追記」節に記載した手順で、一度だけ手動bootstrapを実施する必要がある。** 手順内で「bootstrap実行」と「検証」を別々のgitツリーで行うことが必須(理由も同ドキュメントに詳述、レビューで発覚した論理的な罠を踏まえた設計)。

これを怠ると、初回の自動`apply`実行は(データ破壊なく)`shouldBlockFreshApply`ガードにより安全に失敗し続けるだけなので、本番を壊す心配はない。

また、新規secret **`PLANETSCALE_DATABASE_URL`** をGitHub Environment "production" に追加する必要がある(このセッションからは追加不可、オーナーの手動作業)。

## 副次的効果

上記のbootstrapとこのPRのマージが完了すれば、issue #788で追加した`20260723150000_add_channel_points_capability.sql`(まだ本番PlanetScaleに未適用)も、次回の本番デプロイ(mainへのpush)で自動的に適用されるようになる。

## レビュー

設計レビュー・実装レビューとも複数ラウンド実施(fableクォータ上限のためopusで代替実施、加えてclaude[bot]自動レビューも2ラウンド)。検出・修正した主な指摘:

- Critical: bootstrapが新規migrationファイルを巻き込んでしまう内部矛盾(→手順・検証ロジックを訂正、検証は別ツリーで行う設計に変更)
- workflow_dispatch経由の本番ガード欠落(→runtimeガード追加)
- concurrency: workflowレベルの`cancel-in-progress: true`が本番migrationジョブを巻き込んでキャンセルしうる(→ 当初job-level concurrencyで対応したが不十分と再指摘を受け、独立workflowファイルへ分離する設計に変更)
- タイムアウト未設定(`pg_advisory_lock`がブロックし続けるリスク)(→`timeout-minutes: 10`追加)
- ドキュメント整合性(件数表記の陳腐化等)

## Test plan

- [x] `deploy-cloudflare.yml`/`planetscale-migrate.yml`のYAML構文をjs-yamlでパース確認
- [x] `git diff`ベースでの複数回の自己レビュー・claude-review対応(Critical/Major指摘の解消を実機データ・実コードで追跡確認)
- [ ] オーナーによる本番bootstrap実施 + `PLANETSCALE_DATABASE_URL` secret追加(このPRのマージ前後、必須)
- [ ] preview環境へのマージ後、`planetscale-migrate.yml`がpreviewでは実行されない(production/mainのみ対象)ことを確認
- [ ] preview→main昇格後、本番デプロイで`planetscale-migrate.yml`が正常に動作することを確認。可能であれば、mainへ短時間に連続pushして、先行のmigration runがキャンセルされずキューで待機・完走することも実機確認する(concurrency分離の実地検証。`PLANETSCALE_DATABASE_URL`未設定のためこのPR時点では検証不可)