### PR TITLE
feat(overlay): 接続中の定期ポーリングを全廃し、キルスイッチを WebSocket 経路へ移す

### DIFF
--- a/src/lib/overlay-realtime/contract.ts
+++ b/src/lib/overlay-realtime/contract.ts
@@ -1,5 +1,15 @@
 export const OVERLAY_REALTIME_SCHEMA_VERSION = 1 as const
 export const OVERLAY_REALTIME_PROTOCOL_VERSION = 1 as const
+
+/**
+ * `server_notice` code meaning the room is no longer allowlisted.
+ *
+ * Lives in the shared contract because the standalone Worker sends it and the
+ * browser client acts on it. Two independent literals would let a rename
+ * silently turn the operator kill switch into a no-op: the room would close its
+ * sockets while the client waited for a notice code it no longer recognised.
+ */
+export const OVERLAY_REALTIME_TRANSPORT_DISABLED = 'transport_disabled' as const
 export const MAX_REALTIME_DRAWS = 15
 export const MAX_REALTIME_EVENT_BYTES = 64 * 1024
 const MAX_PUBLIC_CARD_DESCRIPTION_LENGTH = 1_024

--- a/src/lib/overlay-realtime/contract.ts
+++ b/src/lib/overlay-realtime/contract.ts
@@ -10,6 +10,24 @@ export const OVERLAY_REALTIME_PROTOCOL_VERSION = 1 as const
  * sockets while the client waited for a notice code it no longer recognised.
  */
 export const OVERLAY_REALTIME_TRANSPORT_DISABLED = 'transport_disabled' as const
+
+/**
+ * `server_notice` code the room emits on its periodic check so a client can
+ * tell "nothing happened" apart from "this socket is dead".
+ *
+ * Once history polling stops running on a timer, a half-open socket — one that
+ * never delivers a close event — would silently starve the overlay forever.
+ * The room already wakes on that interval for the kill switch, so the liveness
+ * signal is free: it costs no extra wake and no HTTP request.
+ */
+export const OVERLAY_REALTIME_HEARTBEAT = 'heartbeat' as const
+
+/**
+ * How often a room with live sockets emits the heartbeat above. Shared so the
+ * client can derive its liveness deadline from the same number the Worker uses
+ * instead of two constants drifting apart.
+ */
+export const OVERLAY_REALTIME_HEARTBEAT_MS = 60_000
 export const MAX_REALTIME_DRAWS = 15
 export const MAX_REALTIME_EVENT_BYTES = 64 * 1024
 const MAX_PUBLIC_CARD_DESCRIPTION_LENGTH = 1_024
@@ -94,9 +112,26 @@ export type OverlayRealtimeServerMessage =
       protocolVersion: typeof OVERLAY_REALTIME_PROTOCOL_VERSION
       connectionId: string
       serverTime: string
