### PR TITLE
perf(overlay): rollout config version を history polling に載せて config 専用ポーリングを廃止

### DIFF
--- a/src/app/api/overlay/[streamerId]/events/route.ts
+++ b/src/app/api/overlay/[streamerId]/events/route.ts
@@ -19,6 +19,7 @@ import {
   buildPollingRealtimeEvents,
   isValidStreamerId,
 } from "@/lib/overlay-realtime/contract";
+import { resolveOverlayRealtimeConfigVersion } from "@/lib/overlay-realtime/resolve-config";
 import { getOverlayDemoEvent } from "@/lib/overlay/demo-event-store";
 
 // A redemption produces at most 15 rows. The larger bounded page keeps one
@@ -358,6 +359,19 @@ export async function GET(
         : null,
       ...(demoSince ? { demoEvent } : {}),
       overlayVersion: process.env.NEXT_PUBLIC_OVERLAY_VERSION ?? "dev",
+      // Rollout/rollback signal carried on a request the overlay already makes.
+      //
+      // Every overlay polls this endpoint: every ~3s in polling-only mode and
+      // every ~30s as gap recovery while the socket is healthy. Echoing the
+      // effective config version here lets the client drop its separate
+      // 30-second config poll, which was roughly half of all overlay traffic,
+      // without weakening the kill switch: an operator flipping the allowlist
+      // is now noticed on the next pass the client was making anyway (faster in
+      // polling-only mode, unchanged while DO-connected).
+      //
+      // Computed through the shared resolver so this value can never disagree
+      // with what the config endpoint would return.
+      realtimeConfigVersion: resolveOverlayRealtimeConfigVersion(streamerId),
     });
   } catch (error) {
     return handleApiError(error, "Overlay Events API");

--- a/src/app/api/overlay/[streamerId]/realtime-config/route.ts
+++ b/src/app/api/overlay/[streamerId]/realtime-config/route.ts
@@ -1,28 +1,9 @@
 import { NextResponse } from 'next/server'
-import {
-  OVERLAY_REALTIME_PROTOCOL_VERSION,
-  type OverlayRealtimeConfigV1,
-  isOverlayRealtimeStreamerEnabled,
-  isValidStreamerId,
-} from '@/lib/overlay-realtime/contract'
+import { isValidStreamerId } from '@/lib/overlay-realtime/contract'
+import { resolveOverlayRealtimeConfig } from '@/lib/overlay-realtime/resolve-config'
 
 interface RouteParams {
   params: Promise<{ streamerId: string }>
-}
-
-function websocketBaseUrl(): string | null {
-  const raw = process.env.OVERLAY_REALTIME_WS_URL
-  if (!raw) return null
-  try {
-    const parsed = new URL(raw)
-    if (parsed.protocol !== 'https:' && parsed.protocol !== 'wss:') return null
-    parsed.pathname = ''
-    parsed.search = ''
-    parsed.hash = ''
-    return parsed.toString().replace(/\/$/, '')
-  } catch {
-    return null
-  }
 }
 
 /**
@@ -32,6 +13,15 @@ function websocketBaseUrl(): string | null {
  * change mode/allowlist through Worker secrets without rebuilding old OBS
  * pages, which is the kill switch required to fall back to polling-only during
  * a Durable Objects incident.
+ *
+ * Connected overlays no longer poll this endpoint on their own timer: the
+ * events endpoint echoes `realtimeConfigVersion` on every pass a client already
+ * makes, and the client refetches here only when that value changes. This
+ * endpoint is therefore a startup + change-triggered read.
+ *
+ * The short cache TTL is deliberately kept. A longer TTL would risk serving a
+ * pre-change config to the very refetch that a detected change triggered; the
+ * traffic saving comes from removing the timer, not from caching.
  */
 export async function GET(
   _request: Request,
@@ -42,30 +32,7 @@ export async function GET(
     return NextResponse.json({ error: 'Invalid streamer ID' }, { status: 400 })
   }
 
-  const baseUrl = websocketBaseUrl()
-  const doEnabled =
-    isOverlayRealtimeStreamerEnabled(
-      process.env.OVERLAY_REALTIME_MODE,
-      process.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST,
-      streamerId
-    )
-    && baseUrl !== null
-
-  const config: OverlayRealtimeConfigV1 = {
-    schemaVersion: 1,
-    mode: doEnabled ? 'do-primary' : 'polling-only',
-    ...(doEnabled ? { webSocketUrl: baseUrl } : {}),
-    protocolVersion: OVERLAY_REALTIME_PROTOCOL_VERSION,
-    retryPolicy: {
-      baseDelayMs: 500,
-      maxDelayMs: 30_000,
-    },
-    // This value changes with the effective public config and is deliberately
-    // free of secret material. Clients use it only for diagnostics/reload.
-    configVersion: doEnabled ? 'do-primary-v1' : 'polling-only-v1',
-  }
-
-  return NextResponse.json(config, {
+  return NextResponse.json(resolveOverlayRealtimeConfig(streamerId), {
     headers: {
       'Cache-Control': 'public, max-age=15, stale-while-revalidate=15',
     },

--- a/src/lib/overlay-realtime/resolve-config.ts
+++ b/src/lib/overlay-realtime/resolve-config.ts
@@ -1,0 +1,94 @@
+import {
+  OVERLAY_REALTIME_PROTOCOL_VERSION,
+  type OverlayRealtimeConfigV1,
+  isOverlayRealtimeStreamerEnabled,
+} from '@/lib/overlay-realtime/contract'
+
+/**
+ * Single place where the app Worker decides a streamer's effective overlay
+ * transport.
+ *
+ * Both `/api/overlay/[streamerId]/realtime-config` (which the OBS browser
+ * source reads at startup) and `/api/overlay/[streamerId]/events` (which
+ * carries the change signal on every poll) must answer with the exact same
+ * effective config. If they were computed independently, a future change to the
+ * allowlist format could make the events endpoint advertise a config version
+ * that the config endpoint never returns, and clients would refetch forever.
+ *
+ * `contract.ts` deliberately owns the allowlist parsing itself so the
+ * standalone Worker shares it; this module only adds the app-Worker-specific
+ * pieces (env lookup and WebSocket base URL).
+ */
+
+function websocketBaseUrl(): string | null {
+  const raw = process.env.OVERLAY_REALTIME_WS_URL
+  if (!raw) return null
+  try {
+    const parsed = new URL(raw)
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'wss:') return null
+    parsed.pathname = ''
+    parsed.search = ''
+    parsed.hash = ''
+    return parsed.toString().replace(/\/$/, '')
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolve whether Durable Objects are the primary transport for this streamer.
+ *
+ * A missing/invalid `OVERLAY_REALTIME_WS_URL` degrades to polling even when the
+ * allowlist enables the streamer, because telling a client `do-primary` without
+ * a reachable socket URL would strand it on the slow reconnect path.
+ */
+export function resolveOverlayRealtimeEnabled(streamerId: string): boolean {
+  return (
+    isOverlayRealtimeStreamerEnabled(
+      process.env.OVERLAY_REALTIME_MODE,
+      process.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST,
+      streamerId
+    ) && websocketBaseUrl() !== null
+  )
+}
+
+/**
+ * Public config version for a streamer.
+ *
+ * This is the value the events endpoint echoes so a connected overlay can
+ * notice a rollout/rollback without polling the config endpoint on its own
+ * timer. It is derived from the same predicate as the full config and contains
+ * no secret material.
+ */
+export function resolveOverlayRealtimeConfigVersion(streamerId: string): string {
+  return resolveOverlayRealtimeEnabled(streamerId)
+    ? 'do-primary-v1'
+    : 'polling-only-v1'
+}
+
+/** Full public runtime configuration for an OBS browser source. */
+export function resolveOverlayRealtimeConfig(
+  streamerId: string
+): OverlayRealtimeConfigV1 {
+  const baseUrl = websocketBaseUrl()
+  const doEnabled =
+    isOverlayRealtimeStreamerEnabled(
+      process.env.OVERLAY_REALTIME_MODE,
+      process.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST,
+      streamerId
+    ) && baseUrl !== null
+
+  return {
+    schemaVersion: 1,
+    mode: doEnabled ? 'do-primary' : 'polling-only',
+    ...(doEnabled ? { webSocketUrl: baseUrl } : {}),
+    protocolVersion: OVERLAY_REALTIME_PROTOCOL_VERSION,
+    retryPolicy: {
+      baseDelayMs: 500,
+      maxDelayMs: 30_000,
+    },
+    // Changes with the effective public config and is deliberately free of
+    // secret material. Clients use it for rollout/rollback detection.
+    configVersion: doEnabled ? 'do-primary-v1' : 'polling-only-v1',
+  }
+}

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -69,6 +69,13 @@ interface PollingResponse {
   realtimeEvents?: GachaRealtimeEventV1[]
   nextCursor?: PollingCursor | null
   demoEvent?: PollingEvent | null
+  /**
+   * Effective overlay transport version, echoed by the events endpoint so a
+   * connected overlay notices a rollout/rollback without polling the config
+   * endpoint on its own timer. Optional so an overlay served by an older
+   * deployment keeps working unchanged.
+   */
+  realtimeConfigVersion?: string
 }
 
 /**
@@ -97,7 +104,23 @@ export interface SubscribeOptions {
 
 const MAX_SEEN_EVENT_IDS = 512
 const SEEN_EVENT_TTL_MS = 24 * 60 * 60 * 1000
-const CONFIG_REFRESH_MS = 30_000
+/**
+ * Safety net only. Rollout/rollback is normally noticed through the
+ * `realtimeConfigVersion` echoed by the events endpoint on a request the
+ * overlay already makes, so this timer exists purely for the case where
+ * history polling itself is broken and can no longer carry the signal.
+ */
+const CONFIG_SAFETY_REFRESH_MS = 5 * 60_000
+/**
+ * Floor between config fetches triggered by a version mismatch.
+ *
+ * Without it, a config endpoint outage would make every 3-second polling pass
+ * refetch (the safe fallback version never matches the server's), which would
+ * be worse than the fixed timer this replaced. Thirty seconds keeps the
+ * degraded case identical to the previous fixed interval while leaving a real
+ * change to be picked up on the first pass that observes it.
+ */
+const CONFIG_CHANGE_REFETCH_FLOOR_MS = 30_000
 const WS_CONNECT_TIMEOUT_MS = 10_000
 const CONNECTED_GAP_RECOVERY_MS = 30_000
 
@@ -115,14 +138,21 @@ function eventUrl(
   return url.toString()
 }
 
-function configUrl(streamerId: string): string {
+function configUrl(streamerId: string, expectedVersion?: string): string {
   // The endpoint has a 15-second public cache TTL. Do not append the
   // millisecond cache-buster used by history polling: doing so would create an
   // unbounded set of edge cache keys and defeat inexpensive rollout config.
-  return new URL(
+  const url = new URL(
     `/api/overlay/${streamerId}/realtime-config`,
     window.location.origin
-  ).toString()
+  )
+  // When a refetch was triggered by a version change observed on the events
+  // endpoint, key the request by that version. This is bounded (one key per
+  // config version that has ever existed, not per millisecond) and guarantees
+  // the cache cannot answer a change-triggered refetch with the pre-change
+  // response it is still holding.
+  if (expectedVersion) url.searchParams.set('v', expectedVersion)
+  return url.toString()
 }
 
 function fetchJsonWithXhr<T>(url: string, fetchError: unknown): Promise<T> {
@@ -267,6 +297,9 @@ export function subscribeToGachaResults(
   let reconnectAttempt = 0
   let pollInFlight = false
   let currentConfig: OverlayRealtimeConfigV1 | null = null
+  /** Guards the change-triggered refetch against a config endpoint outage. */
+  let lastConfigAttemptAt = 0
+  let configRefreshInFlight = false
   let historyCursor: PollingCursor = {
     redeemedAt: new Date().toISOString(),
     historyId: '',
@@ -355,6 +388,11 @@ export function subscribeToGachaResults(
           ? Math.max(intervalMs, CONNECTED_GAP_RECOVERY_MS)
           : intervalMs
       schedulePoll(nextInterval)
+
+      // Rollout/rollback detection rides on this response instead of a separate
+      // config poll. refreshConfig() owns the socket and poll timers, so it is
+      // started after the next pass is scheduled and is allowed to override it.
+      maybeRefreshConfigFor(historyResponse.realtimeConfigVersion)
     } catch (error) {
       retryCount += 1
       const exhausted = Number.isFinite(maxRetries) && retryCount > maxRetries
@@ -473,10 +511,18 @@ export function subscribeToGachaResults(
     }
   }
 
-  const refreshConfig = async () => {
-    if (disposed) return
+  const refreshConfig = async (expectedVersion?: string) => {
+    if (disposed || configRefreshInFlight) return
+    configRefreshInFlight = true
+    lastConfigAttemptAt = Date.now()
+    // A change-triggered refetch must not race the safety-net timer into two
+    // concurrent config states; the timer is always re-armed in `finally`.
+    if (configTimer) clearTimeout(configTimer)
     try {
-      const config = await fetchJson<unknown>(configUrl(streamerId), 'default')
+      const config = await fetchJson<unknown>(
+        configUrl(streamerId, expectedVersion),
+        'default'
+      )
       if (!validConfig(config)) throw new Error('invalid config')
       const previousMode = currentConfig?.mode
       const previousUrl = currentConfig?.webSocketUrl
@@ -518,8 +564,34 @@ export function subscribeToGachaResults(
       }
       options.onStatusChange?.('CONFIG_FALLBACK:POLLING_ONLY')
     } finally {
-      if (!disposed) configTimer = setTimeout(() => void refreshConfig(), CONFIG_REFRESH_MS)
+      configRefreshInFlight = false
+      if (!disposed) {
+        configTimer = setTimeout(
+          () => void refreshConfig(),
+          CONFIG_SAFETY_REFRESH_MS
+        )
+      }
     }
+  }
+
+  /**
+   * Apply a config change that history polling reported.
+   *
+   * The events endpoint echoes the effective config version on every pass the
+   * overlay already makes, so an operator flipping the allowlist is noticed
+   * without a dedicated 30-second config poll per overlay. Detection is
+   * therefore faster in polling-only mode (~3s) and unchanged while
+   * DO-connected (~30s), while removing roughly half of all overlay requests.
+   *
+   * The floor keeps a config endpoint outage from turning every polling pass
+   * into a refetch: the safe fallback version never matches the server's, so an
+   * ungated comparison would loop.
+   */
+  const maybeRefreshConfigFor = (reportedVersion: string | undefined) => {
+    if (disposed || !reportedVersion) return
+    if (reportedVersion === currentConfig?.configVersion) return
+    if (Date.now() - lastConfigAttemptAt < CONFIG_CHANGE_REFETCH_FLOOR_MS) return
+    void refreshConfig(reportedVersion)
   }
 
   if (typeof window === 'undefined') {

--- a/tests/unit/overlay-events-api.test.ts
+++ b/tests/unit/overlay-events-api.test.ts
@@ -548,6 +548,10 @@ describe("GET /api/overlay/[streamerId]/events", () => {
       events: [],
       nextCursor: null,
       overlayVersion: "v-test",
+      // Rollout/rollback signal the overlay reads instead of polling the config
+      // endpoint on its own timer. Without any OVERLAY_REALTIME_* env stubbed,
+      // the shared resolver denies by default.
+      realtimeConfigVersion: "polling-only-v1",
     });
   });
 });

--- a/tests/unit/overlay-realtime-config-signal.test.ts
+++ b/tests/unit/overlay-realtime-config-signal.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  resolveOverlayRealtimeConfig,
+  resolveOverlayRealtimeConfigVersion,
+  resolveOverlayRealtimeEnabled,
+} from '@/lib/overlay-realtime/resolve-config'
+
+const STREAMER_ID = '123e4567-e89b-42d3-a456-426614174000'
+const OTHER_STREAMER_ID = '223e4567-e89b-42d3-a456-426614174000'
+
+/**
+ * The overlay stopped polling the config endpoint on its own timer and instead
+ * reacts to the `realtimeConfigVersion` echoed by the events endpoint.
+ *
+ * That only works if the version the events endpoint reports is always exactly
+ * the version the config endpoint would return. If the two could disagree, a
+ * connected overlay would refetch the config on every polling pass forever, so
+ * the invariant is fixed here rather than left to review.
+ */
+describe('overlay realtime config change signal', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  function enableFor(streamerId: string) {
+    vi.stubEnv('OVERLAY_REALTIME_MODE', 'do-primary')
+    vi.stubEnv('OVERLAY_REALTIME_STREAMER_ALLOWLIST', streamerId)
+    vi.stubEnv('OVERLAY_REALTIME_WS_URL', 'https://realtime.example')
+  }
+
+  it('reports the same version the full config carries when enabled', () => {
+    enableFor(STREAMER_ID)
+    expect(resolveOverlayRealtimeConfigVersion(STREAMER_ID)).toBe(
+      resolveOverlayRealtimeConfig(STREAMER_ID).configVersion
+    )
+    expect(resolveOverlayRealtimeConfigVersion(STREAMER_ID)).toBe('do-primary-v1')
+  })
+
+  it('reports the same version the full config carries when not allowlisted', () => {
+    enableFor(OTHER_STREAMER_ID)
+    expect(resolveOverlayRealtimeConfigVersion(STREAMER_ID)).toBe(
+      resolveOverlayRealtimeConfig(STREAMER_ID).configVersion
+    )
+    expect(resolveOverlayRealtimeConfigVersion(STREAMER_ID)).toBe('polling-only-v1')
+  })
+
+  it('changes version when the operator flips the allowlist', () => {
+    enableFor(STREAMER_ID)
+    const enabled = resolveOverlayRealtimeConfigVersion(STREAMER_ID)
+
+    // Kill switch: the streamer is dropped from the allowlist.
+    vi.stubEnv('OVERLAY_REALTIME_STREAMER_ALLOWLIST', OTHER_STREAMER_ID)
+    const disabled = resolveOverlayRealtimeConfigVersion(STREAMER_ID)
+
+    expect(enabled).not.toBe(disabled)
+    expect(disabled).toBe('polling-only-v1')
+  })
+
+  it('degrades to polling-only when the WebSocket URL is missing or insecure', () => {
+    vi.stubEnv('OVERLAY_REALTIME_MODE', 'do-primary')
+    vi.stubEnv('OVERLAY_REALTIME_STREAMER_ALLOWLIST', STREAMER_ID)
+
+    vi.stubEnv('OVERLAY_REALTIME_WS_URL', '')
+    expect(resolveOverlayRealtimeEnabled(STREAMER_ID)).toBe(false)
+    expect(resolveOverlayRealtimeConfigVersion(STREAMER_ID)).toBe('polling-only-v1')
+
+    // Telling a client `do-primary` over an insecure endpoint would strand it
+    // on the reconnect path, so the resolver must reject it as well.
+    vi.stubEnv('OVERLAY_REALTIME_WS_URL', 'http://realtime.example')
+    expect(resolveOverlayRealtimeEnabled(STREAMER_ID)).toBe(false)
+    expect(resolveOverlayRealtimeConfigVersion(STREAMER_ID)).toBe('polling-only-v1')
+  })
+
+  it('never leaks the publish secret through the version signal', () => {
+    enableFor(STREAMER_ID)
+    vi.stubEnv('OVERLAY_REALTIME_PUBLISH_SECRET', 'must-never-leak')
+    expect(resolveOverlayRealtimeConfigVersion(STREAMER_ID)).not.toContain(
+      'must-never-leak'
+    )
+  })
+})

--- a/tests/unit/realtime.test.ts
+++ b/tests/unit/realtime.test.ts
@@ -423,7 +423,7 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
       constructor(readonly url: string) {
         ControlledWebSocket.instances.push(this)
         // Complete the connection before its 10-second timeout. The test is
-        // about the 30-second config refresh; leaving sockets CONNECTING would
+        // about the config refresh safety net; leaving sockets CONNECTING would
         // correctly exercise timeout/reconnect cycles and make the instance
         // count depend on unrelated backoff timing.
         queueMicrotask(() => {
@@ -480,7 +480,11 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     await flushPromises()
     expect(ControlledWebSocket.instances).toHaveLength(1)
 
-    await vi.advanceTimersByTimeAsync(30_000)
+    // Connected overlays no longer poll the config endpoint every 30 seconds;
+    // the change signal normally rides on history polling (covered by the test
+    // below). This case drives the five-minute safety-net refresh, which is the
+    // path that must still work when history polling cannot carry the signal.
+    await vi.advanceTimersByTimeAsync(5 * 60_000)
     await flushPromises()
     expect(ControlledWebSocket.instances).toHaveLength(2)
 
@@ -493,6 +497,111 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     // A config endpoint change starts a fresh connection policy, so the next
     // outage uses the initial half-jitter delay (random is stubbed to zero).
     expect(statuses).toContain('DO_RECONNECT_WAIT:50')
+    cleanup()
+  })
+
+  it('applies a rollout change reported by history polling without a config timer', async () => {
+    // The overlay used to poll /realtime-config every 30 seconds purely to
+    // notice a rollout/rollback, which was roughly half of all overlay
+    // requests. The events endpoint now echoes the effective config version on
+    // a pass the overlay already makes, so this is the path that must keep the
+    // kill switch working.
+    class ControlledWebSocket {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+      static readonly instances: ControlledWebSocket[] = []
+      readyState = ControlledWebSocket.CONNECTING
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: { code: number }) => void) | null = null
+
+      constructor(readonly url: string) {
+        ControlledWebSocket.instances.push(this)
+        queueMicrotask(() => {
+          this.readyState = ControlledWebSocket.OPEN
+          this.onopen?.()
+        })
+      }
+
+      send() {}
+      close(code = 1000) {
+        this.readyState = 3
+        this.onclose?.({ code })
+      }
+    }
+    vi.stubGlobal('WebSocket', ControlledWebSocket)
+
+    // What the operator has currently rolled out. Both endpoints read it, the
+    // way the shared server-side resolver guarantees in production.
+    let serverVersion = 'test-v1'
+    let configCalls = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/realtime-config')) {
+        configCalls += 1
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'do-primary',
+          webSocketUrl:
+            serverVersion === 'test-v1'
+              ? 'https://realtime-a.example'
+              : 'https://realtime-b.example',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: serverVersion,
+        })
+      }
+      return jsonResponse({ events: [], realtimeConfigVersion: serverVersion })
+    }))
+
+    const cleanup = subscribeToGachaResults('ignored', vi.fn(), {
+      retryDelay: 1_000,
+    })
+    await flushPromises()
+    expect(ControlledWebSocket.instances).toHaveLength(1)
+    expect(configCalls).toBe(1)
+
+    // Operator flips the rollout. No config poll is scheduled for another five
+    // minutes, so only the history pass can carry this.
+    serverVersion = 'test-v2'
+
+    // Gap recovery while the socket is healthy runs every 30 seconds.
+    await vi.advanceTimersByTimeAsync(30_000)
+    await flushPromises()
+
+    expect(configCalls).toBe(2)
+    expect(ControlledWebSocket.instances).toHaveLength(2)
+    expect(ControlledWebSocket.instances[1].url).toContain('realtime-b.example')
+    cleanup()
+  })
+
+  it('does not refetch the config on every pass while the config endpoint is down', async () => {
+    // The safe fallback version never matches what the events endpoint reports,
+    // so an ungated comparison would turn every 3-second polling pass into a
+    // config refetch — worse than the fixed timer this replaced.
+    let configCalls = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/realtime-config')) {
+        configCalls += 1
+        throw new Error('config endpoint down')
+      }
+      return jsonResponse({ events: [], realtimeConfigVersion: 'polling-only-v1' })
+    }))
+
+    const cleanup = subscribeToGachaResults('ignored', vi.fn(), {
+      retryDelay: 3_000,
+    })
+    await flushPromises()
+    const afterStartup = configCalls
+
+    // Ten polling passes at three seconds each.
+    await vi.advanceTimersByTimeAsync(30_000)
+    await flushPromises()
+
+    // At most one additional attempt per 30-second floor, never one per pass.
+    expect(configCalls - afterStartup).toBeLessThanOrEqual(2)
     cleanup()
   })
 


