### PR TITLE
fix(collections): 旧Supabase実行経路をPlanetScaleへ移行する

### DIFF
--- a/src/app/api/cards/collections/route.ts
+++ b/src/app/api/cards/collections/route.ts
@@ -1,6 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
+import { type NextRequest, NextResponse } from "next/server";
 import { getSession, canUseStreamerFeatures } from "@/lib/session";
-import { getSupabaseAdmin } from "@/lib/supabase/admin";
 import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
 import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
 import { ERROR_MESSAGES } from "@/lib/constants";
@@ -12,16 +11,97 @@ import {
 } from "@/lib/collections/collection-existence";
 import { validatePackName } from "@/lib/validation/collection-name";
 import type { ApiRateLimitResponse } from "@/types/api";
-// ---------------------------------------------------------------------------
-// #573: rename_card_pack RPC の pg 直結経路 (isPgWriteEnabled()) 用。フラグ未設定時
-// (既定 'postgrest')はこれらのモジュールの実行パスに一切入らないため、import が
-// 存在するだけでは挙動に影響しない(#570 の設計。tests/setup.ts の getDb throw
-// スタブが「postgrest 経路で getDb が呼ばれない」ことを構造的に保証)。
-// ---------------------------------------------------------------------------
 import { getDb } from "@/lib/db/client";
-import { isPgWriteEnabled } from "@/lib/db/flags";
 import { withDbRetry } from "@/lib/db/retry";
 import { isPgFunctionNotFoundError } from "@/lib/db/errors";