+      /**
+       * Room fanout counter at connect time.
+       *
+       * Lets a client baseline itself so the next delivery is recognisably
+       * contiguous. Optional so a client served by a newer deployment keeps
+       * working against a room that has not been redeployed yet.
+       */
+      seq?: number
     }
   | {
       type: 'gacha_result'
+      /**
+       * Monotonic per-room fanout counter.
+       *
+       * A jump means this socket missed a delivery, which is the only reason a
+       * healthy connection needs to poll history at all. Carried beside the
+       * event rather than inside it so the authoritative envelope that polling
+       * rebuilds from the database stays byte-identical to the pushed one.
+       */
+      seq?: number
       event: GachaRealtimeEventV1
     }
   | {

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  OVERLAY_REALTIME_HEARTBEAT_MS,
   OVERLAY_REALTIME_PROTOCOL_VERSION,
   OVERLAY_REALTIME_TRANSPORT_DISABLED,
   buildPollingRealtimeEvents,
@@ -129,7 +130,19 @@ const TRANSPORT_DISABLED_NOTICE = OVERLAY_REALTIME_TRANSPORT_DISABLED
  */
 const CONFIG_CHANGE_REFETCH_FLOOR_MS = 30_000
 const WS_CONNECT_TIMEOUT_MS = 10_000
-const CONNECTED_GAP_RECOVERY_MS = 30_000
+/**
+ * How long a healthy socket may stay silent before the client gives up on it.
+ *
+ * The room emits a heartbeat every `OVERLAY_REALTIME_HEARTBEAT_MS`, so missing
+ * more than two in a row means the socket is half-open: alive to the browser
+ * but delivering nothing. Two intervals of slack keeps a single delayed wake or
+ * a brief network stall from churning connections.
+ *
+ * This replaces the fixed 30-second history poll. A connected overlay now makes
+ * no periodic HTTP request at all; it reloads history only when it reconnects
+ * or when a sequence gap proves it missed a delivery.
+ */
+const SOCKET_LIVENESS_TIMEOUT_MS = OVERLAY_REALTIME_HEARTBEAT_MS * 2.5
 
 function eventUrl(
   streamerId: string,
@@ -307,6 +320,13 @@ export function subscribeToGachaResults(
   /** Guards the change-triggered refetch against a config endpoint outage. */
   let lastConfigAttemptAt = 0
   let configRefreshInFlight = false
+  /**
+   * Last per-room fanout number this socket observed. `null` until the room
+   * reports one, which keeps the client compatible with a room that has not
+   * been redeployed yet.
+   */
+  let lastSeq: number | null = null
+  let livenessTimer: ReturnType<typeof setTimeout> | null = null
   let historyCursor: PollingCursor = {
     redeemedAt: new Date().toISOString(),
     historyId: '',
@@ -384,17 +404,16 @@ export function subscribeToGachaResults(
       }
 
       retryCount = 0
-      // Once the low-latency socket is healthy, polling becomes a periodic
-      // reconciliation pass instead of a competing 3-second primary. A room
-      // outage immediately restores the normal interval through onclose, and
-      // reconnect always triggers an immediate pass before slowing down again.
-      const nextInterval =
+      // A healthy socket schedules no further pass at all. History is reloaded
+      // only on reconnect (onopen polls immediately), on a sequence gap, or if
+      // the room stops proving liveness — so a connected overlay makes no
+      // periodic HTTP request. A room outage restores normal polling through
+      // onclose, which is also what the liveness deadline triggers.
+      const socketHealthy =
         currentConfig?.mode === 'do-primary'
         && typeof WebSocket !== 'undefined'
         && socket?.readyState === WebSocket.OPEN
-          ? Math.max(intervalMs, CONNECTED_GAP_RECOVERY_MS)
-          : intervalMs
-      schedulePoll(nextInterval)
+      if (!socketHealthy) schedulePoll(intervalMs)
 
       // Rollout/rollback detection rides on this response instead of a separate
       // config poll. refreshConfig() owns the socket and poll timers, so it is
@@ -419,8 +438,37 @@ export function subscribeToGachaResults(
     }
   }
 
+  /**
+   * Restart the silence deadline for the current socket.
+   *
+   * Called for every server frame, gacha or heartbeat alike. If it ever fires,
+   * the socket is delivering nothing despite looking open, so it is closed
+   * deliberately: `onclose` then resumes history polling and reconnects, which
+   * is the same recovery path a clean disconnect takes.
+   */
+  const armLiveness = () => {
+    if (livenessTimer) clearTimeout(livenessTimer)
+    if (disposed) return
+    livenessTimer = setTimeout(() => {
+      if (disposed || !socket) return
+      options.onStatusChange?.('DO_LIVENESS_TIMEOUT')
+      try {
+        socket.close(1006, 'No server frames')
+      } catch {
+        // Falling through to closeSocket still restores polling.
+      }
+      closeSocket()
+      if (pollTimer) clearTimeout(pollTimer)
+      schedulePoll(0)
+      scheduleReconnect()
+    }, SOCKET_LIVENESS_TIMEOUT_MS)
+  }
+
   const closeSocket = () => {
     socketGeneration += 1
+    if (livenessTimer) clearTimeout(livenessTimer)
+    livenessTimer = null
+    lastSeq = null
     if (connectTimeout) clearTimeout(connectTimeout)
     connectTimeout = null
     if (reconnectTimer) clearTimeout(reconnectTimer)
@@ -493,6 +541,16 @@ export function subscribeToGachaResults(
             closeSocket()
             return
           }
+          // Any frame proves the socket is alive, including a heartbeat that
+          // carries no payload.
+          armLiveness()
+          if (parsed.type === 'welcome') {
+            // Baseline from the room so the next delivery is contiguous rather
+            // than looking like a miss. The immediate poll scheduled by onopen
+            // already covers whatever happened while disconnected.
+            lastSeq = typeof parsed.seq === 'number' ? parsed.seq : null
+            return
+          }
           if (parsed.type === 'server_notice') {
             options.onStatusChange?.(`DO_NOTICE:${parsed.code}`)
             if (parsed.code === TRANSPORT_DISABLED_NOTICE) {
@@ -504,7 +562,23 @@ export function subscribeToGachaResults(
             }
             return
           }
-          if (parsed.type === 'gacha_result') ingest(parsed.event, 'durable-object')
+          if (parsed.type === 'gacha_result') {
+            // A jump proves this socket missed a delivery. That is the only
+            // reason a healthy connection reloads history now that the fixed
+            // 30-second pass is gone; the database still decides what was
+            // actually missed, this only decides *when* to ask.
+            if (
+              typeof parsed.seq === 'number'
+              && lastSeq !== null
+              && parsed.seq > lastSeq + 1
+            ) {
+              options.onStatusChange?.(`DO_SEQ_GAP:${lastSeq}->${parsed.seq}`)
+              if (pollTimer) clearTimeout(pollTimer)
+              schedulePoll(0)
+            }
+            if (typeof parsed.seq === 'number') lastSeq = parsed.seq
+            ingest(parsed.event, 'durable-object')
+          }
         } catch {
           options.onStatusChange?.('DO_MESSAGE_INVALID')
         }
@@ -638,6 +712,7 @@ export function subscribeToGachaResults(
     if (configTimer) clearTimeout(configTimer)
     if (reconnectTimer) clearTimeout(reconnectTimer)
     if (connectTimeout) clearTimeout(connectTimeout)
+    if (livenessTimer) clearTimeout(livenessTimer)
     closeSocket()
   }
 }

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -327,6 +327,18 @@ export function subscribeToGachaResults(
    */
   let lastSeq: number | null = null
   let livenessTimer: ReturnType<typeof setTimeout> | null = null
+  /**
+   * Config version that was in effect when the room reported itself disabled.
+   *
+   * The room is authoritative about whether it will serve this streamer, and
+   * the two allowlists (app Worker and standalone Worker) are separate secrets
+   * that can disagree mid-rollout. Without this marker a room that says
+   * "disabled" while the config endpoint still says `do-primary` sends the
+   * client into a reconnect-with-backoff loop against an endpoint that answers
+   * 503 — observed in preview during the kill-switch test. Reconnecting is
+   * allowed again as soon as the operator publishes a different config.
+   */
+  let disabledForConfigVersion: string | null = null
   let historyCursor: PollingCursor = {
     redeemedAt: new Date().toISOString(),
     historyId: '',
@@ -554,10 +566,16 @@ export function subscribeToGachaResults(
           if (parsed.type === 'server_notice') {
             options.onStatusChange?.(`DO_NOTICE:${parsed.code}`)
             if (parsed.code === TRANSPORT_DISABLED_NOTICE) {
-              // The room itself reports that the operator disabled it. This is
-              // authoritative, so it bypasses the version-mismatch floor and
-              // applies the kill switch immediately instead of waiting for the
-              // next history pass to notice.
+              // The room itself reports that the operator disabled it. Remember
+              // which config this applies to so a config endpoint that still
+              // advertises `do-primary` cannot immediately reconnect us into the
+              // room that just refused to serve.
+              disabledForConfigVersion = currentConfig?.configVersion ?? null
+              closeSocket()
+              if (pollTimer) clearTimeout(pollTimer)
+              schedulePoll(0)
+              // Authoritative signal, so it bypasses the version-mismatch floor
+              // instead of waiting for the next history pass to notice.
               void refreshConfig()
             }
             return
@@ -629,8 +647,27 @@ export function subscribeToGachaResults(
         // recovery needlessly slow after a valid config update.
         reconnectAttempt = 0
       }
+      // A new config supersedes whatever the room said about the old one.
+      if (
+        disabledForConfigVersion !== null
+        && config.configVersion !== disabledForConfigVersion
+      ) {
+        disabledForConfigVersion = null
+      }
+
       if (config.mode === 'do-primary') {
-        if (previousMode !== config.mode || previousUrl !== config.webSocketUrl || !socket) {
+        if (config.configVersion === disabledForConfigVersion) {
+          // The room refused this exact config. Stay on polling — which still
+          // delivers every committed event — rather than retrying a socket the
+          // server has already said it will not serve.
+          options.onStatusChange?.('DO_SUPPRESSED:room_disabled')
+          if (pollTimer) clearTimeout(pollTimer)
+          schedulePoll(0)
+        } else if (
+          previousMode !== config.mode
+          || previousUrl !== config.webSocketUrl
+          || !socket
+        ) {
           connectWebSocket()
         }
       } else {

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -9,6 +9,7 @@
 
 import {
   OVERLAY_REALTIME_PROTOCOL_VERSION,
+  OVERLAY_REALTIME_TRANSPORT_DISABLED,
   buildPollingRealtimeEvents,
   type GachaRealtimeEventV1,
   type OverlayRealtimeConfigV1,
@@ -111,6 +112,12 @@ const SEEN_EVENT_TTL_MS = 24 * 60 * 60 * 1000
  * history polling itself is broken and can no longer carry the signal.
  */
 const CONFIG_SAFETY_REFRESH_MS = 5 * 60_000
+/**
+ * Room-reported kill switch. Imported from the shared contract rather than
+ * re-declared so a rename cannot leave the Worker sending a code the client
+ * silently ignores.
+ */
+const TRANSPORT_DISABLED_NOTICE = OVERLAY_REALTIME_TRANSPORT_DISABLED
 /**
  * Floor between config fetches triggered by a version mismatch.
  *
@@ -484,6 +491,17 @@ export function subscribeToGachaResults(
           if (parsed.type === 'welcome' && parsed.protocolVersion !== OVERLAY_REALTIME_PROTOCOL_VERSION) {
             options.onStatusChange?.('DO_PROTOCOL_MISMATCH')
             closeSocket()
+            return
+          }
+          if (parsed.type === 'server_notice') {
+            options.onStatusChange?.(`DO_NOTICE:${parsed.code}`)
+            if (parsed.code === TRANSPORT_DISABLED_NOTICE) {
+              // The room itself reports that the operator disabled it. This is
+              // authoritative, so it bypasses the version-mismatch floor and
+              // applies the kill switch immediately instead of waiting for the
+              // next history pass to notice.
+              void refreshConfig()
+            }
             return
           }
           if (parsed.type === 'gacha_result') ingest(parsed.event, 'durable-object')

--- a/tests/unit/overlay-realtime-worker.test.ts
+++ b/tests/unit/overlay-realtime-worker.test.ts
@@ -257,8 +257,24 @@ function createRoomHarness(socketCount = 0) {
     serializeAttachment: vi.fn(),
     deserializeAttachment: vi.fn(),
   }))
+  // The kill-switch alarm reads and writes storage directly rather than through
+  // a transaction, and schedules itself, so the harness models those too.
+  let alarmAt: number | null = null
   const state = {
-    storage: { transaction },
+    storage: {
+      transaction,
+      get: async <V>(key: string) => records.get(key) as V | undefined,
+      put: async (key: string, value: unknown) => {
+        records.set(key, structuredClone(value))
+      },
+      delete: async (key: string) => {
+        records.delete(key)
+      },
+      getAlarm: async () => alarmAt,
+      setAlarm: async (time: number) => {
+        alarmAt = time
+      },
+    },
     getWebSockets: vi.fn(() => sockets),
     acceptWebSocket: vi.fn(),
   }
@@ -275,6 +291,7 @@ function createRoomHarness(socketCount = 0) {
     sockets,
     state,
     env,
+    getAlarmAt: () => alarmAt,
     room: new OverlayRoom(
       state as unknown as ConstructorParameters<typeof OverlayRoom>[0],
       env as unknown as ConstructorParameters<typeof OverlayRoom>[1]
@@ -399,5 +416,101 @@ describe('OverlayRoom Durable Object', () => {
 
     harness.room.webSocketMessage(socket as never, '{')
     expect(socket.close).toHaveBeenCalledWith(1007, 'Invalid JSON')
+  })
+})
+
+/**
+ * Operator kill switch over the socket.
+ *
+ * The allowlist lives in a Worker secret, so a hibernating socket never learns
+ * that its room was disabled. Before this alarm existed the client would keep a
+ * healthy-looking socket open against a room that no longer receives publishes,
+ * and simply stop showing gacha — the user-visible failure #803 was about.
+ */
+describe('OverlayRoom kill switch alarm', () => {
+  const OTHER_STREAMER_ID = '223e4567-e89b-42d3-a456-426614174000'
+
+  it('arms the alarm and records room identity when a client connects', async () => {
+    // WebSocketPair is a Workers runtime global with no Node equivalent; the
+    // room only needs the pair's two ends and the accept/attach calls, which
+    // the harness already records.
+    const makeSocket = () => ({
+      readyState: 1,
+      send: vi.fn(),
+      close: vi.fn(),
+      serializeAttachment: vi.fn(),
+      deserializeAttachment: vi.fn(),
+    })
+    vi.stubGlobal('WebSocketPair', class {
+      0 = makeSocket()
+      1 = makeSocket()
+    })
+
+    const harness = createRoomHarness()
+    const response = await harness.room.fetch(
+      new Request(`https://room.internal/room/connect/${STREAMER_ID}`)
+    )
+
+    expect(response.status).toBe(101)
+    // alarm() receives no request, so the room must persist its own identity.
+    expect(harness.records.get('room-streamer-id')).toBe(STREAMER_ID)
+    expect(harness.getAlarmAt()).not.toBeNull()
+  })
+
+  it('keeps sockets and reschedules while the room is still allowlisted', async () => {
+    const harness = createRoomHarness(2)
+    harness.records.set('room-streamer-id', STREAMER_ID)
+
+    await harness.room.alarm()
+
+    for (const socket of harness.sockets) {
+      expect(socket.close).not.toHaveBeenCalled()
+    }
+    expect(harness.getAlarmAt()).not.toBeNull()
+  })
+
+  it('notifies and disconnects every socket once the room is removed', async () => {
+    const harness = createRoomHarness(2)
+    harness.records.set('room-streamer-id', STREAMER_ID)
+    // Operator kill switch: this streamer is no longer allowlisted.
+    harness.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST = OTHER_STREAMER_ID
+
+    await harness.room.alarm()
+
+    for (const socket of harness.sockets) {
+      const sent = socket.send.mock.calls.map((args) => JSON.parse(String(args[0])))
+      expect(sent).toContainEqual({
+        type: 'server_notice',
+        code: 'transport_disabled',
+      })
+      // 1008 is in the client's no-reconnect list, so a disabled room cannot
+      // turn into a reconnect storm against a Worker that would reject it.
+      expect(socket.close).toHaveBeenCalledWith(1008, 'Realtime transport disabled')
+    }
+    // Nothing left to police: the room must not keep paying for wakeups.
+    expect(harness.records.has('room-streamer-id')).toBe(false)
+  })
+
+  it('stops rescheduling once the room has no sockets left', async () => {
+    const harness = createRoomHarness(0)
+    harness.records.set('room-streamer-id', STREAMER_ID)
+
+    await harness.room.alarm()
+
+    expect(harness.getAlarmAt()).toBeNull()
+    expect(harness.records.has('room-streamer-id')).toBe(false)
+  })
+
+  it('never disconnects a healthy room just because its identity is missing', async () => {
+    // A storage miss must not be mistaken for "operator disabled this room".
+    // Polling still recovers every committed event, so retrying is strictly
+    // safer than dropping live sockets.
+    const harness = createRoomHarness(1)
+    harness.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST = OTHER_STREAMER_ID
+
+    await harness.room.alarm()
+
+    expect(harness.sockets[0].close).not.toHaveBeenCalled()
+    expect(harness.getAlarmAt()).not.toBeNull()
   })
 })

--- a/tests/unit/realtime.test.ts
+++ b/tests/unit/realtime.test.ts
@@ -666,6 +666,77 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     cleanup()
   })
 
+  it('does not reconnect into a room that reported itself disabled', async () => {
+    // Found in preview during the kill-switch test: the two allowlists (app
+    // Worker and standalone Worker) are separate secrets, so mid-rollout the
+    // room can refuse a streamer while the config endpoint still says
+    // `do-primary`. Reconnecting there just loops against 503 responses.
+    class ControlledWebSocket {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+      static readonly instances: ControlledWebSocket[] = []
+      readyState = ControlledWebSocket.CONNECTING
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: { code: number }) => void) | null = null
+
+      constructor(readonly url: string) {
+        ControlledWebSocket.instances.push(this)
+        queueMicrotask(() => {
+          this.readyState = ControlledWebSocket.OPEN
+          this.onopen?.()
+        })
+      }
+
+      send() {}
+      close(code = 1000) {
+        this.readyState = 3
+        this.onclose?.({ code })
+      }
+      emit(event: unknown) {
+        this.onmessage?.({ data: JSON.stringify(event) })
+      }
+    }
+    vi.stubGlobal('WebSocket', ControlledWebSocket)
+
+    // The app Worker keeps advertising do-primary throughout.
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/realtime-config')) {
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'do-primary',
+          webSocketUrl: 'https://realtime.example',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: 'do-primary-v1',
+        })
+      }
+      return jsonResponse({ events: [], realtimeConfigVersion: 'do-primary-v1' })
+    }))
+
+    const statuses: string[] = []
+    const cleanup = subscribeToGachaResults('ignored', vi.fn(), {
+      retryDelay: 3_000,
+      onStatusChange: (status) => statuses.push(status),
+    })
+    await flushPromises()
+    expect(ControlledWebSocket.instances).toHaveLength(1)
+
+    ControlledWebSocket.instances[0].emit({
+      type: 'server_notice',
+      code: 'transport_disabled',
+    })
+    await vi.advanceTimersByTimeAsync(30_000)
+    await flushPromises()
+
+    // No second socket: the room's refusal outranks a config that has not
+    // caught up yet, and polling keeps delivering every committed event.
+    expect(ControlledWebSocket.instances).toHaveLength(1)
+    expect(statuses).toContain('DO_SUPPRESSED:room_disabled')
+    cleanup()
+  })
+
   it('closes a socket that stops proving liveness and falls back to polling', async () => {
     // A half-open socket looks open to the browser but delivers nothing. With
     // the periodic history pass gone, this deadline is what keeps that from

--- a/tests/unit/realtime.test.ts
+++ b/tests/unit/realtime.test.ts
@@ -532,21 +532,21 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     }
     vi.stubGlobal('WebSocket', ControlledWebSocket)
 
-    // What the operator has currently rolled out. Both endpoints read it, the
-    // way the shared server-side resolver guarantees in production.
-    let serverVersion = 'test-v1'
+    // A streamer that has not been rolled out yet still polls history as its
+    // primary transport, so that is the pass which carries the enable signal.
+    // (The disable direction is covered by the room's server_notice below,
+    // because a connected overlay no longer polls on a timer at all.)
+    let serverVersion = 'polling-only-v1'
     let configCalls = 0
     vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
       if (url.includes('/realtime-config')) {
         configCalls += 1
+        const enabled = serverVersion !== 'polling-only-v1'
         return jsonResponse({
           schemaVersion: 1,
-          mode: 'do-primary',
-          webSocketUrl:
-            serverVersion === 'test-v1'
-              ? 'https://realtime-a.example'
-              : 'https://realtime-b.example',
+          mode: enabled ? 'do-primary' : 'polling-only',
+          ...(enabled ? { webSocketUrl: 'https://realtime-b.example' } : {}),
           protocolVersion: 1,
           retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
           configVersion: serverVersion,
@@ -556,23 +556,183 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     }))
 
     const cleanup = subscribeToGachaResults('ignored', vi.fn(), {
-      retryDelay: 1_000,
+      retryDelay: 3_000,
     })
     await flushPromises()
-    expect(ControlledWebSocket.instances).toHaveLength(1)
+    expect(ControlledWebSocket.instances).toHaveLength(0)
     expect(configCalls).toBe(1)
 
-    // Operator flips the rollout. No config poll is scheduled for another five
-    // minutes, so only the history pass can carry this.
-    serverVersion = 'test-v2'
+    // Operator enables this streamer. No config poll is scheduled for another
+    // five minutes, so only the history pass can carry this.
+    serverVersion = 'do-primary-v1'
 
-    // Gap recovery while the socket is healthy runs every 30 seconds.
     await vi.advanceTimersByTimeAsync(30_000)
     await flushPromises()
 
     expect(configCalls).toBe(2)
-    expect(ControlledWebSocket.instances).toHaveLength(2)
-    expect(ControlledWebSocket.instances[1].url).toContain('realtime-b.example')
+    expect(ControlledWebSocket.instances).toHaveLength(1)
+    expect(ControlledWebSocket.instances[0].url).toContain('realtime-b.example')
+    cleanup()
+  })
+
+  it('stops polling history while the socket is healthy and resumes on a gap', async () => {
+    // The point of the sequence number: a connected overlay makes no periodic
+    // HTTP request, and reloads history only when it can prove it missed a
+    // delivery.
+    class ControlledWebSocket {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+      static readonly instances: ControlledWebSocket[] = []
+      readyState = ControlledWebSocket.CONNECTING
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: { code: number }) => void) | null = null
+
+      constructor(readonly url: string) {
+        ControlledWebSocket.instances.push(this)
+        queueMicrotask(() => {
+          this.readyState = ControlledWebSocket.OPEN
+          this.onopen?.()
+        })
+      }
+
+      send() {}
+      close(code = 1000) {
+        this.readyState = 3
+        this.onclose?.({ code })
+      }
+      emit(event: unknown) {
+        this.onmessage?.({ data: JSON.stringify(event) })
+      }
+    }
+    vi.stubGlobal('WebSocket', ControlledWebSocket)
+
+    let historyCalls = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/realtime-config')) {
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'do-primary',
+          webSocketUrl: 'https://realtime.example',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: 'do-primary-v1',
+        })
+      }
+      historyCalls += 1
+      return jsonResponse({ events: [], realtimeConfigVersion: 'do-primary-v1' })
+    }))
+
+    const [event] = buildPollingRealtimeEvents(STREAMER_ID, [{
+      id: 'history-seq-1',
+      eventId: 'batch-seq-1',
+      redeemedAt: '2026-07-24T00:00:02.000Z',
+      userTwitchUsername: 'viewer',
+      card: CARD_A,
+    }])
+    const statuses: string[] = []
+    const cleanup = subscribeToGachaResults('ignored', vi.fn(), {
+      retryDelay: 3_000,
+      onStatusChange: (status) => statuses.push(status),
+    })
+    await flushPromises()
+    const socket = ControlledWebSocket.instances[0]
+    socket.emit({ type: 'welcome', protocolVersion: 1, connectionId: 'c1', serverTime: '', seq: 7 })
+    // Connecting deliberately reloads history once (onopen closes the gap left
+    // by the previous socket). Settle that before measuring the steady state.
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+    const afterConnect = historyCalls
+
+    // Ten minutes of a room that is alive but has nothing to deliver. The
+    // heartbeat is what the real room emits on its kill-switch wake; without
+    // it the liveness deadline would (correctly) tear the socket down.
+    for (let minute = 0; minute < 10; minute += 1) {
+      await vi.advanceTimersByTimeAsync(60_000)
+      socket.emit({ type: 'server_notice', code: 'heartbeat' })
+      await flushPromises()
+    }
+    expect(historyCalls).toBe(afterConnect)
+
+    // seq 7 -> 9 skips one delivery, which is the only thing that should make a
+    // connected overlay reload history.
+    socket.emit({ type: 'gacha_result', seq: 9, event })
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+    expect(historyCalls).toBeGreaterThan(afterConnect)
+    expect(statuses).toContain('DO_SEQ_GAP:7->9')
+    cleanup()
+  })
+
+  it('closes a socket that stops proving liveness and falls back to polling', async () => {
+    // A half-open socket looks open to the browser but delivers nothing. With
+    // the periodic history pass gone, this deadline is what keeps that from
+    // starving the overlay forever.
+    class ControlledWebSocket {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+      static readonly instances: ControlledWebSocket[] = []
+      readyState = ControlledWebSocket.CONNECTING
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: { code: number }) => void) | null = null
+
+      constructor(readonly url: string) {
+        ControlledWebSocket.instances.push(this)
+        queueMicrotask(() => {
+          this.readyState = ControlledWebSocket.OPEN
+          this.onopen?.()
+        })
+      }
+
+      send() {}
+      close(code = 1000) {
+        this.readyState = 3
+        this.onclose?.({ code })
+      }
+      emit(event: unknown) {
+        this.onmessage?.({ data: JSON.stringify(event) })
+      }
+    }
+    vi.stubGlobal('WebSocket', ControlledWebSocket)
+
+    let historyCalls = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/realtime-config')) {
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'do-primary',
+          webSocketUrl: 'https://realtime.example',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: 'do-primary-v1',
+        })
+      }
+      historyCalls += 1
+      return jsonResponse({ events: [], realtimeConfigVersion: 'do-primary-v1' })
+    }))
+
+    const statuses: string[] = []
+    const cleanup = subscribeToGachaResults('ignored', vi.fn(), {
+      retryDelay: 3_000,
+      onStatusChange: (status) => statuses.push(status),
+    })
+    await flushPromises()
+    const socket = ControlledWebSocket.instances[0]
+    socket.emit({ type: 'welcome', protocolVersion: 1, connectionId: 'c1', serverTime: '', seq: 0 })
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+    const afterConnect = historyCalls
+
+    // Two heartbeats missed plus slack.
+    await vi.advanceTimersByTimeAsync(60_000 * 2.5 + 100)
+    await flushPromises()
+
+    expect(statuses).toContain('DO_LIVENESS_TIMEOUT')
+    expect(historyCalls).toBeGreaterThan(afterConnect)
     cleanup()
   })
 

