### PR TITLE
fix(eventsub): 本番ガチャ通知をPlanetScaleへ固定する

### DIFF
--- a/src/lib/services/eventsub-redemption.ts
+++ b/src/lib/services/eventsub-redemption.ts
@@ -3,7 +3,7 @@
  *
  * 背景: src/app/api/twitch/eventsub/route.ts に実装されていたガチャ抽選実行・
  * チャット通知・レイド処理のロジックを、以下2つの理由からこのモジュールへ
- * 純粋に移動（ロジック変更ゼロ）した。
+ * 当初はロジック変更なしで移動した。
  *
  * 1. Issue #787（EventSubリプレイ機構）: メンテナンス中に KV へ退避された
  *    EventSub notification を後から再処理する新規エンドポイント
@@ -15,10 +15,9 @@
  *    maintenance退避判定など、Webhook受信の関心事のみを残し、実際のガチャ
  *    実行・通知ロジックはこちらに集約する。
  *
- * 移動元の route.ts と全く同じロジック・コメントを保持しており、関数本体の
- * 中身は一切変更していない（Issue #787 の絶対条件）。
+ * 抽出後の修正はこの共有モジュールだけに集約し、ライブWebhookとリプレイが
+ * 必ず同じPlanetScale・通知契約を使う。
  */
-import { getSupabaseAdmin, getSupabaseAdminNoCache } from "@/lib/supabase/admin";
 import { GachaService } from "@/lib/services/gacha";
 import { TWITCH_CHAT_MESSAGE_MAX_CHARACTERS } from "@/lib/constants";
 import { handleApiError } from "@/lib/error-handler";
@@ -33,17 +32,39 @@ import { countCharacters } from "@/lib/text-utils";
 import { resolvePackDisplayName } from "@/lib/collection-packs";
 import { runInBackground } from "@/lib/background-task";
 export { runInBackground } from "@/lib/background-task";
-// #573: チャット通知プレースホルダ用 get_user_card_counts（読み取り専用 RPC）の
-// pg 直結分岐用。フラグ未設定時(既定 'postgrest')はこれらのモジュールの実行パスに
-// 一切入らないため、import が存在するだけでは挙動に影響しない(#570 の設計。
-// tests/setup.ts の getDb throw スタブも「postgrest 経路で getDb が呼ばれない」
-// ことを構造的に保証している)。
+// #573/#803: チャット通知プレースホルダ、売り切れ設定取得ともPlanetScale固定。
+// 退役済みSupabase clientと旧driver secretの値には依存しない。
 import { getDb } from "@/lib/db/client";
-import { getGachaDbDriver } from "@/lib/db/flags";
 import { withDbRetry } from "@/lib/db/retry";
+import { eq } from "drizzle-orm";
+import { streamers as streamersTable } from "@/lib/db/schema";
 
 export const CARD_LIST_SEPARATOR = "、";
 export const DEFAULT_MULTI_DRAW_CHAT_TEMPLATE = '@{user} が{draws}連ガチャで {rarityCounts} を獲得しました！{cards}';
+
+/**
+ * ガチャ確定後の補助通知エラーをbest-effortで永続化する。
+ *
+ * Error reporter自体が停止していても、既に確定したカード付与・ポイント返還・
+ * EventSub 2xxを巻き戻してはならない。reportErrorは通常内部で失敗を吸収するが、
+ * テストdoubleや将来の実装変更がrejectしても通知境界から漏らさないため、ここで
+ * 最終防御する。console warnはDBを使わずCloudflare Observabilityへ残る。
+ */
+async function reportNotificationError(
+  error: unknown,
+  context: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await reportError(error, context);
+  } catch (reportingError) {
+    logger.warn('[EventSub] Failed to persist notification error', {
+      context: context.context,
+      error: reportingError instanceof Error
+        ? reportingError.message
+        : String(reportingError),
+    });
+  }
+}
 // Issue #597: {packName} でデフォルト(未分類)パックの表示名オーバーライドが
 // 未設定の場合のフォールバックラベル。チャット文言は他の箇所(rarityMap等)と
 // 同様に i18n非対応でハードコードする。messages/*.json の
@@ -359,7 +380,7 @@ export async function postRedemptionNotify(data: RedemptionNotifyData): Promise<
         error: result.reason instanceof Error ? result.reason.message : String(result.reason),
         streamerId: data.streamer.id,
       });