+import { and, eq } from "drizzle-orm";
+import { streamers as streamersTable } from "@/lib/db/schema";
+
+interface OwnedStreamerCatalogResult {
+  streamer: { id: string; card_pack_names: string[] } | null;
+  cardPackNamesUnavailable: boolean;
+  error: unknown;
+}
+
+/**
+ * 所有権確認とパック一覧を同一の PlanetScale クエリで取得する。
+ *
+ * ここは認可境界なので、`streamerId` 単独の検索に分離してはならない。Drizzle の
+ * 値バインディングを使い、利用者が指定した ID を SQL 文字列へ連結しないことで
+ * SQL injection を防ぎつつ、従来の Supabase の `.eq(...).eq(...)` と同じ
+ * 「所有者でなければ存在しない」契約を維持する。
+ *
+ * card_pack_names の schema rollout 中だけは、既存 API と同じ挙動として所有権を
+ * 再確認してから空配列を返す。PATCH は一覧がない状態で安全に rename できないため、
+ * 呼び出し側が `cardPackNamesUnavailable` を 503 へ変換する。
+ */
+async function loadOwnedStreamerCatalog(
+  streamerId: string,
+  twitchUserId: string,
+): Promise<OwnedStreamerCatalogResult> {
+  const ownershipFilter = and(
+    eq(streamersTable.id, streamerId),
+    eq(streamersTable.twitch_user_id, twitchUserId),
+  );
+
+  try {
+    const rows = await withDbRetry(
+      async () => {
+        const { db } = await getDb();
+        return db
+          .select({
+            id: streamersTable.id,
+            card_pack_names: streamersTable.card_pack_names,
+          })
+          .from(streamersTable)
+          .where(ownershipFilter)
+          .limit(1);
+      },
+      "cards collections: load owned catalog",
+      { idempotent: true },
+    );
+    const row = rows[0] ?? null;
+    return {
+      streamer: row
+        ? {
+            id: row.id,
+            card_pack_names: Array.isArray(row.card_pack_names) ? row.card_pack_names : [],
+          }
+        : null,
+      cardPackNamesUnavailable: false,
+      error: null,
+    };
+  } catch (error) {
+    if (!isMissingCardPackNamesColumnError(error)) {
+      return { streamer: null, cardPackNamesUnavailable: false, error };
+    }
+
+    try {
+      const rows = await withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          return db
+            .select({ id: streamersTable.id })
+            .from(streamersTable)
+            .where(ownershipFilter)
+            .limit(1);
+        },
+        "cards collections: load ownership without catalog",
+        { idempotent: true },
+      );
+      return {
+        streamer: rows[0] ? { id: rows[0].id, card_pack_names: [] } : null,
+        // 42703 は catalog 列の未展開だけを示し、行の所有までは示さない。
+        // fallback が0行なら非所有者なので、PATCH が deploy-window の 503 を返して
+        // リソースの存在を曖昧にしてはならない。所有者だけが 503 の対象になる。
+        cardPackNamesUnavailable: Boolean(rows[0]),
+        error: null,
+      };
+    } catch (fallbackError) {
+      return { streamer: null, cardPackNamesUnavailable: false, error: fallbackError };
+    }
+  }
+}
 
 /**
  * rename_card_pack RPC のエラーを PostgREST .rpc() の error と同じ
@@ -151,43 +231,11 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const supabaseAdmin = getSupabaseAdmin();
-
-    // Verify the session owns this streamer profile, and read the pre-defined
-    // pack list in the same query.
-    const { data: streamer, error: streamerError } = await supabaseAdmin
-      .from("streamers")
-      .select("id, card_pack_names")
-      .eq("id", streamerId)
-      .eq("twitch_user_id", session.twitchUserId)
-      .maybeSingle();
-
-    if (streamerError) {
-      // Deploy-window fallback: column not migrated yet → no packs exist.
-      if (isMissingCardPackNamesColumnError(streamerError)) {
-        const { data: ownedStreamer } = await supabaseAdmin
-          .from("streamers")
-          .select("id")
-          .eq("id", streamerId)
-          .eq("twitch_user_id", session.twitchUserId)
-          .maybeSingle();
-        if (!ownedStreamer) {
-          return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
-        }
-        return NextResponse.json({ collections: [] });
-      }
+    const result = await loadOwnedStreamerCatalog(streamerId, session.twitchUserId);
+    if (result.error || !result.streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
     }
-
-    if (!streamer) {
-      return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
-    }
-
-    const collections = Array.isArray(streamer.card_pack_names)
-      ? (streamer.card_pack_names as string[])
-      : [];
-
-    return NextResponse.json({ collections });
+    return NextResponse.json({ collections: result.streamer.card_pack_names });
   } catch (error) {
     return handleApiError(error, "Cards Collections API: GET");
   }
@@ -287,35 +335,14 @@ export async function PATCH(request: NextRequest) {
     }
     const newName = newNameValidation.value;
 
-    const supabaseAdmin = getSupabaseAdmin();
-
-    // Ownership check + current catalog snapshot, so we can validate
-    // membership/duplication with a normal 400 BEFORE ever calling the RPC
-    // (the RPC re-validates too, but only as defense-in-depth against races —
-    // see RENAME_CARD_PACK_VALIDATION_ERRORS above).
-    const { data: streamer, error: streamerError } = await supabaseAdmin
-      .from("streamers")
-      .select("id, card_pack_names")
-      .eq("id", streamerId)
-      .eq("twitch_user_id", session.twitchUserId)
-      .maybeSingle();
-
-    if (streamerError) {
-      // Deploy-window fallback: the card_pack_names column (and therefore any
-      // pack the streamer could rename) isn't migrated yet.
-      if (isMissingCardPackNamesColumnError(streamerError)) {
-        return NextResponse.json({ error: ERROR_MESSAGES.PACK_RENAME_NOT_READY }, { status: 503 });
-      }
+    const result = await loadOwnedStreamerCatalog(streamerId, session.twitchUserId);
+    if (result.error || !result.streamer) {
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
     }
-
-    if (!streamer) {
-      return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
+    if (result.cardPackNamesUnavailable) {
+      return NextResponse.json({ error: ERROR_MESSAGES.PACK_RENAME_NOT_READY }, { status: 503 });
     }
-
-    const catalog: string[] = Array.isArray(streamer.card_pack_names)
-      ? (streamer.card_pack_names as string[])
-      : [];
+    const catalog = result.streamer.card_pack_names;
 
     if (oldName === newName) {
       return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
@@ -327,18 +354,10 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
     }
 
-    // #573: isPgWriteEnabled() のときだけ pg 直結経路へ分岐する。pg 側は
-    // PostgREST .rpc() と同一の { data, error } 形状へ正規化して返す
-    // (renameCardPackRpcPg の doc コメント参照)ため、直後の既存エラー分岐
-    // (isMissingRenameCardPackFunctionError → 503 / RENAME_CARD_PACK_VALIDATION_ERRORS
-    // → 400 / それ以外 → handleDatabaseError)はそのまま両経路で共有される。
-    const { error: rpcError } = isPgWriteEnabled()
-      ? await renameCardPackRpcPg(streamerId, oldName, newName)
-      : await supabaseAdmin.rpc("rename_card_pack", {
-          p_streamer_id: streamerId,
-          p_old_name: oldName,
-          p_new_name: newName,
-        });
+    // postgres.js は RPC エラーを throw するため、下流の既存 HTTP エラー契約へ
+    // 正規化する renameCardPackRpcPg を必ず使う。実行時フラグで退役済み
+    // Supabase 経路へ戻る余地をなくすことが #806 の要件である。
+    const { error: rpcError } = await renameCardPackRpcPg(streamerId, oldName, newName);
 
     if (rpcError) {
       if (isMissingRenameCardPackFunctionError(rpcError)) {

--- a/tests/unit/api/cards-collections-route.test.ts
+++ b/tests/unit/api/cards-collections-route.test.ts
@@ -1,26 +1,21 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { NextRequest } from "next/server";
+import { MySqlDialect } from "drizzle-orm/mysql-core";
 import { GET, PATCH } from "@/app/api/cards/collections/route";
 import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { checkRateLimit } from "@/lib/rate-limit";
-import { getSupabaseAdmin } from "@/lib/supabase/admin";
+import { getDb } from "@/lib/db/client";
 import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
-import { createMockQueryBuilder } from "../../utils/supabase-mock";
 
 vi.mock("@/lib/session");
 vi.mock("@/lib/rate-limit");
 vi.mock("@/lib/csrf");
 vi.mock("@/lib/request-validation");
-vi.mock("@/lib/supabase/admin", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/supabase/admin")>();
-  return { ...actual, getSupabaseAdmin: vi.fn() };
-});
 
 const mockGetSession = vi.mocked(getSession);
 const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures);
 const mockCheckRateLimit = vi.mocked(checkRateLimit);
-const mockGetSupabaseAdmin = vi.mocked(getSupabaseAdmin);
 const mockValidateCSRFToken = vi.mocked(validateCSRFToken);
 const mockValidateContentType = vi.mocked(validateContentType);
 
@@ -38,25 +33,44 @@ function mockAdmin(opts: {
   streamerError?: unknown;
   fallbackStreamer?: { id: string } | null;
 }) {
-  const streamerQuery = createMockQueryBuilder();
-  (streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
-    data: opts.streamer ?? null,
-    error: opts.streamerError ?? null,
-  });
-  const fallbackQuery = createMockQueryBuilder();
-  (fallbackQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
-    data: opts.fallbackStreamer ?? null,
-    error: null,
-  });
-  let calls = 0;
-  mockGetSupabaseAdmin.mockReturnValue({
-    from: vi.fn(() => {
-      calls += 1;
-      return calls === 1 ? streamerQuery : fallbackQuery;
+  const responses = [
+    opts.streamerError
+      ? { error: opts.streamerError }
+      : { rows: opts.streamer ? [opts.streamer] : [] },
+    { rows: opts.fallbackStreamer ? [opts.fallbackStreamer] : [] },
+  ];
+  let selectIndex = 0;
+  const whereExpressions: unknown[] = [];
+  const db = {
+    select: vi.fn((fields: Record<string, unknown>) => {
+      const response = responses[Math.min(selectIndex++, responses.length - 1)];
+      const resolve = () => {
+        if ("error" in response) return Promise.reject(response.error);
+        return Promise.resolve(
+          response.rows.map((row) =>
+            Object.fromEntries(
+              Object.keys(fields).map((key) => [key, row[key as keyof typeof row] ?? null]),
+            ),
+          ),
+        );
+      };
+      const builder = {
+        from: vi.fn(),
+        where: vi.fn((expression: unknown) => {
+          whereExpressions.push(expression);
+          return builder;
+        }),
+        limit: vi.fn(),
+        then: (onFulfilled: (value: unknown) => unknown, onRejected: (reason: unknown) => unknown) =>
+          resolve().then(onFulfilled, onRejected),
+      };
+      builder.from.mockReturnValue(builder);
+      builder.limit.mockReturnValue(builder);
+      return builder;
     }),
-  } as unknown as ReturnType<typeof getSupabaseAdmin>);
-
-  return { streamerQuery, fallbackQuery };
+  };
+  vi.mocked(getDb).mockResolvedValue({ db, sql: vi.fn() } as never);
+  return { db, whereExpressions };
 }
 
 describe("GET /api/cards/collections", () => {
@@ -81,7 +95,7 @@ describe("GET /api/cards/collections", () => {
   });
 
   it("returns the streamer's pre-defined pack names", async () => {
-    mockAdmin({
+    const { whereExpressions } = mockAdmin({
       streamer: { id: "streamer-1", card_pack_names: ["weapons", "characters"] },
     });
 
@@ -89,6 +103,14 @@ describe("GET /api/cards/collections", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.collections).toEqual(["weapons", "characters"]);
+
+    // 認可境界は streamerId だけでなく、ログイン中の twitch_user_id も同じ
+    // WHERE に束縛する。SQL化して両カラムと両bind値を固定し、片方を落とす
+    // 回帰(他人のcatalog参照)を防ぐ。
+    const ownershipQuery = new MySqlDialect().sqlToQuery(whereExpressions[0] as never);
+    expect(ownershipQuery.sql).toContain("`streamers`.`id`");
+    expect(ownershipQuery.sql).toContain("`streamers`.`twitch_user_id`");
+    expect(ownershipQuery.params).toEqual(["streamer-1", "twitch-1"]);
   });
 
   it("returns an empty list when no packs are registered", async () => {
@@ -137,8 +159,8 @@ describe("GET /api/cards/collections", () => {
   });
 
   it("returns an empty list when card_pack_names is not deployed yet (READ 42703), after confirming ownership", async () => {
-    // Real PostgREST returns 42703 ("does not exist") for a SELECT on a missing
-    // column, not PGRST204 — the deploy-window fallback must accept that shape,
+    // PostgreSQL returns 42703 ("does not exist") for a SELECT on a missing
+    // column — the deploy-window fallback must accept that shape,
     // and must still verify ownership via a fallback query before responding.
     mockAdmin({
       streamer: undefined,
@@ -176,19 +198,30 @@ function makePatchRequest(body: unknown) {
 function mockAdminForPatch(opts: {
   streamer?: { id: string; card_pack_names?: string[] } | null;
   streamerError?: unknown;
+  fallbackStreamer?: { id: string } | null;
   rpcError?: unknown;
 }) {
-  const streamerQuery = createMockQueryBuilder();
-  (streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
-    data: opts.streamer ?? null,
-    error: opts.streamerError ?? null,
+  const dbMock = mockAdmin({
+    streamer: opts.streamer,
+    streamerError: opts.streamerError,
+    fallbackStreamer: opts.fallbackStreamer,
   });
-  const rpcMock = vi.fn().mockResolvedValue({ data: null, error: opts.rpcError ?? null });
-  mockGetSupabaseAdmin.mockReturnValue({
-    from: vi.fn(() => streamerQuery),
-    rpc: rpcMock,
-  } as unknown as ReturnType<typeof getSupabaseAdmin>);
-  return { streamerQuery, rpcMock };
+  // postgres.js は PostgREST の `{ error }` 応答ではなく例外を投げる。
+  // code と message を持つ Error に正規化し、ルートの実運用エラー分類を再現する。
+  const sqlMock = vi.fn(async (_strings: TemplateStringsArray, ...values: unknown[]) => {
+    void _strings;
+    void values;
+    if (opts.rpcError) {
+      const source = opts.rpcError as { code?: unknown; message?: unknown };
+      throw Object.assign(
+        new Error(typeof source.message === "string" ? source.message : String(opts.rpcError)),
+        { code: typeof source.code === "string" ? source.code : undefined },
+      );
+    }
+    return [];
+  });
+  vi.mocked(getDb).mockResolvedValue({ db: dbMock.db, sql: sqlMock } as never);
+  return { db: dbMock.db, sqlMock };
 }
 
 describe("PATCH /api/cards/collections", () => {
@@ -258,7 +291,7 @@ describe("PATCH /api/cards/collections", () => {
   });
 
   it("calls the rename_card_pack RPC with the exact validated arguments on success", async () => {
-    const { rpcMock } = mockAdminForPatch({
+    const { sqlMock } = mockAdminForPatch({
       streamer: { id: "streamer-1", card_pack_names: ["weapons", "characters"] },
     });
 
@@ -267,11 +300,8 @@ describe("PATCH /api/cards/collections", () => {
     );
 
     expect(res.status).toBe(200);
-    expect(rpcMock).toHaveBeenCalledWith("rename_card_pack", {
-      p_streamer_id: "streamer-1",
-      p_old_name: "weapons",
-      p_new_name: "armory",
-    });
+    expect(sqlMock).toHaveBeenCalledTimes(1);
+    expect(sqlMock.mock.calls[0].slice(1)).toEqual(["streamer-1", "weapons", "armory"]);
     const body = await res.json();
     expect(body.success).toBe(true);
     expect(body.cardPackNames).toEqual(["armory", "characters"]);
@@ -288,13 +318,27 @@ describe("PATCH /api/cards/collections", () => {
   });
 
   it("returns 503 when the ownership SELECT itself hits the card_pack_names deploy window", async () => {
-    mockAdminForPatch({
+    const { sqlMock } = mockAdminForPatch({
       streamer: undefined,
       streamerError: { code: "42703", message: "column streamers.card_pack_names does not exist" },
+      fallbackStreamer: { id: "streamer-1" },
     });
 
     const res = await PATCH(makePatchRequest({ streamerId: "streamer-1", oldName: "weapons", newName: "armory" }));
     expect(res.status).toBe(503);
+    expect(sqlMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 rather than 503 when the 42703 fallback finds no owned streamer", async () => {
+    const { sqlMock } = mockAdminForPatch({
+      streamer: undefined,
+      streamerError: { code: "42703", message: "column streamers.card_pack_names does not exist" },
+      fallbackStreamer: null,
+    });
+
+    const res = await PATCH(makePatchRequest({ streamerId: "streamer-1", oldName: "weapons", newName: "armory" }));
+    expect(res.status).toBe(403);
+    expect(sqlMock).not.toHaveBeenCalled();
   });
 
   it("maps an unexpected RPC error to 500", async () => {

--- a/tests/unit/write-rpc-driver-parity.test.ts
+++ b/tests/unit/write-rpc-driver-parity.test.ts
@@ -9,8 +9,9 @@
  * 各 RPC について以下を固定する(既存 parity テストと同じ観点。
  * tests/unit/gacha-rpc-driver-parity.test.ts / dashboard-data-rpc-driver-parity.test.ts
  * / storage-db-driver-parity.test.ts の流儀を踏襲):
- *   1. postgrest 経路(フラグ未設定 = 既定 'postgrest'): getDb が一切呼ばれず
- *      既存 .rpc() 呼び出しの引数・外部挙動が完全に不変
+ *   1. #806 以外は postgrest 経路(フラグ未設定 = 既定 'postgrest')で getDb が
+ *      一切呼ばれず、既存 .rpc() 呼び出しの引数・外部挙動が完全に不変
+ *      (#806 の rename_card_pack は退役経路をなくすため常時 PlanetScale)
  *   2. pg 経路(DB_DRIVER=pg): 名前付き引数 + 明示キャストの SQL が実行され、
  *      戻り値/エラーが PostgREST .rpc() と同一形状に正規化される
  *   3. 冪等性設定: 非冪等 RPC (rename_card_pack / activate_support_code) は
@@ -368,7 +369,7 @@ describe('batch_update_card_drop_rates (#573)', () => {
 // 2. rename_card_pack
 // =============================================================================
 
-describe('rename_card_pack (#573)', () => {
+describe('rename_card_pack (#806)', () => {
   function makePatchRequest(body: unknown) {
     return new NextRequest('http://localhost/api/cards/collections', {
       method: 'PATCH',
@@ -377,44 +378,37 @@ describe('rename_card_pack (#573)', () => {
     })
   }
 
-  function mockAdminForPatch(opts: { streamer?: { id: string; card_pack_names?: string[] } | null; rpc?: ReturnType<typeof vi.fn> }) {
-    const streamerQuery = createMockQueryBuilder()
-    ;(streamerQuery.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
-      data: opts.streamer ?? null,
-      error: null,
-    })
-    const rpc = opts.rpc ?? vi.fn().mockResolvedValue({ data: null, error: null })
-    mockGetSupabaseAdmin.mockReturnValue({
-      from: vi.fn(() => streamerQuery),
-      rpc,
-    } as unknown as ReturnType<typeof getSupabaseAdmin>)
-    return { streamerQuery, rpc }
+  /**
+   * #806 以降 collections route は、所有権確認も rename RPC も常に
+   * PlanetScale の Drizzle/postgres.js 経路を通る。SELECT の thenable は
+   * Drizzle のクエリビルダが await 可能である実装契約を最小限で再現する。
+   */
+  function mockPgForPatch(
+    streamer: { id: string; card_pack_names?: string[] } | null,
+    sqlMock: ReturnType<typeof createSqlMock>
+  ) {
+    return primePgDbWithSelectResponses(sqlMock, [streamer ? [streamer] : []])
   }
 
   const CATALOG_STREAMER = { id: 'streamer-1', card_pack_names: ['weapons', 'characters'] }
 
