### PR TITLE
fix(overlay): preserve polling cursor microseconds

### DIFF
--- a/src/app/api/overlay/[streamerId]/events/route.ts
+++ b/src/app/api/overlay/[streamerId]/events/route.ts
@@ -58,78 +58,83 @@ function normalizeDateParam(value: string | null): string | null {
   // cursor to that value, every later poll therefore returned HTTP 400 and no
   // subsequent gacha result could be displayed.
   const match = value.match(
-    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|([+-]| )(\d{2}):(\d{2}))$/
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,6}))?(Z|([+-]| )(\d{2}):(\d{2}))$/
   );
-  if (match) {
-    const [
-      ,
-      yearText,
-      monthText,
-      dayText,
-      hourText,
-      minuteText,
-      secondText,
-      fraction = "",
-      timezone,
-      offsetSign,
-      offsetHourText,
-      offsetMinuteText,
-    ] = match;
-    const year = Number(yearText);
-    const month = Number(monthText);
-    const day = Number(dayText);
-    const hour = Number(hourText);
-    const minute = Number(minuteText);
-    const second = Number(secondText);
-    const millisecond = Number(fraction.padEnd(3, "0").slice(0, 3));
-    const localTimestamp = Date.UTC(
-      year,
-      month - 1,
-      day,
-      hour,
-      minute,
-      second,
-      millisecond
-    );
-    const localDate = new Date(localTimestamp);
+  if (!match) return null;
 
-    // Date.UTC normalizes invalid calendar values (for example February 30)
-    // instead of rejecting them. Compare every component so a malformed
-    // public cursor cannot silently move the polling window to another day.
-    if (
-      localDate.getUTCFullYear() !== year ||
-      localDate.getUTCMonth() !== month - 1 ||
-      localDate.getUTCDate() !== day ||
-      localDate.getUTCHours() !== hour ||
-      localDate.getUTCMinutes() !== minute ||
-      localDate.getUTCSeconds() !== second
-    ) {
-      return null;
-    }
+  const [
+    ,
+    yearText,
+    monthText,
+    dayText,
+    hourText,
+    minuteText,
+    secondText,
+    fraction = "",
+    timezone,
+    offsetSign,
+    offsetHourText,
+    offsetMinuteText,
+  ] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  // PostgreSQL represents years before 1 CE with a separate BC suffix rather
+  // than ISO year zero. This public cursor grammar intentionally excludes BC
+  // and extended years so every accepted value remains a four-digit DB value.
+  if (year < 1) return null;
 
-    let offsetMinutes = 0;
-    if (timezone !== "Z") {
-      const offsetHours = Number(offsetHourText);
-      const offsetMinutePart = Number(offsetMinuteText);
-      if (offsetHours > 23 || offsetMinutePart > 59) return null;
-      // A literal plus in a query string can be normalized to a space by an
-      // application/x-www-form-urlencoded parser before NextRequest exposes
-      // the value. In the timezone-sign position only, treat that space as a
-      // positive offset. The strict surrounding timestamp pattern prevents
-      // accepting arbitrary whitespace or a malformed public cursor.
-      offsetMinutes =
-        (offsetSign === "-" ? -1 : 1) *
-        (offsetHours * 60 + offsetMinutePart);
-    }
+  // Build at whole-second precision. JavaScript Date stores only
+  // milliseconds, while PostgreSQL cursors use up to six fractional digits.
+  // Keeping the fraction outside Date prevents truncating the authoritative
+  // `(redeemed_at, id)` cursor and re-reading the same database row forever.
+  // setUTCFullYear is used instead of Date.UTC so four-digit years below 100
+  // are not implicitly remapped into 1900-1999.
+  const localDate = new Date(0);
+  localDate.setUTCFullYear(year, month - 1, day);
+  localDate.setUTCHours(hour, minute, second, 0);
 
-    return new Date(localTimestamp - offsetMinutes * 60_000).toISOString();
+  // Date setters normalize invalid calendar values (for example February 30)
+  // instead of rejecting them. Compare every component so a malformed public
+  // cursor cannot silently move the polling window to another day.
+  if (
+    localDate.getUTCFullYear() !== year ||
+    localDate.getUTCMonth() !== month - 1 ||
+    localDate.getUTCDate() !== day ||
+    localDate.getUTCHours() !== hour ||
+    localDate.getUTCMinutes() !== minute ||
+    localDate.getUTCSeconds() !== second
+  ) {
+    return null;
   }
 
-  // Retain compatibility with older callers that sent another
-  // ECMAScript-supported date form; responses always canonicalize back to
-  // UTC ISO milliseconds before reaching the database predicate.
-  const timestamp = Date.parse(value);
-  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
+  let offsetMinutes = 0;
+  if (timezone !== "Z") {
+    const offsetHours = Number(offsetHourText);
+    const offsetMinutePart = Number(offsetMinuteText);
+    if (offsetHours > 23 || offsetMinutePart > 59) return null;
+    // A literal plus in a query string can be normalized to a space by an
+    // application/x-www-form-urlencoded parser before NextRequest exposes
+    // the value. In the timezone-sign position only, treat that space as a
+    // positive offset. The strict surrounding timestamp pattern prevents
+    // accepting arbitrary whitespace or a malformed public cursor.
+    offsetMinutes =
+      (offsetSign === "-" ? -1 : 1) *
+      (offsetHours * 60 + offsetMinutePart);
+  }
+
+  const utcDate = new Date(localDate.getTime() - offsetMinutes * 60_000);
+  // A valid four-digit local year can cross into year 0 or 10000 after offset
+  // conversion. Date#toISOString uses an extended signed-year representation
+  // there, which is outside this endpoint's strict cursor grammar and would
+  // make fixed-width canonicalization unsafe.
+  const utcYear = utcDate.getUTCFullYear();
+  if (utcYear < 1 || utcYear > 9999) return null;
+  const utcWholeSecond = utcDate.toISOString().slice(0, 19);
+  return `${utcWholeSecond}${fraction ? `.${fraction}` : ""}Z`;
 }
 
 /**

--- a/src/lib/overlay-realtime/publisher.ts
+++ b/src/lib/overlay-realtime/publisher.ts
@@ -113,6 +113,7 @@ async function buildCommittedEnvelope(
 }
 
 interface OverlayRealtimePublisherEnvironment {
+  runtime: 'workers' | 'local'
   mode: string | undefined
   streamerAllowlist: string | undefined
   publishUrl: string | undefined
@@ -166,6 +167,7 @@ async function getPublisherEnvironment(): Promise<OverlayRealtimePublisherEnviro
     // stale build-time URL, or bypass polling-only mode after a binding is
     // deliberately removed.
     return {
+      runtime: 'workers',
       mode: stringBinding(runtimeEnv, 'OVERLAY_REALTIME_MODE'),
       streamerAllowlist: stringBinding(
         runtimeEnv,
@@ -187,6 +189,7 @@ async function getPublisherEnvironment(): Promise<OverlayRealtimePublisherEnviro
         errorName: error instanceof Error ? error.name : 'unknown',
       })
       return {
+        runtime: 'workers',
         mode: undefined,
         streamerAllowlist: undefined,
         publishUrl: undefined,
@@ -198,6 +201,7 @@ async function getPublisherEnvironment(): Promise<OverlayRealtimePublisherEnviro
     // `next dev` and Vitest have no OpenNext request context. Their environment
     // is process-local and cannot cross the preview/production Workers boundary.
     return {
+      runtime: 'local',
       mode: process.env.OVERLAY_REALTIME_MODE,
       streamerAllowlist: process.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST,
       publishUrl: process.env.OVERLAY_REALTIME_PUBLISH_URL,
@@ -228,10 +232,9 @@ function retryableStatus(status: number): boolean {
 async function discardResponseBody(response: Response): Promise<void> {
   if (!response.body) return
   try {
-    // The publisher needs only the HTTP status. Cloudflare counts a response
-    // whose headers arrived but whose body remains unread as an open
-    // connection; canceling it promptly releases that slot for concurrent
-    // EventSub deliveries without parsing or logging private response data.
+    // The publisher needs only the HTTP status. Canceling the unread stream is
+    // Cloudflare's recommended cleanup and releases its remaining resources
+    // without parsing or logging private response data.
     await response.body.cancel()
   } catch {
     // Transport cleanup is best-effort. A successfully classified publish
@@ -265,7 +268,11 @@ export async function publishCommittedGachaBatch(
   try {
     const secret = publisherEnv.publishSecret
     const url = resolvePublishUrl(streamerId, publisherEnv.publishUrl)
-    if (!secret || !url) {
+    if (
+      !secret
+      || !url
+      || (publisherEnv.runtime === 'workers' && !publisherEnv.publishService)
+    ) {
       logger.warn('[overlay-realtime] publisher configuration missing', { streamerId })
       return { outcome: 'skipped', attempts: 0, errorCode: 'configuration-missing' }
     }

--- a/src/lib/overlay-realtime/publisher.ts
+++ b/src/lib/overlay-realtime/publisher.ts
@@ -117,6 +117,11 @@ interface OverlayRealtimePublisherEnvironment {
   streamerAllowlist: string | undefined
   publishUrl: string | undefined
   publishSecret: string | undefined
+  publishService: OverlayRealtimeServiceBinding | undefined
+}
+
+interface OverlayRealtimeServiceBinding {
+  fetch(request: Request): Promise<Response>
 }
 
 function stringBinding(
@@ -125,6 +130,20 @@ function stringBinding(
 ): string | undefined {
   const value = env[key]
   return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function serviceBinding(
+  env: Record<string, unknown>
+): OverlayRealtimeServiceBinding | undefined {
+  const value = env.OVERLAY_REALTIME_SERVICE
+  return (
+    typeof value === 'object'
+    && value !== null
+    && 'fetch' in value
+    && typeof value.fetch === 'function'
+  )
+    ? value as OverlayRealtimeServiceBinding
+    : undefined
 }
 
 /**
@@ -157,6 +176,7 @@ async function getPublisherEnvironment(): Promise<OverlayRealtimePublisherEnviro
         runtimeEnv,
         'OVERLAY_REALTIME_PUBLISH_SECRET'
       ),
+      publishService: serviceBinding(runtimeEnv),
     }
   } catch (error) {
     if (process.env.NODE_ENV === 'production') {
@@ -171,6 +191,7 @@ async function getPublisherEnvironment(): Promise<OverlayRealtimePublisherEnviro
         streamerAllowlist: undefined,
         publishUrl: undefined,
         publishSecret: undefined,
+        publishService: undefined,
       }
     }
 
@@ -181,6 +202,7 @@ async function getPublisherEnvironment(): Promise<OverlayRealtimePublisherEnviro
       streamerAllowlist: process.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST,
       publishUrl: process.env.OVERLAY_REALTIME_PUBLISH_URL,
       publishSecret: process.env.OVERLAY_REALTIME_PUBLISH_SECRET,
+      publishService: undefined,
     }
   }
 }
@@ -260,7 +282,7 @@ export async function publishCommittedGachaBatch(
       const timeout = setTimeout(() => controller.abort(), 1_500)
 
       try {
-        const response = await fetch(url, {
+        const requestInit: RequestInit = {
           method: 'POST',
           body,
           headers: {
@@ -270,7 +292,14 @@ export async function publishCommittedGachaBatch(
             'x-twica-signature': signature,
           },
           signal: controller.signal,
-        })
+        }
+        // Cloudflare rejects global fetch() calls from one Worker to another
+        // Worker on the same zone. The Service Binding is the supported,
+        // zero-network-hop path in deployed Workers; global fetch remains only
+        // for next dev and Vitest, where no Workers binding exists.
+        const response = publisherEnv.publishService
+          ? await publisherEnv.publishService.fetch(new Request(url, requestInit))
+          : await fetch(url, requestInit)
         if (response.ok) return { outcome: 'accepted', attempts: attempt }
         if (!retryableStatus(response.status) || attempt >= maxAttempts) {
           logger.warn('[overlay-realtime] publish rejected', {

--- a/src/lib/overlay-realtime/publisher.ts
+++ b/src/lib/overlay-realtime/publisher.ts
@@ -138,28 +138,50 @@ function stringBinding(
  * for `next dev`, Vitest, and other non-Workers execution contexts.
  */
 async function getPublisherEnvironment(): Promise<OverlayRealtimePublisherEnvironment> {
-  let runtimeEnv: Record<string, unknown> = {}
   try {
     const { getCloudflareContext } = await import('@opennextjs/cloudflare')
     const { env } = await getCloudflareContext({ async: true })
-    runtimeEnv = env as unknown as Record<string, unknown>
-  } catch {
-    // OpenNext does not install a request context in local Node execution.
-  }
+    const runtimeEnv = env as unknown as Record<string, unknown>
+    // Treat Workers bindings as one atomic configuration snapshot. Falling
+    // back one key at a time could combine a rotated runtime secret with a
+    // stale build-time URL, or bypass polling-only mode after a binding is
+    // deliberately removed.
+    return {
+      mode: stringBinding(runtimeEnv, 'OVERLAY_REALTIME_MODE'),
+      streamerAllowlist: stringBinding(
+        runtimeEnv,
+        'OVERLAY_REALTIME_STREAMER_ALLOWLIST'
+      ),
+      publishUrl: stringBinding(runtimeEnv, 'OVERLAY_REALTIME_PUBLISH_URL'),
+      publishSecret: stringBinding(
+        runtimeEnv,
+        'OVERLAY_REALTIME_PUBLISH_SECRET'
+      ),
+    }
+  } catch (error) {
+    if (process.env.NODE_ENV === 'production') {
+      // A production publish must fail closed when its Workers request context
+      // is unavailable. The polling source remains authoritative, so skipping
+      // is safer than sending with possibly stale build-time credentials.
+      logger.warn('[overlay-realtime] runtime publisher context unavailable', {
+        errorName: error instanceof Error ? error.name : 'unknown',
+      })
+      return {
+        mode: undefined,
+        streamerAllowlist: undefined,
+        publishUrl: undefined,
+        publishSecret: undefined,
+      }
+    }
 
-  return {
-    mode:
-      stringBinding(runtimeEnv, 'OVERLAY_REALTIME_MODE') ??
-      process.env.OVERLAY_REALTIME_MODE,
-    streamerAllowlist:
-      stringBinding(runtimeEnv, 'OVERLAY_REALTIME_STREAMER_ALLOWLIST') ??
-      process.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST,
-    publishUrl:
-      stringBinding(runtimeEnv, 'OVERLAY_REALTIME_PUBLISH_URL') ??
-      process.env.OVERLAY_REALTIME_PUBLISH_URL,
-    publishSecret:
-      stringBinding(runtimeEnv, 'OVERLAY_REALTIME_PUBLISH_SECRET') ??
-      process.env.OVERLAY_REALTIME_PUBLISH_SECRET,
+    // `next dev` and Vitest have no OpenNext request context. Their environment
+    // is process-local and cannot cross the preview/production Workers boundary.
+    return {
+      mode: process.env.OVERLAY_REALTIME_MODE,
+      streamerAllowlist: process.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST,
+      publishUrl: process.env.OVERLAY_REALTIME_PUBLISH_URL,
+      publishSecret: process.env.OVERLAY_REALTIME_PUBLISH_SECRET,
+    }
   }
 }
 