### PR DESCRIPTION
## 背景

#706 の全streamer展開後に overlay トラフィックの内訳を実測したところ、
`/api/overlay/{id}/realtime-config` が **約49%** を占めていた
（`/events` 84.0 req/min に対し `/realtime-config` 79.6 req/min）。

rollout/rollback を知るためだけに30秒ごとに叩いているもので、実質変化しない値を
ポーリングし続けている状態だった。

単に間隔を延ばす案は採らなかった。**この30秒間隔はキルスイッチの伝播経路そのもの**で、
延ばすとロールバックの効きが直接鈍るため。

## 変更

events エンドポイントが実効 config version を返し、クライアントは
**もともと行っているパス**でその変化を検知して config を取り直す。

| | 変更前 | 変更後 |
|---|---|---|
| polling-only 時の検知 | 30秒 | **約3秒** |
| DO接続時の検知 | 30秒 | 約30秒（同等） |
| config 専用リクエスト | 30秒ごと | **廃止**（5分の安全網のみ） |

**キルスイッチは同等以上に速くなり、リクエストだけが減る。**

## 潰した落とし穴

1. **無限再取得** — `safe-fallback` の version はサーバ値と決して一致しないため、
   素直に比較すると config エンドポイント障害時に毎パス再取得して置き換え前より悪化する。
   30秒のフロアを入れ、劣化時が従来と同率になるようテストで固定した。