-  it('postgrest 経路(フラグ未設定): 既存 supabase-js RPC で実行され getDb は呼ばれない', async () => {
-    const { rpc } = mockAdminForPatch({ streamer: CATALOG_STREAMER })
+  it('DB_DRIVER 未設定でも PlanetScale の Drizzle/postgres.js 経路で実行される', async () => {
+    const sqlMock = createSqlMock([{ rows: [] }])
+    const selectMock = mockPgForPatch(CATALOG_STREAMER, sqlMock)
 
     const res = await collectionsPatch(
       makePatchRequest({ streamerId: 'streamer-1', oldName: 'weapons', newName: 'armory' })
     )
 
     expect(res.status).toBe(200)
-    expect(rpc).toHaveBeenCalledWith('rename_card_pack', {
-      p_streamer_id: 'streamer-1',
-      p_old_name: 'weapons',
-      p_new_name: 'armory',
-    })
-    expect(getDb).not.toHaveBeenCalled()
+    expect(selectMock).toHaveBeenCalledTimes(1)
+    expect(sqlMock).toHaveBeenCalledTimes(1)
+    expect(renderSqlCall(sqlMock, 0).values).toEqual(['streamer-1', 'weapons', 'armory'])
   })
 
-  it('pg 経路 正常系: 名前付き引数(::uuid 明示キャスト)で呼ばれ、レスポンス形状が postgrest 経路と一致する', async () => {
-    vi.stubEnv('DB_DRIVER', 'pg')
-    const rpc = vi.fn()
-    mockAdminForPatch({ streamer: CATALOG_STREAMER, rpc })
+  it('固定 PlanetScale 経路: 名前付き引数(::uuid 明示キャスト)で呼ばれ、既存レスポンス形状を維持する', async () => {
     const sqlMock = createSqlMock([{ rows: [] }])
-    primePgDb(sqlMock)
+    const selectMock = mockPgForPatch(CATALOG_STREAMER, sqlMock)
 
     const res = await collectionsPatch(
       makePatchRequest({ streamerId: 'streamer-1', oldName: 'weapons', newName: '  armory  ' })
@@ -431,16 +425,14 @@ describe('rename_card_pack (#573)', () => {
     expect(text).toContain('p_old_name => $')
     expect(text).toContain('p_new_name => $')
     expect(values).toEqual(['streamer-1', 'weapons', 'armory'])
-    expect(rpc).not.toHaveBeenCalled()
+    expect(selectMock).toHaveBeenCalledTimes(1)
   })
 
   it('pg 経路 42883 (RPC未デプロイ): 既存と同じ 503 (PACK_RENAME_NOT_READY) を返す', async () => {
-    vi.stubEnv('DB_DRIVER', 'pg')
-    mockAdminForPatch({ streamer: CATALOG_STREAMER })
     const sqlMock = createSqlMock([
       { reject: pgError('42883', 'function rename_card_pack(uuid, text, text) does not exist') },
     ])
-    primePgDb(sqlMock)
+    mockPgForPatch(CATALOG_STREAMER, sqlMock)
 
     const res = await collectionsPatch(
       makePatchRequest({ streamerId: 'streamer-1', oldName: 'weapons', newName: 'armory' })
@@ -452,10 +444,8 @@ describe('rename_card_pack (#573)', () => {
   it('pg 経路 レース由来の RAISE EXCEPTION (OLD_NAME_NOT_FOUND): 既存と同じ 400 を返す', async () => {
     // ルートの事前チェックを通過した後、RPC 実行までの間に並行編集が割り込んだ
     // レースを模す(cards-collections-route.test.ts の既存 postgrest テストと同種)。
-    vi.stubEnv('DB_DRIVER', 'pg')
-    mockAdminForPatch({ streamer: CATALOG_STREAMER })
     const sqlMock = createSqlMock([{ reject: pgError('P0001', 'OLD_NAME_NOT_FOUND') }])
-    primePgDb(sqlMock)
+    mockPgForPatch(CATALOG_STREAMER, sqlMock)
 
     const res = await collectionsPatch(
       makePatchRequest({ streamerId: 'streamer-1', oldName: 'weapons', newName: 'armory' })
@@ -465,15 +455,13 @@ describe('rename_card_pack (#573)', () => {
   })
 
   it('非冪等: CONNECTION_CLOSED でもリトライされず(1回のみ実行)、既存と同じ 500 を返す', async () => {
-    vi.stubEnv('DB_DRIVER', 'pg')
-    mockAdminForPatch({ streamer: CATALOG_STREAMER })
     // 2回目の応答を成功にしておき、「リトライされていれば成功していた」状況でも
     // 1回で打ち切られること(=非冪等 RPC を安全側で扱えていること)を証明する
     const sqlMock = createSqlMock([
       { reject: pgError('CONNECTION_CLOSED', 'write CONNECTION_CLOSED') },
       { rows: [] },
     ])
-    primePgDb(sqlMock)
+    mockPgForPatch(CATALOG_STREAMER, sqlMock)
 
     const res = await collectionsPatch(
       makePatchRequest({ streamerId: 'streamer-1', oldName: 'weapons', newName: 'armory' })


### PR DESCRIPTION
## 障害

Cards Collections APIが退役済みSupabase admin clientへ到達し、Error Reporter Issue #806を本番で継続発行していました。

## 修正

- GET/PATCHの所有権確認とcatalog取得をDrizzle/PlanetScaleへ固定
- rename_card_pack RPCをpostgres.js経路へ固定し、旧driver flag分岐を削除
- 42703デプロイ窓でも非所有者403、所有者503を維持
- streamer idとsession twitch user idの両方をWHEREに含む認可契約をSQL化してテスト
- 非冪等rename RPCは接続断でも再試行しない

## 検証

- 対象テスト: 45件成功
- 全unit test: success
- typecheck: success
- 対象ESLint: success
- git diff --check: success
- 独立厳格レビュー: BLOCKER/HIGH/MEDIUM/LOWすべて0

Closes #806
Refs #803
Refs #708