### PR TITLE
fix(overlay): 画像読込停止で後続ガチャが消える障害を修正

### DIFF
--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -155,6 +155,12 @@ const RELOAD_DEFER_RETRY_MS = 30 * 1000;
 // (メタデータ未ロードでNaN等)に使う「再生終了見込み」の安全上限。
 // リロード延期判定(soundPlayingUntilRef)のフォールバックにのみ使う
 const SOUND_DURATION_FALLBACK_MS = 15 * 1000;
+// OBS Browser Source may keep a large animated image request pending without
+// firing either `load` or `error`. Aspect-ratio detection is presentation-only,
+// so it must never hold the business-event queue indefinitely. After this
+// bounded wait the card renders with the normal landscape layout; a slow image
+// may continue loading in the actual card element without blocking later draws.
+const IMAGE_METADATA_TIMEOUT_MS = 1_500;
 
 // sessionStorage キー。リロード前後で状態を引き継ぐために使う
 const RELOAD_COOLDOWN_STORAGE_KEY = "twica-overlay-reload";
@@ -216,6 +222,15 @@ export default function OverlayPage() {
   // 連続引き換え時に前のカードが消えて最後の1件しか表示されない問題を解消
   const queueRef = useRef<GachaResult[]>([]);
   const isDisplayingRef = useRef(false);
+  // Image metadata checks are cancellable because their Promise is awaited by
+  // the display queue. Cleanup must resolve (not merely clear) pending checks,
+  // otherwise the suspended processQueue closure and its card remain retained.
+  const activeImageCheckCancelsRef = useRef<Set<() => void>>(new Set());
+  const isOverlayMountedRef = useRef(false);
+  // A streamer change can reuse this component instance. The generation lets
+  // an old async image check distinguish that transport cleanup from the new
+  // subscription setup, even when the mounted flag has already become true.
+  const queueGenerationRef = useRef(0);
   const playedSoundGroupIdsRef = useRef<Set<string>>(new Set());
   // processQueueの再帰呼び出し用ref（useCallback内で自身を参照するため）
   const processQueueRef = useRef<() => void>(() => {});
@@ -470,24 +485,52 @@ export default function OverlayPage() {
       }
 
       const img = new window.Image();
+      let settled = false;
+      let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+      // `finish` is shared by load/error/timeout so only the first terminal
+      // signal can update layout state. A late load after timeout must not
+      // overwrite the aspect ratio of a newer card already being displayed.
+      const finish = (
+        isPortrait: boolean,
+        isSmall: boolean,
+        updateLayout = true
+      ) => {
+        if (settled) return;
+        settled = true;
+        if (timeoutId !== null) {
+          clearTimeout(timeoutId);
+        }
+        activeImageCheckCancelsRef.current.delete(cancel);
+        if (updateLayout && isOverlayMountedRef.current) {
+          setIsPortraitImage(isPortrait);
+          setIsSmallImage(isSmall);
+        }
+        resolve(isPortrait);
+      };
+      const cancel = () => {
+        // Cleanup resolves the awaited check while deliberately suppressing
+        // layout updates. processQueue's generation check below then prevents
+        // the cancelled card from scheduling animation or sound.
+        finish(false, false, false);
+      };
+      activeImageCheckCancelsRef.current.add(cancel);
+
       img.onload = () => {
         // 画像の縦が横より大きい（正方形でない縦長画像）の場合はポートレイト
         // Portrait if height is greater than width (not a square)
         const isPortrait = img.height > img.width;
-        setIsPortraitImage(isPortrait);
-
         // 画像が400x400未満の場合は小さい画像として判定
         // 小さい画像モードを自動適用するために使用
         const isSmall = img.width < 400 && img.height < 400;
-        setIsSmallImage(isSmall);
-
-        resolve(isPortrait);
+        finish(isPortrait, isSmall);
       };
       img.onerror = () => {
-        setIsPortraitImage(false);
-        setIsSmallImage(false);
-        resolve(false);
+        finish(false, false);
       };
+      timeoutId = setTimeout(() => {
+        finish(false, false);
+      }, IMAGE_METADATA_TIMEOUT_MS);
       img.src = imageUrl;
     });
   }, []);