2. **キャッシュ由来の取りこぼし** — 変化起因の再取得には version を query key として付けた。
   `configUrl` のコメントが禁じるミリ秒バスターと違いキー空間が有界で、
   かつ変更前の応答が返ることを防ぐ。
3. **2ルートの判定ずれ** — events と realtime-config が別々に判定すると、
   version がずれた瞬間にクライアントが永久ループする。`resolve-config.ts` に集約し、
   この不変条件をテストで固定した。

`realtimeConfigVersion` は任意フィールドなので、旧デプロイ配信中の overlay は従来どおり動作する。

## 検証（すべて実測）

**静的検証**: 全3,328テスト passed（新規8追加）/ typecheck 0 / lint エラー0 / supabase guard EXIT=0

**preview 実経路テスト（AGENTS.md 必須）**: 実チャネルポイントを **6回** 引き換え

- チャット通知 6件すべて `sent` / `attempt_count=1` / エラー0
- **overlay の順次表示を DOM 実測で確認**（#803 の症状が再発していないことの確認）:

```text
20:50:57.414  「あずまぐ が引いたカード ... コモン」 img=1  ← 1枚目
20:51:05.026  (空)                                          ← 約7.6秒で消去
20:51:19.421  「あずまぐ が引いたカード ... コモン」 img=1  ← 2枚目
20:51:28.027  (空)                                          ← 約8.6秒で消去
```

- **config ポーリング停止を両側から確認**:
  - クライアント: `CONFIG:` ログが起動時1回のみ（旧実装なら2.5分で5回）
  - サーバ: `wrangler tail` 2.1分の観測で `/realtime-config` が **1回のみ**（変更前は約4回）
- preview tail: エラー0 / 例外0 / 429・5xx なし

## 計測上の注意（次回の検証者向け）

DOM 計測に `setInterval` を使うと、overlay タブが非アクティブのとき Chrome が
最大1回/分へスロットリングし、約8秒の表示窓を取りこぼす。
実際に一度「表示なし」と誤検知した。**MutationObserver を使うこと。**

## 参照

- #706 の全streamer展開: https://github.com/azumag/twica/issues/706#issuecomment-5080338270

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaEUAEC1ZJ4p8V4ZXzDw8x