--- a/src/lib/overlay-realtime/publisher.ts
+++ b/src/lib/overlay-realtime/publisher.ts
@@ -225,6 +225,21 @@ function retryableStatus(status: number): boolean {
   return status === 408 || status === 429 || status >= 500
 }
 
+async function discardResponseBody(response: Response): Promise<void> {
+  if (!response.body) return
+  try {
+    // The publisher needs only the HTTP status. Cloudflare counts a response
+    // whose headers arrived but whose body remains unread as an open
+    // connection; canceling it promptly releases that slot for concurrent
+    // EventSub deliveries without parsing or logging private response data.
+    await response.body.cancel()
+  } catch {
+    // Transport cleanup is best-effort. A successfully classified publish
+    // response must not be turned into a failed gacha notification because its
+    // already-unused body stream was concurrently closed by the runtime.
+  }
+}
+
 /**
  * Publish after the database transaction has committed.
  *
@@ -300,6 +315,7 @@ export async function publishCommittedGachaBatch(
         const response = publisherEnv.publishService
           ? await publisherEnv.publishService.fetch(new Request(url, requestInit))
           : await fetch(url, requestInit)
+        await discardResponseBody(response)
         if (response.ok) return { outcome: 'accepted', attempts: attempt }
         if (!retryableStatus(response.status) || attempt >= maxAttempts) {
           logger.warn('[overlay-realtime] publish rejected', {

--- a/src/lib/overlay-realtime/publisher.ts
+++ b/src/lib/overlay-realtime/publisher.ts
@@ -275,6 +275,12 @@ export async function publishCommittedGachaBatch(
         if (!retryableStatus(response.status) || attempt >= maxAttempts) {
           logger.warn('[overlay-realtime] publish rejected', {
             streamerId,
+            // Origin/path are public routing metadata and contain no signature,
+            // secret, or payload. Keeping them in the rejection log makes a
+            // stale cross-environment endpoint diagnosable without weakening
+            // the HMAC boundary or exposing viewer/card data.
+            targetOrigin: url.origin,
+            targetPath: url.pathname,
             status: response.status,
             attempt,
           })

--- a/src/lib/overlay-realtime/publisher.ts
+++ b/src/lib/overlay-realtime/publisher.ts
@@ -112,8 +112,58 @@ async function buildCommittedEnvelope(
   return event
 }
 
-function resolvePublishUrl(streamerId: string): URL | null {
-  const base = process.env.OVERLAY_REALTIME_PUBLISH_URL
+interface OverlayRealtimePublisherEnvironment {
+  mode: string | undefined
+  streamerAllowlist: string | undefined
+  publishUrl: string | undefined
+  publishSecret: string | undefined
+}
+
+function stringBinding(
+  env: Record<string, unknown>,
+  key: keyof NodeJS.ProcessEnv
+): string | undefined {
+  const value = env[key]
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+/**
+ * Resolve private publisher configuration from the active Workers request.
+ *
+ * OpenNext exposes Cloudflare runtime variables and secrets through
+ * `getCloudflareContext().env`. Reading that binding first is important:
+ * Workers secrets can be rotated independently of a Next.js build, whereas a
+ * direct `process.env.NAME` reference may retain the value that existed while
+ * the server bundle was produced. `process.env` remains the explicit fallback
+ * for `next dev`, Vitest, and other non-Workers execution contexts.
+ */
+async function getPublisherEnvironment(): Promise<OverlayRealtimePublisherEnvironment> {
+  let runtimeEnv: Record<string, unknown> = {}
+  try {
+    const { getCloudflareContext } = await import('@opennextjs/cloudflare')
+    const { env } = await getCloudflareContext({ async: true })
+    runtimeEnv = env as unknown as Record<string, unknown>
+  } catch {
+    // OpenNext does not install a request context in local Node execution.
+  }
+
+  return {
+    mode:
+      stringBinding(runtimeEnv, 'OVERLAY_REALTIME_MODE') ??
+      process.env.OVERLAY_REALTIME_MODE,
+    streamerAllowlist:
+      stringBinding(runtimeEnv, 'OVERLAY_REALTIME_STREAMER_ALLOWLIST') ??
+      process.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST,
+    publishUrl:
+      stringBinding(runtimeEnv, 'OVERLAY_REALTIME_PUBLISH_URL') ??
+      process.env.OVERLAY_REALTIME_PUBLISH_URL,
+    publishSecret:
+      stringBinding(runtimeEnv, 'OVERLAY_REALTIME_PUBLISH_SECRET') ??
+      process.env.OVERLAY_REALTIME_PUBLISH_SECRET,
+  }
+}
+
+function resolvePublishUrl(streamerId: string, base: string | undefined): URL | null {
   if (!base) return null
   try {
     const url = new URL(base)
@@ -144,17 +194,18 @@ export async function publishCommittedGachaBatch(
   payload: OverlayPublishPayload,
   options: OverlayPublishOptions
 ): Promise<OverlayPublishResult> {
+  const publisherEnv = await getPublisherEnvironment()
   if (!isOverlayRealtimeStreamerEnabled(
-    process.env.OVERLAY_REALTIME_MODE,
-    process.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST,
+    publisherEnv.mode,
+    publisherEnv.streamerAllowlist,
     streamerId
   )) {
     return { outcome: 'skipped', attempts: 0, errorCode: 'mode-disabled' }
   }
 
   try {
-    const secret = process.env.OVERLAY_REALTIME_PUBLISH_SECRET
-    const url = resolvePublishUrl(streamerId)
+    const secret = publisherEnv.publishSecret
+    const url = resolvePublishUrl(streamerId, publisherEnv.publishUrl)
     if (!secret || !url) {
       logger.warn('[overlay-realtime] publisher configuration missing', { streamerId })
       return { outcome: 'skipped', attempts: 0, errorCode: 'configuration-missing' }

--- a/tests/unit/overlay-events-api.test.ts
+++ b/tests/unit/overlay-events-api.test.ts
@@ -248,7 +248,7 @@ describe("GET /api/overlay/[streamerId]/events", () => {
   it("前レスポンスのPostgreSQLマイクロ秒cursorを正規化して次のqueryへ渡す", async () => {
     const afterId = "123e4567-e89b-42d3-a456-426614174001";
     const postgresCursor = "2026-07-24T14:40:14.511943+00:00";
-    const normalizedCursor = "2026-07-24T14:40:14.511Z";
+    const normalizedCursor = "2026-07-24T14:40:14.511943Z";
     const db = useRows([]);
 
     // createRequest はoverlayのnextCursor往復と同じくURLSearchParamsを使う。
@@ -275,14 +275,16 @@ describe("GET /api/overlay/[streamerId]/events", () => {
   });
 
   it("Cloudflareで+が空白化されたPostgreSQL cursorを正規化してqueryへ渡す", async () => {
-    const blankedOffsetCursor = "2026-07-24T14:40:14.511943 00:00";
-    const normalizedCursor = "2026-07-24T14:40:14.511Z";
+    const rawPlusCursor = "2026-07-24T14:40:14.511943+00:00";
+    const normalizedCursor = "2026-07-24T14:40:14.511943Z";
     const db = useRows([]);
 
-    // CDNが未エスケープの+を空白へ復号した場合も、polling cursorの意味は
-    // +00:00と同じである。URLSearchParams経由でその実際の入力形を固定する。
+    // 生の+を含むquery stringはURLSearchParamsでSPACEに復号される。この経路を
+    // 明示して、CDNやform decoderを通ったpolling cursorも受理する契約を固定する。
     const response = await GET(
-      createRequest({ since: blankedOffsetCursor }),
+      new NextRequest(
+        `http://localhost/api/overlay/${STREAMER_ID}/events?since=${rawPlusCursor}`
+      ),
       routeParams()
     );
 
@@ -295,7 +297,7 @@ describe("GET /api/overlay/[streamerId]/events", () => {
     );
   });
 
-  it("nextCursorはPostgreSQL timestampをUTC ISO millisecondsで返す", async () => {
+  it("nextCursorはPostgreSQL timestampのマイクロ秒を保持したUTC ISOで返す", async () => {
     const rawPostgresTimestamp = "2026-07-24T14:40:14.511943+00:00";
     useRows([
       {
@@ -312,9 +314,119 @@ describe("GET /api/overlay/[streamerId]/events", () => {
 
     expect(response.status).toBe(200);
     expect(body.nextCursor).toEqual({
-      redeemedAt: "2026-07-24T14:40:14.511Z",
+      redeemedAt: "2026-07-24T14:40:14.511943Z",
       historyId: DISPLAY_ROW.id,
     });
+  });
+
+  it("マイクロ秒cursorの次pollは同一行を除外する複合条件を維持する", async () => {
+    const rawPostgresTimestamp = "2026-07-24T14:40:14.511943+00:00";
+    const historyId = "123e4567-e89b-42d3-a456-426614174001";
+    const db = createDbMock([
+      {
+        rows: [
+          {
+            ...DISPLAY_ROW,
+            id: historyId,
+            redeemed_at: rawPostgresTimestamp,
+          },
+        ],
+      },
+      { rows: [] },
+    ]);
+    vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as never);
+
+    const firstResponse = await GET(
+      createRequest({ since: SINCE }),
+      routeParams()
+    );
+    const firstBody = await firstResponse.json();
+
+    expect(firstBody.nextCursor).toEqual({
+      redeemedAt: "2026-07-24T14:40:14.511943Z",
+      historyId,
+    });
+
+    const secondResponse = await GET(
+      createRequest({
+        since: firstBody.nextCursor.redeemedAt,
+        afterId: firstBody.nextCursor.historyId,
+      }),
+      routeParams()
+    );
+
+    expect(secondResponse.status).toBe(200);
+    expect(db.calls[1].whereCondition).toEqual(
+      and(
+        eq(gachaHistoryTable.streamer_id, STREAMER_ID),
+        or(
+          gt(gachaHistoryTable.redeemed_at, "2026-07-24T14:40:14.511943Z"),
+          and(
+            eq(gachaHistoryTable.redeemed_at, "2026-07-24T14:40:14.511943Z"),
+            gt(gachaHistoryTable.id, historyId)
+          )
+        )
+      )
+    );
+  });
+
+  it("signed offsetをUTC日付境界をまたいでマイクロ秒まで正規化する", async () => {
+    const db = useRows([]);
+    const cursors = [
+      {
+        input: "2026-07-24T00:15:00.123456+09:30",
+        expected: "2026-07-23T14:45:00.123456Z",
+      },
+      {
+        input: "2026-07-24T23:30:00.654321-04:00",
+        expected: "2026-07-25T03:30:00.654321Z",
+      },
+    ];
+
+    for (const { input, expected } of cursors) {
+      const response = await GET(createRequest({ since: input }), routeParams());
+      expect(response.status).toBe(200);
+      expect(db.calls.at(-1)?.whereCondition).toEqual(
+        and(
+          eq(gachaHistoryTable.streamer_id, STREAMER_ID),
+          gt(gachaHistoryTable.redeemed_at, expected)
+        )
+      );
+    }
+  });
+
+  it("leap dayは受理し、calendar・offset・非ISO入力はDB接続前に拒否する", async () => {
+    const db = useRows([]);
+    const leapDay = await GET(
+      createRequest({ since: "2024-02-29T23:59:59.123456Z" }),
+      routeParams()
+    );
+
+    expect(leapDay.status).toBe(200);
+    expect(db.calls[0].whereCondition).toEqual(
+      and(
+        eq(gachaHistoryTable.streamer_id, STREAMER_ID),
+        gt(gachaHistoryTable.redeemed_at, "2024-02-29T23:59:59.123456Z")
+      )
+    );
+
+    const invalidCursors = [
+      "0000-01-01T00:00:00Z",
+      "2024-02-30T00:00:00Z",
+      "2024-01-01T24:00:00Z",
+      "2024-01-01T00:00:00+24:00",
+      "2024-01-01T00:00:00+00:60",
+      "0001-01-01T00:00:00+23:59",
+      "9999-12-31T23:59:59-23:59",
+      "2024-01-01T00:00:00",
+      "1721832014511",
+      "2024/01/01 00:00:00Z",
+    ];
+    for (const since of invalidCursors) {
+      const response = await GET(createRequest({ since }), routeParams());
+      expect(response.status).toBe(400);
+    }
+    expect(db.calls).toHaveLength(1);
   });
 
   it("PlanetScale queryが必要列・join・安定順・bounded limitを使う", async () => {

--- a/tests/unit/overlay-realtime-publisher.test.ts
+++ b/tests/unit/overlay-realtime-publisher.test.ts
@@ -171,6 +171,137 @@ describe('publishCommittedGachaBatch', () => {
     ).resolves.toBe(true)
   })
 
+  it('does not mix missing Workers bindings with stale process values', async () => {
+    vi.mocked(getCloudflareContext).mockResolvedValue({ env: {} } as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      publishCommittedGachaBatch(
+        STREAMER_ID,
+        {
+          card: {
+            id: 'card-1',
+            name: 'Card',
+            description: null,
+            image_url: null,
+            rarity: 'common',
+          },
+          userTwitchUsername: 'viewer',
+        },
+        { batchId: 'batch-1' }
+      )
+    ).resolves.toEqual({
+      outcome: 'skipped',
+      attempts: 0,
+      errorCode: 'mode-disabled',
+    })
+    expect(getDb).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when a Workers publisher credential is missing', async () => {
+    vi.mocked(getCloudflareContext).mockResolvedValue({
+      env: {
+        OVERLAY_REALTIME_MODE: 'do-primary',
+        OVERLAY_REALTIME_STREAMER_ALLOWLIST: STREAMER_ID,
+        OVERLAY_REALTIME_PUBLISH_URL:
+          'https://runtime-overlay-realtime.example.workers.dev',
+      },
+    } as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      publishCommittedGachaBatch(
+        STREAMER_ID,
+        {
+          card: {
+            id: 'card-1',
+            name: 'Card',
+            description: null,
+            image_url: null,
+            rarity: 'common',
+          },
+          userTwitchUsername: 'viewer',
+        },
+        { batchId: 'batch-1' }
+      )
+    ).resolves.toEqual({
+      outcome: 'skipped',
+      attempts: 0,
+      errorCode: 'configuration-missing',
+    })
+    expect(getDb).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('honors the Workers polling-only kill switch over stale process mode', async () => {
+    vi.mocked(getCloudflareContext).mockResolvedValue({
+      env: {
+        OVERLAY_REALTIME_MODE: 'polling-only',
+        OVERLAY_REALTIME_STREAMER_ALLOWLIST: STREAMER_ID,
+        OVERLAY_REALTIME_PUBLISH_URL:
+          'https://runtime-overlay-realtime.example.workers.dev',
+        OVERLAY_REALTIME_PUBLISH_SECRET: 'rotated-runtime-secret',
+      },
+    } as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      publishCommittedGachaBatch(
+        STREAMER_ID,
+        {
+          card: {
+            id: 'card-1',
+            name: 'Card',
+            description: null,
+            image_url: null,
+            rarity: 'common',
+          },
+          userTwitchUsername: 'viewer',
+        },
+        { batchId: 'batch-1' }
+      )
+    ).resolves.toEqual({
+      outcome: 'skipped',
+      attempts: 0,
+      errorCode: 'mode-disabled',
+    })
+    expect(getDb).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the production Workers context cannot be read', async () => {
+    process.env.NODE_ENV = 'production'
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      publishCommittedGachaBatch(
+        STREAMER_ID,
+        {
+          card: {
+            id: 'card-1',
+            name: 'Card',
+            description: null,
+            image_url: null,
+            rarity: 'common',
+          },
+          userTwitchUsername: 'viewer',
+        },
+        { batchId: 'batch-1' }
+      )
+    ).resolves.toEqual({
+      outcome: 'skipped',
+      attempts: 0,
+      errorCode: 'mode-disabled',
+    })
+    expect(getDb).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('does no database or network work behind the polling-only kill switch', async () => {
     process.env.OVERLAY_REALTIME_MODE = 'polling-only'
     const fetchMock = vi.fn()

--- a/tests/unit/overlay-realtime-publisher.test.ts
+++ b/tests/unit/overlay-realtime-publisher.test.ts
@@ -57,6 +57,7 @@ describe('publishCommittedGachaBatch', () => {
   })
 
   afterEach(() => {
+    vi.unstubAllEnvs()
     process.env = { ...ORIGINAL_ENV }
     vi.unstubAllGlobals()
     vi.useRealTimers()
@@ -274,7 +275,7 @@ describe('publishCommittedGachaBatch', () => {
   })
 
   it('fails closed when the production Workers context cannot be read', async () => {
-    process.env.NODE_ENV = 'production'
+    vi.stubEnv('NODE_ENV', 'production')
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
 

--- a/tests/unit/overlay-realtime-publisher.test.ts
+++ b/tests/unit/overlay-realtime-publisher.test.ts
@@ -217,8 +217,13 @@ describe('publishCommittedGachaBatch', () => {
   })
 
   it('publishes through the Workers Service Binding instead of global fetch', async () => {
+    const cancelBody = vi.fn().mockResolvedValue(undefined)
     const serviceFetch = vi.fn().mockResolvedValue(
-      Response.json({ accepted: true }, { status: 202 })
+      {
+        ok: true,
+        status: 202,
+        body: { cancel: cancelBody },
+      } as unknown as Response
     )
     vi.mocked(getCloudflareContext).mockResolvedValue({
       env: {
@@ -252,6 +257,7 @@ describe('publishCommittedGachaBatch', () => {
 
     expect(globalFetch).not.toHaveBeenCalled()
     expect(serviceFetch).toHaveBeenCalledTimes(1)
+    expect(cancelBody).toHaveBeenCalledTimes(1)
     const request = serviceFetch.mock.calls[0][0] as Request
     expect(request).toBeInstanceOf(Request)
     expect(request.method).toBe('POST')

--- a/tests/unit/overlay-realtime-publisher.test.ts
+++ b/tests/unit/overlay-realtime-publisher.test.ts
@@ -172,6 +172,62 @@ describe('publishCommittedGachaBatch', () => {
     ).resolves.toBe(true)
   })
 
+  it('publishes through the Workers Service Binding instead of global fetch', async () => {
+    const serviceFetch = vi.fn().mockResolvedValue(
+      Response.json({ accepted: true }, { status: 202 })
+    )
+    vi.mocked(getCloudflareContext).mockResolvedValue({
+      env: {
+        OVERLAY_REALTIME_MODE: 'do-primary',
+        OVERLAY_REALTIME_STREAMER_ALLOWLIST: STREAMER_ID,
+        OVERLAY_REALTIME_PUBLISH_URL:
+          'https://twica-overlay-realtime-preview.example.workers.dev',
+        OVERLAY_REALTIME_PUBLISH_SECRET: 'runtime-service-secret',
+        OVERLAY_REALTIME_SERVICE: { fetch: serviceFetch },
+      },
+    } as never)
+    const globalFetch = vi.fn()
+    vi.stubGlobal('fetch', globalFetch)
+
+    await expect(
+      publishCommittedGachaBatch(
+        STREAMER_ID,
+        {
+          card: {
+            id: 'card-1',
+            name: 'Card',
+            description: null,
+            image_url: null,
+            rarity: 'common',
+          },
+          userTwitchUsername: 'viewer',
+        },
+        { batchId: 'batch-1' }
+      )
+    ).resolves.toEqual({ outcome: 'accepted', attempts: 1 })
+
+    expect(globalFetch).not.toHaveBeenCalled()
+    expect(serviceFetch).toHaveBeenCalledTimes(1)
+    const request = serviceFetch.mock.calls[0][0] as Request
+    expect(request).toBeInstanceOf(Request)
+    expect(request.method).toBe('POST')
+    expect(new URL(request.url).pathname).toBe(
+      `/internal/v1/rooms/${STREAMER_ID}/publish`
+    )
+    const body = await request.clone().text()
+    const headers = Object.fromEntries(request.headers.entries())
+    await expect(
+      verifyPublishSignature(
+        'runtime-service-secret',
+        new URL(request.url).pathname,
+        body,
+        headers['x-twica-timestamp'],
+        headers['x-twica-nonce'],
+        headers['x-twica-signature']
+      )
+    ).resolves.toBe(true)
+  })
+
   it('does not mix missing Workers bindings with stale process values', async () => {
     vi.mocked(getCloudflareContext).mockResolvedValue({ env: {} } as never)
     const fetchMock = vi.fn()

--- a/tests/unit/overlay-realtime-publisher.test.ts
+++ b/tests/unit/overlay-realtime-publisher.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getCloudflareContext } from '@opennextjs/cloudflare'
 import { getDb } from '@/lib/db/client'
 import { verifyPublishSignature } from '@/lib/overlay-realtime/signature'
+
+vi.mock('@opennextjs/cloudflare', () => ({
+  getCloudflareContext: vi.fn(),
+}))
 
 vi.mock('@/lib/logger', () => ({
   logger: {
@@ -40,6 +45,9 @@ async function flushPromises(): Promise<void> {
 describe('publishCommittedGachaBatch', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(getCloudflareContext).mockRejectedValue(
+      new Error('Cloudflare request context is unavailable in unit tests')
+    )
     process.env.OVERLAY_REALTIME_MODE = 'do-primary'
     process.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST = STREAMER_ID
     process.env.OVERLAY_REALTIME_PUBLISH_URL =
@@ -106,6 +114,56 @@ describe('publishCommittedGachaBatch', () => {
         process.env.OVERLAY_REALTIME_PUBLISH_SECRET!,
         url.pathname,
         body,
+        headers['x-twica-timestamp'],
+        headers['x-twica-nonce'],
+        headers['x-twica-signature']
+      )
+    ).resolves.toBe(true)
+  })
+
+  it('prefers rotated Workers runtime secrets over build-time process values', async () => {
+    vi.mocked(getCloudflareContext).mockResolvedValue({
+      env: {
+        OVERLAY_REALTIME_MODE: 'do-primary',
+        OVERLAY_REALTIME_STREAMER_ALLOWLIST: STREAMER_ID,
+        OVERLAY_REALTIME_PUBLISH_URL:
+          'https://runtime-overlay-realtime.example.workers.dev',
+        OVERLAY_REALTIME_PUBLISH_SECRET: 'rotated-runtime-secret',
+      },
+    } as never)
+    process.env.OVERLAY_REALTIME_PUBLISH_URL =
+      'https://stale-build-value.example.workers.dev'
+    process.env.OVERLAY_REALTIME_PUBLISH_SECRET = 'stale-build-secret'
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({ accepted: true }, { status: 202 })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      publishCommittedGachaBatch(
+        STREAMER_ID,
+        {
+          card: {
+            id: 'card-1',
+            name: 'Card',
+            description: null,
+            image_url: null,
+            rarity: 'common',
+          },
+          userTwitchUsername: 'viewer',
+        },
+        { batchId: 'batch-1' }
+      )
+    ).resolves.toEqual({ outcome: 'accepted', attempts: 1 })
+
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+    expect(url.hostname).toBe('runtime-overlay-realtime.example.workers.dev')
+    const headers = init.headers as Record<string, string>
+    await expect(
+      verifyPublishSignature(
+        'rotated-runtime-secret',
+        url.pathname,
+        String(init.body),
         headers['x-twica-timestamp'],
         headers['x-twica-nonce'],
         headers['x-twica-signature']

--- a/tests/unit/overlay-realtime-publisher.test.ts
+++ b/tests/unit/overlay-realtime-publisher.test.ts
@@ -123,6 +123,9 @@ describe('publishCommittedGachaBatch', () => {
   })
 
   it('prefers rotated Workers runtime secrets over build-time process values', async () => {
+    const serviceFetch = vi.fn().mockResolvedValue(
+      Response.json({ accepted: true }, { status: 202 })
+    )
     vi.mocked(getCloudflareContext).mockResolvedValue({
       env: {
         OVERLAY_REALTIME_MODE: 'do-primary',
@@ -130,6 +133,7 @@ describe('publishCommittedGachaBatch', () => {
         OVERLAY_REALTIME_PUBLISH_URL:
           'https://runtime-overlay-realtime.example.workers.dev',
         OVERLAY_REALTIME_PUBLISH_SECRET: 'rotated-runtime-secret',
+        OVERLAY_REALTIME_SERVICE: { fetch: serviceFetch },
       },
     } as never)
     process.env.OVERLAY_REALTIME_PUBLISH_URL =
@@ -157,19 +161,59 @@ describe('publishCommittedGachaBatch', () => {
       )
     ).resolves.toEqual({ outcome: 'accepted', attempts: 1 })
 
-    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+    expect(fetchMock).not.toHaveBeenCalled()
+    const request = serviceFetch.mock.calls[0][0] as Request
+    const url = new URL(request.url)
     expect(url.hostname).toBe('runtime-overlay-realtime.example.workers.dev')
-    const headers = init.headers as Record<string, string>
+    const body = await request.clone().text()
+    const headers = Object.fromEntries(request.headers.entries())
     await expect(
       verifyPublishSignature(
         'rotated-runtime-secret',
         url.pathname,
-        String(init.body),
+        body,
         headers['x-twica-timestamp'],
         headers['x-twica-nonce'],
         headers['x-twica-signature']
       )
     ).resolves.toBe(true)
+  })
+
+  it('fails closed when a Workers Service Binding is missing', async () => {
+    vi.mocked(getCloudflareContext).mockResolvedValue({
+      env: {
+        OVERLAY_REALTIME_MODE: 'do-primary',
+        OVERLAY_REALTIME_STREAMER_ALLOWLIST: STREAMER_ID,
+        OVERLAY_REALTIME_PUBLISH_URL:
+          'https://runtime-overlay-realtime.example.workers.dev',
+        OVERLAY_REALTIME_PUBLISH_SECRET: 'runtime-secret',
+      },
+    } as never)
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      publishCommittedGachaBatch(
+        STREAMER_ID,
+        {
+          card: {
+            id: 'card-1',
+            name: 'Card',
+            description: null,
+            image_url: null,
+            rarity: 'common',
+          },
+          userTwitchUsername: 'viewer',
+        },
+        { batchId: 'batch-1' }
+      )
+    ).resolves.toEqual({
+      outcome: 'skipped',
+      attempts: 0,
+      errorCode: 'configuration-missing',
+    })
+    expect(getDb).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('publishes through the Workers Service Binding instead of global fetch', async () => {

--- a/tests/unit/overlay-realtime-worker.test.ts
+++ b/tests/unit/overlay-realtime-worker.test.ts
@@ -93,10 +93,12 @@ describe('overlay realtime Worker router', () => {
 
     expect(response.status).toBe(202)
     expect(idFromName).toHaveBeenCalledWith(STREAMER_ID)
-    expect(roomFetch).toHaveBeenCalledWith(
-      'https://room.internal/publish',
-      expect.objectContaining({ method: 'POST', body })
-    )
+    expect(roomFetch).toHaveBeenCalledTimes(1)
+    const roomRequest = roomFetch.mock.calls[0][0] as Request
+    expect(roomRequest).toBeInstanceOf(Request)
+    expect(roomRequest.method).toBe('POST')
+    expect(new URL(roomRequest.url).pathname).toBe('/publish')
+    expect(await roomRequest.text()).toBe(body)
   })
 
   it('does not touch a room when the signature is invalid', async () => {

--- a/tests/unit/overlay-realtime-worker.test.ts
+++ b/tests/unit/overlay-realtime-worker.test.ts
@@ -98,6 +98,9 @@ describe('overlay realtime Worker router', () => {
     expect(roomRequest).toBeInstanceOf(Request)
     expect(roomRequest.method).toBe('POST')
     expect(new URL(roomRequest.url).pathname).toBe('/publish')
+    expect(roomRequest.headers.get('x-internal-streamer-id')).toBe(STREAMER_ID)
+    expect(roomRequest.headers.get('x-internal-nonce')).toBe(nonce)
+    expect(roomRequest.headers.get('x-internal-timestamp')).toBe(timestamp)
     expect(await roomRequest.text()).toBe(body)
   })
 

--- a/workers/overlay-realtime/src/index.ts
+++ b/workers/overlay-realtime/src/index.ts
@@ -481,6 +481,14 @@ export class OverlayRoom {
       return json({ accepted: true, fanoutCount, failedCount }, 202)
     }
 
+    // This fallback is reachable only through the Durable Object binding, not
+    // from the public Worker router. Keep the method and normalized pathname in
+    // observability logs so production-only routing differences can be
+    // diagnosed without recording signed headers, card payloads, or usernames.
+    console.warn('[overlay-realtime] room route miss', {
+      method: request.method,
+      pathname: url.pathname,
+    })
     return json({ error: 'Not found' }, 404)
   }
 

--- a/workers/overlay-realtime/src/index.ts
+++ b/workers/overlay-realtime/src/index.ts
@@ -226,7 +226,13 @@ const overlayRealtimeWorker = {
       if (!validation.ok) return json({ error: validation.error }, 400)
 
       const id = env.OVERLAY_ROOMS.idFromName(publishStreamerId)
-      return env.OVERLAY_ROOMS.get(id).fetch('https://room.internal/publish', {
+      // Build one concrete Request before crossing the Durable Object binding.
+      // Cloudflare accepts both fetch(url, init) and fetch(Request), but the
+      // latter makes the exact method, internal pathname, headers, and body a
+      // single immutable value. Keeping that boundary explicit removes
+      // overload interpretation as a variable when diagnosing a runtime-only
+      // room route miss.
+      const roomRequest = new Request('https://room.internal/publish', {
         method: 'POST',
         body,
         headers: {
@@ -236,6 +242,17 @@ const overlayRealtimeWorker = {
           'x-internal-timestamp': String(auth.timestamp),
         },
       })
+      const roomResponse = await env.OVERLAY_ROOMS.get(id).fetch(roomRequest)
+      if (!roomResponse.ok) {
+        // Only non-secret routing metadata is logged. The signed request body,
+        // nonce, username, and card fields remain excluded from observability.
+        console.warn('[overlay-realtime] room publish rejected', {
+          method: roomRequest.method,
+          pathname: new URL(roomRequest.url).pathname,
+          status: roomResponse.status,
+        })
+      }
+      return roomResponse
     }
 
     return json({ error: 'Not found' }, 404)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -78,7 +78,10 @@ binding = "R2_SOUNDS"
 bucket_name = "twica-sound-dev"
 
 # Authoritative preview PostgreSQL connection.
+# The previous config was deleted after its stale direct sessions exhausted the
+# PlanetScale connection limit. Keep this preview-only config capped at five
+# origin connections so preview validation cannot starve production traffic.
 [[env.preview.hyperdrive]]
 binding = "HYPERDRIVE_PLANETSCALE"
-id = "4b8d1f014cce457fbbc009f3c09592f4"
+id = "5caf2d40d4f04fc49bc47053ab47ec22"
 localConnectionString = "postgres://user:password@localhost:5432/postgres"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -45,6 +45,13 @@ binding = "HYPERDRIVE_PLANETSCALE"
 id = "1dc2ec4d087e41a6931e8e18944c1fd2"
 localConnectionString = "postgres://user:password@localhost:5432/postgres"
 
+# Cloudflare blocks global fetch() from one Worker to another Worker on the
+# same zone. Bind the realtime publisher directly so signed gacha events stay
+# on Cloudflare's internal path and never depend on workers.dev routing.
+[[services]]
+binding = "OVERLAY_REALTIME_SERVICE"
+service = "twica-overlay-realtime"
+
 # Public value that must survive dashboard-only configuration overwrites.
 [vars]
 NEXT_PUBLIC_TWITCH_CLIENT_ID = "okxjgv064gr80kcijf1b0e182x394o"
@@ -88,3 +95,7 @@ bucket_name = "twica-sound-dev"
 binding = "HYPERDRIVE_PLANETSCALE"
 id = "5caf2d40d4f04fc49bc47053ab47ec22"
 localConnectionString = "postgres://user:password@localhost:5432/postgres"
+
+[[env.preview.services]]
+binding = "OVERLAY_REALTIME_SERVICE"
+service = "twica-overlay-realtime-preview"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -36,7 +36,10 @@ preview_bucket_name = "twica-sound-dev"
 # Authoritative production PostgreSQL connection. The retired Supabase
 # Hyperdrive binding was removed so a stale DB target cannot open the old
 # project after shutdown. Query caching remains disabled on the referenced
-# Hyperdrive config to preserve event-polling freshness.
+# Hyperdrive config to preserve event-polling freshness. Its external
+# origin_connection_limit is intentionally 10; together with preview's 5 this
+# remains below PlanetScale's 25 direct-connection ceiling and leaves headroom
+# because Cloudflare documents the Hyperdrive limit as a soft maximum.
 [[hyperdrive]]
 binding = "HYPERDRIVE_PLANETSCALE"
 id = "1dc2ec4d087e41a6931e8e18944c1fd2"


### PR DESCRIPTION
## 概要

緊急修正 #817 / #818 の本番復旧後レビューと、preview実引き換え試験で判明したフォローアップをまとめて解消します。

- PostgreSQLの1〜6桁小数秒をnextCursorと次poll predicateで保持
- JavaScript Dateのミリ秒切り捨てによる同一行再取得を防止
- Date.parse fallbackを削除し、明示したtimezone付き形式だけを受理
- 正負offset・日付境界・calendar/offset/年境界を厳格検証
- raw `+` がSPACE復号された入力互換を維持
- OpenNextからWorkers runtime secretsを取得し、build時の古い値との混在を防止
- preview/prodのHyperdrive接続枠をPlanetScale上限内に固定
- Cloudflare Worker間publishを公開`workers.dev`へのglobal fetchからService Bindingへ変更
- Realtime Worker/アプリの拒否ログに秘密情報を含まない経路診断を追加
- publish応答bodyを明示的に破棄し、未読streamの残存resourceを解放

## 原因

Cloudflareは同一zoneのWorkerから別Workerへのglobal `fetch()`をService Bindingなしでは拒否します。previewアプリからRealtime Workerの`workers.dev` URLへ送ったPOSTは対象Workerへ到達する前に404となっていました。外部curlは到達するため、URL/HMAC/DO内部ルートだけの検証では再現できないCloudflare実環境固有の経路差でした。

## 独立レビュー

cursor修正は3巡実施し、HIGH 1件、MEDIUM 3件を解消後、全severity指摘ゼロ。Service Binding追加を含む最終差分も緊急反映後に独立厳格レビューを実施します。

## 自動検証

- 全unit: 246 files / 3410 tests passed（34 Docker tests skipped）
- Realtime Worker + publisher: 26 tests passed
- `npm run typecheck` passed
- `npm run overlay-realtime:typecheck` passed
- OpenNext Cloudflare production build passed
- `git diff --check` passed

## preview実環境検証

- Twitch `azumagbanjo` で対象の実チャネルポイント報酬を複数回引き換え
- 最終HEADの連続2回で異なるカード（`dda` → `あsdふぁ`）をDB保存
- 2回目の`あsdふぁ`がOBS browser sourceに表示されることを連続キャプチャで確認
- 2回ともTwitchチャット送信成功（attempt 1）
- Service Binding反映後はアプリログからRealtime publish 404が消失
- Realtime Worker内部`/publish`処理成功を確認

## ロールアウト

previewで上記ゲートを通過済み。CIとフォローアップレビュー完了後にmergeし、本番デプロイと同じ実引き換え/チャット/OBS確認を行います。
