### PR TITLE
fix(overlay): canonicalize polling cursor

### DIFF
--- a/src/app/api/overlay/[streamerId]/events/route.ts
+++ b/src/app/api/overlay/[streamerId]/events/route.ts
@@ -58,7 +58,7 @@ function normalizeDateParam(value: string | null): string | null {
   // cursor to that value, every later poll therefore returned HTTP 400 and no
   // subsequent gacha result could be displayed.
   const match = value.match(
-    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|([+-])(\d{2}):(\d{2}))$/
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|([+-]| )(\d{2}):(\d{2}))$/
   );
   if (match) {
     const [
@@ -112,8 +112,13 @@ function normalizeDateParam(value: string | null): string | null {
       const offsetHours = Number(offsetHourText);
       const offsetMinutePart = Number(offsetMinuteText);
       if (offsetHours > 23 || offsetMinutePart > 59) return null;
+      // A literal plus in a query string can be normalized to a space by an
+      // application/x-www-form-urlencoded parser before NextRequest exposes
+      // the value. In the timezone-sign position only, treat that space as a
+      // positive offset. The strict surrounding timestamp pattern prevents
+      // accepting arbitrary whitespace or a malformed public cursor.
       offsetMinutes =
-        (offsetSign === "+" ? 1 : -1) *
+        (offsetSign === "-" ? -1 : 1) *
         (offsetHours * 60 + offsetMinutePart);
     }
 
@@ -298,6 +303,19 @@ export async function GET(
     // forever and prevent later committed rows from being reached.
     const lastHistoryRow =
       overlayHistoryRows[overlayHistoryRows.length - 1] ?? null;
+    // Never expose the database driver's signed-offset/microsecond wire value
+    // as the next public cursor. A canonical UTC cursor avoids query-string
+    // plus-sign ambiguity on every later OBS poll even if an intermediary
+    // applies form-decoding semantics. The row already passed through the
+    // same database timestamp contract used by the query predicate, so a
+    // normalization failure indicates a server-side invariant violation.
+    const normalizedNextCursor = lastHistoryRow
+      ? normalizeDateParam(lastHistoryRow.redeemed_at)
+      : null;
+    if (lastHistoryRow && !normalizedNextCursor) {
+      throw new Error("Invalid redeemed_at value returned by the database");
+    }
+
     return NextResponse.json({
       // Existing OBS pages retain the legacy row shape. New controllers opt
       // into V1 to avoid returning duplicate card payloads during rollout.
@@ -306,7 +324,7 @@ export async function GET(
         : { events }),
       nextCursor: lastHistoryRow
         ? {
-            redeemedAt: lastHistoryRow.redeemed_at,
+            redeemedAt: normalizedNextCursor,
             historyId: lastHistoryRow.id,
           }
         : null,

--- a/tests/unit/overlay-events-api.test.ts
+++ b/tests/unit/overlay-events-api.test.ts
@@ -274,6 +274,49 @@ describe("GET /api/overlay/[streamerId]/events", () => {
     );
   });
 
+  it("Cloudflareで+が空白化されたPostgreSQL cursorを正規化してqueryへ渡す", async () => {
+    const blankedOffsetCursor = "2026-07-24T14:40:14.511943 00:00";
+    const normalizedCursor = "2026-07-24T14:40:14.511Z";
+    const db = useRows([]);
+
+    // CDNが未エスケープの+を空白へ復号した場合も、polling cursorの意味は
+    // +00:00と同じである。URLSearchParams経由でその実際の入力形を固定する。
+    const response = await GET(
+      createRequest({ since: blankedOffsetCursor }),
+      routeParams()
+    );
+
+    expect(response.status).toBe(200);
+    expect(db.calls[0].whereCondition).toEqual(
+      and(
+        eq(gachaHistoryTable.streamer_id, STREAMER_ID),
+        gt(gachaHistoryTable.redeemed_at, normalizedCursor)
+      )
+    );
+  });
+
+  it("nextCursorはPostgreSQL timestampをUTC ISO millisecondsで返す", async () => {
+    const rawPostgresTimestamp = "2026-07-24T14:40:14.511943+00:00";
+    useRows([
+      {
+        ...DISPLAY_ROW,
+        redeemed_at: rawPostgresTimestamp,
+      },
+    ]);
+
+    const response = await GET(
+      createRequest({ since: SINCE }),
+      routeParams()
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.nextCursor).toEqual({
+      redeemedAt: "2026-07-24T14:40:14.511Z",
+      historyId: DISPLAY_ROW.id,
+    });
+  });
+
   it("PlanetScale queryが必要列・join・安定順・bounded limitを使う", async () => {
     const db = useRows([]);
 


### PR DESCRIPTION
## 概要

本番OBSで1件目のガチャ結果だけ表示され、2件目以降のpollingがHTTP 400になる障害の追加ホットフィックスです。

- query layerで `+` が空白化されたUTC offset cursorを厳格なtimestamp位置に限って受理
- DBのmicroseconds/signed-offset値を公開nextCursorでUTC ISO milliseconds (`Z`) に正規化
- 入力と出力の回帰テストを追加

## 緊急対応

本番復旧を優先するため、ユーザー指示により事前の独立レビューは省略します。復旧確認後に厳格なフォローアップレビューを実施し、指摘があれば別PRで解消します。

## デプロイ前検証

- `./node_modules/.bin/vitest run tests/unit/overlay-events-api.test.ts` (11 passed)
- `./node_modules/.bin/eslint src/app/api/overlay/[streamerId]/events/route.ts tests/unit/overlay-events-api.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`