@@ -583,6 +626,7 @@ export default function OverlayPage() {
    * 古いバージョンを参照する問題を回避する
    */
   const processQueue = useCallback(async () => {
+    const queueGeneration = queueGenerationRef.current;
     const next = queueRef.current.shift();
     if (!next) {
       isDisplayingRef.current = false;
@@ -592,6 +636,12 @@ export default function OverlayPage() {
 
     // 画像のアスペクト比をチェック（autoPortraitモード用）
     await checkImageAspectRatio(next.card.image_url);
+    if (
+      !isOverlayMountedRef.current
+      || queueGeneration !== queueGenerationRef.current
+    ) {
+      return;
+    }
 
     // このカードのレアリティに紐づくエフェクトを解決する。
     // effects スイッチが OFF なら常に "none"（全レアリティ無効）。
@@ -945,7 +995,9 @@ export default function OverlayPage() {
   // 依存配列は streamerId のみ。displayResult/addDebugLog は ref 経由で参照し、
   // callback の再生成（soundSettings 変更等）で subscription が破棄・再作成されないようにする
   useEffect(() => {
+    isOverlayMountedRef.current = true;
     const playedSoundGroupIds = playedSoundGroupIdsRef.current;
+    const activeImageCheckCancels = activeImageCheckCancelsRef.current;
 
     queueMicrotask(() => {
       addDebugLogRef.current(`Starting subscription for streamer: ${streamerId}`);
@@ -1011,6 +1063,12 @@ export default function OverlayPage() {
     cleanupRef.current = cleanup;
 
     return () => {
+      isOverlayMountedRef.current = false;
+      queueGenerationRef.current += 1;
+      for (const cancel of [...activeImageCheckCancels]) {
+        cancel();
+      }
+      activeImageCheckCancels.clear();
       // キューをクリアして未再生アイテムを破棄
       queueRef.current = [];
       isDisplayingRef.current = false;

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -199,6 +199,185 @@ describe('OverlayPage', () => {
     expect(playMock).toHaveBeenCalledTimes(1)
   })
 
+  it('画像メタデータ取得が停止しても、タイムアウト後にN連キューを最後まで進める', async () => {
+    vi.useFakeTimers()
+
+    let imageLoadCount = 0
+    const imageInstances: MockImage[] = []
+    class MockImage {
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      width = 640
+      height = 480
+
+      set src(value: string) {
+        void value
+        imageLoadCount += 1
+        imageInstances.push(this)
+        // 重いGIFなどでブラウザの画像メタデータ取得が完了しない場合でも、
+        // 表示キュー全体を無期限に止めないことがこの回帰テストの対象である。
+        // 1・3枚目だけは通常どおりロード完了し、2枚目は意図的に無応答にする。
+        if (imageLoadCount !== 2) {
+          setTimeout(() => this.onload?.(), 0)
+        }
+      }
+    }
+    vi.stubGlobal('Image', MockImage)
+
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
+      options.onSuccess?.()
+      return vi.fn()
+    })
+
+    render(<OverlayPage />)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        card: {
+          id: 'card-1', name: 'Alpha', description: null,
+          image_url: 'https://example.com/alpha.png', rarity: 'rare',
+        },
+        cards: [
+          {
+            id: 'card-1', name: 'Alpha', description: null,
+            image_url: 'https://example.com/alpha.png', rarity: 'rare',
+          },
+          {
+            id: 'card-2', name: 'Beta', description: null,
+            image_url: 'https://example.com/stalled.gif', rarity: 'common',
+          },
+          {
+            id: 'card-3', name: 'Gamma', description: null,
+            image_url: 'https://example.com/gamma.png', rarity: 'legendary',
+          },
+        ],
+        userTwitchUsername: 'Viewer',
+      })
+    })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+
+    // 1枚目の表示終了後、2枚目の画像ロードは応答しない。切替の0.5秒後から
+    // タイムアウト直前まで結果領域は空であり、2枚目が早まって表示されない。
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6500 + 1499)
+    })
+    expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
+    expect(screen.queryByText('Beta')).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1 + 100)
+    })
+    expect(screen.getByText('Beta')).toBeInTheDocument()
+
+    // 2枚目の表示終了後は3枚目の通常ロードへ戻り、無応答だった1枚によって
+    // キューが恒久停止しない。
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6500 + 100)
+    })
+    expect(screen.getByText('Gamma')).toBeInTheDocument()
+
+    // タイムアウト済みの2枚目が後から縦長としてロード完了しても、現在の3枚目の
+    // レイアウトを変更してはならない。autoPortraitの既定値はtrueなので、古い
+    // onload が state を更新すると通常カードの見出し(Gamma)が画像のみ表示に
+    // 切り替わって消える。この確認で stale callback の汚染を防ぐ。
+    imageInstances[1].width = 100
+    imageInstances[1].height = 200
+    await act(async () => {
+      imageInstances[1].onload?.()
+    })
+    expect(screen.getByText('Gamma')).toBeInTheDocument()
+  })
+
+  it('画像メタデータ待機中にunmountすると、タイムアウト後も後続カードを開始しない', async () => {
+    vi.useFakeTimers()
+
+    const imageInstances: MockImage[] = []
+    class MockImage {
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      width = 640
+      height = 480
+
+      set src(value: string) {
+        void value
+        imageInstances.push(this)
+        // 最初のカードだけ通常ロード、2枚目は無応答にしてunmount時の保留状態を作る。
+        if (imageInstances.length === 1) {
+          setTimeout(() => this.onload?.(), 0)
+        }
+      }
+    }
+    vi.stubGlobal('Image', MockImage)
+
+    const playMock = vi.fn().mockResolvedValue(undefined)
+    class MockAudio {
+      currentTime = 0
+      preload = ''
+      constructor(src?: string) {
+        void src
+      }
+      play = playMock
+      pause = vi.fn()
+    }
+    vi.stubGlobal('Audio', MockAudio)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ soundUrl: 'https://example.com/gacha.mp3', soundEnabled: true }),
+    }))
+
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
+      options.onSuccess?.()
+      return vi.fn()
+    })
+
+    const view = render(<OverlayPage />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    playMock.mockClear()
+
+    const cards = ['Alpha', 'Beta', 'Gamma'].map((name, index) => ({
+      id: `card-${index + 1}`,
+      name,
+      description: null,
+      image_url: `https://example.com/${name.toLowerCase()}.png`,
+      rarity: 'rare',
+    }))
+    act(() => {
+      onGachaResult?.({ type: 'gacha', card: cards[0], cards, userTwitchUsername: 'Viewer' })
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6600)
+    })
+    expect(imageInstances).toHaveLength(2)
+    const playsBeforeUnmount = playMock.mock.calls.length
+
+    view.unmount()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000)
+    })
+
+    // cleanup後に保留タイムアウトが解決しても、3枚目を開始する追加処理・音再生を
+    // 行わない。インスタンス数は後続の画像判定が起きていないことの決定的な観測点。
+    expect(imageInstances).toHaveLength(2)
+    expect(playMock).toHaveBeenCalledTimes(playsBeforeUnmount)
+  })
+
   // エフェクト演出を1枚のカードで発火させる共通ヘルパ
   const renderWithGacha = async (
     search: string,


### PR DESCRIPTION
## 概要

本番OBSオーバーレイで、重いGIF等の画像メタデータ取得が `load` / `error` のどちらも返さない場合に、2枚目以降のガチャ結果キューが永久停止する障害を修正します。

## 原因

カード表示前の縦横比判定を無期限に `await` していました。本番の本人オーバーレイで、2.3MB GIFのイベント受信後に表示処理が停止することを再現済みです。

## 修正

- 画像メタデータ判定を1.5秒で標準レイアウトへフォールバック
- `load` / `error` / timeoutをsingle-settlement化し、遅延 `onload` による後続カードの状態汚染を防止
- unmount・streamer切替時に保留判定を解決・キャンセル
- mounted flagとqueue generationでcleanup後の表示・タイマー・効果音を遮断
- 永久pending、遅延 `onload`、unmountの回帰テストを追加

## 検証

- OverlayPage: 28 tests passed
- Overlay transport関連: 39 tests passed
- TypeScript: passed
- ESLint（対象2ファイル）: passed
- Production build: passed
- 独立Sol再レビュー: 全重要度0件