--- a/workers/overlay-realtime/src/index.ts
+++ b/workers/overlay-realtime/src/index.ts
@@ -1,5 +1,7 @@
 import {
   MAX_REALTIME_EVENT_BYTES,
+  OVERLAY_REALTIME_HEARTBEAT,
+  OVERLAY_REALTIME_HEARTBEAT_MS,
   OVERLAY_REALTIME_TRANSPORT_DISABLED,
   isOverlayRealtimeStreamerEnabled,
   isValidStreamerId,
@@ -75,7 +77,16 @@ const ROOM_STREAMER_ID_KEY = 'room-streamer-id'
  * polling it replaces: a room with several OBS browser sources costs one wake,
  * not one request per source.
  */
-const KILL_SWITCH_CHECK_MS = 60_000
+const KILL_SWITCH_CHECK_MS = OVERLAY_REALTIME_HEARTBEAT_MS
+/**
+ * Monotonic fanout counter for this room.
+ *
+ * Clients use gaps in it to decide when a healthy socket still needs to reload
+ * history. It is deliberately per-room and not persisted anywhere else: it
+ * identifies *deliveries*, while `eventId` identifies *events*, and only the
+ * database is authoritative about the latter.
+ */
+const ROOM_SEQ_KEY = 'room-seq'
 
 interface RoomRateLimitLedger {
   windowStartedAt: number
@@ -390,6 +401,23 @@ export class OverlayRoom {
     })
   }
 
