### PR TITLE
fix(twitch): 522時のtoken refreshを安全化

### DIFF
--- a/src/app/api/auth/twitch/login/route.ts
+++ b/src/app/api/auth/twitch/login/route.ts
@@ -4,7 +4,6 @@ import { ADDITIONAL_SCOPES } from '@/lib/twitch/scopes'
 import { cookies } from 'next/headers'
 import { checkRateLimit, rateLimits, getClientIp } from '@/lib/rate-limit'
 import { handleAuthError } from '@/lib/auth-error-handler'
-import { reportAuthError } from '@/lib/sentry/error-handler'
 import { setRequestContext, clearUserContext } from '@/lib/sentry/user-context'
 import { ERROR_MESSAGES, STATE_COOKIE_OPTIONS, COOKIE_NAMES } from '@/lib/constants'
 import { getBaseUrl } from '@/lib/url-utils'
@@ -261,11 +260,8 @@ export async function GET(request: Request) {
 
     return NextResponse.json({ authUrl })
   } catch (error) {
-    reportAuthError(error, {
-      provider: 'twitch',
-      action: 'login',
-    })
-    
+    // handleAuthError が唯一の永続化責任点。ここで別途 reportAuthError を呼ぶと
+    // 同一例外が2件の errors 行・自動issueになる。
     // Return JSON for API routes since the frontend expects JSON response
     // フロントエンドがJSONレスポンスを期待しているため、APIルート用にJSONを返す
     return handleAuthError(error, 'unknown_error', { route: 'twitch_login' }, { returnJson: true })

--- a/src/lib/auth-error-handler.ts
+++ b/src/lib/auth-error-handler.ts
@@ -119,7 +119,10 @@ export async function handleAuthError(
   const errorDetails = AUTH_ERROR_MAP[errorType] || AUTH_ERROR_MAP.unknown_error
 
   if (errorDetails.shouldLog) {
-    logger.error(`${errorDetails.message}:`, {
+    // reportAuthError がこの境界の唯一の errors writer。logger.error も内部で
+    // logErrorFromLogger を起動するため、同じ失敗を二重永続化して #810/#811 の
+    // ような重複issueを作る。診断用のconsole出力は warning に留める。
+    logger.warn(`${errorDetails.message}:`, {
       error,
       errorType,
       context,

--- a/src/lib/twitch/auth.ts
+++ b/src/lib/twitch/auth.ts
@@ -6,6 +6,202 @@ const TWITCH_AUTH_URL = 'https://id.twitch.tv/oauth2/authorize'
 const TWITCH_TOKEN_URL = 'https://id.twitch.tv/oauth2/token'
 const TWITCH_API_URL = 'https://api.twitch.tv/helix'
 
+// Twitch の refresh token はローテーションされ得るため、同じ POST を無制限に
+// 再送してはいけない。ここでは一時的な gateway/network 障害だけを、短く上限付きで
+// 再試行する。Retry-After を優先し、無い場合は同時復旧時の集中を避ける full jitter
+// を使う。認可コード交換は単回使用のため、このヘルパーを意図的に使わない。
+const REFRESH_RETRYABLE_STATUSES = new Set([408, 429, 500, 502, 503, 504, 522, 523, 524])
+const MAX_REFRESH_ATTEMPTS = 3
+const MAX_RETRY_AFTER_MS = 2_000
+const RETRY_BASE_DELAY_MS = 100
+
+type RetryAfter = { kind: 'missing' | 'invalid' } | { kind: 'valid'; delayMs: number }
+
+const IMF_FIXDATE = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d{2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d{2}):(\d{2}):(\d{2}) GMT$/
+const RFC850_DATE = /^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), (\d{2})-(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)-(\d{2}) (\d{2}):(\d{2}):(\d{2}) GMT$/
+const ASCTIME_DATE = /^(Mon|Tue|Wed|Thu|Fri|Sat|Sun) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)(?: (\d{2})|  (\d)) (\d{2}):(\d{2}):(\d{2}) (\d{4})$/
+
+const MONTH_INDEX: Record<string, number> = {
+  Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5,
+  Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11,
+}
+const WEEKDAY_INDEX: Record<string, number> = {
+  Sun: 0, Sunday: 0,
+  Mon: 1, Monday: 1,
+  Tue: 2, Tuesday: 2,
+  Wed: 3, Wednesday: 3,
+  Thu: 4, Thursday: 4,
+  Fri: 5, Friday: 5,
+  Sat: 6, Saturday: 6,
+}
+
+interface HttpDateParts {
+  weekday: string
+  day: number
+  month: number
+  year: number
+  hour: number
+  minute: number
+  second: number
+}
+
+function toUtcTimestamp(parts: HttpDateParts, checkWeekday = true): number | null {
+  if (
+    parts.day < 1 || parts.day > 31
+    || parts.hour < 0 || parts.hour > 23
+    || parts.minute < 0 || parts.minute > 59
+    // RFC 5322由来のHTTP-dateはleap secondの60だけを追加で許容する。
+    || parts.second < 0 || parts.second > 60
+  ) {
+    return null
+  }
+
+  const normalizedSecond = Math.min(parts.second, 59)
+  const date = new Date(0)
+  date.setUTCFullYear(parts.year, parts.month, parts.day)
+  date.setUTCHours(parts.hour, parts.minute, normalizedSecond, 0)
+
+  // Date は31 Feb等を翌月へ正規化するため、全componentをround-tripして拒否する。
+  if (
+    date.getUTCFullYear() !== parts.year
+    || date.getUTCMonth() !== parts.month
+    || date.getUTCDate() !== parts.day
+    || date.getUTCHours() !== parts.hour
+    || date.getUTCMinutes() !== parts.minute
+    || date.getUTCSeconds() !== normalizedSecond
+    || (checkWeekday && date.getUTCDay() !== WEEKDAY_INDEX[parts.weekday])
+  ) {
+    return null
+  }
+
+  return date.getTime() + (parts.second === 60 ? 1_000 : 0)
+}
+
+function parseHttpDate(value: string, now: number): number | null {
+  const imf = IMF_FIXDATE.exec(value)
+  if (imf) {
+    return toUtcTimestamp({
+      weekday: imf[1],
+      day: Number(imf[2]),
+      month: MONTH_INDEX[imf[3]],
+      year: Number(imf[4]),
+      hour: Number(imf[5]),
+      minute: Number(imf[6]),
+      second: Number(imf[7]),
+    })
+  }
+
+  const rfc850 = RFC850_DATE.exec(value)
+  if (rfc850) {
+    const nowDate = new Date(now)
+    const currentYear = nowDate.getUTCFullYear()
+    let year = Math.floor(currentYear / 100) * 100 + Number(rfc850[4])
+    // 2桁年は現在を中心とした100年間へ置く。さらに候補timestampが厳密に
+    // 50年超未来なら、RFC 9110 §5.6.7どおり直近の同じ下2桁の過去年へ戻す。
+    if (year < currentYear - 50) year += 100
+    const parts: HttpDateParts = {
+      weekday: rfc850[1],
+      day: Number(rfc850[2]),
+      month: MONTH_INDEX[rfc850[3]],
+      year,
+      hour: Number(rfc850[5]),
+      minute: Number(rfc850[6]),
+      second: Number(rfc850[7]),
+    }
+    const candidate = toUtcTimestamp(parts, false)
+    if (candidate === null) return null
+    const fiftyYearsFromNow = new Date(now)
+    fiftyYearsFromNow.setUTCFullYear(currentYear + 50)
+    if (candidate > fiftyYearsFromNow.getTime()) {
+      parts.year -= 100
+    }
+    return toUtcTimestamp(parts)
+  }
+
+  const asctime = ASCTIME_DATE.exec(value)
+  if (asctime) {
+    return toUtcTimestamp({
+      weekday: asctime[1],
+      month: MONTH_INDEX[asctime[2]],
+      day: Number(asctime[3] ?? asctime[4]),
+      hour: Number(asctime[5]),
+      minute: Number(asctime[6]),
+      second: Number(asctime[7]),
+      year: Number(asctime[8]),
+    })
+  }
+
+  return null
+}
+
+function parseRetryAfter(value: string | null, now = Date.now()): RetryAfter {
+  if (!value) return { kind: 'missing' }
+  // RFC 9110 §10.2.3 の delay-seconds は 1*DIGIT。小数・符号付き値は
+  // Number() なら通るが仕様上は不正なので、HTTP-date の解析へ回す。
+  if (/^\d+$/.test(value)) {
+    const seconds = Number(value)
+    return Number.isSafeInteger(seconds)
+      ? { kind: 'valid', delayMs: seconds * 1_000 }
+      : { kind: 'invalid' }
+  }
+  // Date.parse はRFC外の値・存在しない日付を正規化し、RFC850の2桁年規則も
+  // 実装依存になる。3形式を明示parseし、曜日/calendar/50年規則まで検証する。
+  const retryAt = parseHttpDate(value, now)
+  return retryAt === null
+    ? { kind: 'invalid' }
+    : { kind: 'valid', delayMs: Math.max(0, retryAt - now) }
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function postRefreshToken(body: URLSearchParams): Promise<Response> {
+  for (let attempt = 0; attempt < MAX_REFRESH_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetch(TWITCH_TOKEN_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+      })
+      if (response.ok || !REFRESH_RETRYABLE_STATUSES.has(response.status) || attempt === MAX_REFRESH_ATTEMPTS - 1) {
+        return response
+      }
+
+      const retryAfter = parseRetryAfter(response.headers.get('Retry-After'))
+      // Retry-After は「最低限待つ時間」であり、ローカル上限へ丸めて早く再送すると
+      // RFC 9110 の意味を破る。上限を超える場合はこのリクエスト内では再送せず、
+      // 呼び出し元へ一時失敗を返して次の通常リクエストに委ねる。
+      if (retryAfter.kind === 'valid' && retryAfter.delayMs > MAX_RETRY_AFTER_MS) {
+        logger.warn('Twitch token refresh Retry-After exceeds local retry window', {
+          status: response.status,
+          retryAfterMs: retryAfter.delayMs,
+        })
+        return response
+      }
+      const cap = Math.min(MAX_RETRY_AFTER_MS, RETRY_BASE_DELAY_MS * 2 ** attempt)
+      const delay = retryAfter.kind === 'valid'
+        ? retryAfter.delayMs
+        : Math.floor(Math.random() * (cap + 1))
+      // 本文をログに出さず、再送前に破棄する。Twitch の失敗応答を接続上に滞留させない。
+      await response.text()
+      logger.warn('Twitch token refresh transient failure; retrying', { status: response.status, attempt: attempt + 1, delay })
+      await wait(delay)
+    } catch {
+      if (attempt === MAX_REFRESH_ATTEMPTS - 1) {
+        throw new TwitchTokenRefreshError()
+      }
+      const cap = Math.min(MAX_RETRY_AFTER_MS, RETRY_BASE_DELAY_MS * 2 ** attempt)
+      const delay = Math.floor(Math.random() * (cap + 1))
+      logger.warn('Twitch token refresh network failure; retrying', { attempt: attempt + 1, delay })
+      await wait(delay)
+    }
+  }
+
+  // ループは常に return/throw するが、型検査上の到達不能分岐を明示する。
+  throw new TwitchTokenRefreshError()
+}
+
 export interface TwitchUser {
   id: string
   login: string
@@ -23,15 +219,67 @@ export interface TwitchTokens {
   scope: string[]
 }
 
+function isTwitchTokens(value: unknown): value is TwitchTokens {
+  if (!value || typeof value !== 'object') return false
+  const tokens = value as Record<string, unknown>
+  return typeof tokens.access_token === 'string'
+    && tokens.access_token.length > 0
+    && typeof tokens.refresh_token === 'string'
+    && tokens.refresh_token.length > 0
+    && typeof tokens.expires_in === 'number'
+    && Number.isFinite(tokens.expires_in)
+    && tokens.expires_in >= 0
+    && typeof tokens.token_type === 'string'
+    && tokens.token_type.length > 0
+    && Array.isArray(tokens.scope)
+    && tokens.scope.every(scope => typeof scope === 'string')
+}
+
+async function parseTwitchTokens(
+  response: Response,
+  createSafeError: () => Error,
+): Promise<TwitchTokens> {
+  try {
+    // Response.json() の SyntaxError は不正JSONの本文断片を message に含める実装がある。
+    // token endpoint は入力値や資格情報を反射し得るため、本文はローカル変数内だけで
+    // JSON.parse し、失敗時は元例外を捨てた固定エラーへ置換する。
+    const parsed: unknown = JSON.parse(await response.text())
+    if (isTwitchTokens(parsed)) return parsed
+  } catch {
+    // JSON/stream の元例外は Error.cause にも保持しない。永続 writer まで届くのは
+    // createSafeError() が生成する status/kind だけのエラーでなければならない。
+  }
+  throw createSafeError()
+}
+
 export class TwitchOAuthTokenExchangeError extends Error {
   constructor(
     message: string,
     public readonly status: number,
-    public readonly errorBody: string,
     public readonly isInvalidAuthorizationCode: boolean
   ) {
     super(message)
     this.name = 'TwitchOAuthTokenExchangeError'
+  }
+}
+
+/**
+ * Token endpoint の失敗本文はプロバイダが入力値を反射する可能性があるため保持しない。
+ * status のみを公開し、Error.message / logger / errors context / BOT last_error のどこにも
+ * access token・refresh token・client secret が流れない境界を型として固定する。
+ */
+export class TwitchTokenRefreshError extends Error {
+  constructor(
+    public readonly status?: number,
+    public readonly retryable = status === undefined || REFRESH_RETRYABLE_STATUSES.has(status),
+    public readonly kind: 'network' | 'http' | 'invalid_response' = status === undefined ? 'network' : 'http',
+  ) {
+    super(kind === 'invalid_response'
+      ? 'Failed to refresh authentication token: invalid response'
+      : status === undefined
+        ? 'Failed to refresh authentication token: network error'
+        : `Failed to refresh authentication token: ${status}`)
+    this.name = 'TwitchTokenRefreshError'
   }
 }
 
@@ -127,23 +375,32 @@ export async function exchangeCodeForTokens(
     const invalidAuthorizationCode = isInvalidAuthorizationCodeResponse(response.status, errorBody)
 
     if (invalidAuthorizationCode) {
-      // OAuth code is single-use and short-lived; retries/replays are expected client behavior.
-      // Log as warning to avoid noisy issue generation.
+      // OAuth code is single-use and short-lived; callback は再送せず新しい認可を求める。
+      // 利用者操作で起こり得る失敗なので warning に留める。
       logger.warn('Token exchange rejected: invalid or expired authorization code', { status: response.status })
     } else {
-      logger.error('Token exchange failed:', { status: response.status, errorBody })
+      // callback 側の handleAuthError が await reportAuthError で永続化する。
+      // ここで logger.error を使うと logger の自動永続化と二重になり #810/#811 の
+      // 同一障害 issue を作るため、診断用コンソール出力だけに留める。
+      logger.warn('Token exchange failed:', { status: response.status })
     }
-    // Twitch APIの拒否理由（コード期限切れ、redirect URI不一致等）をエラーメッセージに含める
-    // 呼び出し元のhandleAuthError経由でSupabase/GitHub Issuesに詳細が記録される
+    // Token endpoint 本文は入力値・資格情報を反射し得るため、拒否理由そのものは
+    // Errorへ含めずstatusと安全な分類だけをcallbackのhandleAuthErrorへ渡す。
     throw new TwitchOAuthTokenExchangeError(
-      `Authentication failed: ${response.status} ${errorBody}`,
+      `Authentication failed: ${response.status}`,
       response.status,
-      errorBody,
       invalidAuthorizationCode
     )
   }
 
-  return response.json()
+  return parseTwitchTokens(
+    response,
+    () => new TwitchOAuthTokenExchangeError(
+      'Authentication failed: invalid token response',
+      response.status,
+      false,
+    ),
+  )
 }
 
 export async function getTwitchUser(accessToken: string): Promise<TwitchUser> {
@@ -173,25 +430,28 @@ export async function refreshTwitchToken(
   const clientId = getEnvVar('NEXT_PUBLIC_TWITCH_CLIENT_ID', true)!
   const clientSecret = getEnvVar('TWITCH_CLIENT_SECRET', true)!
 
-  const response = await fetch(TWITCH_TOKEN_URL, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-    },
-    body: new URLSearchParams({
-      client_id: clientId,
-      client_secret: clientSecret,
-      refresh_token: refreshToken,
-      grant_type: 'refresh_token',
-    }),
-  })
+  const response = await postRefreshToken(new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+    grant_type: 'refresh_token',
+  }))
 
   if (!response.ok) {
-    const errorBody = await response.text()
-    logger.error('Token refresh failed:', { status: response.status, errorBody })
-    // Twitch APIのエラー詳細をメッセージに含め、呼び出し元で原因を特定可能にする
-    throw new Error(`Failed to refresh authentication token: ${response.status} ${errorBody}`)
+    // 本文は接続を解放するため読むが、Error・ログ・永続化contextには保持しない。
+    await response.text()
+    // 400/401 は失効した refresh token 等の恒久エラーなので postRefreshToken は再送しない。
+    // 応答本文は監視経路へ流さない。プロバイダが入力値を反射しても機密情報を残さないため。
+    // 呼び出し側がユーザー/BOT の識別子を付けて失敗を永続化するため、ここは
+    // console-only warning にする。低レベル層でも error にすると同じ障害が二重起票される。
+    logger.warn('Token refresh failed:', { status: response.status })
+    throw new TwitchTokenRefreshError(response.status)
   }
 
-  return response.json()
+  return parseTwitchTokens(
+    response,
+    // 2xxでも本文が壊れている場合は資格情報そのものの恒久失効とは断定できない。
+    // BOTを無効化せず、次の通常リクエストで回復を試せる一時失敗として分類する。
+    () => new TwitchTokenRefreshError(response.status, true, 'invalid_response'),
+  )
 }

--- a/src/lib/twitch/token-manager.ts
+++ b/src/lib/twitch/token-manager.ts
@@ -1,6 +1,6 @@
 import { getSupabaseAdmin } from '@/lib/supabase/admin';
 import { withRetry } from '@/lib/supabase/retry';
-import { refreshTwitchToken, type TwitchTokens } from './auth';
+import { refreshTwitchToken, TwitchTokenRefreshError, type TwitchTokens } from './auth';
 import { logger } from '@/lib/logger';
 // -----------------------------------------------------------------------------
 // #572 (#570 パイロット踏襲): pg 直結経路。
@@ -43,6 +43,24 @@ export class TwitchTokenError extends Error {
     super(message);
     this.name = 'TwitchTokenError';
   }
+}
+
+// Cloudflare Workers の fetch/DB I/O はリクエストコンテキストに所属するため、pending
+// Promise をmodule scopeへ保存して別リクエストからawaitしてはいけない。並行refreshは
+// token endpointまで各リクエスト内で完結させ、保存時に「交換に使用した旧refresh token」
+// を条件とするDB CASだけで競合を解決する。CAS loserはwinnerのaccess tokenを再読込するため
+// ローテーション済み資格情報を上書きしない。Durable Objectによる分散直列化は、現時点では
+// DB CASで整合性を満たせるためYAGNIとし、request-scoped I/O境界を優先する。
+
+function shouldDisableBotCredential(error: unknown): boolean {
+  // Twitch が資格情報の失効を示す400/401だけを再認証対象にする。403/404/501等は
+  // client設定・WAF・上流機能の問題でも起こるため、単にretry対象外という理由だけで
+  // BOTを無効化してはいけない（retry方針とcredential失効判定は別の責務）。
+  // 522/network/壊れた2xx応答やDB保存障害で status='error' にすると、取得クエリの
+  // active filterから永久除外され、障害復旧後も自動再試行できなくなる。
+  return error instanceof TwitchTokenRefreshError
+    && error.kind === 'http'
+    && (error.status === 400 || error.status === 401);
 }
 
 /**
@@ -422,9 +440,10 @@ async function getBotAccountForChatPg(broadcasterTwitchUserId: string): Promise<
   try {
     const tokens = await refreshTwitchToken(account.twitch_refresh_token);
     const refreshedExpiresAt = new Date(Date.now() + tokens.expires_in * 1000);
+    let accessToken = tokens.access_token;
 
     try {
-      await withDbRetry(
+      const updated = await withDbRetry(
         async () => {
           const { db } = await getDb();
           return db
@@ -437,17 +456,39 @@ async function getBotAccountForChatPg(broadcasterTwitchUserId: string): Promise<
               status: 'active',
               last_error: null,
             })
-            .where(eq(twitchBotAccountsTable.id, account.id));
+            .where(and(
+              eq(twitchBotAccountsTable.id, account.id),
+              eq(twitchBotAccountsTable.twitch_refresh_token, account.twitch_refresh_token),
+            ))
+            .returning({ twitch_access_token: twitchBotAccountsTable.twitch_access_token });
         },
         'getBotAccountForChat(save refreshed token)',
-        // リトライしても同じトークン値を書く UPDATE のため冪等（リトライ可）
+        // 旧 refresh token 条件付きCASなので、isolate間競合・接続断後の再試行でも
+        // 後勝ちの古い資格情報が新しいローテーション結果を上書きしない。
         { idempotent: true },
       );
-    } catch (error) {
-      if (!isMissingBotSchemaErrorPg(error)) {
-        // 外側の catch で status:'error' 保存 + null 返却（既存経路と同じ流れ）
-        throw error;
+
+      if (updated.length === 0) {
+        const winner = await withDbRetry(
+          async () => {
+            const { db } = await getDb();
+            return db
+              .select({ twitch_access_token: twitchBotAccountsTable.twitch_access_token })
+              .from(twitchBotAccountsTable)
+              .where(eq(twitchBotAccountsTable.id, account.id))
+              .limit(1);
+          },
+          'getBotAccountForChat(read CAS winner)',
+          { idempotent: true },
+        );
+        const winnerAccessToken = winner[0]?.twitch_access_token;
+        if (!winnerAccessToken) {
+          throw new Error('Concurrent BOT token refresh winner is unavailable');
+        }
+        accessToken = winnerAccessToken;
       }
+    } catch (error) {
+      if (!isMissingBotSchemaErrorPg(error)) throw error;
       logger.warn('Twitch BOT accounts table not found in schema, returning refreshed token without saving', {
         broadcasterTwitchUserId,
       });
@@ -458,32 +499,34 @@ async function getBotAccountForChatPg(broadcasterTwitchUserId: string): Promise<
       senderId: account.twitch_user_id,
       username: account.twitch_username,
       displayName: account.twitch_display_name,
-      accessToken: tokens.access_token,
+      accessToken,
       ownerType: account.owner_type,
     };
   } catch (error) {
-    logger.error('Failed to refresh BOT Twitch access token', { broadcasterTwitchUserId, error });
-    // 既存 postgrest 経路はこの update の結果（error）を確認せず無視する（best-effort）。
-    // pg 直結では失敗が throw になるため catch で握りつぶし、「必ず null を返す」
-    // 同じ外部挙動に合わせる（ここで throw すると経路によって呼び出し元の挙動が変わる）。
-    try {
-      await withDbRetry(
-        async () => {
-          const { db } = await getDb();
-          return db
-            .update(twitchBotAccountsTable)
-            .set({
-              status: 'error',
-              last_error: error instanceof Error ? error.message : String(error),
-            })
-            .where(eq(twitchBotAccountsTable.id, account.id));
-        },
-        'getBotAccountForChat(save error status)',
-        // リトライしても同じ値（catch 済みエラーの文字列）を書く UPDATE のため冪等
-        { idempotent: true },
-      );
-    } catch {
-      // best-effort 書き込みの失敗は無視（既存経路がエラーを確認しないのと同等）
+    // Token endpoint 本文や下位例外は永続化せず、固定理由だけを1回記録する。
+    logger.error('Failed to refresh BOT Twitch access token', {
+      broadcasterTwitchUserId,
+      accountId: account.id,
+    });
+    if (shouldDisableBotCredential(error)) {
+      try {
+        await withDbRetry(
+          async () => {
+            const { db } = await getDb();
+            return db
+              .update(twitchBotAccountsTable)
+              .set({ status: 'error', last_error: 'token_refresh_failed' })
+              .where(and(
+                eq(twitchBotAccountsTable.id, account.id),
+                eq(twitchBotAccountsTable.twitch_refresh_token, account.twitch_refresh_token),
+              ));
+          },
+          'getBotAccountForChat(save error status)',
+          { idempotent: true },
+        );
+      } catch {
+        // best-effort。エラー状態保存の失敗で chat 呼出しへ例外を追加しない。
+      }
     }
     return null;
   }
@@ -609,28 +652,29 @@ export async function getBotAccountForChat(broadcasterTwitchUserId: string): Pro
   if (!botAccount) {
     return null;
   }
+  const account = botAccount;
 
-  const expiresAt = new Date(botAccount.twitch_token_expires_at);
+  const expiresAt = new Date(account.twitch_token_expires_at);
   if (isNaN(expiresAt.getTime())) {
     return null;
   }
 
   if (expiresAt > new Date()) {
     return {
-      accountId: botAccount.id,
-      senderId: botAccount.twitch_user_id,
-      username: botAccount.twitch_username,
-      displayName: botAccount.twitch_display_name,
-      accessToken: botAccount.twitch_access_token,
-      ownerType: botAccount.owner_type,
+      accountId: account.id,
+      senderId: account.twitch_user_id,
+      username: account.twitch_username,
+      displayName: account.twitch_display_name,
+      accessToken: account.twitch_access_token,
+      ownerType: account.owner_type,
     };
   }
 
   try {
-    const tokens = await refreshTwitchToken(botAccount.twitch_refresh_token);
+    const tokens = await refreshTwitchToken(account.twitch_refresh_token);
     const refreshedExpiresAt = new Date(Date.now() + tokens.expires_in * 1000);
 
-    const { error } = await supabaseAdmin
+    const { data: updated, error } = await supabaseAdmin
       .from('twitch_bot_accounts')
       .update({
         twitch_access_token: tokens.access_token,
@@ -640,34 +684,56 @@ export async function getBotAccountForChat(broadcasterTwitchUserId: string): Pro
         status: 'active',
         last_error: null,
       })
-      .eq('id', botAccount.id);
+      .eq('id', account.id)
+      .eq('twitch_refresh_token', account.twitch_refresh_token)
+      .select('twitch_access_token')
+      .maybeSingle();
 
-    if (error && !isMissingBotSchemaError(error)) {
-      throw error;
-    }
+    if (error && !isMissingBotSchemaError(error)) throw error;
     if (isMissingBotSchemaError(error)) {
       logger.warn('Twitch BOT accounts table not found in schema, returning refreshed token without saving', {
         broadcasterTwitchUserId,
       });
     }
 
+    let accessToken = updated?.twitch_access_token as string | undefined;
+    if (!error && !accessToken) {
+      const { data: winner, error: winnerError } = await supabaseAdmin
+        .from('twitch_bot_accounts')
+        .select('twitch_access_token')
+        .eq('id', account.id)
+        .maybeSingle();
+      if (winnerError || !winner?.twitch_access_token) {
+        throw new Error('Concurrent BOT token refresh winner is unavailable');
+      }
+      accessToken = winner.twitch_access_token;
+    }
+
     return {
-      accountId: botAccount.id,
-      senderId: botAccount.twitch_user_id,
-      username: botAccount.twitch_username,
-      displayName: botAccount.twitch_display_name,
-      accessToken: tokens.access_token,
-      ownerType: botAccount.owner_type,
+      accountId: account.id,
+      senderId: account.twitch_user_id,
+      username: account.twitch_username,
+      displayName: account.twitch_display_name,
+      accessToken: accessToken ?? tokens.access_token,
+      ownerType: account.owner_type,
     };
   } catch (error) {
-    logger.error('Failed to refresh BOT Twitch access token', { broadcasterTwitchUserId, error });
-    await supabaseAdmin
-      .from('twitch_bot_accounts')
-      .update({
-        status: 'error',
-        last_error: error instanceof Error ? error.message : String(error),
-      })
-      .eq('id', botAccount.id);
+    logger.error('Failed to refresh BOT Twitch access token', {
+      broadcasterTwitchUserId,
+      accountId: account.id,
+    });
+    if (shouldDisableBotCredential(error)) {
+      try {
+        await supabaseAdmin
+          .from('twitch_bot_accounts')
+          .update({ status: 'error', last_error: 'token_refresh_failed' })
+          .eq('id', account.id)
+          .eq('twitch_refresh_token', account.twitch_refresh_token);
+      } catch {
+        // PostgREST transport reject も best-effort として吸収し、PG経路と同じく
+        // chat 呼出しへ二次例外を伝播させたり別のAPI writerを増やしたりしない。
+      }
+    }
     return null;
   }
 }
@@ -796,18 +862,20 @@ export async function getCustomBotAccountDisplayForStreamer(
  * refreshTwitchAccessToken の pg 直結実装 (#572)
  *
  * users への UPDATE（書き込み）を含む関数のため、呼び出し元は isPgWriteEnabled() で
- * 関数全体を分岐する。スコープ同期（saveTwitchScopes）は共有関数のまま呼び、その
- * 内部で再度フラグ分岐される。PGRST204（トークン列未デプロイ）のデプロイ窓
- * フォールバックは、pg 直結では UPDATE 対象列の欠落が SQLSTATE 42703 になるため
- * isPgMissingColumnError で再現する（トークン値はログに出さない既存慣習を踏襲）。
+ * 関数全体を分岐する。tokenとscopeは同じCAS UPDATEへ統合し、OAuth callbackが
+ * 並行して保存した新しいtoken/scopeを旧refresh結果の後続UPDATEで上書きしない。
+ * PGRST204（トークン列未デプロイ）のデプロイ窓フォールバックは、pg 直結では
+ * UPDATE対象列の欠落がSQLSTATE 42703になるためisPgMissingColumnErrorで再現する。
  */
 async function refreshTwitchAccessTokenPg(twitchUserId: string, refreshToken: string): Promise<string> {
   try {
     const tokens = await refreshTwitchToken(refreshToken);
     const expiresAt = new Date(Date.now() + tokens.expires_in * 1000);
+    let wonRefreshRace = false;
+    let accessToken = tokens.access_token;
 
     try {
-      await withDbRetry(
+      const updated = await withDbRetry(
         async () => {
           // 規約: getDb() は queryFn の中で呼ぶ（src/lib/db/retry.ts 参照）
           const { db } = await getDb();
@@ -817,20 +885,43 @@ async function refreshTwitchAccessTokenPg(twitchUserId: string, refreshToken: st
               twitch_access_token: tokens.access_token,
               twitch_refresh_token: tokens.refresh_token,
               twitch_token_expires_at: expiresAt.toISOString(),
+              twitch_scopes: tokens.scope ?? [],
             })
-            .where(eq(usersTable.twitch_user_id, twitchUserId));
+            // requestを跨いだPromise共有はWorkersで禁止されるため、交換に使った旧
+            // refresh tokenがまだ現行値の場合だけtoken/scopeを原子的に保存する。
+            // 接続断後のDB retryでも
+            // 1回目が成功済みなら2回目は0件となり、winnerの値を再取得できる。
+            .where(and(
+              eq(usersTable.twitch_user_id, twitchUserId),
+              eq(usersTable.twitch_refresh_token, refreshToken),
+            ))
+            .returning({ twitch_access_token: usersTable.twitch_access_token });
         },
         'refreshTwitchAccessToken(save)',
-        // リトライしても同じトークン値を書く UPDATE のため冪等（リトライ可）。
-        // なお、このリトライは同一呼び出し内の再送としては冪等だが、リトライ待機
-        // （バックオフ合計で最大約1.4秒 = 100+300+1000ms）の間に別リクエストの並行
-        // リフレッシュが新しいトークンを書き込んだ場合、古い値で上書きする競合窓を
-        // 広げる側面がある。この競合自体は postgrest 経路の並行リフレッシュにも
-        // 存在する既知の性質であり（検知手段のないブラインド UPDATE）、リトライ禁止に
-        // すると一時障害だけで確実にトークンが失われる方が害が大きいため、リトライを
-        // 許容する。根本対応（楽観ロック）は Phase 2 以降の検討事項。
+        // CAS は再実行時に旧値が一致しなくなるため、接続断後も安全にリトライ可能。
         { idempotent: true },
       );
+      wonRefreshRace = updated.length > 0;
+
+      if (!wonRefreshRace) {
+        const winner = await withDbRetry(
+          async () => {
+            const { db } = await getDb();
+            return db
+              .select({ twitch_access_token: usersTable.twitch_access_token })
+              .from(usersTable)
+              .where(eq(usersTable.twitch_user_id, twitchUserId))
+              .limit(1);
+          },
+          'refreshTwitchAccessToken(read CAS winner)',
+          { idempotent: true },
+        );
+        const winnerAccessToken = winner[0]?.twitch_access_token;
+        if (!winnerAccessToken) {
+          throw new Error('Concurrent Twitch token refresh winner is unavailable');
+        }
+        accessToken = winnerAccessToken;
+      }
     } catch (error) {
       if (isPgMissingColumnError(error)) {
         logger.warn('Twitch token columns not found in schema, returning token without saving', { twitchUserId, error });
@@ -839,27 +930,14 @@ async function refreshTwitchAccessTokenPg(twitchUserId: string, refreshToken: st
       throw error;
     }
 
-    // リフレッシュレスポンスのスコープで DB を全置換する（best-effort）。
-    // 設計判断の詳細は postgrest 経路（下の refreshTwitchAccessToken 本体）の
-    // 同箇所コメントを参照（DB/トークン乖離の永続化防止のための全置換）。
-    if (tokens.scope && tokens.scope.length > 0) {
-      try {
-        await saveTwitchScopes(twitchUserId, tokens.scope);
-      } catch (scopeSaveError) {
-        logger.warn('Failed to sync scopes on token refresh (best-effort)', {
-          twitchUserId,
-          error: scopeSaveError instanceof Error ? scopeSaveError.message : String(scopeSaveError),
-        });
-      }
-    }
-
-    return tokens.access_token;
-  } catch (error) {
-    logger.error('Failed to refresh Twitch access token', { twitchUserId, error });
+    return accessToken;
+  } catch {
+    // 永続化責任は bootstrap/rewards/callback 等の API 境界に統一する。ここで
+    // logger.error を使うと同じ例外を下位層と境界の双方が errors へ書く。
+    logger.warn('Failed to refresh Twitch access token', { twitchUserId });
     throw new TwitchTokenError(
       'Failed to refresh Twitch access token',
-      'REFRESH_FAILED',
-      error instanceof Error ? error : undefined
+      'REFRESH_FAILED'
     );
   }
 }
@@ -875,14 +953,18 @@ async function refreshTwitchAccessToken(twitchUserId: string, refreshToken: stri
     const expiresAt = new Date(Date.now() + tokens.expires_in * 1000);
 
     const supabaseAdmin = getSupabaseAdmin();
-    const { error } = await supabaseAdmin
+    const { data: updated, error } = await supabaseAdmin
       .from('users')
       .update({
         twitch_access_token: tokens.access_token,
         twitch_refresh_token: tokens.refresh_token,
         twitch_token_expires_at: expiresAt.toISOString(),
+        twitch_scopes: tokens.scope ?? [],
       })
-      .eq('twitch_user_id', twitchUserId);
+      .eq('twitch_user_id', twitchUserId)
+      .eq('twitch_refresh_token', refreshToken)
+      .select('twitch_access_token')
+      .maybeSingle();
 
     if (error) {
       // If columns don't exist (PGRST204), just return the token without saving
@@ -892,36 +974,27 @@ async function refreshTwitchAccessToken(twitchUserId: string, refreshToken: stri
       }
       throw error;
     }
+    let accessToken = updated?.twitch_access_token as string | undefined;
+    const wonRefreshRace = Boolean(accessToken);
 
-    // リフレッシュレスポンスのスコープでDBを全置換する（best-effort）
-    // Twitchのrefreshレスポンスはトークンの実スコープを返す（公式ドキュメント準拠）。
-    // 以前はDBスコープとマージしていたが、トークンにないスコープがDBに残ると
-    // DB/トークン乖離が永続化し401エラーの原因になるため、全置換に変更。
-    // callbackの自動リダイレクト機構により、追加スコープはログイン時に復元される。
-    //
-    // Full replace DB scopes with refresh response scopes (best-effort).
-    // Twitch refresh response returns actual token scopes (per official docs).
-    // Previously merged with DB scopes, but stale DB scopes cause permanent
-    // DB/token divergence and repeated 401 errors. Full replace keeps DB in sync.
-    // Callback's auto-redirect mechanism recovers additional scopes on login.
-    if (tokens.scope && tokens.scope.length > 0) {
-      try {
-        await saveTwitchScopes(twitchUserId, tokens.scope);
-      } catch (scopeSaveError) {
-        logger.warn('Failed to sync scopes on token refresh (best-effort)', {
-          twitchUserId,
-          error: scopeSaveError instanceof Error ? scopeSaveError.message : String(scopeSaveError),
-        });
+    if (!wonRefreshRace) {
+      const { data: winner, error: winnerError } = await supabaseAdmin
+        .from('users')
+        .select('twitch_access_token')
+        .eq('twitch_user_id', twitchUserId)
+        .maybeSingle();
+      if (winnerError || !winner?.twitch_access_token) {
+        throw new Error('Concurrent Twitch token refresh winner is unavailable');
       }
+      accessToken = winner.twitch_access_token;
     }
 
-    return tokens.access_token;
-  } catch (error) {
-    logger.error('Failed to refresh Twitch access token', { twitchUserId, error });
+    return accessToken!;
+  } catch {
+    logger.warn('Failed to refresh Twitch access token', { twitchUserId });
     throw new TwitchTokenError(
       'Failed to refresh Twitch access token',
-      'REFRESH_FAILED',
-      error instanceof Error ? error : undefined
+      'REFRESH_FAILED'
     );
   }
 }

--- a/tests/unit/token-manager-driver-parity.test.ts
+++ b/tests/unit/token-manager-driver-parity.test.ts
@@ -9,7 +9,7 @@
  * フルスイートは実行せず、このファイル（と関連する変更分）のみを対象とする。
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import {
   getTwitchAccessToken,
   getBotAccountForChat,
@@ -21,14 +21,20 @@ import {
   saveTwitchScopes,
 } from '@/lib/twitch/token-manager'
 import { getSupabaseAdmin } from '@/lib/supabase/admin'
-import { refreshTwitchToken } from '@/lib/twitch/auth'
+import { refreshTwitchToken, TwitchTokenRefreshError } from '@/lib/twitch/auth'
 import { getDb } from '@/lib/db/client'
 import {
   twitchBotAccounts as twitchBotAccountsTable,
   users as usersTable,
 } from '@/lib/db/schema'
 
-vi.mock('@/lib/twitch/auth')
+// 自動モックは Error subclass の constructor を vi.fn に置換し、status を失わせる。
+// token-manager は 4xx/5xx の恒久性を `TwitchTokenRefreshError.status` で判定するため、
+// 実クラスを保持したまま、外部 I/O を行う refresh 関数だけを差し替える。
+vi.mock('@/lib/twitch/auth', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/twitch/auth')>()
+  return { ...actual, refreshTwitchToken: vi.fn() }
+})
 // logger.error は実装だと Supabase errors パイプラインへ fire-and-forget するため、
 // テストでは副作用のないモックに差し替える（dashboard-data-driver-parity と同じ）
 vi.mock('@/lib/logger', () => ({
@@ -45,6 +51,7 @@ vi.mock('@/lib/logger', () => ({
 interface PostgrestResult {
   data?: unknown
   error?: unknown
+  reject?: unknown
 }
 
 function createSupabaseClientMock(resultsByTable: Record<string, PostgrestResult[]>) {
@@ -52,6 +59,10 @@ function createSupabaseClientMock(resultsByTable: Record<string, PostgrestResult
     Object.entries(resultsByTable).map(([table, results]) => [table, [...results]])
   )
   const updateCalls: Array<{ table: string; values: Record<string, unknown> }> = []
+  const updateFilterCalls: Array<{
+    table: string
+    filters: Array<{ column: string; value: unknown }>
+  }> = []
   const from = vi.fn((table: string) => {
     const queue = queues[table]
     if (!queue || queue.length === 0) {
@@ -59,23 +70,34 @@ function createSupabaseClientMock(resultsByTable: Record<string, PostgrestResult
     }
     const result = queue.length > 1 ? (queue.shift() as PostgrestResult) : queue[0]
     const resolved = { data: result.data ?? null, error: result.error ?? null }
+    const resolve = () => result.reject === undefined
+      ? Promise.resolve(resolved)
+      : Promise.reject(result.reject)
+    let activeUpdateFilters: Array<{ column: string; value: unknown }> | null = null
     const builder: any = {
       select: vi.fn(() => builder),
-      eq: vi.fn(() => builder),
+      eq: vi.fn((column: string, value: unknown) => {
+        // CASの安全性はUPDATEのID条件と旧refresh token条件の両方に依存する。
+        // 読み取りチェーンのeqは混ぜず、update()後のfilterだけを記録する。
+        activeUpdateFilters?.push({ column, value })
+        return builder
+      }),
       order: vi.fn(() => builder),
       limit: vi.fn(() => builder),
       update: vi.fn((values: Record<string, unknown>) => {
         updateCalls.push({ table, values })
+        activeUpdateFilters = []
+        updateFilterCalls.push({ table, filters: activeUpdateFilters })
         return builder
       }),
-      maybeSingle: vi.fn(() => Promise.resolve(resolved)),
-      single: vi.fn(() => Promise.resolve(resolved)),
+      maybeSingle: vi.fn(resolve),
+      single: vi.fn(resolve),
       then: (onFulfilled: any, onRejected: any) =>
-        Promise.resolve(resolved).then(onFulfilled, onRejected),
+        resolve().then(onFulfilled, onRejected),
     }
     return builder
   })
-  return { from, updateCalls }
+  return { from, updateCalls, updateFilterCalls }
 }
 
 // ---------------------------------------------------------------------------
@@ -234,7 +256,7 @@ describe('token-manager: postgrest / pg 経路の互換 (#572)', () => {
       await expect(getTwitchAccessToken('123456789')).resolves.toBeNull()
     })
 
-    it('DB_DRIVER=pg: 期限切れ時のリフレッシュ保存とスコープ全置換が users へ正しい set/where で UPDATE される', async () => {
+    it('DB_DRIVER=pg: tokenとscopeを同じCAS UPDATEで保存し、無条件の後続scope UPDATEを行わない', async () => {
       vi.stubEnv('DB_DRIVER', 'pg')
       vi.mocked(refreshTwitchToken).mockResolvedValue(REFRESHED_TOKENS)
       const pg = createDrizzleDbMock({
@@ -245,24 +267,113 @@ describe('token-manager: postgrest / pg 経路の互換 (#572)', () => {
       const token = await getTwitchAccessToken('123456789')
 
       expect(token).toBe('new-token')
-      // 1回目: refreshTwitchAccessTokenPg のトークン保存
+      // OAuth callback の新しい scope を古い refresh 処理が後から上書きしないよう、
+      // token と scope は旧 refresh token 条件付きの1回の UPDATE にまとめる。
+      expect(pg.updateCalls).toHaveLength(1)
       expect(pg.updateCalls[0].table).toBe(usersTable)
       expect(pg.updateCalls[0].set).toEqual({
         twitch_access_token: 'new-token',
         twitch_refresh_token: 'new-refresh-token',
         twitch_token_expires_at: expect.any(String),
+        twitch_scopes: ['user:read:email'],
       })
-      expect(pg.updateCalls[0].where).toEqual(eq(usersTable.twitch_user_id, '123456789'))
-      // 2回目: saveTwitchScopesPg のスコープ全置換
-      expect(pg.updateCalls[1].table).toBe(usersTable)
-      expect(pg.updateCalls[1].set).toEqual({ twitch_scopes: ['user:read:email'] })
-      expect(pg.updateCalls[1].where).toEqual(eq(usersTable.twitch_user_id, '123456789'))
+      expect(pg.updateCalls[0].where).toEqual(and(
+        eq(usersTable.twitch_user_id, '123456789'),
+        eq(usersTable.twitch_refresh_token, 'refresh-token'),
+      ))
+    })
+
+    it('同一userの2並行refreshは2回交換し、CAS loserもwinner tokenを返して後続UPDATEしない', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+      const loserTokens = {
+        ...REFRESHED_TOKENS,
+        access_token: 'loser-access-token',
+        refresh_token: 'loser-refresh-token',
+        scope: ['loser:scope'],
+      }
+      const winnerTokens = {
+        ...REFRESHED_TOKENS,
+        access_token: 'winner-access-token',
+        refresh_token: 'winner-refresh-token',
+        scope: ['winner:scope'],
+      }
+      vi.mocked(refreshTwitchToken)
+        .mockResolvedValueOnce(winnerTokens)
+        .mockResolvedValueOnce(loserTokens)
+      const pg = createDrizzleDbMock({
+        selects: [
+          { rows: [{ ...VALID_USER_TOKEN_ROW, twitch_token_expires_at: PAST_ISO }] },
+          { rows: [{ ...VALID_USER_TOKEN_ROW, twitch_token_expires_at: PAST_ISO }] },
+          { rows: [{ twitch_access_token: 'winner-access-token' }] },
+        ],
+        updates: [
+          { rows: [{ twitch_access_token: 'winner-access-token' }] },
+          { rows: [] },
+        ],
+      })
+      primePgDb(pg)
+
+      const results = await Promise.all([
+        getTwitchAccessToken('123456789'),
+        getTwitchAccessToken('123456789'),
+      ])
+
+      expect(refreshTwitchToken).toHaveBeenCalledTimes(2)
+      expect(results).toEqual(['winner-access-token', 'winner-access-token'])
+      expect(pg.updateCalls).toHaveLength(2)
+      expect(pg.updateCalls[0].set).toMatchObject({
+        twitch_access_token: 'winner-access-token',
+        twitch_refresh_token: 'winner-refresh-token',
+        twitch_scopes: ['winner:scope'],
+      })
+      for (const call of pg.updateCalls) {
+        // loser の書込み試行も同じ旧 refresh token を条件とするため、winner が
+        // rotation を保存した後は0件となり、資格情報もscopeも上書きできない。
+        expect(call.where).toEqual(and(
+          eq(usersTable.twitch_user_id, '123456789'),
+          eq(usersTable.twitch_refresh_token, 'refresh-token'),
+        ))
+      }
+      expect(pg.updateCalls[1].set).toMatchObject({
+        twitch_access_token: 'loser-access-token',
+        twitch_refresh_token: 'loser-refresh-token',
+        twitch_scopes: ['loser:scope'],
+      })
+      // CAS後にscopeだけを無条件保存する3回目のUPDATEが無いことが、
+      // callbackが保存した新scopeとのinterleaving回帰を構造的に防ぐ。
+      expect(pg.updateCalls).toHaveLength(2)
+    })
+
+    it('PostgRESTでもCAS loserはwinnerのaccess tokenを再読込する', async () => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      vi.mocked(refreshTwitchToken).mockResolvedValue({ ...REFRESHED_TOKENS, scope: [] })
+      const client = createSupabaseClientMock({
+        users: [
+          { data: { ...VALID_USER_TOKEN_ROW, twitch_token_expires_at: PAST_ISO } },
+          { data: null },
+          { data: { twitch_access_token: 'postgrest-winner-token' } },
+        ],
+      })
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+
+      await expect(getTwitchAccessToken('123456789')).resolves.toBe('postgrest-winner-token')
+      expect(client.updateCalls).toHaveLength(1)
+      expect(client.updateFilterCalls).toEqual([{
+        table: 'users',
+        filters: [
+          { column: 'twitch_user_id', value: '123456789' },
+          { column: 'twitch_refresh_token', value: 'refresh-token' },
+        ],
+      }])
     })
 
     it('DB_DRIVER=pg-read: 読み取りは pg・期限切れ時のトークン保存は postgrest のまま（フラグ使い分けの検証）', async () => {
       vi.stubEnv('DB_DRIVER', 'pg-read')
       vi.mocked(refreshTwitchToken).mockResolvedValue({ ...REFRESHED_TOKENS, scope: [] })
-      const client = createSupabaseClientMock({ users: [{ data: null }] })
+      // pg-read の refresh 保存は PostgREST CAS の更新結果を返す。
+      const client = createSupabaseClientMock({
+        users: [{ data: { twitch_access_token: 'new-token' } }],
+      })
       vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
       const pg = createDrizzleDbMock({
         selects: [{ rows: [{ ...VALID_USER_TOKEN_ROW, twitch_token_expires_at: PAST_ISO }] }],
@@ -272,9 +383,24 @@ describe('token-manager: postgrest / pg 経路の互換 (#572)', () => {
       const token = await getTwitchAccessToken('123456789')
 
       expect(token).toBe('new-token')
-      // 書き込み（トークン保存）は postgrest 経路（refreshTwitchAccessToken 本体）
+      // pg-read の書込みもtoken/scopeを同じPostgREST CASへまとめる。
       expect(client.updateCalls).toHaveLength(1)
-      expect(client.updateCalls[0].table).toBe('users')
+      expect(client.updateCalls[0]).toEqual({
+        table: 'users',
+        values: {
+          twitch_access_token: 'new-token',
+          twitch_refresh_token: 'new-refresh-token',
+          twitch_token_expires_at: expect.any(String),
+          twitch_scopes: [],
+        },
+      })
+      expect(client.updateFilterCalls).toEqual([{
+        table: 'users',
+        filters: [
+          { column: 'twitch_user_id', value: '123456789' },
+          { column: 'twitch_refresh_token', value: 'refresh-token' },
+        ],
+      }])
       // pg 側では update が呼ばれない
       expect(pg.updateCalls).toHaveLength(0)
     })
@@ -516,12 +642,179 @@ describe('token-manager: postgrest / pg 経路の互換 (#572)', () => {
         status: 'active',
         last_error: null,
       })
-      expect(pg.updateCalls[0].where).toEqual(eq(twitchBotAccountsTable.id, 'bot-account-1'))
+      expect(pg.updateCalls[0].where).toEqual(and(
+        eq(twitchBotAccountsTable.id, 'bot-account-1'),
+        eq(twitchBotAccountsTable.twitch_refresh_token, 'bot-refresh-token'),
+      ))
     })
 
-    it('リフレッシュ失敗: pg 経路で status=error が保存され null を返す（既存挙動と同じ）', async () => {
+    it('同一BOTの2並行refreshは2回交換し、CAS loserもwinner tokenを返して上書きしない', async () => {
       vi.stubEnv('DB_DRIVER', 'pg')
-      vi.mocked(refreshTwitchToken).mockRejectedValue(new Error('refresh failed'))
+      const loserTokens = {
+        ...REFRESHED_TOKENS,
+        access_token: 'loser-bot-access-token',
+        refresh_token: 'loser-bot-refresh-token',
+        scope: ['loser:bot-scope'],
+      }
+      const winnerTokens = {
+        ...REFRESHED_TOKENS,
+        access_token: 'winner-bot-token',
+        refresh_token: 'winner-bot-refresh-token',
+        scope: ['winner:bot-scope'],
+      }
+      vi.mocked(refreshTwitchToken)
+        .mockResolvedValueOnce(winnerTokens)
+        .mockResolvedValueOnce(loserTokens)
+      const expiredBot = { ...BOT_ROW, twitch_token_expires_at: PAST_ISO }
+      const pg = createDrizzleDbMock({
+        selects: [
+          { rows: [STREAMER_ROW] },
+          { rows: [STREAMER_ROW] },
+          { rows: [SETTINGS_CUSTOM] },
+          { rows: [SETTINGS_CUSTOM] },
+          { rows: [expiredBot] },
+          { rows: [expiredBot] },
+          { rows: [{ twitch_access_token: 'winner-bot-token' }] },
+        ],
+        updates: [
+          { rows: [{ twitch_access_token: 'winner-bot-token' }] },
+          { rows: [] },
+        ],
+      })
+      primePgDb(pg)
+
+      const results = await Promise.all([
+        getBotAccountForChat('broadcaster-1'),
+        getBotAccountForChat('broadcaster-2'),
+      ])
+
+      expect(refreshTwitchToken).toHaveBeenCalledTimes(2)
+      expect(results.map(result => result?.accessToken)).toEqual([
+        'winner-bot-token',
+        'winner-bot-token',
+      ])
+      expect(pg.updateCalls).toHaveLength(2)
+      expect(pg.updateCalls[0].set).toMatchObject({
+        twitch_access_token: 'winner-bot-token',
+        twitch_refresh_token: 'winner-bot-refresh-token',
+        scopes: ['winner:bot-scope'],
+      })
+      for (const call of pg.updateCalls) {
+        expect(call.where).toEqual(and(
+          eq(twitchBotAccountsTable.id, 'bot-account-1'),
+          eq(twitchBotAccountsTable.twitch_refresh_token, 'bot-refresh-token'),
+        ))
+      }
+      expect(pg.updateCalls[1].set).toMatchObject({
+        twitch_access_token: 'loser-bot-access-token',
+        twitch_refresh_token: 'loser-bot-refresh-token',
+        scopes: ['loser:bot-scope'],
+      })
+    })
+
+    it('PostgRESTでもBOTのCAS loserはwinnerのaccess tokenを再読込する', async () => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      vi.mocked(refreshTwitchToken).mockResolvedValue(REFRESHED_TOKENS)
+      const expiredBot = { ...BOT_ROW, twitch_token_expires_at: PAST_ISO }
+      const client = createSupabaseClientMock({
+        streamers: [{ data: STREAMER_ROW }],
+        streamer_chat_sender_settings: [{ data: SETTINGS_CUSTOM }],
+        twitch_bot_accounts: [
+          { data: expiredBot },
+          { data: null },
+          { data: { twitch_access_token: 'postgrest-winner-bot-token' } },
+        ],
+      })
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+
+      await expect(getBotAccountForChat('broadcaster-1')).resolves.toMatchObject({
+        accessToken: 'postgrest-winner-bot-token',
+      })
+      expect(client.updateCalls).toHaveLength(1)
+      expect(client.updateFilterCalls).toEqual([{
+        table: 'twitch_bot_accounts',
+        filters: [
+          { column: 'id', value: 'bot-account-1' },
+          { column: 'twitch_refresh_token', value: 'bot-refresh-token' },
+        ],
+      }])
+    })
+
+    it('BOTの一時的522失敗はactiveを維持し、次の呼び出しで回復する', async () => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+      const expiredBot = { ...BOT_ROW, twitch_token_expires_at: PAST_ISO }
+      vi.mocked(refreshTwitchToken).mockRejectedValueOnce(new TwitchTokenRefreshError(522))
+      const firstPg = createDrizzleDbMock({
+        selects: [
+          { rows: [STREAMER_ROW] },
+          { rows: [SETTINGS_CUSTOM] },
+          { rows: [expiredBot] },
+        ],
+      })
+      primePgDb(firstPg)
+
+      await expect(getBotAccountForChat('broadcaster-1')).resolves.toBeNull()
+      // transient失敗ではstatusを変更しないため、active filterから除外されない。
+      expect(firstPg.updateCalls).toHaveLength(0)
+      const { logger } = await import('@/lib/logger')
+      expect(JSON.stringify(vi.mocked(logger.error).mock.calls)).not.toContain('gateway unavailable')
+
+      vi.mocked(refreshTwitchToken).mockResolvedValueOnce(REFRESHED_TOKENS)
+      const secondPg = createDrizzleDbMock({
+        selects: [
+          { rows: [STREAMER_ROW] },
+          { rows: [SETTINGS_CUSTOM] },
+          { rows: [expiredBot] },
+        ],
+      })
+      primePgDb(secondPg)
+      await expect(getBotAccountForChat('broadcaster-1')).resolves.toMatchObject({
+        accessToken: 'new-token',
+      })
+      expect(refreshTwitchToken).toHaveBeenCalledTimes(2)
+    })
+
+    it.each([
+      ['custom_bot', SETTINGS_CUSTOM],
+      ['official_bot', { sender_mode: 'official_bot', custom_bot_account_id: null }],
+    ])('PostgRESTの%sもnetwork失敗ではactiveを維持し、次回回復する', async (mode, settings) => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      const expiredBot = {
+        ...BOT_ROW,
+        owner_type: mode === 'official_bot' ? 'system' : 'streamer',
+        twitch_token_expires_at: PAST_ISO,
+      }
+      vi.mocked(refreshTwitchToken).mockRejectedValueOnce(new TwitchTokenRefreshError())
+      const firstClient = createSupabaseClientMock({
+        streamers: [{ data: STREAMER_ROW }],
+        streamer_chat_sender_settings: [{ data: settings }],
+        twitch_bot_accounts: [{ data: expiredBot }],
+      })
+      vi.mocked(getSupabaseAdmin).mockReturnValue(firstClient as any)
+
+      await expect(getBotAccountForChat('broadcaster-1')).resolves.toBeNull()
+      expect(firstClient.updateCalls).toHaveLength(0)
+
+      vi.mocked(refreshTwitchToken).mockResolvedValueOnce(REFRESHED_TOKENS)
+      const secondClient = createSupabaseClientMock({
+        streamers: [{ data: STREAMER_ROW }],
+        streamer_chat_sender_settings: [{ data: settings }],
+        twitch_bot_accounts: [
+          { data: expiredBot },
+          { data: { twitch_access_token: 'new-token' } },
+        ],
+      })
+      vi.mocked(getSupabaseAdmin).mockReturnValue(secondClient as any)
+
+      await expect(getBotAccountForChat('broadcaster-1')).resolves.toMatchObject({
+        accessToken: 'new-token',
+      })
+      expect(refreshTwitchToken).toHaveBeenCalledTimes(2)
+    })
+
+    it.each([400, 401])('資格情報失効status=%iだけはpg経路で status=error を保存する', async status => {
+      vi.stubEnv('DB_DRIVER', 'pg')
+      vi.mocked(refreshTwitchToken).mockRejectedValue(new TwitchTokenRefreshError(status))
       const pg = createDrizzleDbMock({
         selects: [
           { rows: [STREAMER_ROW] },
@@ -536,8 +829,96 @@ describe('token-manager: postgrest / pg 経路の互換 (#572)', () => {
       expect(result).toBeNull()
       expect(pg.updateCalls).toHaveLength(1)
       expect(pg.updateCalls[0].table).toBe(twitchBotAccountsTable)
-      expect(pg.updateCalls[0].set).toEqual({ status: 'error', last_error: 'refresh failed' })
-      expect(pg.updateCalls[0].where).toEqual(eq(twitchBotAccountsTable.id, 'bot-account-1'))
+      expect(pg.updateCalls[0].set).toEqual({ status: 'error', last_error: 'token_refresh_failed' })
+      expect(pg.updateCalls[0].where).toEqual(and(
+        eq(twitchBotAccountsTable.id, 'bot-account-1'),
+        eq(twitchBotAccountsTable.twitch_refresh_token, 'bot-refresh-token'),
+      ))
+    })
+
+    it.each([400, 401])('資格情報失効status=%iだけはPostgRESTでも status=error を保存する', async status => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      vi.mocked(refreshTwitchToken).mockRejectedValue(new TwitchTokenRefreshError(status))
+      const client = createSupabaseClientMock({
+        streamers: [{ data: STREAMER_ROW }],
+        streamer_chat_sender_settings: [{ data: SETTINGS_CUSTOM }],
+        twitch_bot_accounts: [
+          { data: { ...BOT_ROW, twitch_token_expires_at: PAST_ISO } },
+          { data: null },
+        ],
+      })
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+
+      await expect(getBotAccountForChat('broadcaster-1')).resolves.toBeNull()
+      expect(client.updateCalls).toEqual([{
+        table: 'twitch_bot_accounts',
+        values: { status: 'error', last_error: 'token_refresh_failed' },
+      }])
+      // 先行refresh/callbackが資格情報を更新済みならactiveをerrorへ戻さない。
+      // 恒久エラー状態の保存にもIDと交換時点の旧refresh tokenを必須にする。
+      expect(client.updateFilterCalls).toEqual([{
+        table: 'twitch_bot_accounts',
+        filters: [
+          { column: 'id', value: 'bot-account-1' },
+          { column: 'twitch_refresh_token', value: 'bot-refresh-token' },
+        ],
+      }])
+    })
+
+    it.each([
+      ['pg', 403],
+      ['pg', 404],
+      ['pg', 501],
+      ['postgrest', 403],
+      ['postgrest', 404],
+      ['postgrest', 501],
+    ])('%s経路のstatus=%iは資格情報失効と断定せずactiveを維持する', async (driver, status) => {
+      vi.mocked(refreshTwitchToken).mockRejectedValue(new TwitchTokenRefreshError(status))
+      const expiredBot = { ...BOT_ROW, twitch_token_expires_at: PAST_ISO }
+
+      if (driver === 'pg') {
+        vi.stubEnv('DB_DRIVER', 'pg')
+        const pg = createDrizzleDbMock({
+          selects: [
+            { rows: [STREAMER_ROW] },
+            { rows: [SETTINGS_CUSTOM] },
+            { rows: [expiredBot] },
+          ],
+        })
+        primePgDb(pg)
+        await expect(getBotAccountForChat('broadcaster-1')).resolves.toBeNull()
+        expect(pg.updateCalls).toHaveLength(0)
+      } else {
+        vi.stubEnv('DB_DRIVER', undefined)
+        const client = createSupabaseClientMock({
+          streamers: [{ data: STREAMER_ROW }],
+          streamer_chat_sender_settings: [{ data: SETTINGS_CUSTOM }],
+          twitch_bot_accounts: [{ data: expiredBot }],
+        })
+        vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+        await expect(getBotAccountForChat('broadcaster-1')).resolves.toBeNull()
+        expect(client.updateCalls).toHaveLength(0)
+      }
+    })
+
+    it('PostgRESTの恒久エラー状態保存がtransport rejectしてもnullへ縮退する', async () => {
+      vi.stubEnv('DB_DRIVER', undefined)
+      vi.mocked(refreshTwitchToken).mockRejectedValue(new TwitchTokenRefreshError(401))
+      const client = createSupabaseClientMock({
+        streamers: [{ data: STREAMER_ROW }],
+        streamer_chat_sender_settings: [{ data: SETTINGS_CUSTOM }],
+        twitch_bot_accounts: [
+          { data: { ...BOT_ROW, twitch_token_expires_at: PAST_ISO } },
+          { reject: new Error('status update transport failed') },
+        ],
+      })
+      vi.mocked(getSupabaseAdmin).mockReturnValue(client as any)
+
+      await expect(getBotAccountForChat('broadcaster-1')).resolves.toBeNull()
+      expect(client.updateCalls).toEqual([{
+        table: 'twitch_bot_accounts',
+        values: { status: 'error', last_error: 'token_refresh_failed' },
+      }])
     })
 
     it('sender_mode=streamer / 設定なし: 両経路とも null（BOT スキーマ未デプロイ窓 42P01 も null）', async () => {

--- a/tests/unit/twitch-auth.test.ts
+++ b/tests/unit/twitch-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 vi.mock('@/lib/env-validation', () => ({
   getEnvVar: vi.fn((name: string) => {
@@ -75,6 +75,10 @@ describe('exchangeCodeForTokens', () => {
     vi.restoreAllMocks()
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('正常系: トークンが正しく返される', async () => {
     const mockTokens = {
       access_token: 'test-access-token',
@@ -94,7 +98,7 @@ describe('exchangeCodeForTokens', () => {
     expect(result).toEqual(mockTokens)
   })
 
-  it('異常系: エラーメッセージにステータスコードとレスポンス本文が含まれる', async () => {
+  it('異常系: invalid authorization codeを分類するが、token endpoint本文はErrorへ保持しない', async () => {
     const errorBody = '{"status":400,"message":"Invalid authorization code"}'
 
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
@@ -105,7 +109,7 @@ describe('exchangeCodeForTokens', () => {
 
     await expect(
       exchangeCodeForTokens('expired-code', 'http://localhost/callback')
-    ).rejects.toThrow('Authentication failed: 400 ' + errorBody)
+    ).rejects.toThrow('Authentication failed: 400')
 
     const { logger } = await import('@/lib/logger')
     expect(logger.warn).toHaveBeenCalledWith(
@@ -136,7 +140,42 @@ describe('exchangeCodeForTokens', () => {
 
     await expect(
       exchangeCodeForTokens('code', 'http://localhost/callback')
-    ).rejects.toThrow('Authentication failed: 500 Internal Server Error')
+    ).rejects.toThrow('Authentication failed: 500')
+  })
+
+  it('522でもauthorization code交換は単回で、再送しない', async () => {
+    const secretSentinel = 'SECRET_SENTINEL_FROM_TOKEN_ENDPOINT'
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(`error code: 522 ${secretSentinel}`, { status: 522 })
+    )
+    const { exchangeCodeForTokens } = await import('@/lib/twitch/auth')
+
+    await expect(exchangeCodeForTokens('single-use-code', 'http://localhost/callback'))
+      .rejects.toThrow('Authentication failed: 522')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const { logger } = await import('@/lib/logger')
+    // callback の reportAuthError だけを永続化点にする。logger.error は自動永続化するため禁止。
+    expect(logger.error).not.toHaveBeenCalled()
+    expect(logger.warn).toHaveBeenCalledWith('Token exchange failed:', { status: 522 })
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain(secretSentinel)
+  })
+
+  it('2xxの不正token JSONは本文を捨てた固定Errorへ変換する', async () => {
+    const secretSentinel = 'SECRET_MALFORMED_EXCHANGE_BODY'
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(`{"access_token":"${secretSentinel}"`, { status: 200 })
+    )
+    const { exchangeCodeForTokens } = await import('@/lib/twitch/auth')
+
+    const error = await exchangeCodeForTokens('code', 'http://localhost/callback')
+      .catch(value => value as Error)
+    if (!(error instanceof Error)) throw new Error('Expected malformed exchange response to reject')
+
+    expect(error.message).toBe('Authentication failed: invalid token response')
+    expect(error.message).not.toContain(secretSentinel)
+    const { logger } = await import('@/lib/logger')
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain(secretSentinel)
   })
 
   it('異常系: fetchが失敗した場合はそのまま例外が伝播する', async () => {
@@ -192,6 +231,10 @@ describe('refreshTwitchToken', () => {
     vi.restoreAllMocks()
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('正常系: 新しいトークンが返される', async () => {
     const mockTokens = {
       access_token: 'new-access-token',
@@ -211,15 +254,269 @@ describe('refreshTwitchToken', () => {
     expect(result).toEqual(mockTokens)
   })
 
-  it('異常系: エラーメッセージにステータスコードとレスポンス本文が含まれる', async () => {
+  it('異常系: ステータスだけを保持し、token endpoint本文をErrorへ含めない', async () => {
+    const secretSentinel = 'SECRET_SENTINEL_REFRESH_BODY'
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('{"message":"Invalid refresh token"}', { status: 400 })
+      new Response(`{"message":"Invalid refresh token ${secretSentinel}"}`, { status: 400 })
     )
 
     const { refreshTwitchToken } = await import('@/lib/twitch/auth')
 
-    await expect(
-      refreshTwitchToken('expired-refresh-token')
-    ).rejects.toThrow(/Failed to refresh authentication token: 400/)
+    const error = await refreshTwitchToken('expired-refresh-token').catch(value => value as Error)
+    if (!(error instanceof Error)) throw new Error('Expected token refresh to reject')
+    expect(error.message).toBe('Failed to refresh authentication token: 400')
+    expect(error.message).not.toContain(secretSentinel)
+    const { logger } = await import('@/lib/logger')
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain(secretSentinel)
+  })
+
+  it('2xxの不正refresh JSONは本文を捨て、BOTを無効化しない一時失敗へ分類する', async () => {
+    const secretSentinel = 'SECRET_MALFORMED_REFRESH_BODY'
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(`{"refresh_token":"${secretSentinel}"`, { status: 200 })
+    )
+    const { refreshTwitchToken, TwitchTokenRefreshError } = await import('@/lib/twitch/auth')
+
+    const error = await refreshTwitchToken('old-refresh-token').catch(value => value as Error)
+    if (!(error instanceof Error)) throw new Error('Expected malformed refresh response to reject')
+
+    expect(error).toBeInstanceOf(TwitchTokenRefreshError)
+    expect(error.message).toBe('Failed to refresh authentication token: invalid response')
+    expect(error.message).not.toContain(secretSentinel)
+    expect(error).toMatchObject({ status: 200, retryable: true, kind: 'invalid_response' })
+  })
+
+  it('522の一時障害は一度だけ待機して再試行し、成功トークンを返す', async () => {
+    vi.useFakeTimers()
+    const mockTokens = { access_token: 'new-access', refresh_token: 'new-refresh', expires_in: 3600, token_type: 'bearer', scope: [] }
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('error code: 522', { status: 522 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(mockTokens), { status: 200 }))
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const { refreshTwitchToken } = await import('@/lib/twitch/auth')
+
+    const result = refreshTwitchToken('old-refresh-token')
+    await vi.runAllTimersAsync()
+
+    await expect(result).resolves.toEqual(mockTokens)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('Retry-Afterのdelta-secondsを最低待機時間として尊重する', async () => {
+    vi.useFakeTimers()
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('busy', { status: 429, headers: { 'Retry-After': '1' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'a', refresh_token: 'r', expires_in: 1, token_type: 'bearer', scope: [] }), { status: 200 }))
+    const { refreshTwitchToken } = await import('@/lib/twitch/auth')
+
+    const result = refreshTwitchToken('old-refresh-token')
+    await vi.runAllTimersAsync()
+
+    await expect(result).resolves.toMatchObject({ access_token: 'a' })
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1_000)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([
+    'Fri, 24 Jul 2026 12:00:01 GMT',
+    'Friday, 24-Jul-26 12:00:01 GMT',
+    'Fri Jul 24 12:00:01 2026',
+  ])('Retry-AfterのRFC HTTP-dateを尊重する: %s', async retryAfter => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-24T12:00:00.000Z'))
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('busy', {
+        status: 503,
+        headers: { 'Retry-After': retryAfter },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'a', refresh_token: 'r', expires_in: 1, token_type: 'bearer', scope: [] }), { status: 200 }))
+    const { refreshTwitchToken } = await import('@/lib/twitch/auth')
+
+    const result = refreshTwitchToken('old-refresh-token')
+    await vi.runAllTimersAsync()
+
+    await expect(result).resolves.toMatchObject({ access_token: 'a' })
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1_000)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('RFC850の2桁年は50年規則で2070年と解釈し、長すぎる待機を早送りしない', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-24T12:00:00.000Z'))
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('busy', {
+        status: 503,
+        headers: { 'Retry-After': 'Thursday, 24-Jul-70 12:00:01 GMT' },
+      })
+    )
+    const { refreshTwitchToken } = await import('@/lib/twitch/auth')
+
+    await expect(refreshTwitchToken('old-refresh-token')).rejects.toThrow(/503/)
+    // NodeのDate.parseは`-70`を1970年にするが、RFCでは現在から50年以内の2070年。
+    // 44年先を0msへ丸めず、このリクエスト内の再送を中止する。
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('RFC850の2桁年がexact 50年先なら過去年へ補正しない', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-24T12:00:00.000Z'))
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('busy', {
+        status: 503,
+        headers: { 'Retry-After': 'Friday, 24-Jul-76 12:00:00 GMT' },
+      })
+    )
+    const { refreshTwitchToken } = await import('@/lib/twitch/auth')
+
+    await expect(refreshTwitchToken('old-refresh-token')).rejects.toThrow(/503/)
+    // RFCの境界は「50年超」。exact 50年は2076年のままなので、
+    // このリクエスト内で待たずに呼び出し元へ失敗を返す。
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('RFC850の2桁年が50年と1秒先なら100年前へ補正する', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-24T12:00:00.000Z'))
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('busy', {
+        status: 503,
+        headers: { 'Retry-After': 'Saturday, 24-Jul-76 12:00:01 GMT' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        access_token: 'a', refresh_token: 'r', expires_in: 1, token_type: 'bearer', scope: [],
+      }), { status: 200 }))
+    const { refreshTwitchToken } = await import('@/lib/twitch/auth')
+
+    const result = refreshTwitchToken('old-refresh-token')
+    await vi.runAllTimersAsync()
+
+    await expect(result).resolves.toMatchObject({ access_token: 'a' })
+    // 2076年候補は50年と1秒先なので1976年へ戻り、過去日時として即時再試行する。
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('HTTP-dateのleap secondは直前の59秒から1秒後として扱う', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2016-12-31T23:59:59.000Z'))
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('busy', {
+        status: 503,
+        headers: { 'Retry-After': 'Sat, 31 Dec 2016 23:59:60 GMT' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        access_token: 'a', refresh_token: 'r', expires_in: 1, token_type: 'bearer', scope: [],
+      }), { status: 200 }))
+    const { refreshTwitchToken } = await import('@/lib/twitch/auth')
+
+    const result = refreshTwitchToken('old-refresh-token')
+    await vi.runAllTimersAsync()
+
+    await expect(result).resolves.toMatchObject({ access_token: 'a' })
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1_000)
+  })
+
+  it('過去のRetry-After HTTP-dateは待機0msで再試行する', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-24T12:00:01.000Z'))
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('busy', {
+        status: 503,
+        headers: { 'Retry-After': 'Fri, 24 Jul 2026 12:00:00 GMT' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'a', refresh_token: 'r', expires_in: 1, token_type: 'bearer', scope: [] }), { status: 200 }))
+    const { refreshTwitchToken } = await import('@/lib/twitch/auth')
+
+    const result = refreshTwitchToken('old-refresh-token')
+    await vi.runAllTimersAsync()
+
+    await expect(result).resolves.toMatchObject({ access_token: 'a' })
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 0)
+  })
+
+  it.each([
+    'not-a-date',
+    '1.5',
+    '+1',
+    '-1',
+    '2026-07-24',
+    '9007199254740992',
+    'Tue, 31 Feb 2026 12:00:01 GMT',
+    'Thu, 24 Jul 2026 12:00:01 GMT',
+  ])('RFC外のRetry-Afterはfull-jitterへフォールバックする: %s', async retryAfter => {
+    vi.useFakeTimers()
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('busy', { status: 503, headers: { 'Retry-After': retryAfter } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ access_token: 'a', refresh_token: 'r', expires_in: 1, token_type: 'bearer', scope: [] }), { status: 200 }))
+    const { refreshTwitchToken } = await import('@/lib/twitch/auth')
+
+    const result = refreshTwitchToken('old-refresh-token')
+    await vi.runAllTimersAsync()
+
+    await expect(result).resolves.toMatchObject({ access_token: 'a' })
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 50)
+  })
+
+  it('Retry-Afterがローカル上限を超える場合は早く丸めて再送しない', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('busy', { status: 503, headers: { 'Retry-After': '3' } })
+    )
+    const { refreshTwitchToken } = await import('@/lib/twitch/auth')
+
+    await expect(refreshTwitchToken('old-refresh-token')).rejects.toThrow(/503/)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('400のinvalid refresh tokenは再試行しない', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{"message":"Invalid refresh token"}', { status: 400 })
+    )
+    const { refreshTwitchToken } = await import('@/lib/twitch/auth')
+
+    await expect(refreshTwitchToken('invalid-refresh-token')).rejects.toThrow(/400/)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('network failureは上限3回で停止し、元例外本文をErrorへ持ち越さない', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const secretSentinel = 'SECRET_NETWORK_SENTINEL'
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error(secretSentinel))
+    const { refreshTwitchToken } = await import('@/lib/twitch/auth')
+
+    const result = refreshTwitchToken('old-refresh-token')
+    // fake timerを進める前にreject handlerを接続し、Nodeのunhandled判定を避ける。
+    const captured = result.catch(value => value as Error)
+    await vi.runAllTimersAsync()
+
+    const error = await captured
+    if (!(error instanceof Error)) throw new Error('Expected network refresh to reject')
+    expect(error.message).toBe('Failed to refresh authentication token: network error')
+    expect(error.message).not.toContain(secretSentinel)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('retryable statusも上限3回で停止する', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      // Response bodyは単回消費なので、各retryへ新しいResponseを返す。
+      new Response('gateway unavailable', { status: 522 })
+    )
+    const { refreshTwitchToken } = await import('@/lib/twitch/auth')
+
+    const result = refreshTwitchToken('old-refresh-token')
+    const rejected = expect(result).rejects.toThrow('Failed to refresh authentication token: 522')
+    await vi.runAllTimersAsync()
+
+    await rejected
+    expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 })

--- a/tests/unit/twitch-oauth-error-reporting.test.ts
+++ b/tests/unit/twitch-oauth-error-reporting.test.ts
@@ -1,0 +1,233 @@
+/**
+ * OAuth 失敗を下位層と HTTP 境界の双方で errors テーブルへ書くと、error reporter が
+ * 同じ障害から複数の Issue を作成する。このテストは実際の auth/token-manager/error
+ * handler を通し、永続 writer がリクエストごとに一度だけであることを固定する。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const mocks = vi.hoisted(() => ({
+  cookieGet: vi.fn(),
+  cookieSet: vi.fn(),
+  getSession: vi.fn(),
+  canUseStreamerFeatures: vi.fn(),
+  checkRateLimit: vi.fn(),
+  getRateLimitIdentifier: vi.fn(),
+  getSupabaseAdmin: vi.fn(),
+  reportAuthError: vi.fn(),
+  logErrorFromLogger: vi.fn(),
+}))
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(() => Promise.resolve({ get: mocks.cookieGet, set: mocks.cookieSet, delete: vi.fn() })),
+}))
+vi.mock('@/lib/supabase/admin', () => ({ getSupabaseAdmin: mocks.getSupabaseAdmin }))
+vi.mock('@/lib/session', () => ({
+  getSession: mocks.getSession,
+  canUseStreamerFeatures: mocks.canUseStreamerFeatures,
+  signSession: vi.fn(async (value: string) => value),
+}))
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: mocks.checkRateLimit,
+  getRateLimitIdentifier: mocks.getRateLimitIdentifier,
+  getClientIp: vi.fn(() => '127.0.0.1'),
+  rateLimits: { authCallback: {}, twitchRewardsGet: {} },
+}))
+vi.mock('@/lib/sentry/error-handler', () => ({
+  reportAuthError: mocks.reportAuthError,
+  logErrorFromLogger: mocks.logErrorFromLogger,
+  reportError: vi.fn(),
+  reportApiError: vi.fn(),
+}))
+vi.mock('@/lib/url-utils', () => ({ getBaseUrl: vi.fn(() => 'http://localhost:3000') }))
+vi.mock('@/lib/maintenance/guard', () => ({ guardWriteRedirect: vi.fn(() => null) }))
+vi.mock('@/lib/twitch/linked-account-auth', () => ({ handleLinkedAccountCallback: vi.fn() }))
+
+import { GET as callbackGet } from '@/app/api/auth/twitch/callback/route'
+import { GET as loginGet } from '@/app/api/auth/twitch/login/route'
+import { GET as rewardsGet } from '@/app/api/twitch/rewards/route'
+import { GET as bootstrapGet } from '@/app/api/twitch/channel-point-bootstrap/route'
+
+it('token-managerはrequest-scoped I/Oをmodule-scope Mapへ保持しない', () => {
+  const source = readFileSync(
+    resolve(process.cwd(), 'src/lib/twitch/token-manager.ts'),
+    'utf8',
+  )
+  // Workers isolateは複数requestで再利用される。module-scope Mapを許すと、将来
+  // pending Promise以外の名前へ変えてもrequest-scoped I/O共有が再発し得るため、
+  // このtoken管理モジュールでは用途を限定せずmodule-scope Map自体を禁止する。
+  const moduleScopeMap = source.match(
+    /^(?:export\s+)?(?:const|let|var)\s+\w+(?:\s*:[^=\n]+)?\s*=\s*new\s+Map\b/gm,
+  )
+
+  expect(moduleScopeMap).toBeNull()
+  expect(source).not.toMatch(/(?:SingleFlight|RefreshFlights)/)
+})
+
+const SECRET = 'SECRET_SENTINEL_TOKEN_ENDPOINT_BODY'
+const CODE = 'SECRET_SENTINEL_AUTHORIZATION_CODE'
+
+function userTokenQuery() {
+  const query: Record<string, ReturnType<typeof vi.fn>> = {
+    select: vi.fn(), eq: vi.fn(), maybeSingle: vi.fn(), from: vi.fn(), update: vi.fn(),
+  }
+  query.select.mockReturnValue(query)
+  query.eq.mockReturnValue(query)
+  query.maybeSingle.mockResolvedValue({
+    data: {
+      twitch_access_token: 'expired-access-token',
+      twitch_refresh_token: 'expired-refresh-token',
+      twitch_token_expires_at: new Date(Date.now() - 60_000).toISOString(),
+    },
+    error: null,
+  })
+  return query
+}
+
+function scopeThenExpiredTokenQuery() {
+  const query: Record<string, ReturnType<typeof vi.fn>> = {
+    select: vi.fn(), eq: vi.fn(), maybeSingle: vi.fn(), from: vi.fn(), update: vi.fn(),
+  }
+  query.select.mockImplementation((columns: string) => {
+    query.maybeSingle.mockResolvedValue(columns === 'twitch_scopes'
+      ? { data: { twitch_scopes: ['channel:read:redemptions'] }, error: null }
+      : { data: {
+        twitch_access_token: 'expired-access-token',
+        twitch_refresh_token: 'expired-refresh-token',
+        twitch_token_expires_at: new Date(Date.now() - 60_000).toISOString(),
+      }, error: null })
+    return query
+  })
+  query.eq.mockReturnValue(query)
+  return query
+}
+
+function allPersistedArguments(): string {
+  return JSON.stringify([
+    ...mocks.reportAuthError.mock.calls,
+    ...mocks.logErrorFromLogger.mock.calls,
+  ])
+}
+
+describe('OAuth error reporting has exactly one durable writer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'public-client-id'
+    process.env.TWITCH_CLIENT_SECRET = 'server-secret'
+    mocks.checkRateLimit.mockResolvedValue({ success: true, limit: 10, remaining: 9, reset: Date.now() + 60_000 })
+    mocks.getRateLimitIdentifier.mockResolvedValue('test-rate-limit-key')
+    mocks.cookieGet.mockImplementation((name: string) => name === 'twitch_auth_state' ? { value: 'state-1' } : undefined)
+  })
+
+  it('login route の失敗もhandleAuthErrorだけが一度記録する', async () => {
+    mocks.checkRateLimit.mockRejectedValueOnce(new Error('login rate-limit backend failed'))
+
+    const response = await loginGet(new Request('http://localhost:3000/api/auth/twitch/login'))
+
+    expect(response.status).toBe(500)
+    expect(mocks.reportAuthError).toHaveBeenCalledTimes(1)
+    expect(mocks.logErrorFromLogger).not.toHaveBeenCalled()
+  })
+
+  it('callback の 522 token exchange は reportAuthError だけに一度記録し、code/body を渡さない', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(SECRET, { status: 522 })
+    )
+    try {
+      const response = await callbackGet(new NextRequest(`http://localhost:3000/api/auth/twitch/callback?code=${CODE}&state=state-1`))
+
+      // NextResponse.redirect の既定 status は 307。ここでは redirect 種別ではなく、
+      // exchange failure が callback 境界まで到達したことだけを確認する。
+      expect(response.status).toBe(307)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(mocks.reportAuthError).toHaveBeenCalledTimes(1)
+      expect(mocks.logErrorFromLogger).not.toHaveBeenCalled()
+      const serialized = allPersistedArguments()
+      expect(serialized).not.toContain(SECRET)
+      expect(serialized).not.toContain(CODE)
+    } finally {
+      fetchMock.mockRestore()
+    }
+  })
+
+  it('callback の2xx不正token JSONも本文を捨てて一度だけ記録する', async () => {
+    const malformedSecret = 'SECRET_MALFORMED_CALLBACK_BODY'
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(`{"access_token":"${malformedSecret}"`, { status: 200 })
+    )
+    try {
+      const response = await callbackGet(new NextRequest(`http://localhost:3000/api/auth/twitch/callback?code=${CODE}&state=state-1`))
+
+      expect(response.status).toBe(307)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(mocks.reportAuthError).toHaveBeenCalledTimes(1)
+      expect(mocks.logErrorFromLogger).not.toHaveBeenCalled()
+      const serialized = allPersistedArguments()
+      expect(serialized).not.toContain(malformedSecret)
+      expect(serialized).not.toContain(CODE)
+    } finally {
+      fetchMock.mockRestore()
+    }
+  })
+
+  it('期限切れ token の 522 refresh は rewards API 境界で一度だけ記録し、provider body を渡さない', async () => {
+    mocks.getSession.mockResolvedValue({ twitchUserId: 'streamer-1' })
+    mocks.canUseStreamerFeatures.mockReturnValue(true)
+    const query = userTokenQuery()
+    mocks.getSupabaseAdmin.mockReturnValue({ from: vi.fn(() => query) })
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => new Response(SECRET, { status: 522 }))
+    try {
+      const response = await rewardsGet(new Request('http://localhost:3000/api/twitch/rewards'))
+
+      expect(response.status).toBe(500)
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+      expect(mocks.reportAuthError).not.toHaveBeenCalled()
+      expect(mocks.logErrorFromLogger).toHaveBeenCalledTimes(1)
+      expect(allPersistedArguments()).not.toContain(SECRET)
+    } finally {
+      fetchMock.mockRestore()
+    }
+  }, 10_000)
+
+  it('期限切れtokenの2xx不正refresh JSONもrewards境界で本文を捨てて一度だけ記録する', async () => {
+    const malformedSecret = 'SECRET_MALFORMED_REFRESH_BODY'
+    mocks.getSession.mockResolvedValue({ twitchUserId: 'streamer-1' })
+    mocks.canUseStreamerFeatures.mockReturnValue(true)
+    const query = userTokenQuery()
+    mocks.getSupabaseAdmin.mockReturnValue({ from: vi.fn(() => query) })
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(`{"refresh_token":"${malformedSecret}"`, { status: 200 })
+    )
+    try {
+      const response = await rewardsGet(new Request('http://localhost:3000/api/twitch/rewards'))
+
+      expect(response.status).toBe(500)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(mocks.reportAuthError).not.toHaveBeenCalled()
+      expect(mocks.logErrorFromLogger).toHaveBeenCalledTimes(1)
+      expect(allPersistedArguments()).not.toContain(malformedSecret)
+    } finally {
+      fetchMock.mockRestore()
+    }
+  })
+
+  it('期限切れ token の 522 refresh は bootstrap API 境界でも一度だけ記録する', async () => {
+    mocks.getSession.mockResolvedValue({ twitchUserId: 'streamer-1' })
+    mocks.canUseStreamerFeatures.mockReturnValue(true)
+    mocks.getSupabaseAdmin.mockReturnValue({ from: vi.fn(() => scopeThenExpiredTokenQuery()) })
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => new Response(SECRET, { status: 522 }))
+    try {
+      const response = await bootstrapGet(new NextRequest('http://localhost:3000/api/twitch/channel-point-bootstrap'))
+
+      expect(response.status).toBe(500)
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+      expect(mocks.reportAuthError).not.toHaveBeenCalled()
+      expect(mocks.logErrorFromLogger).toHaveBeenCalledTimes(1)
+      expect(allPersistedArguments()).not.toContain(SECRET)
+    } finally {
+      fetchMock.mockRestore()
+    }
+  }, 10_000)
+})

--- a/tests/unit/twitch-token-manager.test.ts
+++ b/tests/unit/twitch-token-manager.test.ts
@@ -136,14 +136,16 @@ describe('Twitch Token Manager', () => {
         from: vi.fn().mockReturnThis(),
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
-        maybeSingle: vi.fn().mockResolvedValueOnce({
-          data: {
-            twitch_access_token: 'expired-token',
-            twitch_refresh_token: 'refresh-token',
-            twitch_token_expires_at: new Date(Date.now() - 3600000).toISOString(),
-          },
-          error: null,
-        }),
+        maybeSingle: vi.fn()
+          .mockResolvedValueOnce({
+            data: {
+              twitch_access_token: 'expired-token',
+              twitch_refresh_token: 'refresh-token',
+              twitch_token_expires_at: new Date(Date.now() - 3600000).toISOString(),
+            },
+            error: null,
+          })
+          .mockResolvedValueOnce({ data: { twitch_access_token: 'new-token' }, error: null }),
         update: vi.fn().mockReturnThis(),
         insert: vi.fn().mockResolvedValue({ error: null }),
       };
@@ -160,6 +162,80 @@ describe('Twitch Token Manager', () => {
       const token = await getTwitchAccessToken('123456789');
       expect(token).toBe('new-token');
       expect(refreshTwitchToken).toHaveBeenCalledWith('refresh-token');
+    });
+
+    it('refresh失敗後も次の呼び出しが再試行できる', async () => {
+      const expired = {
+        twitch_access_token: 'expired-token',
+        twitch_refresh_token: 'refresh-token',
+        twitch_token_expires_at: new Date(Date.now() - 3600000).toISOString(),
+      };
+      const mockSupabaseAdmin: MockSupabaseAdmin = {
+        from: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn()
+          .mockResolvedValueOnce({ data: expired, error: null })
+          .mockResolvedValueOnce({ data: expired, error: null })
+          .mockResolvedValueOnce({ data: { twitch_access_token: 'recovered-token' }, error: null }),
+        update: vi.fn().mockReturnThis(),
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      };
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabaseAdmin as never);
+      vi.mocked(refreshTwitchToken)
+        .mockRejectedValueOnce(new Error('transient'))
+        .mockResolvedValueOnce({
+          access_token: 'recovered-token',
+          refresh_token: 'recovered-refresh',
+          expires_in: 3600,
+          token_type: 'bearer',
+          scope: [],
+        });
+
+      await expect(getTwitchAccessToken('flight-cleanup-user')).rejects.toMatchObject({
+        code: 'REFRESH_FAILED',
+      });
+      await expect(getTwitchAccessToken('flight-cleanup-user')).resolves.toBe('recovered-token');
+      expect(refreshTwitchToken).toHaveBeenCalledTimes(2);
+    });
+
+    it('異なるユーザーのrefreshは互いに待たず独立して実行する', async () => {
+      const mockSupabaseAdmin: MockSupabaseAdmin = {
+        from: vi.fn().mockReturnThis(),
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn()
+          .mockResolvedValueOnce({ data: {
+            twitch_access_token: 'expired-a',
+            twitch_refresh_token: 'refresh-a',
+            twitch_token_expires_at: new Date(0).toISOString(),
+          }, error: null })
+          .mockResolvedValueOnce({ data: {
+            twitch_access_token: 'expired-b',
+            twitch_refresh_token: 'refresh-b',
+            twitch_token_expires_at: new Date(0).toISOString(),
+          }, error: null })
+          .mockResolvedValueOnce({ data: { twitch_access_token: 'token-a' }, error: null })
+          .mockResolvedValueOnce({ data: { twitch_access_token: 'token-b' }, error: null }),
+        update: vi.fn().mockReturnThis(),
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      };
+      vi.mocked(getSupabaseAdmin).mockReturnValue(mockSupabaseAdmin as never);
+      const resolvers = new Map<string, (tokens: {
+        access_token: string; refresh_token: string; expires_in: number; token_type: string; scope: string[];
+      }) => void>();
+      vi.mocked(refreshTwitchToken).mockImplementation(refreshToken => new Promise(resolve => {
+        resolvers.set(refreshToken, resolve);
+      }));
+
+      const first = getTwitchAccessToken('user-a');
+      const second = getTwitchAccessToken('user-b');
+      await vi.waitFor(() => expect(refreshTwitchToken).toHaveBeenCalledTimes(2));
+      resolvers.get('refresh-a')?.({ access_token: 'token-a', refresh_token: 'next-a', expires_in: 3600, token_type: 'bearer', scope: [] });
+      resolvers.get('refresh-b')?.({ access_token: 'token-b', refresh_token: 'next-b', expires_in: 3600, token_type: 'bearer', scope: [] });
+
+      await expect(Promise.all([first, second])).resolves.toEqual(['token-a', 'token-b']);
+      expect(refreshTwitchToken).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -663,19 +739,23 @@ describe('Twitch Token Manager', () => {
   });
 
   describe('refreshTwitchAccessToken - スコープ同期', () => {
-    it('リフレッシュ時にsaveTwitchScopesが呼ばれる', async () => {
+    it('リフレッシュ時にtokenとscopeを1回のCAS UPDATEで保存する', async () => {
       const mockSupabaseAdmin: MockSupabaseAdmin = {
         from: vi.fn().mockReturnThis(),
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
-        maybeSingle: vi.fn().mockResolvedValue({
-          data: {
-            twitch_access_token: 'expired-token',
-            twitch_refresh_token: 'refresh-token',
-            twitch_token_expires_at: new Date(Date.now() - 3600000).toISOString(),
-          },
-          error: null,
-        }),
+        maybeSingle: vi.fn()
+          // 初回は期限切れトークンの読み取り。
+          .mockResolvedValueOnce({
+            data: {
+              twitch_access_token: 'expired-token',
+              twitch_refresh_token: 'refresh-token',
+              twitch_token_expires_at: new Date(Date.now() - 3600000).toISOString(),
+            },
+            error: null,
+          })
+          // CAS update が成功したときは、select で更新済み行が返る。
+          .mockResolvedValueOnce({ data: { twitch_access_token: 'new-token' }, error: null }),
         update: vi.fn().mockReturnThis(),
         insert: vi.fn().mockResolvedValue({ error: null }),
       };
@@ -692,42 +772,42 @@ describe('Twitch Token Manager', () => {
       const token = await getTwitchAccessToken('123456789');
       expect(token).toBe('new-token');
 
-      // saveTwitchScopes が呼ばれることを確認（update が2回呼ばれる: トークン保存 + スコープ保存）
-      // from が 'users' テーブルに対して呼ばれている
+      expect(mockSupabaseAdmin.update).toHaveBeenCalledTimes(1);
       expect(mockSupabaseAdmin.update).toHaveBeenCalledWith({
+        twitch_access_token: 'new-token',
+        twitch_refresh_token: 'new-refresh-token',
+        twitch_token_expires_at: expect.any(String),
         twitch_scopes: ['user:read:email', 'user:write:chat'],
       });
     });
 
-    it('saveTwitchScopes失敗時もトークンが正常に返る', async () => {
-      // 1回目のeqでトークン保存成功、2回目でスコープ保存失敗
-      let eqCallCount = 0;
-      const mockSupabaseAdmin: MockSupabaseAdmin = {
-        from: vi.fn().mockReturnThis(),
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockImplementation(() => {
-          eqCallCount++;
-          if (eqCallCount === 1) {
-            // getTwitchAccessToken の select チェーン
-            return {
-              maybeSingle: vi.fn().mockResolvedValue({
-                data: {
-                  twitch_access_token: 'expired-token',
-                  twitch_refresh_token: 'refresh-token',
-                  twitch_token_expires_at: new Date(Date.now() - 3600000).toISOString(),
-                },
-                error: null,
-              }),
-            };
-          }
-          if (eqCallCount === 2) {
-            // refreshTwitchAccessToken の update チェーン → 成功
-            return { error: null };
-          }
-          // saveTwitchScopes の update チェーン → 失敗
-          return { error: { code: 'PGRST000', message: 'Connection failed' } };
+    it('token/scopeのCAS保存失敗はrefresh失敗とし、無条件の後続scope UPDATEを行わない', async () => {
+      const expiredRow = {
+        twitch_access_token: 'expired-token',
+        twitch_refresh_token: 'refresh-token',
+        twitch_token_expires_at: new Date(Date.now() - 3600000).toISOString(),
+      };
+      const readBuilder: any = {
+        select: vi.fn(() => readBuilder),
+        eq: vi.fn(() => readBuilder),
+        maybeSingle: vi.fn().mockResolvedValue({ data: expiredRow, error: null }),
+      };
+      const refreshBuilder: any = {
+        update: vi.fn(() => refreshBuilder),
+        eq: vi.fn(() => refreshBuilder),
+        select: vi.fn(() => refreshBuilder),
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: null,
+          error: { code: 'PGRST000', message: 'Connection failed' },
         }),
-        update: vi.fn().mockReturnThis(),
+      };
+      const mockSupabaseAdmin: MockSupabaseAdmin = {
+        from: vi.fn()
+          .mockReturnValueOnce(readBuilder)
+          .mockReturnValueOnce(refreshBuilder),
+        select: vi.fn(),
+        eq: vi.fn(),
+        update: vi.fn(),
         insert: vi.fn().mockResolvedValue({ error: null }),
       };
 
@@ -740,9 +820,17 @@ describe('Twitch Token Manager', () => {
         scope: ['user:read:email', 'user:write:chat'],
       });
 
-      // saveTwitchScopes が失敗してもトークンは正常に返される
-      const token = await getTwitchAccessToken('123456789');
-      expect(token).toBe('new-token');
+      await expect(getTwitchAccessToken('123456789')).rejects.toMatchObject({
+        code: 'REFRESH_FAILED',
+      });
+      expect(mockSupabaseAdmin.from).toHaveBeenCalledTimes(2);
+      expect(refreshBuilder.update).toHaveBeenCalledTimes(1);
+      expect(refreshBuilder.update).toHaveBeenCalledWith({
+        twitch_access_token: 'new-token',
+        twitch_refresh_token: 'new-refresh-token',
+        twitch_token_expires_at: expect.any(String),
+        twitch_scopes: ['user:read:email', 'user:write:chat'],
+      });
     });
 
     it('リフレッシュレスポンスのスコープでDBが全置換される（マージではない）', async () => {
@@ -752,14 +840,16 @@ describe('Twitch Token Manager', () => {
         from: vi.fn().mockReturnThis(),
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
-        maybeSingle: vi.fn().mockResolvedValue({
-          data: {
-            twitch_access_token: 'expired-token',
-            twitch_refresh_token: 'refresh-token',
-            twitch_token_expires_at: new Date(Date.now() - 3600000).toISOString(),
-          },
-          error: null,
-        }),
+        maybeSingle: vi.fn()
+          .mockResolvedValueOnce({
+            data: {
+              twitch_access_token: 'expired-token',
+              twitch_refresh_token: 'refresh-token',
+              twitch_token_expires_at: new Date(Date.now() - 3600000).toISOString(),
+            },
+            error: null,
+          })
+          .mockResolvedValueOnce({ data: { twitch_access_token: 'new-token' }, error: null }),
         update: vi.fn().mockReturnThis(),
         insert: vi.fn().mockResolvedValue({ error: null }),
       };
@@ -777,13 +867,17 @@ describe('Twitch Token Manager', () => {
       const token = await getTwitchAccessToken('123456789');
       expect(token).toBe('new-token');
 
-      // 全置換: リフレッシュレスポンスのスコープのみ（DBの既存user:write:chatは含まれない）
+      // 全置換scopeもtokenと同じCASに含め、古いrefresh処理から後続UPDATEしない。
+      expect(mockSupabaseAdmin.update).toHaveBeenCalledTimes(1);
       expect(mockSupabaseAdmin.update).toHaveBeenCalledWith({
+        twitch_access_token: 'new-token',
+        twitch_refresh_token: 'new-refresh-token',
+        twitch_token_expires_at: expect.any(String),
         twitch_scopes: ['user:read:email', 'channel:read:redemptions'],
       });
     });
 
-    it('リフレッシュレスポンスにスコープがない場合、saveTwitchScopesは呼ばれない', async () => {
+    it('リフレッシュレスポンスのスコープが空なら同じCAS UPDATEへ空配列を保存する', async () => {
       const updateMock = vi.fn().mockReturnThis();
       const mockSupabaseAdmin: MockSupabaseAdmin = {
         from: vi.fn().mockReturnThis(),
@@ -812,11 +906,12 @@ describe('Twitch Token Manager', () => {
 
       await getTwitchAccessToken('123456789');
 
-      // update はトークン保存の1回だけ（スコープ保存は呼ばれない）
+      // scope が空でも別UPDATEへ分けず、tokenと同じCASでDB状態を全置換する。
       expect(updateMock).toHaveBeenCalledTimes(1);
       expect(updateMock).toHaveBeenCalledWith(
         expect.objectContaining({
           twitch_access_token: 'new-token',
+          twitch_scopes: [],
         })
       );
     });


### PR DESCRIPTION
## 概要

Twitch OAuth token endpoint の一時的な 522 系障害を安全に扱い、refresh token の並行更新・機密情報のログ流出・重複エラー永続化を防ぎます。

## 変更

- refresh token 交換だけを対象に、408/429/500/502/503/504/522/523/524を最大3回、`Retry-After`優先＋full jitterで再試行
- 単回使用のauthorization code交換は再送しない
- token endpoint本文、authorization code、refresh token、client secretをError・永続ログへ渡さない
- Cloudflare Workersのrequest境界を跨ぐmodule-scope Promise共有を廃止
- user/BOT token更新を旧refresh token付きCASにし、loserはwinner tokenを再取得
- user token・refresh token・期限・scopeを同じCAS UPDATEへ統合
- BOTを`error`にするのはHTTP 400/401だけとし、522/network/403/404/501等ではactiveを維持
- OAuthエラーのdurable writerをAPI境界の1箇所へ統一

## 検証

- 対象: 116 tests passed
- full unit: 3396 passed / 34 skipped
- `npm run typecheck`
- 変更8ファイルのESLint
- `npm run build`
- `git diff --check`
- Sol厳格レビュー: BLOCKER/HIGH/MEDIUM/LOWすべて0

Fixes #810
Fixes #812

Related: #811, #670, #653