-      await reportError(result.reason, {
+      await reportNotificationError(result.reason, {
         context: `eventsub:postRedemptionNotify:${label}`,
         streamerId: data.streamer.id,
         broadcasterTwitchUserId: data.broadcasterTwitchUserId,
@@ -416,7 +437,7 @@ export async function postSoldOutNotify(data: SoldOutNotifyData): Promise<void> 
           redemptionId,
           reason: result.reason,
         });
-        await reportError(new Error(`cancelRedemption failed: ${result.reason ?? 'unknown'}`), {
+        await reportNotificationError(new Error(`cancelRedemption failed: ${result.reason ?? 'unknown'}`), {
           context: 'eventsub:postSoldOutNotify:cancelRedemption',
           broadcasterTwitchUserId,
           rewardId,
@@ -432,7 +453,7 @@ export async function postSoldOutNotify(data: SoldOutNotifyData): Promise<void> 
         redemptionId,
         error: error instanceof Error ? error.message : String(error),
       });
-      await reportError(error, {
+      await reportNotificationError(error, {
         context: 'eventsub:postSoldOutNotify:cancelRedemption',
         broadcasterTwitchUserId,
         rewardId,
@@ -449,17 +470,35 @@ export async function postSoldOutNotify(data: SoldOutNotifyData): Promise<void> 
   }
 
   try {
-    const supabaseAdmin = getSupabaseAdmin();
-    const { data: streamer, error } = await supabaseAdmin
-      .from('streamers')
-      .select('chat_announcement_enabled')
-      .eq('twitch_user_id', broadcasterTwitchUserId)
-      .maybeSingle();
-
-    if (error) {
+    let streamer: { chat_announcement_enabled: boolean } | null = null;
+    try {
+      // Sold-out redemptions use the same post-commit notification boundary as
+      // successful draws. Reading settings from PlanetScale here prevents the
+      // retired Supabase stub from also breaking point-refund notifications.
+      const rows = await withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          return db
+            .select({ chat_announcement_enabled: streamersTable.chat_announcement_enabled })
+            .from(streamersTable)
+            .where(eq(streamersTable.twitch_user_id, broadcasterTwitchUserId))
+            .limit(1);
+        },
+        "eventsub:postSoldOutNotify:streamer",
+        { idempotent: true },
+      );
+      streamer = rows[0] ?? null;
+    } catch (error) {
       logger.warn('[postSoldOutNotify] Failed to fetch chat announcement settings', {
         broadcasterTwitchUserId,
-        error: error.message,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      // Point refund has already been attempted, so monitoring failure must not
+      // turn the webhook into a retry storm. Persist the deployment/permission
+      // failure best-effort, then preserve the existing no-chat fallback.
+      await reportNotificationError(error, {
+        context: 'eventsub:postSoldOutNotify:streamerSettings',
+        broadcasterTwitchUserId,
       });
       return;
     }
@@ -485,7 +524,7 @@ export async function postSoldOutNotify(data: SoldOutNotifyData): Promise<void> 
       broadcasterTwitchUserId,
       error: error instanceof Error ? error.message : String(error),
     });
-    await reportError(error, {
+    await reportNotificationError(error, {
       context: 'eventsub:postSoldOutNotify:chatAnnouncement',
       broadcasterTwitchUserId,
     });
@@ -698,8 +737,8 @@ export async function handleRedemption(messageId: string, event: {
 
 /**
  * sendChatAnnouncement の {num}/{unique}/{newCards} 用 get_user_card_counts RPC の
- * pg 直結(postgres.js)実装 (#573)。getGachaDbDriver() === 'pg' のときのみ呼ばれる
- * (フラグ分岐の判断根拠は呼び出し側 userCardCountsPromise のコメント参照)。
+ * pg 直結(postgres.js)実装 (#573/#803)。Supabase admin clientは現在fail-closed
+ * stubのため、EventSub成功後の通知経路もPlanetScaleへ固定する。
  *
  * PostgREST .rpc() と同一の { data, error } 形状へ正規化して返すことで、呼び出し側の
  * 既存分岐（error → logger.warn + プレースホルダを未定義のまま空文字化 / data →
@@ -749,6 +788,42 @@ export async function fetchUserCardCountsRpcPg(
   } catch (error) {
     return {
       data: null,
+      error: { message: error instanceof Error ? error.message : String(error) },
+    };
+  }
+}
+
+/**
+ * チャット通知の `{all}` 用に、PlanetScale上のアクティブカード総数を取得する。
+ *
+ * 旧実装は退役済みSupabase admin stubから `.from('cards')` を呼び、テンプレートが
+ * `{all}` を含む本番ガチャだけを同期的に失敗させていた。通知はガチャ確定後の処理
+ * なので、読み取り失敗は既存契約どおりerror値へ正規化し、カード付与自体や他の
+ * 通知処理を巻き戻さない。接続取得をretry callback内に置くことで一時切断だけを
+ * bounded retryする。
+ */
+async function fetchActiveCardCountPg(
+  streamerId: string,
+): Promise<{ count: number | null; error: { message: string } | null }> {
+  try {
+    const count = await withDbRetry(
+      async () => {
+        const { sql } = await getDb();
+        const rows = await sql<{ count: number }[]>`
+          select count(*)::integer as count
+          from cards
+          where streamer_id = ${streamerId}::uuid
+            and is_active = true
+        `;
+        return rows[0]?.count ?? 0;
+      },
+      "eventsub:sendChatAnnouncement:activeCardCount",
+      { idempotent: true },
+    );
+    return { count, error: null };
+  } catch (error) {
+    return {
+      count: null,
       error: { message: error instanceof Error ? error.message : String(error) },
     };
   }
@@ -844,16 +919,10 @@ export async function sendChatAnnouncement(
   let newCardNames: string[] = [];
 
   if (needsCardCount || needsUniqueCount || needsAllCount || needsNewCardInfo) {
-    const supabaseAdminNoCache = getSupabaseAdminNoCache();
-
     // {all} は配信者のアクティブカード総数のため、直接 cards テーブルを count クエリ
     // {all}: count active cards for this streamer (user-independent)
     const allCountPromise = needsAllCount
-      ? supabaseAdminNoCache
-          .from('cards')
-          .select('id', { count: 'exact', head: true })
-          .eq('streamer_id', streamer.id)
-          .eq('is_active', true)
+      ? fetchActiveCardCountPg(streamer.id)
       : null;
 
     // {num} / {unique} は RPC `get_user_card_counts` で DB 側 GROUP BY 済みの
@@ -863,23 +932,11 @@ export async function sendChatAnnouncement(
     // The RPC handles GROUP BY server-side, avoiding PostgREST 1000-row cap.
     // RPC does not filter by is_active, so we filter on the client.
     //
-    // #573: この呼び出しはガチャ EventSub フロー内（ガチャ成功後のチャット通知）
-    // のため、全体フラグ（DB_DRIVER / isPgReadEnabled）ではなく execute_gacha_transaction
-    // と同じ getGachaDbDriver() で分岐する。GACHA_DB_DRIVER=postgrest による緊急
-    // ロールバック時に通知経路だけ pg 直結に残る「経路の食い違い」を作らない —
-    // ロールバックは1つのレバーでガチャ実行フロー全体を旧経路へ戻せる必要がある
-    // （gacha.ts getIssuedCounts と同じ判断）。
-    // pg 側は同一の { data, error } 形状へ正規化して返すため、下の
-    // userCardCountsResult の消費コード（error → warn / data → 集計）は
-    // 両経路で完全に共有される（NoCache 相当である根拠・エラー処理方針は
-    // fetchUserCardCountsRpcPg の doc コメント参照）。
+    // Supabase admin clientはfail-closed stubなので、環境に残る旧driver secretを
+    // 参照してはならない。直前のガチャ確定と同じPlanetScaleを直接読むことで、
+    // `{num}` / `{unique}` / `{newCards}`へ最新の所持数を反映する。
     const userCardCountsPromise = (needsCardCount || needsUniqueCount || needsNewCardInfo)
-      ? (getGachaDbDriver() === 'pg'
-          ? fetchUserCardCountsRpcPg(userId, streamer.id)
-          : supabaseAdminNoCache.rpc('get_user_card_counts', {
-              p_twitch_user_id: userId,
-              p_streamer_id: streamer.id,
-            }))
+      ? fetchUserCardCountsRpcPg(userId, streamer.id)
       : null;
 
     // transient な transport / runtime 例外が throw されるとチャット通知全体が
@@ -899,6 +956,10 @@ export async function sendChatAnnouncement(
             streamerId: streamer.id,
             error: allCountResult.error.message,
           });
+          await reportNotificationError(new Error(allCountResult.error.message), {
+            context: 'eventsub:sendChatAnnouncement:activeCardCount',
+            streamerId: streamer.id,
+          });
         } else {
           allCount = allCountResult?.count ?? 0;
         }
@@ -910,6 +971,10 @@ export async function sendChatAnnouncement(
             streamerId: streamer.id,
             userTwitchId: userId,
             error: userCardCountsResult.error.message,
+          });
+          await reportNotificationError(new Error(userCardCountsResult.error.message), {
+            context: 'eventsub:sendChatAnnouncement:userCardCounts',
+            streamerId: streamer.id,
           });
           if (needsUniqueCount || needsNewCardInfo) {
             // RPC 失敗時は 0 にフォールバックせず、未定義のままプレースホルダを空文字化
@@ -948,6 +1013,10 @@ export async function sendChatAnnouncement(
         streamerId: streamer.id,
         userTwitchId: userId,
         error: err instanceof Error ? err.message : String(err),
+      });
+      await reportNotificationError(err, {
+        context: 'eventsub:sendChatAnnouncement:countQueries',
+        streamerId: streamer.id,
       });
     }
   }

--- a/tests/unit/eventsub-redemption-limit.test.ts
+++ b/tests/unit/eventsub-redemption-limit.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDb } from '@/lib/db/client'
+import { reportError } from '@/lib/sentry/error-handler'
 
 // Issue #108 / PR #450: カード発行可能枚数の上限到達はストリーマーの設定運用上の正常イベントなので、
 // EventSub の redemption ハンドラーで reportError (= GitHub Issue 化) を呼ばずに warn ログのみで終わること。
@@ -10,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   cancelRedemption: vi.fn(),
   sendChatMessage: vi.fn(),
-  // streamers.select('chat_announcement_enabled') の返り値。テストごとに上書きする。
+  // PlanetScaleのstreamers SELECT結果。テストごとに上書きする。
   // デフォルトはnull(=行なし)とし、既存テストの「チャット通知は送られない」挙動を維持する。
   streamerSettings: null as { chat_announcement_enabled: boolean } | null,
 }))
@@ -47,31 +49,17 @@ vi.mock('@/lib/twitch/channel-points', () => ({
   cancelRedemption: mocks.cancelRedemption,
 }))
 
-// 既存履歴チェック (gacha_history.select.eq.maybeSingle) を「未処理」として返すための supabase admin モック。
-// New event id → no existing history row → handleRedemption proceeds to gachaService call.
-// streamers テーブルへのクエリ (Issue #544 のチャット通知設定取得) は mocks.streamerSettings を返す。
+// 旧Supabase互換fixture。postSoldOutNotifyのstreamers設定取得はPlanetScaleへ移行済みであり、
+// このmockから配信者設定を返すと退役経路へ戻ってもテストが通るため、常に行なしに固定する。
 vi.mock('@/lib/supabase/admin', () => ({
   getSupabaseAdmin: vi.fn(() => ({
-    from: vi.fn((table: string) => {
-      if (table === 'streamers') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              maybeSingle: vi.fn().mockImplementation(() =>
-                Promise.resolve({ data: mocks.streamerSettings, error: null })
-              ),
-            })),
-          })),
-        }
-      }
-      return {
-        select: vi.fn(() => ({
-          eq: vi.fn(() => ({
-            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
-          })),
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
         })),
-      }
-    }),
+      })),
+    })),
   })),
   getSupabaseAdminNoCache: vi.fn(),
 }))
