### PR TITLE
db: add transactional chat notification outbox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,3 +180,77 @@ jobs:
 
       - name: Check migration order
         run: npm run check:migration-order -- --base=origin/${{ github.base_ref }}
+
+  planetscale-migration-postgres:
+    name: PlanetScale migration PostgreSQL 17
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 10
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apply PlanetScale baseline and additive migrations
+        # SQL文字列テストではPL/pgSQLの構文や三値論理を検証できない。実運用と同じ
+        # PostgreSQL 17へ各ファイルを個別transactionで順序どおり適用し、途中の
+        # 1ファイルでも失敗したらON_ERROR_STOPでjobを停止する。
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -X -1 -v ON_ERROR_STOP=1 -h 127.0.0.1 -U postgres -d postgres \
+            -f db/planetscale/migrations/20260719180000_planetscale_bootstrap.sql
+          psql -X -1 -v ON_ERROR_STOP=1 -h 127.0.0.1 -U postgres -d postgres \
+            -f db/planetscale/migrations/20260719180100_planetscale_public_schema_baseline.sql
+          psql -X -1 -v ON_ERROR_STOP=1 -h 127.0.0.1 -U postgres -d postgres \
+            -f db/planetscale/grants.sql
+          # runtime migration runnerと同じdescriptor parserで、共通migrationと
+          # PlanetScale専用migrationをマージ・provider filter・名前順sortする。
+          # CIだけ別の対象集合を再実装すると、新しい共通migrationを見落とすため。
+          mapfile -t migrations < <(node -e "
+            const path = require('node:path');
+            const core = require('./scripts/lib/db-migrate-core');
+            const descriptors = core.loadMigrationFilesFromDirs([
+              path.resolve('supabase/migrations'),
+              path.resolve('db/planetscale/migrations'),
+            ]);
+            const errors = core.collectDescriptorErrors(descriptors);
+            if (errors.length > 0) throw new Error(JSON.stringify(errors));
+            for (const descriptor of descriptors) {
+              if (
+                BigInt(descriptor.version) > 20260719180100n
+                && core.isProviderApplicable(descriptor, 'planetscale')
+              ) {
+                console.log(path.join(descriptor.sourceDir, descriptor.filename));
+              }
+            }
+          ")
+          for migration in "${migrations[@]}"; do
+            psql -X -1 -v ON_ERROR_STOP=1 -h 127.0.0.1 -U postgres -d postgres \
+              -f "$migration"
+          done
+
+      - name: Verify transactional gacha outbox invariants
+        # 旧RPC互換、single/N連、歯抜け復旧、NULL副作用0、権限、lease fencingを
+        # 実DBで検証し、新RPC欠落による全ガチャfail-closedをPR段階で防ぐ。
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -X -1 -v ON_ERROR_STOP=1 -h 127.0.0.1 -U postgres -d postgres \
+            -f tests/fixtures/transactional-chat-outbox-postgres.sql
+
+      - name: Verify concurrent duplicate fencing
+        # 先行COMMIT前に同じeventを別接続から実行し、同じcard/別cardのどちらでも
+        # 後続がlimit_reachedではなくduplicateへ収束することを確認する。
+        env:
+          PGPASSWORD: postgres
+        run: bash tests/fixtures/transactional-chat-outbox-concurrency.sh

--- a/db/planetscale/migrations/20260725100000_transactional_chat_outbox.sql
+++ b/db/planetscale/migrations/20260725100000_transactional_chat_outbox.sql
@@ -1,0 +1,371 @@
+-- migration-transaction: required
+-- migration-providers: planetscale
+
+-- Issue #708/#803: ガチャ確定とTwitchチャット通知を原子的に結ぶtransactional outbox。
+--
+-- 外部API送信をDB transaction内で実行するとロック時間と障害範囲が拡大するため、
+-- ガチャ履歴/カード付与と同じexecute_gacha_transaction内では配送payloadだけを
+-- 永続化する。配送Workerは後から短いclaim UPDATEで所有権を取得して送信する。
+-- Twitch Chat APIにはidempotency keyがないため配送保証はat-least-onceであり、
+-- 送信成功直後からsent記録前の停止時だけ重複し得る（欠落より再送を優先する）。
+CREATE TABLE public.chat_notification_outbox (
+  id uuid PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
+  batch_id text NOT NULL UNIQUE,
+  payload_version smallint NOT NULL DEFAULT 1 CHECK (payload_version = 1),
+  payload jsonb NOT NULL,
+  expected_draw_count integer NOT NULL CHECK (expected_draw_count > 0),
+  assembled_draw_count integer NOT NULL CHECK (
+    assembled_draw_count > 0 AND assembled_draw_count = expected_draw_count
+  ),
+  status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'processing', 'sent', 'dead')),
+  attempt_count integer NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+  next_attempt_at timestamptz NOT NULL DEFAULT now(),
+  lease_id uuid,
+  lease_expires_at timestamptz,
+  last_error text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  sent_at timestamptz,
+  dead_at timestamptz,
+  CHECK (
+    (status = 'processing' AND lease_id IS NOT NULL AND lease_expires_at IS NOT NULL)
+    OR (status <> 'processing' AND lease_id IS NULL AND lease_expires_at IS NULL)
+  ),
+  CHECK (
+    (status IN ('pending', 'processing') AND sent_at IS NULL AND dead_at IS NULL)
+    OR (status = 'sent' AND sent_at IS NOT NULL AND dead_at IS NULL)
+    OR (status = 'dead' AND dead_at IS NOT NULL AND sent_at IS NULL)
+  )
+);
+
+CREATE INDEX chat_notification_outbox_due_idx
+  ON public.chat_notification_outbox (next_attempt_at, created_at)
+  WHERE status = 'pending';
+
+CREATE INDEX chat_notification_outbox_expired_lease_idx
+  ON public.chat_notification_outbox (lease_expires_at)
+  WHERE status = 'processing';
+
+-- relayは送信済みを7日、調査用DLQを30日だけ保持して削除する。partial indexにより
+-- payload本体を全走査せず期限行を探せ、outboxが無制限にDB容量を消費しない。
+CREATE INDEX chat_notification_outbox_sent_cleanup_idx
+  ON public.chat_notification_outbox (sent_at)
+  WHERE status = 'sent';
+
+CREATE INDEX chat_notification_outbox_dead_cleanup_idx
+  ON public.chat_notification_outbox (dead_at)
+  WHERE status = 'dead';
+
+-- PostgreSQLでは「旧7引数」と「追加引数にDEFAULTを持つ11引数」を同名overloadに
+-- すると旧呼出しがambiguousになる。schema-first期間の旧アプリを壊さないよう、
+-- 新アプリ専用のversioned別名・全引数必須RPCとして追加し、旧RPCは変更しない。
+CREATE FUNCTION public.execute_gacha_transaction_with_chat_outbox(
+  p_event_id text,
+  p_user_twitch_id text,
+  p_user_twitch_username text,
+  p_card_id uuid,
+  p_streamer_id uuid,
+  p_reward_cost integer,
+  p_reward_id text,
+  p_chat_batch_id text,
+  p_draw_index integer,
+  p_draw_count integer,
+  p_collection_name text
+) RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_history_id uuid;
+  v_max_issuance_count integer;
+  v_issued_count integer;
+  v_cards_payload jsonb;
+  v_outbox_count integer;
+  v_card_count integer;
+  v_unique_count integer;
+  v_all_count integer;
+  v_new_card_names jsonb;
+  v_is_duplicate boolean := false;
+BEGIN
+  IF p_event_id IS NULL THEN
+    RAISE EXCEPTION 'event_id must not be null';
+  END IF;
+  -- PostgreSQLの比較演算はNULLをfalseではなくunknownにするため、範囲比較だけでは
+  -- NULLを拒否できない。履歴だけ作ってoutboxを組み立てない半端な成功を防ぐ。
+  IF p_draw_index IS NULL OR p_draw_count IS NULL
+     OR p_draw_index < 1 OR p_draw_count < 1 OR p_draw_count > 15
+     OR p_draw_index > p_draw_count THEN
+    RAISE EXCEPTION 'invalid draw position: %/%', p_draw_index, p_draw_count;
+  END IF;
+  IF p_chat_batch_id IS NOT NULL
+     AND p_event_id <> (CASE
+       WHEN p_draw_index = 1 THEN p_chat_batch_id
+       ELSE p_chat_batch_id || ':' || p_draw_index::text
+     END) THEN
+    RAISE EXCEPTION 'event_id does not match chat batch draw position';
+  END IF;
+
+  -- Twitch再送・live/Cron replayが同じeventを別transactionで同時実行し得る。
+  -- card行だけをlockすると、別cardを抽選した再送は直列化されず、同じcardでも
+  -- 先行COMMIT後の発行上限をduplicate判定より先に見て誤返金し得る。event_idの
+  -- 64bit hashをtransaction advisory lockにし、同一eventのduplicate確認から
+  -- outbox再構成までを直列化する。hash衝突は無関係な2件を一時直列化するだけで、
+  -- correctnessや権限境界を壊さない。
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_event_id, 803));
+
+  -- duplicate final drawでも下の全履歴再構成を実行する。歯抜けbatchで不足drawを
+  -- 埋めた後、既存の最終eventへ到達した場合にoutboxを作り損ねないため。
+  SELECT id INTO v_history_id
+  FROM gacha_history
+  WHERE event_id = p_event_id;
+  v_is_duplicate := FOUND;
+
+  IF NOT v_is_duplicate THEN
+    SELECT max_issuance_count
+      INTO v_max_issuance_count
+      FROM cards
+      WHERE id = p_card_id
+        AND streamer_id = p_streamer_id
+        AND is_active = true
+      FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object('is_duplicate', false, 'limit_reached', true);
+    END IF;
+
+    IF v_max_issuance_count IS NOT NULL THEN
+      SELECT COUNT(*) INTO v_issued_count
+        FROM user_cards
+        WHERE card_id = p_card_id;
+
+      IF v_issued_count >= v_max_issuance_count THEN
+        RETURN jsonb_build_object('is_duplicate', false, 'limit_reached', true);
+      END IF;
+    END IF;
+
+    INSERT INTO gacha_history (
+      event_id, user_twitch_id, user_twitch_username, card_id, streamer_id,
+      reward_cost, reward_id
+    )
+    VALUES (
+      p_event_id, p_user_twitch_id, p_user_twitch_username, p_card_id,
+      p_streamer_id, p_reward_cost, p_reward_id
+    )
+    ON CONFLICT (event_id) DO NOTHING
+    RETURNING id INTO v_history_id;
+
+    IF v_history_id IS NULL THEN
+      -- pre-check後に同じeventを別transactionがcommitした競合。カード付与はせず、
+      -- duplicate finalなら下のoutbox再構成だけを安全に試みる。
+      v_is_duplicate := true;
+    ELSE
+      INSERT INTO users (twitch_user_id, twitch_username, twitch_display_name)
+      VALUES (p_user_twitch_id, p_user_twitch_username, p_user_twitch_username)
+      ON CONFLICT (twitch_user_id) DO NOTHING;
+
+      SELECT id INTO v_user_id FROM users WHERE twitch_user_id = p_user_twitch_id;
+
+      IF v_user_id IS NOT NULL THEN
+        INSERT INTO user_cards (user_id, card_id, obtained_at)
+        VALUES (v_user_id, p_card_id, now());
+      END IF;
+    END IF;
+  END IF;
+
+  IF p_chat_batch_id IS NOT NULL AND p_draw_index = p_draw_count THEN
+    -- N連途中にbuilding行を残すと、webhookが2xxを返した後の部分失敗で永久孤児に
+    -- なる。最終drawのtransaction内で、確定済みgacha_historyをevent_id順に
+    -- 再構成し、全件揃った場合だけ完成済みpendingを1件作る。
+    WITH expected_events AS (
+      SELECT
+        draw_index,
+        CASE
+          WHEN draw_index = 1 THEN p_chat_batch_id
+          ELSE p_chat_batch_id || ':' || draw_index::text
+        END AS event_id
+      FROM generate_series(1, p_draw_count) AS draw(draw_index)
+    ),
+    ordered_cards AS (
+      SELECT
+        expected_events.draw_index,
+        jsonb_build_object(
+          'id', c.id,
+          'name', c.name,
+          'description', c.description,
+          'image_url', c.image_url,
+          'rarity', c.rarity,
+          'drop_rate', c.drop_rate,
+          'max_issuance_count', c.max_issuance_count
+        ) AS card_payload
+      FROM expected_events
+      JOIN gacha_history gh ON gh.event_id = expected_events.event_id
+      JOIN cards c ON c.id = gh.card_id
+      WHERE gh.streamer_id = p_streamer_id
+        AND gh.user_twitch_id = p_user_twitch_id
+    )
+    SELECT jsonb_agg(card_payload ORDER BY draw_index), count(*)::integer
+      INTO v_cards_payload, v_outbox_count
+      FROM ordered_cards;
+
+    IF v_outbox_count <> p_draw_count THEN
+      RAISE EXCEPTION 'chat outbox history incomplete for batch %: expected %, found %',
+        p_chat_batch_id, p_draw_count, v_outbox_count;
+    END IF;
+
+    -- chat無効時は所有数集約もoutbox INSERTも実行しない。enabled streamerの1行
+    -- 存在確認だけに絞り、通知を使わない配信者のガチャコストを増やさない。
+    IF EXISTS (
+      SELECT 1
+      FROM streamers
+      WHERE id = p_streamer_id
+        AND chat_announcement_enabled = true
+    ) THEN
+      -- 所有数系placeholderをrelay時に再問合せすると、retry待ちの別ガチャやカード
+      -- 設定変更で元の通知本文が変わる。ユーザー所持を1回だけ集約し、{num}、
+      -- {unique}、{all}、{newCards}をこのtransactionの同一statement snapshotで
+      -- 固定する。relayはこのversioned値だけを使い、外部送信リトライを決定的にする。
+      WITH user_card_counts AS (
+      SELECT
+        uc.card_id,
+        count(*)::integer AS final_count,
+        bool_or(c.is_active = true) AS is_active
+      FROM users u
+      JOIN user_cards uc ON uc.user_id = u.id
+      JOIN cards c
+        ON c.id = uc.card_id
+       AND c.streamer_id = p_streamer_id
+      WHERE u.twitch_user_id = p_user_twitch_id
+      GROUP BY uc.card_id
+    ),
+    expected_events AS (
+      SELECT
+        draw_index,
+        CASE
+          WHEN draw_index = 1 THEN p_chat_batch_id
+          ELSE p_chat_batch_id || ':' || draw_index::text
+        END AS event_id
+      FROM generate_series(1, p_draw_count) AS draw(draw_index)
+    ),
+    drawn_card_counts AS (
+      SELECT
+        gh.card_id,
+        min(expected_events.draw_index) AS first_draw_index,
+        count(*)::integer AS drawn_count,
+        min(c.name) AS card_name
+      FROM expected_events
+      JOIN gacha_history gh ON gh.event_id = expected_events.event_id
+      JOIN cards c ON c.id = gh.card_id
+      GROUP BY gh.card_id
+    )
+    SELECT
+      coalesce((
+        SELECT final_count
+        FROM user_card_counts
+        WHERE card_id = (v_cards_payload -> 0 ->> 'id')::uuid
+      ), 0),
+      (SELECT count(*)::integer FROM user_card_counts WHERE is_active),
+      (
+        SELECT count(*)::integer
+        FROM cards
+        WHERE streamer_id = p_streamer_id
+          AND is_active = true
+      ),
+      coalesce((
+        SELECT jsonb_agg(drawn.card_name ORDER BY drawn.first_draw_index)
+        FROM drawn_card_counts drawn
+        JOIN user_card_counts owned ON owned.card_id = drawn.card_id
+        WHERE owned.final_count > 0
+          AND owned.final_count - drawn.drawn_count <= 0
+      ), '[]'::jsonb)
+      INTO v_card_count, v_unique_count, v_all_count, v_new_card_names;
+
+      -- chat無効時はoutbox自体を作らず、DB容量・relay負荷をゼロにする。設定値と
+      -- payloadはこのtransaction時点のsnapshotなので、後続relayで設定が変わっても
+      -- 当該引き換えの通知内容を再現できる。
+      INSERT INTO public.chat_notification_outbox (
+      batch_id, payload_version, payload, expected_draw_count,
+      assembled_draw_count, status
+    )
+    SELECT
+      p_chat_batch_id,
+      1,
+      jsonb_build_object(
+        'batchId', p_chat_batch_id,
+        'broadcasterTwitchUserId', s.twitch_user_id,
+        'userId', p_user_twitch_id,
+        'streamer', jsonb_build_object(
+          'id', s.id,
+          'chat_announcement_enabled', s.chat_announcement_enabled,
+          'chat_announcement_template', s.chat_announcement_template,
+          'chat_announcement_multi_template', s.chat_announcement_multi_template,
+          'chat_announcement_multi_show_cards', s.chat_announcement_multi_show_cards,
+          'default_card_pack_name', s.default_card_pack_name
+        ),
+        'gachaResult', jsonb_build_object(
+          'type', 'gacha',
+          'card', v_cards_payload -> 0,
+          'cards', v_cards_payload,
+          'userTwitchUsername', p_user_twitch_username,
+          'rewardId', p_reward_id,
+          'collectionName', p_collection_name
+        ),
+        'chatSnapshot', jsonb_build_object(
+          'cardCount', v_card_count,
+          'uniqueCount', v_unique_count,
+          'allCount', v_all_count,
+          'newCardNames', v_new_card_names
+        )
+      ),
+      p_draw_count,
+      p_draw_count,
+      'pending'
+    FROM streamers s
+    WHERE s.id = p_streamer_id
+      AND s.chat_announcement_enabled = true
+      ON CONFLICT (batch_id) DO NOTHING;
+    END IF;
+  END IF;
+
+  IF v_is_duplicate THEN
+    RETURN jsonb_build_object(
+      'is_duplicate', true,
+      -- final duplicateは歯抜け/応答消失回復で再構成した完全なカード列を返す。
+      -- アプリは残drawだけの配列をoverlay batchとして誤採番せずに済む。
+      'cards', CASE
+        WHEN p_chat_batch_id IS NOT NULL AND p_draw_index = p_draw_count
+          THEN v_cards_payload
+        ELSE NULL
+      END
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'is_duplicate', false,
+    'limit_reached', false,
+    'history_id', v_history_id,
+    'cards', CASE
+      WHEN p_chat_batch_id IS NOT NULL AND p_draw_index = p_draw_count
+        THEN v_cards_payload
+      ELSE NULL
+    END
+  );
+END;
+$$;
+
+COMMENT ON TABLE public.chat_notification_outbox IS
+  'Twitch chat transactional outbox. At-least-once delivery; sent後のack前停止時は重複し得る。';
+
+COMMENT ON FUNCTION public.execute_gacha_transaction_with_chat_outbox(
+  text, text, text, uuid, uuid, integer, text, text, integer, integer, text
+) IS
+  'ガチャ確定とchat outbox組立を同一transactionで実行するversioned RPC。旧7引数RPCはschema-first互換のため別名で残す。';
+
+REVOKE ALL ON FUNCTION public.execute_gacha_transaction_with_chat_outbox(
+  text, text, text, uuid, uuid, integer, text, text, integer, integer, text
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON TABLE public.chat_notification_outbox FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.chat_notification_outbox TO service_role;
+GRANT EXECUTE ON FUNCTION public.execute_gacha_transaction_with_chat_outbox(
+  text, text, text, uuid, uuid, integer, text, text, integer, integer, text
+) TO service_role;

--- a/tests/fixtures/transactional-chat-outbox-concurrency.sh
+++ b/tests/fixtures/transactional-chat-outbox-concurrency.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Issue #803: 同一EventSubをlive処理とCron replayが別接続で同時実行しても、
+# 発行上限より先にduplicateとして直列化されることをPostgreSQL 17で検証する。
+# 単一SQL transactionのfixtureでは接続間競合を再現できないため、先行RPCを
+# COMMIT前で保持し、後続RPCを意図的に競合させる。
+
+readonly DB_HOST="${PGHOST:-127.0.0.1}"
+readonly DB_PORT="${PGPORT:-5432}"
+readonly DB_USER="${PGUSER:-postgres}"
+readonly DB_NAME="${PGDATABASE:-postgres}"
+readonly PSQL=(psql -X -qAt -v ON_ERROR_STOP=1 \
+  -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME")
+
+FIRST_OUTPUT="$(mktemp)"
+SECOND_OUTPUT="$(mktemp)"
+FIRST_ERROR="$(mktemp)"
+cleanup() {
+  rm -f "$FIRST_OUTPUT" "$SECOND_OUTPUT" "$FIRST_ERROR"
+}
+trap cleanup EXIT
+
+"${PSQL[@]}" -1 <<'SQL'
+INSERT INTO public.streamers (
+  id, twitch_user_id, twitch_username, twitch_display_name,
+  chat_announcement_enabled
+) VALUES (
+  'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+  'concurrency-streamer',
+  'concurrency-streamer',
+  'Concurrency Streamer',
+  true
+);
+
+INSERT INTO public.cards (
+  id, streamer_id, name, rarity, drop_rate, is_active, max_issuance_count
+) VALUES
+  (
+    '55555555-5555-4555-8555-555555555555',
+    'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+    'Same Card', 'common', 0.34, true, 1
+  ),
+  (
+    '66666666-6666-4666-8666-666666666666',
+    'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+    'First Different Card', 'rare', 0.33, true, 1
+  ),
+  (
+    '77777777-7777-4777-8777-777777777777',
+    'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+    'Second Different Card', 'epic', 0.33, true, 1
+  );
+SQL
+
+run_concurrent_case() {
+  local event_id="$1"
+  local viewer_id="$2"
+  local first_card_id="$3"
+  local second_card_id="$4"
+
+  : >"$FIRST_OUTPUT"
+  : >"$SECOND_OUTPUT"
+  : >"$FIRST_ERROR"
+
+  # 先行接続はRPCの副作用を作った後も2秒COMMITせず保持する。後続接続の
+  # 冒頭SELECTからは未commit履歴が見えない状態を決定的に作る。
+  "${PSQL[@]}" >"$FIRST_OUTPUT" 2>"$FIRST_ERROR" <<SQL &
+BEGIN;
+SELECT concat(
+  result ->> 'is_duplicate',
+  '|',
+  coalesce(result ->> 'limit_reached', 'null')
+)
+FROM (
+  SELECT public.execute_gacha_transaction_with_chat_outbox(
+    '$event_id',
+    '$viewer_id',
+    'Concurrency Viewer',
+    '$first_card_id'::uuid,
+    'cccccccc-cccc-4ccc-8ccc-cccccccccccc'::uuid,
+    100,
+    'concurrency-reward',
+    '$event_id',
+    1,
+    1,
+    NULL
+  ) AS result
+) AS first_call;
+SELECT pg_sleep(2);
+COMMIT;
+SQL
+  local first_pid=$!
+
+  # 別接続のtry-lockで、先行RPCがevent advisory lockを実際に保持したことを
+  # 確認する。stdoutのflush時期や固定sleepに依存せず、未commit競合を決定的に作る。
+  local ready=0
+  for _ in $(seq 1 50); do
+    local lock_held
+    lock_held="$("${PSQL[@]}" -c "
+      SELECT NOT pg_try_advisory_lock(hashtextextended('$event_id', 803));
+    ")"
+    # try-lockがtrueだったpoll接続はそのクライアント終了時に自動解放される。
+    # false（NOT後はtrue）なら先行接続が所有中で、後続を開始してよい。
+    if [[ "$lock_held" == 't' ]]; then
+      ready=1
+      break
+    fi
+    if ! kill -0 "$first_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+  done
+  if [[ "$ready" -ne 1 ]]; then
+    wait "$first_pid" || true
+    echo "first concurrent RPC did not reach the pre-commit hold" >&2
+    sed -n '1,120p' "$FIRST_ERROR" >&2
+    return 1
+  fi
+
+  "${PSQL[@]}" >"$SECOND_OUTPUT" <<SQL
+SELECT concat(
+  result ->> 'is_duplicate',
+  '|',
+  coalesce(result ->> 'limit_reached', 'null')
+)
+FROM (
+  SELECT public.execute_gacha_transaction_with_chat_outbox(
+    '$event_id',
+    '$viewer_id',
+    'Concurrency Viewer',
+    '$second_card_id'::uuid,
+    'cccccccc-cccc-4ccc-8ccc-cccccccccccc'::uuid,
+    100,
+    'concurrency-reward',
+    '$event_id',
+    1,
+    1,
+    NULL
+  ) AS result
+) AS second_call;
+SQL
+  wait "$first_pid"
+
+  grep -q '^false|false$' "$FIRST_OUTPUT"
+  grep -q '^true|null$' "$SECOND_OUTPUT"
+
+  # 先行だけがカードを付与し、後続は同一/別cardのどちらを選んでもduplicate。
+  # limit_reachedによる誤返金を許さず、履歴・所有・outboxも各1件へ収束する。
+  local counts
+  counts="$("${PSQL[@]}" <<SQL
+SELECT concat(
+  (SELECT count(*) FROM public.gacha_history WHERE event_id = '$event_id'),
+  '|',
+  (
+    SELECT count(*)
+    FROM public.user_cards uc
+    JOIN public.users u ON u.id = uc.user_id
+    WHERE u.twitch_user_id = '$viewer_id'
+  ),
+  '|',
+  (SELECT count(*) FROM public.chat_notification_outbox WHERE batch_id = '$event_id')
+);
+SQL
+)"
+  if [[ "$counts" != '1|1|1' ]]; then
+    echo "concurrent RPC invariant failed for $event_id: $counts" >&2
+    return 1
+  fi
+}
+
+run_concurrent_case \
+  'concurrent-same-event' \
+  'concurrent-same-viewer' \
+  '55555555-5555-4555-8555-555555555555' \
+  '55555555-5555-4555-8555-555555555555'
+
+run_concurrent_case \
+  'concurrent-different-event' \
+  'concurrent-different-viewer' \
+  '66666666-6666-4666-8666-666666666666' \
+  '77777777-7777-4777-8777-777777777777'
+
+echo "transactional chat outbox concurrency checks passed"

--- a/tests/fixtures/transactional-chat-outbox-postgres.sql
+++ b/tests/fixtures/transactional-chat-outbox-postgres.sql
@@ -1,0 +1,357 @@
+\set ON_ERROR_STOP on
+
+-- Issue #803: migration SQLを文字列として読むだけの単体テストでは、PL/pgSQLの
+-- 構文・三値論理・権限・行ロックを検証できない。CIのPostgreSQL 17へbaselineから
+-- migrationを適用した後、このfixtureで実際のRPCとowner-fenced leaseを検証する。
+
+INSERT INTO public.streamers (
+  id, twitch_user_id, twitch_username, twitch_display_name,
+  chat_announcement_enabled
+) VALUES
+  (
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    'broadcaster', 'broadcaster', 'Broadcaster', true
+  ),
+  (
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+    'disabled', 'disabled', 'Disabled', false
+  );
+
+INSERT INTO public.cards (
+  id, streamer_id, name, rarity, drop_rate, is_active
+) VALUES
+  (
+    '11111111-1111-4111-8111-111111111111',
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    'One', 'common', 0.3, true
+  ),
+  (
+    '22222222-2222-4222-8222-222222222222',
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    'Two', 'rare', 0.3, true
+  ),
+  (
+    '33333333-3333-4333-8333-333333333333',
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    'Three', 'epic', 0.4, true
+  ),
+  (
+    '44444444-4444-4444-8444-444444444444',
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+    'Disabled Card', 'common', 1, true
+  );
+
+CREATE ROLE twica_ci INHERIT BYPASSRLS;
+GRANT service_role TO twica_ci;
+
+DO $$
+DECLARE
+  v_signature text :=
+    'public.execute_gacha_transaction_with_chat_outbox('
+    || 'text,text,text,uuid,uuid,integer,text,text,integer,integer,text)';
+BEGIN
+  -- 新RPCとoutboxはruntimeロールだけに公開し、browser相当ロールへ露出させない。
+  IF has_function_privilege('anon', v_signature, 'EXECUTE')
+     OR has_function_privilege('authenticated', v_signature, 'EXECUTE') THEN
+    RAISE EXCEPTION 'browser role can execute transactional gacha RPC';
+  END IF;
+  IF has_function_privilege('service_role', v_signature, 'EXECUTE') IS NOT TRUE THEN
+    RAISE EXCEPTION 'service_role cannot execute transactional gacha RPC';
+  END IF;
+  IF has_table_privilege('anon', 'public.chat_notification_outbox', 'SELECT') THEN
+    RAISE EXCEPTION 'anon can read chat outbox payload';
+  END IF;
+  -- has_table_privilegeへカンマ区切りを渡すと「いずれか」を満たすだけでtrueに
+  -- なり得るため、runtime relayが必要とする4権限を個別に全件検証する。
+  IF has_table_privilege('service_role', 'public.chat_notification_outbox', 'SELECT') IS NOT TRUE
+     OR has_table_privilege('service_role', 'public.chat_notification_outbox', 'INSERT') IS NOT TRUE
+     OR has_table_privilege('service_role', 'public.chat_notification_outbox', 'UPDATE') IS NOT TRUE
+     OR has_table_privilege('service_role', 'public.chat_notification_outbox', 'DELETE') IS NOT TRUE THEN
+    RAISE EXCEPTION 'service_role lacks chat outbox DML privileges';
+  END IF;
+END
+$$;
+
+SET ROLE twica_ci;
+
+DO $$
+DECLARE
+  v_result jsonb;
+  v_count integer;
+  v_row_count integer;
+  v_lease_a uuid := 'aaaaaaaa-1111-4111-8111-111111111111';
+  v_lease_b uuid := 'bbbbbbbb-2222-4222-8222-222222222222';
+BEGIN
+  -- expand migration期間も旧7引数RPCが曖昧化・破損していないことを実呼出しする。
+  v_result := public.execute_gacha_transaction(
+    'legacy-event',
+    'legacy-viewer',
+    'Legacy Viewer',
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid,
+    100,
+    'legacy-reward'
+  );
+  IF (v_result ->> 'is_duplicate')::boolean IS DISTINCT FROM false THEN
+    RAISE EXCEPTION 'legacy RPC did not succeed: %', v_result;
+  END IF;
+
+  v_result := public.execute_gacha_transaction_with_chat_outbox(
+    'single-event',
+    'single-viewer',
+    'Single Viewer',
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid,
+    100,
+    'single-reward',
+    'single-event',
+    1,
+    1,
+    NULL
+  );
+  IF (v_result ->> 'is_duplicate')::boolean IS DISTINCT FROM false THEN
+    RAISE EXCEPTION 'single draw did not succeed: %', v_result;
+  END IF;
+
+  -- N連は最終drawと同じtransactionで、event_id順の完成payloadを1件だけ作る。
+  PERFORM public.execute_gacha_transaction_with_chat_outbox(
+    'batch-ok', 'batch-viewer', 'Batch Viewer',
+    '11111111-1111-4111-8111-111111111111'::uuid,
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid,
+    300, 'batch-reward', 'batch-ok', 1, 3, 'CI Pack'
+  );
+  PERFORM public.execute_gacha_transaction_with_chat_outbox(
+    'batch-ok:2', 'batch-viewer', 'Batch Viewer',
+    '22222222-2222-4222-8222-222222222222'::uuid,
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid,
+    NULL, 'batch-reward', 'batch-ok', 2, 3, 'CI Pack'
+  );
+  PERFORM public.execute_gacha_transaction_with_chat_outbox(
+    'batch-ok:3', 'batch-viewer', 'Batch Viewer',
+    '33333333-3333-4333-8333-333333333333'::uuid,
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid,
+    NULL, 'batch-reward', 'batch-ok', 3, 3, 'CI Pack'
+  );
+
+  SELECT count(*)::integer
+    INTO v_count
+    FROM public.chat_notification_outbox
+    WHERE batch_id = 'batch-ok'
+      AND status = 'pending'
+      AND expected_draw_count = 3
+      AND assembled_draw_count = 3
+      AND jsonb_array_length(payload #> '{gachaResult,cards}') = 3
+      AND payload #>> '{gachaResult,cards,0,name}' = 'One'
+      AND payload #>> '{gachaResult,cards,1,name}' = 'Two'
+      AND payload #>> '{gachaResult,cards,2,name}' = 'Three'
+      AND payload #>> '{chatSnapshot,cardCount}' = '1'
+      AND payload #>> '{chatSnapshot,uniqueCount}' = '3'
+      AND payload #>> '{chatSnapshot,allCount}' = '3'
+      AND payload #> '{chatSnapshot,newCardNames}' = '["One", "Two", "Three"]'::jsonb;
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'ordered 3-draw outbox was not assembled';
+  END IF;
+
+  -- relay待ち中に所有数やcatalogが変わっても、versioned payloadはcommit時点の
+  -- placeholder値を保持する。送信側が現在値を再問合せしない契約のDB側回帰。
+  INSERT INTO public.user_cards (user_id, card_id)
+  SELECT id, '11111111-1111-4111-8111-111111111111'::uuid
+  FROM public.users
+  WHERE twitch_user_id = 'batch-viewer';
+  UPDATE public.cards
+  SET is_active = false
+  WHERE id = '33333333-3333-4333-8333-333333333333';
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.chat_notification_outbox
+    WHERE batch_id = 'batch-ok'
+      AND payload #>> '{chatSnapshot,cardCount}' = '1'
+      AND payload #>> '{chatSnapshot,uniqueCount}' = '3'
+      AND payload #>> '{chatSnapshot,allCount}' = '3'
+      AND payload #> '{chatSnapshot,newCardNames}' = '["One", "Two", "Three"]'::jsonb
+  ) THEN
+    RAISE EXCEPTION 'chat placeholder snapshot changed after later DB mutations';
+  END IF;
+
+  -- chat無効時はカード履歴だけを確定し、容量を消費するoutbox行を作らない。
+  PERFORM public.execute_gacha_transaction_with_chat_outbox(
+    'disabled-event', 'disabled-viewer', 'Disabled Viewer',
+    '44444444-4444-4444-8444-444444444444'::uuid,
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'::uuid,
+    100, 'disabled-reward', 'disabled-event', 1, 1, NULL
+  );
+  SELECT count(*)::integer INTO v_count
+  FROM public.gacha_history
+  WHERE event_id = 'disabled-event';
+  IF v_count <> 1 OR EXISTS (
+    SELECT 1 FROM public.chat_notification_outbox WHERE batch_id = 'disabled-event'
+  ) THEN
+    RAISE EXCEPTION 'chat-disabled draw did not preserve the zero-outbox invariant';
+  END IF;
+
+  -- 過去障害で最終eventだけ先に存在する歯抜けでも、不足分を補完した後の
+  -- duplicate final呼出しが全履歴からoutboxを復元する。
+  INSERT INTO public.gacha_history (
+    event_id, user_twitch_id, user_twitch_username, card_id, streamer_id,
+    reward_cost, reward_id
+  ) VALUES
+    (
+      'batch-gap', 'gap-viewer', 'Gap Viewer',
+      '11111111-1111-4111-8111-111111111111',
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      300, 'gap-reward'
+    ),
+    (
+      'batch-gap:3', 'gap-viewer', 'Gap Viewer',
+      '33333333-3333-4333-8333-333333333333',
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      NULL, 'gap-reward'
+    );
+  PERFORM public.execute_gacha_transaction_with_chat_outbox(
+    'batch-gap:2', 'gap-viewer', 'Gap Viewer',
+    '22222222-2222-4222-8222-222222222222'::uuid,
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid,
+    NULL, 'gap-reward', 'batch-gap', 2, 3, NULL
+  );
+  v_result := public.execute_gacha_transaction_with_chat_outbox(
+    'batch-gap:3', 'gap-viewer', 'Gap Viewer',
+    '33333333-3333-4333-8333-333333333333'::uuid,
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid,
+    NULL, 'gap-reward', 'batch-gap', 3, 3, NULL
+  );
+  IF (v_result ->> 'is_duplicate')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'gap final was not reported as duplicate: %', v_result;
+  END IF;
+  SELECT count(*)::integer INTO v_count
+  FROM public.chat_notification_outbox
+  WHERE batch_id = 'batch-gap'
+    AND jsonb_array_length(payload #> '{gachaResult,cards}') = 3;
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'gap recovery did not reconstruct the complete outbox';
+  END IF;
+  SELECT count(*)::integer INTO v_count
+  FROM public.user_cards uc
+  JOIN public.users u ON u.id = uc.user_id
+  WHERE u.twitch_user_id = 'gap-viewer';
+  IF v_count <> 1 THEN
+    RAISE EXCEPTION 'gap recovery duplicated a previously persisted card';
+  END IF;
+
+  -- PostgreSQLのNULL比較はunknownになる。NULL draw位置を明示拒否しない回帰では、
+  -- 履歴だけ作ってoutboxが無い半端なsuccessになるため、副作用0まで検証する。
+  BEGIN
+    PERFORM public.execute_gacha_transaction_with_chat_outbox(
+      'null-index', 'null-viewer', 'Null Viewer',
+      '11111111-1111-4111-8111-111111111111'::uuid,
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid,
+      100, 'null-reward', 'null-index', NULL, 1, NULL
+    );
+    RAISE EXCEPTION 'NULL index accepted';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM = 'NULL index accepted' THEN
+      RAISE;
+    END IF;
+  END;
+  BEGIN
+    PERFORM public.execute_gacha_transaction_with_chat_outbox(
+      'null-count', 'null-viewer', 'Null Viewer',
+      '11111111-1111-4111-8111-111111111111'::uuid,
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'::uuid,
+      100, 'null-reward', 'null-count', 1, NULL, NULL
+    );
+    RAISE EXCEPTION 'NULL count accepted';
+  EXCEPTION WHEN OTHERS THEN
+    IF SQLERRM = 'NULL count accepted' THEN
+      RAISE;
+    END IF;
+  END;
+  IF EXISTS (
+    SELECT 1 FROM public.gacha_history
+    WHERE event_id IN ('null-index', 'null-count')
+  ) OR EXISTS (
+    SELECT 1 FROM public.chat_notification_outbox
+    WHERE batch_id IN ('null-index', 'null-count')
+  ) THEN
+    RAISE EXCEPTION 'NULL draw validation left a partial side effect';
+  END IF;
+
+  -- live/Cron同時配送をowner leaseで直列化し、誤ownerのackをfenceする。
+  UPDATE public.chat_notification_outbox
+  SET status = 'processing',
+      lease_id = v_lease_a,
+      lease_expires_at = now() + interval '60 seconds',
+      attempt_count = attempt_count + 1
+  WHERE batch_id = 'single-event'
+    AND status = 'pending';
+  GET DIAGNOSTICS v_row_count = ROW_COUNT;
+  IF v_row_count <> 1 THEN
+    RAISE EXCEPTION 'initial chat outbox claim failed';
+  END IF;
+
+  UPDATE public.chat_notification_outbox
+  SET lease_id = v_lease_b
+  WHERE batch_id = 'single-event'
+    AND (
+      status = 'pending'
+      OR (status = 'processing' AND lease_expires_at <= now())
+    );
+  GET DIAGNOSTICS v_row_count = ROW_COUNT;
+  IF v_row_count <> 0 THEN
+    RAISE EXCEPTION 'unexpired chat outbox lease was claimed twice';
+  END IF;
+
+  UPDATE public.chat_notification_outbox
+  SET status = 'sent', sent_at = now(), lease_id = NULL, lease_expires_at = NULL
+  WHERE batch_id = 'single-event'
+    AND status = 'processing'
+    AND lease_id = v_lease_b;
+  GET DIAGNOSTICS v_row_count = ROW_COUNT;
+  IF v_row_count <> 0 THEN
+    RAISE EXCEPTION 'wrong owner acknowledged chat outbox';
+  END IF;
+
+  UPDATE public.chat_notification_outbox
+  SET status = 'sent', sent_at = now(), lease_id = NULL, lease_expires_at = NULL
+  WHERE batch_id = 'single-event'
+    AND status = 'processing'
+    AND lease_id = v_lease_a;
+  GET DIAGNOSTICS v_row_count = ROW_COUNT;
+  IF v_row_count <> 1 THEN
+    RAISE EXCEPTION 'lease owner could not acknowledge chat outbox';
+  END IF;
+
+  -- 期限切れownerはreclaimでき、attempt_countを引き継いで上限へ進む。
+  UPDATE public.chat_notification_outbox
+  SET status = 'processing',
+      lease_id = v_lease_a,
+      lease_expires_at = now() - interval '1 second',
+      attempt_count = 1
+  WHERE batch_id = 'batch-ok';
+  WITH candidates AS (
+    SELECT id
+    FROM public.chat_notification_outbox
+    WHERE batch_id = 'batch-ok'
+      AND status = 'processing'
+      AND lease_expires_at <= now()
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE public.chat_notification_outbox AS outbox
+  SET lease_id = v_lease_b,
+      lease_expires_at = now() + interval '60 seconds',
+      attempt_count = outbox.attempt_count + 1
+  FROM candidates
+  WHERE outbox.id = candidates.id;
+  GET DIAGNOSTICS v_row_count = ROW_COUNT;
+  IF v_row_count <> 1 OR NOT EXISTS (
+    SELECT 1
+    FROM public.chat_notification_outbox
+    WHERE batch_id = 'batch-ok'
+      AND lease_id = v_lease_b
+      AND attempt_count = 2
+  ) THEN
+    RAISE EXCEPTION 'expired lease was not reclaimed with fencing';
+  END IF;
+END
+$$;
+
+RESET ROLE;

--- a/tests/unit/transactional-chat-outbox-migration.test.ts
+++ b/tests/unit/transactional-chat-outbox-migration.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  join(process.cwd(), 'db/planetscale/migrations/20260725100000_transactional_chat_outbox.sql'),
+  'utf8',
+)
+
+describe('transactional chat outbox migration', () => {
+  it('PlanetScale transaction migrationとして宣言し、versioned RPCで旧7引数を曖昧化しない', () => {
+    expect(migration).toMatch(/^-- migration-transaction: required\n-- migration-providers: planetscale/)
+    expect(migration).toContain('CREATE FUNCTION public.execute_gacha_transaction_with_chat_outbox(')
+    expect(migration).not.toContain('CREATE OR REPLACE FUNCTION public.execute_gacha_transaction(')
+    expect(migration).not.toMatch(/p_chat_batch_id text DEFAULT/i)
+  })
+
+  it('カード付与とoutbox組立を同じRPC transactionに閉じ込める', () => {
+    const historyInsert = migration.indexOf('INSERT INTO gacha_history')
+    const cardInsert = migration.indexOf('INSERT INTO user_cards')
+    const outboxInsert = migration.indexOf('INSERT INTO public.chat_notification_outbox')
+    const successReturn = migration.lastIndexOf("RETURN jsonb_build_object(")
+
+    expect(historyInsert).toBeGreaterThan(0)
+    expect(cardInsert).toBeGreaterThan(historyInsert)
+    expect(outboxInsert).toBeGreaterThan(cardInsert)
+    expect(successReturn).toBeGreaterThan(outboxInsert)
+    expect(migration).toContain('AND s.chat_announcement_enabled = true')
+  })
+
+  it('最終drawで全履歴をevent_id順に再構成し、完成済みpendingだけを作る', () => {
+    const outboxInsert = migration.indexOf('INSERT INTO public.chat_notification_outbox')
+    const duplicateBranch = migration.indexOf('IF v_is_duplicate THEN', outboxInsert)
+    const duplicateReturn = migration.indexOf('RETURN jsonb_build_object(', duplicateBranch)
+
+    expect(migration).toContain('p_draw_index = p_draw_count')
+    expect(migration).toContain('FROM generate_series(1, p_draw_count)')
+    expect(migration).toContain('jsonb_agg(card_payload ORDER BY draw_index)')
+    expect(migration).toContain("RAISE EXCEPTION 'chat outbox history incomplete")
+    // 最終イベントが既存でも、途中の歯抜けが別リクエストで埋まった後なら
+    // outbox を復元してから duplicate を返す必要がある。
+    expect(migration).toContain('v_is_duplicate := FOUND')
+    expect(migration).toContain('ON CONFLICT (batch_id) DO NOTHING')
+    expect(migration).toContain("'cards', CASE")
+    expect(migration).toContain('THEN v_cards_payload')
+    // cardsを同時に返すためjsonb_build_objectは複数行に分かれる。単一行の
+    // 文字列一致ではなく、outbox復元後のduplicate分岐とそのRETURNの順序を固定する。
+    expect(duplicateBranch).toBeGreaterThan(outboxInsert)
+    expect(duplicateReturn).toBeGreaterThan(duplicateBranch)
+    expect(migration).toContain("'pending'")
+    expect(migration).not.toContain("'building'")
+  })
+
+  it('所有数系placeholderをガチャtransactionのversioned payloadへsnapshotする', () => {
+    for (const fragment of [
+      "'chatSnapshot', jsonb_build_object(",
+      "'cardCount', v_card_count",
+      "'uniqueCount', v_unique_count",
+      "'allCount', v_all_count",
+      "'newCardNames', v_new_card_names",
+      'WITH user_card_counts AS (',
+    ]) {
+      expect(migration).toContain(fragment)
+    }
+  })
+
+  it('NULLをPostgreSQL三値論理ですり抜けさせずdraw位置をfail-closedにする', () => {
+    expect(migration).toContain('p_draw_index IS NULL OR p_draw_count IS NULL')
+    expect(migration.indexOf('p_draw_index IS NULL OR p_draw_count IS NULL'))
+      .toBeLessThan(migration.indexOf('p_draw_index < 1'))
+  })
+
+  it('同じeventのlive/Cron並行実行をcard選択に依存せずtransaction単位で直列化する', () => {
+    const eventLock = migration.indexOf(
+      'pg_advisory_xact_lock(hashtextextended(p_event_id, 803))',
+    )
+    const duplicateRead = migration.indexOf('SELECT id INTO v_history_id')
+    const cardLock = migration.indexOf('FOR UPDATE')
+
+    expect(eventLock).toBeGreaterThan(0)
+    expect(eventLock).toBeLessThan(duplicateRead)
+    expect(eventLock).toBeLessThan(cardLock)
+  })
+
+  it('claim/DLQに必要な状態・lease・attempt・due indexを持つ', () => {
+    for (const fragment of [
+      'payload_version smallint NOT NULL DEFAULT 1 CHECK (payload_version = 1)',
+      "CHECK (status IN ('pending', 'processing', 'sent', 'dead'))",
+      'attempt_count integer NOT NULL DEFAULT 0',
+      'next_attempt_at timestamptz NOT NULL DEFAULT now()',
+      'lease_id uuid',
+      'lease_expires_at timestamptz',
+      'chat_notification_outbox_due_idx',
+      'chat_notification_outbox_sent_cleanup_idx',
+      'chat_notification_outbox_dead_cleanup_idx',
+    ]) {
+      expect(migration).toContain(fragment)
+    }
+    expect(migration).toContain('assembled_draw_count = expected_draw_count')
+    expect(migration).toContain('FROM PUBLIC, anon, authenticated')
+  })
+})


### PR DESCRIPTION
## 概要
Issue #803 のschema-first段階として、ガチャ付与とチャット通知payloadを同一transactionで永続化するPlanetScale outboxを追加します。

## 変更
- `chat_notification_outbox` とowner-fenced lease/DLQ/retention index
- single/N連・部分再開・重複EventSubを扱う `execute_gacha_transaction_with_chat_outbox`
- PostgreSQL 17で全migrationを適用するCI job
- 実DBfixture（NULL副作用、snapshot不変、権限）と同一event並行実行テスト

## 検証
- PostgreSQL 17: baseline/grants/全migration/fixture/並行実行 成功
- unit: 247 files / 3321 tests pass（Docker fault-injection 34件は設定未指定でskip）
- integration: 13 tests pass
- typecheck / overlay worker typecheck / Supabase shutdown / maintenance surfaces / migration order: pass
- lint: 0 errors（既存を含む15 warnings）
- 厳格レビュー: 指摘0

## 反映順
このPRをpreviewへ先行mergeし、PlanetScale migration成功後にapplication runtime PRを続けます。