+  /**
+   * Take the next fanout number for this room.
+   *
+   * Allocated after replay/dedupe so a retried publish never burns a number,
+   * and before fanout so a send failure leaves a visible gap. A gap is the
+   * correct outcome there: the client reloads history and the database — not
+   * this counter — decides what it actually missed.
+   */
+  private async allocateSeq(): Promise<number> {
+    return this.state.storage.transaction(async (transaction) => {
+      const stored = await transaction.get<number>(ROOM_SEQ_KEY)
+      const next = (Number.isSafeInteger(stored) ? (stored as number) : 0) + 1
+      await transaction.put(ROOM_SEQ_KEY, next)
+      return next
+    })
+  }
+
   private async consumeEventId(eventId: string): Promise<boolean> {
     return this.state.storage.transaction(async (transaction) => {
       const stored =
@@ -438,6 +466,20 @@ export class OverlayRoom {
     // (polling still recovers every committed event) and retry on the next
     // alarm rather than disconnecting a healthy room on a storage miss.
     if (!streamerId || realtimeEnabled(this.env, streamerId)) {
+      // Still allowed: prove liveness on the same wake. Clients stopped polling
+      // history on a timer, so this is what distinguishes "no gacha happened"
+      // from "this socket died without a close frame".
+      const heartbeat = JSON.stringify({
+        type: 'server_notice',
+        code: OVERLAY_REALTIME_HEARTBEAT,
+      })
+      for (const socket of sockets) {
+        try {
+          socket.send(heartbeat)
+        } catch {
+          // A dead socket is exactly what the client-side deadline handles.
+        }
+      }
       await this.state.storage.setAlarm(Date.now() + KILL_SWITCH_CHECK_MS)
       return
     }
@@ -516,6 +558,9 @@ export class OverlayRoom {
         protocolVersion: 1,
         connectionId: attachment.connectionId,
         serverTime: new Date().toISOString(),
+        // Baseline so the first delivery after connecting is recognisably
+        // contiguous instead of looking like a missed one.
+        seq: await this.state.storage.get<number>(ROOM_SEQ_KEY) ?? 0,
       }))
       return new Response(null, {
         status: 101,
@@ -553,7 +598,8 @@ export class OverlayRoom {
           failedCount: 0,
         }, 202)
       }
-      const message = JSON.stringify({ type: 'gacha_result', event })
+      const seq = await this.allocateSeq()
+      const message = JSON.stringify({ type: 'gacha_result', seq, event })
 
       let fanoutCount = 0
       let failedCount = 0

--- a/workers/overlay-realtime/src/index.ts
+++ b/workers/overlay-realtime/src/index.ts
@@ -1,5 +1,6 @@
 import {
   MAX_REALTIME_EVENT_BYTES,
+  OVERLAY_REALTIME_TRANSPORT_DISABLED,
   isOverlayRealtimeStreamerEnabled,
   isValidStreamerId,
   validateGachaRealtimeEvent,
@@ -55,6 +56,26 @@ const DELIVERY_DEDUPE_TTL_MS = 24 * 60 * 60 * 1_000
 const MAX_CLIENT_MESSAGE_BYTES = 4 * 1024
 const MAX_SOCKET_BUFFER_BYTES = 1024 * 1024
 const CLIENT_MESSAGES_PER_MINUTE = 30
+
+/**
+ * Room identity, needed only so the kill-switch alarm can re-evaluate the
+ * allowlist. The Durable Object ID is derived from the streamer ID but is not
+ * reversible, and `alarm()` receives no request to read it from.
+ */
+const ROOM_STREAMER_ID_KEY = 'room-streamer-id'
+/**
+ * How often a room with live sockets re-checks whether it is still allowed.
+ *
+ * The operator kill switch is a Worker secret change, which existing
+ * hibernating sockets never observe on their own. Without this the client would
+ * hold a socket open against a disabled room and simply stop seeing gacha —
+ * exactly the user-visible failure #803 was about.
+ *
+ * One alarm per room per minute is far cheaper than the per-overlay config
+ * polling it replaces: a room with several OBS browser sources costs one wake,
+ * not one request per source.
+ */
+const KILL_SWITCH_CHECK_MS = 60_000
 
 interface RoomRateLimitLedger {
   windowStartedAt: number
@@ -395,6 +416,54 @@ export class OverlayRoom {
     })
   }
 
+  /**
+   * Disconnect every socket once the operator has removed this room from the
+   * allowlist, then stop rescheduling.
+   *
+   * Reads the allowlist from `this.env`, which the runtime supplies from the
+   * currently deployed Worker version, so a secret change takes effect on the
+   * next alarm without any client-side polling.
+   */
+  async alarm(): Promise<void> {
+    const sockets = this.state.getWebSockets('protocol-v1')
+    if (sockets.length === 0) {
+      // No listeners: let the object go fully idle instead of paying for a
+      // wake every minute for a room nobody is watching.
+      await this.state.storage.delete(ROOM_STREAMER_ID_KEY)
+      return
+    }
+
+    const streamerId = await this.state.storage.get<string>(ROOM_STREAMER_ID_KEY)
+    // A room whose identity is missing cannot be re-evaluated. Keep the sockets
+    // (polling still recovers every committed event) and retry on the next
+    // alarm rather than disconnecting a healthy room on a storage miss.
+    if (!streamerId || realtimeEnabled(this.env, streamerId)) {
+      await this.state.storage.setAlarm(Date.now() + KILL_SWITCH_CHECK_MS)
+      return
+    }
+
+    const notice = JSON.stringify({
+      type: 'server_notice',
+      code: OVERLAY_REALTIME_TRANSPORT_DISABLED,
+    })
+    for (const socket of sockets) {
+      try {
+        socket.send(notice)
+      } catch {
+        // Best effort: the close below is what actually forces the fallback.
+      }
+      try {
+        // 1008 (policy violation) is in the client's no-reconnect list, so a
+        // disabled room does not turn into a reconnect storm against a Worker
+        // that would reject every attempt with 503 anyway.
+        socket.close(1008, 'Realtime transport disabled')
+      } catch {
+        // A failed close must never abort the rest of the room.
+      }
+    }
+    await this.state.storage.delete(ROOM_STREAMER_ID_KEY)
+  }
+
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url)
     if (request.method === 'GET' && url.pathname.startsWith('/room/connect/')) {
@@ -427,6 +496,21 @@ export class OverlayRoom {
       // attachment is then associated with that accepted socket and restored
       // after hibernation through deserializeAttachment().
       server.serializeAttachment(attachment)
+
+      // Arm the kill-switch alarm. `alarm()` gets no request, so the room's own
+      // identity has to be persisted here; the public router already rejected
+      // any malformed ID before routing to this object.
+      const roomStreamerId = decodeURIComponent(
+        url.pathname.slice('/room/connect/'.length)
+      )
+      if (isValidStreamerId(roomStreamerId)) {
+        await this.state.storage.put(ROOM_STREAMER_ID_KEY, roomStreamerId)
+      }
+      // Only arm when nothing is pending. Re-arming on every connect would push
+      // the check out indefinitely for a room that OBS reconnects frequently.
+      if (await this.state.storage.getAlarm() === null) {
+        await this.state.storage.setAlarm(Date.now() + KILL_SWITCH_CHECK_MS)
+      }
       server.send(JSON.stringify({
         type: 'welcome',
         protocolVersion: 1,


### PR DESCRIPTION
#706 / PR #828 の続き。**接続中のオーバーレイが定期HTTPリクエストを一切行わなくなる。**

段階的に3コミット。

## なぜ2段階に分けたか

キルスイッチは「クライアントが config を取り直して polling-only へ戻る」経路で成立しており、
PR #828 でその信号は history polling のレスポンスに載せた。

**平常時ポーリングをゼロにすると、この信号を運ぶ乗り物が無くなる。** 先に room 側から
切断できるようにしないと、allowlist から外した配信者のオーバーレイが
「健全に見えるソケットを保持したまま、ガチャだけ表示されなくなる」という
#803 と同じ利用者可視の障害になる。

## Phase A: キルスイッチを WebSocket 経路へ (`231a176`)

allowlist は Worker secret なので hibernate 中のソケットは変更を観測できない。
**ソケットが生きている room だけ**が60秒ごとに alarm で再評価する。

- 外れていれば `server_notice { code: 'transport_disabled' }` → `close(1008)`
- 1008 はクライアントの再接続除外コードなので、503 を返し続ける Worker への storm にならない
- ソケットが無ければ再スケジュールしない（誰も見ていない room の wake を払わない）
- **storage から識別子が読めない場合は切断しない**。polling が全確定イベントを回収するため、
  storage miss で健全な room を落とすより再試行が安全

## Phase B: 平常時ポーリングの全廃 (`f671ff5`)

room が fanout ごとに単調増加の `seq` を振り、クライアントは**飛びを検知したときだけ**
履歴を読み直す。健全なソケットでは次のパスをスケジュールしない。

**死活検知が必須だった。** close イベントが来ない half-open ソケットは、ブラウザからは
開いて見えるのに何も届かない。定期ポーリングを外すとこれがオーバーレイを永久に飢餓させる。
Phase A の alarm を liveness beacon として兼用し、**追加の wake もHTTPリクエストも発生しない**。

- room は許可されている限り同じ wake で `heartbeat` を送る
- クライアントは全フレームで150秒（60秒 × 2.5）の期限をリセット。切れたら `onclose` と
  同じ復旧経路（ポーリング再開 + 再接続）へ落とす

`seq` は event の中ではなくメッセージ側に置いた。polling がDBから再構築する正本
エンベロープと push されるものをバイト単位で同一に保つため。
**`seq` は「何を取りこぼしたか」を決めない。それは従来どおりDBが決める。**

## 実テストで発見した不具合の修正 (`ec6852f`)

preview でキルスイッチを実際に引いたところ、切断後に**クライアントが再接続を試み続けた**。

1008 の再接続除外は効いていたが、`transport_disabled` 処理で呼ぶ `refreshConfig()` が
config を取り直し、アプリ側 allowlist はまだ do-primary だったため
`connectWebSocket()` が復活していた。

2つの allowlist は別 secret なので、ロールアウト途中は「room は拒否するが config は
do-primary」が**実際に発生する**。room はその streamer を提供するか否かについて権威なので、
`transport_disabled` を受けた時点の configVersion を記録し、別の config が公開されるまで
DO 接続を抑止する。

**ユニットテストでは発見できず、実環境でキルスイッチを引いて初めて出た。** 回帰テストで固定済み。

## preview 実経路テスト結果（すべて実測）

**平常時ポーリングがゼロ**

```
21:25:07  POLLING              ← 接続時の1回のみ
21:25:33  DO_NOTICE:heartbeat
21:26:33  DO_NOTICE:heartbeat  ← 正確に60秒間隔
21:27:33  DO_NOTICE:heartbeat
```

接続後の `POLLING` はゼロ。サーバ側4.8分の観測でも `/events` はページロード時の接続
ポーリングのみ。従来ガチャごとに必ず出ていた `DUPLICATE_EVENT:polling` も消滅
（polling が二重取得しなくなった証拠）。

**ガチャの順次表示（DOM実測）**

```
21:29:04.447  「あずまぐ が引いたカード あsdふぁ コモン」  ← 1枚目
21:29:13.043  (空)                                        ← 約8.6秒で消去
21:29:27.351  「あずまぐ が引いたカード dda コモン」       ← 2枚目
21:29:36.043  (空)                                        ← 約8.7秒で消去
```

outbox は `sent` / `attempt_count=1` / エラー0。

**キルスイッチの実発火**（preview の allowlist から実際に除外して確認）

```
21:31:33.104  DO_NOTICE:transport_disabled
21:31:33.255  DO_CLOSED:1008
21:31:33.255  POLLING             ← フォールバック
```

## 静的検証

全 **3,336 テスト passed**（新規9件）/ typecheck 0 / lint エラー0 / Worker ビルド 0

## ロールバック

両Workerの `OVERLAY_REALTIME_STREAMER_ALLOWLIST` を canary 1件へ戻す（アプリ側を先に）。
polling は全確定イベントを配信し続けるため、DO 経路が完全に落ちても機能は落ちない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaEUAEC1ZJ4p8V4ZXzDw8x