@@ -91,8 +79,29 @@ vi.mock('@/lib/logger', () => ({
 }))
 
 const TEST_SECRET = 'test-eventsub-secret'
+const mockReportError = vi.mocked(reportError)
 
 const ORIGINAL_SECRET = process.env.TWITCH_EVENTSUB_SECRET
+
+/**
+ * postSoldOutNotifyが実行するDrizzleチェーン
+ * `db.select().from().where().limit(1)` を忠実に再現する。
+ * limitの評価時に最新のmocks.streamerSettingsを読むため、各テストは従来どおり
+ * true / false / 行なしを代入するだけで通知契約を切り替えられる。
+ */
+function mockStreamerSettingsDb() {
+  const limit = vi.fn().mockImplementation(() =>
+    Promise.resolve(mocks.streamerSettings ? [mocks.streamerSettings] : []),
+  )
+  const where = vi.fn(() => ({ limit }))
+  const from = vi.fn(() => ({ where }))
+  const select = vi.fn(() => ({ from }))
+
+  vi.mocked(getDb).mockResolvedValue({
+    db: { select } as never,
+    sql: {} as never,
+  })
+}
 
 beforeEach(() => {
   process.env.TWITCH_EVENTSUB_SECRET = TEST_SECRET
@@ -100,6 +109,8 @@ beforeEach(() => {
   mocks.streamerSettings = null
   mocks.cancelRedemption.mockResolvedValue({ success: true })
   mocks.sendChatMessage.mockResolvedValue(true)
+  mockReportError.mockReset().mockResolvedValue(undefined)
+  mockStreamerSettingsDb()
 })
 
 afterEach(() => {
@@ -170,6 +181,7 @@ describe('EventSub redemption: card issuance limit error handling', () => {
     const { GachaService } = await import('@/lib/services/gacha')
     const { reportError } = await import('@/lib/sentry/error-handler')
     const mockReport = vi.mocked(reportError)
+    mockReport.mockRejectedValue(new Error('reporter unavailable'))
     const mockExecute = vi.fn().mockResolvedValue({ success: false, error: CARD_ISSUANCE_MESSAGES.soldOut })
     vi.mocked(GachaService).mockImplementation(() => ({
       executeGachaForEventSub: mockExecute,
@@ -354,6 +366,31 @@ describe('EventSub redemption: sold-out chat notification + channel points refun
     expect(mocks.sendChatMessage).toHaveBeenCalledTimes(1)
   })
 
+  it('sold-out chatとreporterが継続的にrejectしても返還結果とEventSub 200を維持する', async () => {
+    await mockSoldOut()
+    mocks.streamerSettings = { chat_announcement_enabled: true }
+    mocks.cancelRedemption.mockResolvedValue({ success: true })
+    mocks.sendChatMessage.mockRejectedValue(new Error('Twitch chat unavailable'))
+    mockReportError.mockRejectedValue(new Error('reporter unavailable'))
+
+    const { POST } = await import('@/app/api/twitch/eventsub/route')
+    const req = await buildRedemptionRequest(
+      'msg-chat-and-reporter-error-1',
+      'redemption-chat-error-1',
+    )
+    const res = await POST(req as unknown as import('next/server').NextRequest)
+
+    expect(res.status).toBe(200)
+    expect(mocks.cancelRedemption).toHaveBeenCalledTimes(1)
+    expect(mocks.sendChatMessage).toHaveBeenCalledTimes(1)
+    expect(mockReportError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Twitch chat unavailable' }),
+      expect.objectContaining({
+        context: 'eventsub:postSoldOutNotify:chatAnnouncement',
+      }),
+    )
+  })
+
   it('chat_announcement_enabled が false の場合: 返還は試みるがチャット通知はしない', async () => {
     await mockSoldOut()
     mocks.streamerSettings = { chat_announcement_enabled: false }
@@ -377,6 +414,36 @@ describe('EventSub redemption: sold-out chat notification + channel points refun
     const res = await POST(req as unknown as import('next/server').NextRequest)
 
     expect(res.status).toBe(200)
+    expect(mocks.sendChatMessage).not.toHaveBeenCalled()
+  })
+
+  it('streamer設定DBとerror reporterが失敗しても返還済み状態とEventSub 200を維持する', async () => {
+    await mockSoldOut()
+    mocks.cancelRedemption.mockResolvedValue({ success: true })
+    vi.mocked(getDb).mockRejectedValue(new Error('PlanetScale unavailable'))
+    const { reportError } = await import('@/lib/sentry/error-handler')
+    const mockReport = vi.mocked(reportError)
+    mockReport.mockRejectedValue(new Error('reporter unavailable'))
+
+    const { POST } = await import('@/app/api/twitch/eventsub/route')
+    const req = await buildRedemptionRequest(
+      'msg-settings-db-error-1',
+      'redemption-settings-error-1',
+    )
+    const res = await POST(req as unknown as import('next/server').NextRequest)
+
+    expect(res.status).toBe(200)
+    expect(mocks.cancelRedemption).toHaveBeenCalledWith({
+      broadcasterTwitchUserId: 'broadcaster-1',
+      rewardId: 'reward-1',
+      redemptionId: 'redemption-settings-error-1',
+    })
+    expect(mockReport).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'PlanetScale unavailable' }),
+      expect.objectContaining({
+        context: 'eventsub:postSoldOutNotify:streamerSettings',
+      }),
+    )
     expect(mocks.sendChatMessage).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/eventsub-redemption.test.ts
+++ b/tests/unit/eventsub-redemption.test.ts
@@ -4,6 +4,7 @@ import { POST } from '@/app/api/twitch/eventsub/route'
 import { reportError } from '@/lib/sentry/error-handler'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
 import { GachaService } from '@/lib/services/gacha'
+import { postRedemptionNotify } from '@/lib/services/eventsub-redemption'
 
 const mocks = vi.hoisted(() => ({
   executeGachaForEventSub: vi.fn(),
@@ -99,6 +100,7 @@ async function createNotificationRequest(payload: unknown): Promise<NextRequest>
 describe('EventSub redemption handling', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockReportError.mockReset().mockResolvedValue(undefined)
     const historyQuery = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
@@ -163,6 +165,41 @@ describe('EventSub redemption handling', () => {
         context: 'eventsub:handleRedemption',
         broadcasterUserId: 'broadcaster-1',
         gachaError: 'Database error fetching streamer: permission denied',
+      }),
+    )
+  })
+
+  it('post-redemption chatとreporterが継続的にrejectしても通知taskはresolveする', async () => {
+    mockReportError.mockRejectedValue(new Error('reporter unavailable'))
+
+    await expect(postRedemptionNotify({
+      broadcasterTwitchUserId: 'broadcaster-1',
+      streamer: {
+        id: 'streamer-1',
+        chat_announcement_enabled: true,
+        chat_announcement_template: null,
+        chat_announcement_multi_template: null,
+        chat_announcement_multi_show_cards: false,
+      },
+      gachaResult: {
+        card: {
+          id: 'card-1',
+          name: 'Alpha',
+          description: null,
+          image_url: null,
+          rarity: 'rare',
+          drop_rate: 1,
+        },
+        userTwitchUsername: 'Viewer',
+      },
+      userId: 'viewer-1',
+      batchId: 'eventsub-message-1',
+    } as never)).resolves.toBeUndefined()
+
+    expect(mockReportError).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        context: 'eventsub:postRedemptionNotify:chatAnnouncement',
       }),
     )
   })

--- a/tests/unit/eventsub-reward-mismatch.test.ts
+++ b/tests/unit/eventsub-reward-mismatch.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server'
 import { POST } from '@/app/api/twitch/eventsub/route'
 import { reportError } from '@/lib/sentry/error-handler'
 import { getSupabaseAdmin, getSupabaseAdminNoCache } from '@/lib/supabase/admin'
+import { getDb } from '@/lib/db/client'
 import { publishCommittedGachaBatch } from '@/lib/overlay-realtime/publisher'
 import { TwitchChatService } from '@/lib/twitch/chat-service'
 
@@ -77,6 +78,20 @@ const mockGetSupabaseAdminNoCache = vi.mocked(getSupabaseAdminNoCache)
 const mockReportError = vi.mocked(reportError)
 const mockPublishCommittedGachaBatch = vi.mocked(publishCommittedGachaBatch)
 const mockTwitchChatService = vi.mocked(TwitchChatService)
+
+/**
+ * チャット通知の「初出」判定は、ガチャ確定後の最終所持数をPlanetScale上の
+ * get_user_card_countsから読む。旧NoCache RPC fixtureを残すとクエリ失敗が
+ * 通知用の空値へ安全に縮退し、テストが意図する初出条件を検証できないため、
+ * PostgreSQL関数のJSONB戻り値と同じ `[{ result: rows }]` をSQLタグへ返す。
+ */
+function mockUserCardCountRows(
+  rows: Array<{ count: number; card: { id: string; is_active: boolean } }>,
+) {
+  const sql = vi.fn().mockResolvedValue([{ result: rows }])
+  vi.mocked(getDb).mockResolvedValue({ db: {} as never, sql: sql as never })
+  return sql
+}
 
 async function signEventSubBody(secret: string, messageId: string, timestamp: string, body: string): Promise<string> {
   const encoder = new TextEncoder()
@@ -159,6 +174,8 @@ describe('EventSub reward mismatch handling', () => {
     mockGetSupabaseAdminNoCache.mockReturnValue({
       rpc: vi.fn().mockResolvedValue({ data: [], error: null }),
     } as unknown as ReturnType<typeof getSupabaseAdminNoCache>)
+    // 各テストを独立させ、前のケースの最終所持数fixtureを持ち越さない。
+    mockUserCardCountRows([])
   })
 
   it('does not report stale EventSub notifications for unconfigured rewards', async () => {
@@ -482,16 +499,11 @@ describe('EventSub reward mismatch handling', () => {
       { id: 'card-3', name: 'Gamma', description: null, image_url: null, rarity: 'legendary', drop_rate: 1 },
     ] as const
 
-    mockGetSupabaseAdminNoCache.mockReturnValue({
-      rpc: vi.fn().mockResolvedValue({
-        data: [
-          { count: 2, card: { id: 'card-1', is_active: true } },
-          { count: 2, card: { id: 'card-2', is_active: true } },
-          { count: 1, card: { id: 'card-3', is_active: true } },
-        ],
-        error: null,
-      }),
-    } as unknown as ReturnType<typeof getSupabaseAdminNoCache>)
+    mockUserCardCountRows([
+      { count: 2, card: { id: 'card-1', is_active: true } },
+      { count: 2, card: { id: 'card-2', is_active: true } },
+      { count: 1, card: { id: 'card-3', is_active: true } },
+    ])
 
     mocks.executeGachaForEventSub.mockResolvedValue({
       success: true,
@@ -550,15 +562,10 @@ describe('EventSub reward mismatch handling', () => {
       { id: 'card-2', name: 'Beta', description: null, image_url: null, rarity: 'common', drop_rate: 1 },
     ] as const
 
-    mockGetSupabaseAdminNoCache.mockReturnValue({
-      rpc: vi.fn().mockResolvedValue({
-        data: [
-          { count: 1, card: { id: 'card-1', is_active: true } },
-          { count: 3, card: { id: 'card-2', is_active: true } },
-        ],
-        error: null,
-      }),
-    } as unknown as ReturnType<typeof getSupabaseAdminNoCache>)
+    mockUserCardCountRows([
+      { count: 1, card: { id: 'card-1', is_active: true } },
+      { count: 3, card: { id: 'card-2', is_active: true } },
+    ])
 
     mocks.executeGachaForEventSub.mockResolvedValue({
       success: true,
@@ -771,12 +778,9 @@ describe('EventSub reward mismatch handling', () => {
       drop_rate: 1,
     }))
 
-    mockGetSupabaseAdminNoCache.mockReturnValue({
-      rpc: vi.fn().mockResolvedValue({
-        data: cards.map((card) => ({ count: 1, card: { id: card.id, is_active: true } })),
-        error: null,
-      }),
-    } as unknown as ReturnType<typeof getSupabaseAdminNoCache>)
+    mockUserCardCountRows(
+      cards.map((card) => ({ count: 1, card: { id: card.id, is_active: true } })),
+    )
 
     mocks.executeGachaForEventSub.mockResolvedValue({
       success: true,
@@ -844,15 +848,10 @@ describe('EventSub reward mismatch handling', () => {
 
     // Beta は legacy fallback で INSERT 失敗 -> count=0 が返る想定。
     // 旧実装では previousCount = 0 - 1 = -1 で「初出」誤通知。
-    mockGetSupabaseAdminNoCache.mockReturnValue({
-      rpc: vi.fn().mockResolvedValue({
-        data: [
-          { count: 1, card: { id: 'card-1', is_active: true } },
-          { count: 0, card: { id: 'card-2', is_active: true } },
-        ],
-        error: null,
-      }),
-    } as unknown as ReturnType<typeof getSupabaseAdminNoCache>)
+    mockUserCardCountRows([
+      { count: 1, card: { id: 'card-1', is_active: true } },
+      { count: 0, card: { id: 'card-2', is_active: true } },
+    ])
 
     mocks.executeGachaForEventSub.mockResolvedValue({
       success: true,

--- a/tests/unit/eventsub-user-card-counts-driver-parity.test.ts
+++ b/tests/unit/eventsub-user-card-counts-driver-parity.test.ts
@@ -1,20 +1,10 @@
 /**
- * #573: eventsub チャット通知プレースホルダ用 get_user_card_counts RPC の
- * postgrest / pg 直結ドライバ切替パリティテスト
+ * #573/#803: EventSubチャット通知のPlanetScale固定回帰テスト。
  *
- * sendChatAnnouncement の {num}/{unique} は getSupabaseAdminNoCache 経由の RPC で
- * 取得される。この呼び出しはガチャ EventSub フロー内のため、全体フラグではなく
- * ガチャ経路専用の getGachaDbDriver() === 'pg' のときのみ RPC 実行が pg 直結
- * (fetchUserCardCountsRpcPg) に切り替わることを固定する:
- *   1. フラグ未設定時(既定 'postgrest')は getDb が一切呼ばれず既存挙動が不変
- *   2. pg 経路(GACHA_DB_DRIVER=pg)では NoCache クライアントの rpc へ流れず、
- *      同一 RPC データから同一のプレースホルダ({num}=当選カード所持数 /
- *      {unique}=アクティブ種類数)が組み立てられる（名前付き引数 + ::uuid 明示キャスト）
- *   3. 既存 postgrest 経路のこの呼び出しには 42883 フォールバックが無いため、
- *      pg 経路でも特別扱いせず「warn ログ + プレースホルダ未定義のまま通知送信」
- *      の同じ外部挙動になる（postgrest へのフォールスルーもしない）
- *   4. GACHA_DB_DRIVER=postgrest による緊急ロールバックはガチャ実行(execute_gacha_
- *      transaction)と通知経路を一括で旧経路へ戻す(経路の食い違いを作らない)
+ * 旧driver secretの有無・値に関係なく、`{num}/{unique}/{newCards}/{all}`を
+ * PlanetScaleから取得し、退役済みNoCache clientを呼ばないことを固定する。
+ * DB/RPC障害時は空placeholderでチャット通知を継続しつつ、deployment errorを
+ * best-effortで永続監視へ送り、reporter障害もEventSub 2xxへ影響させない。
  *
  * モックの流儀は tests/unit/eventsub-reward-mismatch.test.ts（EventSub 署名付き
  * POST + GachaService / chat-service モック）と
@@ -103,7 +93,10 @@ async function signEventSubBody(secret: string, messageId: string, timestamp: st
  * {num}/{unique} を含むテンプレートを持つ配信者への単発ガチャ成功を再現する
  * 署名付き EventSub 通知リクエストを作る。
  */
-async function createRedemptionRequest(messageId: string): Promise<NextRequest> {
+async function createRedemptionRequest(
+  messageId: string,
+  template = '@{user} {card} 所持{num}枚目 コンプ進捗{unique}',
+): Promise<NextRequest> {
   const secret = 'eventsub-test-secret'
   process.env.TWITCH_EVENTSUB_SECRET = secret
   const timestamp = '2026-07-01T10:00:00Z'
@@ -127,7 +120,7 @@ async function createRedemptionRequest(messageId: string): Promise<NextRequest> 
       streamer: {
         id: 'streamer-1',
         chat_announcement_enabled: true,
-        chat_announcement_template: '@{user} {card} 所持{num}枚目 コンプ進捗{unique}',
+        chat_announcement_template: template,
         chat_announcement_multi_template: null,
         chat_announcement_multi_show_cards: false,
       },
@@ -206,21 +199,18 @@ describe('EventSub get_user_card_counts ドライバパリティ (#573)', () => 
     vi.unstubAllEnvs()
   })
 
-  it('postgrest 経路(フラグ未設定): NoCache クライアントの rpc で実行され getDb は呼ばれない', async () => {
-    const rpc = vi.fn().mockResolvedValue({ data: USER_CARD_COUNT_ROWS, error: null })
+  it('フラグ未設定でもPlanetScale RPCを使い、退役済みNoCache clientを呼ばない', async () => {
+    const rpc = vi.fn()
     mockGetSupabaseAdminNoCache.mockReturnValue({
       rpc,
     } as unknown as ReturnType<typeof getSupabaseAdminNoCache>)
+    const sqlMock = setupPgSql([{ rows: [{ result: USER_CARD_COUNT_ROWS }] }])
 
-    const response = await POST(await createRedemptionRequest('eventsub-counts-postgrest'))
+    const response = await POST(await createRedemptionRequest('eventsub-counts-default'))
 
     expect(response.status).toBe(200)
-    // 既存経路の呼び出し形状(名前付きパラメータのオブジェクト)が不変であること
-    expect(rpc).toHaveBeenCalledWith('get_user_card_counts', {
-      p_twitch_user_id: 'viewer-1',
-      p_streamer_id: 'streamer-1',
-    })
-    expect(getDb).not.toHaveBeenCalled()
+    expect(sqlMock).toHaveBeenCalledTimes(1)
+    expect(rpc).not.toHaveBeenCalled()
     expect(mocks.buildMessage).toHaveBeenCalledWith(
       '@{user} {card} 所持{num}枚目 コンプ進捗{unique}',
       expect.objectContaining({ num: 3, unique: 1 }),
@@ -283,7 +273,7 @@ describe('EventSub get_user_card_counts ドライバパリティ (#573)', () => 
     )
     // 通知自体はカウント無しでも必ず送信される
     expect(mocks.sendChatMessage).toHaveBeenCalledWith('broadcaster-1', 'built message')
-    // 既存と同じ warn ログ経路（reportError はしない）
+    // 通知は継続するが、RPC未デプロイは運用監視へ永続化する。
     expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
       'Failed to fetch user card counts for chat announcement',
       expect.objectContaining({
@@ -291,35 +281,91 @@ describe('EventSub get_user_card_counts ドライバパリティ (#573)', () => 
         userTwitchId: 'viewer-1',
       }),
     )
-    expect(mockReportError).not.toHaveBeenCalled()
+    expect(mockReportError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining('get_user_card_counts'),
+      }),
+      expect.objectContaining({
+        context: 'eventsub:sendChatAnnouncement:userCardCounts',
+        streamerId: 'streamer-1',
+      }),
+    )
     // postgrest RPC へのフォールスルーはしない
     expect(rpc).not.toHaveBeenCalled()
   })
 
-  it('緊急ロールバック(DB_DRIVER=pg + GACHA_DB_DRIVER=postgrest): 通知経路もガチャ経路と揃って postgrest で実行される', async () => {
-    // GACHA_DB_DRIVER=postgrest はガチャ実行フロー全体(execute_gacha_transaction と
-    // このチャット通知用 RPC)を1つのレバーで旧経路へ戻す。通知経路が全体フラグ
-    // (DB_DRIVER)で分岐していると、ロールバック時に通知だけ pg 直結に残る
-    // 「経路の食い違い」が起きるため、それが無いこと(getDb 不呼出 + NoCache rpc
-    // 呼出)を固定する。
+  it('旧driver secretがpostgrestでも通知はPlanetScaleに固定する', async () => {
     vi.stubEnv('DB_DRIVER', 'pg')
     vi.stubEnv('GACHA_DB_DRIVER', 'postgrest')
-    const rpc = vi.fn().mockResolvedValue({ data: USER_CARD_COUNT_ROWS, error: null })
+    const rpc = vi.fn()
     mockGetSupabaseAdminNoCache.mockReturnValue({
       rpc,
     } as unknown as ReturnType<typeof getSupabaseAdminNoCache>)
+    const sqlMock = setupPgSql([{ rows: [{ result: USER_CARD_COUNT_ROWS }] }])
 
     const response = await POST(await createRedemptionRequest('eventsub-counts-rollback'))
 
     expect(response.status).toBe(200)
-    expect(rpc).toHaveBeenCalledWith('get_user_card_counts', {
-      p_twitch_user_id: 'viewer-1',
-      p_streamer_id: 'streamer-1',
-    })
-    expect(getDb).not.toHaveBeenCalled()
+    expect(sqlMock).toHaveBeenCalledTimes(1)
+    expect(rpc).not.toHaveBeenCalled()
     expect(mocks.buildMessage).toHaveBeenCalledWith(
       '@{user} {card} 所持{num}枚目 コンプ進捗{unique}',
       expect.objectContaining({ num: 3, unique: 1 }),
+    )
+  })
+
+  it('{all}テンプレートはPlanetScaleのactive card countを使いSupabase stubを呼ばない', async () => {
+    const rpc = vi.fn()
+    mockGetSupabaseAdminNoCache.mockReturnValue({
+      rpc,
+    } as unknown as ReturnType<typeof getSupabaseAdminNoCache>)
+    const sqlMock = setupPgSql([{ rows: [{ count: 42 }] }])
+
+    const response = await POST(
+      await createRedemptionRequest('eventsub-counts-all', '@{user} 全{all}枚'),
+    )
+
+    expect(response.status).toBe(200)
+    expect(sqlMock).toHaveBeenCalledTimes(1)
+    const { text, values } = renderSqlCall(sqlMock, 0)
+    expect(text).toContain('from cards')
+    expect(text).toContain('is_active = true')
+    expect(values).toEqual(['streamer-1'])
+    expect(mocks.buildMessage).toHaveBeenCalledWith(
+      '@{user} 全{all}枚',
+      expect.objectContaining({ all: 42 }),
+    )
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('{all}取得失敗は空placeholderで通知を継続しdeployment errorを記録する', async () => {
+    setupPgSql([{ reject: pgError('42501', 'permission denied for table cards') }])
+    mockReportError.mockRejectedValue(new Error('reporter unavailable'))
+
+    const response = await POST(
+      await createRedemptionRequest('eventsub-counts-all-error', '@{user} 全{all}枚'),
+    )
+
+    expect(response.status).toBe(200)
+    expect(mocks.buildMessage).toHaveBeenCalledWith(
+      '@{user} 全{all}枚',
+      expect.objectContaining({ all: undefined }),
+    )
+    expect(mocks.sendChatMessage).toHaveBeenCalledWith('broadcaster-1', 'built message')
+    expect(mockReportError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'permission denied for table cards',
+      }),
+      expect.objectContaining({
+        context: 'eventsub:sendChatAnnouncement:activeCardCount',
+        streamerId: 'streamer-1',
+      }),
+    )
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      '[EventSub] Failed to persist notification error',
+      expect.objectContaining({
+        context: 'eventsub:sendChatAnnouncement:activeCardCount',
+      }),
     )
   })
 })


### PR DESCRIPTION
## 障害

ガチャ抽選とDB確定の成功後、チャット文面の枚数プレースホルダーを展開する処理が退役済みSupabase経路へ到達し、通知だけが失敗していました。

## 修正

- 通知用のユーザーカード集計・全カード集計をPlanetScaleへ固定
- 売り切れ通知の配信者設定取得をDrizzle/PlanetScaleへ移行
- 補助DB・チャット・エラー報告の失敗をガチャ確定やEventSub応答から分離
- 旧driver secretが残っていてもSupabase経路へ分岐しない回帰テストを追加

## 検証

- EventSub単体テスト: 77/77
- 周辺EventSub/replay/chat: 114/114
- 全unit test: success
- typecheck: success
- build: success
- ESLint / git diff --check: success
- 独立厳格レビュー: BLOCKER/HIGH/MEDIUM/LOWすべて0

Refs #803
Refs #708