### PR TITLE
fix(security): R2画像削除の所有権検証を追加しIDORを塞ぐ (#830)

### DIFF
--- a/src/app/api/cards/[id]/route.ts
+++ b/src/app/api/cards/[id]/route.ts
@@ -475,8 +475,9 @@ export async function PUT(
 
     // #830: 他人のストレージURLを自分のカードへ紐付けることを禁止する。
     // 紐付けを許すと、以降の差し替え・カード削除のクリーンアップで他人の
-    // オブジェクトが削除される。判定は「実際に変わるとき」だけに限定し、
-    // プレフィックス命名以前の既存画像を持つカードの編集は妨げない。
+    // オブジェクトが削除される。判定は「URLが実際に変わるとき」だけに限定する。
+    // 既存値の再送信（画像以外のフィールド編集）は判定対象外なので、所有権を
+    // 判定できないURLを持つ既存カードでも編集が止まらない。
     if (isImageChanging && !(await isAssignableImageUrl(imageUrl, session.twitchUserId))) {
       logger.warn(
         `Cards API: rejected foreign storage image URL on update by user ${session.twitchUserId}: ${imageUrl}`
@@ -531,16 +532,6 @@ export async function PUT(
     if (intraRarityWeight !== undefined) updateData.intra_rarity_weight = intraRarityWeight;
     if (isActive !== undefined) updateData.is_active = isActive;
 
-    // 旧画像のクリーンアップ (#830: 所有権検証は deleteOwnedStorageImage が担当)
-    // 削除失敗はカード更新を妨げない（ログのみ）
-    if (isImageChanging && oldImageUrl) {
-      try {
-        await deleteOwnedStorageImage(oldImageUrl, session.twitchUserId, "Cards API (update)");
-      } catch (storageError) {
-        logger.warn(`Failed to delete old storage image: ${oldImageUrl}`, storageError);
-      }
-    }
-
     const { updatedCard, error } = await updateCardPg(id, updateData);
 
     if (error) {
@@ -551,6 +542,18 @@ export async function PUT(
         );
       }
       return handleDatabaseError(error, "Failed to update card");
+    }
+
+    // 旧画像のクリーンアップ (#830: 所有権検証は deleteOwnedStorageImage が担当)
+    // UPDATE 成功後に実行する。先に削除すると、card_number 重複(409)などで
+    // UPDATE が失敗したときにカードが旧URLを参照したまま実体だけが消える。
+    // 削除失敗はカード更新を妨げない（ログのみ）。
+    if (isImageChanging && oldImageUrl) {
+      try {
+        await deleteOwnedStorageImage(oldImageUrl, session.twitchUserId, "Cards API (update)");
+      } catch (storageError) {
+        logger.warn(`Failed to delete old storage image: ${oldImageUrl}`, storageError);
+      }
     }
 
     // 再計算はベストエフォート: カード更新は成功しているため、

--- a/src/app/api/cards/[id]/route.ts
+++ b/src/app/api/cards/[id]/route.ts
@@ -13,9 +13,8 @@ import { extractTwitchUserId } from "@/types/database";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
 import { logger } from "@/lib/logger.server";
-import { deleteFromR2 } from "@/lib/r2-client";
-import { removeBlobFile } from "@/lib/storage-db";
-import { isR2Url, isVercelBlobUrl, isStorageUrl, getR2KeyFromUrl } from "@/lib/storage-utils";
+import { deleteOwnedStorageImage } from "@/lib/storage-cleanup";
+import { isAssignableImageUrl } from "@/lib/storage-utils";
 import { recalculateIfAutoMode } from "@/lib/recalculate-drop-rates";
 import { CARD_NUMBER_MESSAGES, isCardNumberConflictError, isMissingCardNumberColumnError } from "@/lib/card-number-errors";
 import { CARD_ISSUANCE_MESSAGES, isMissingCardIssuanceColumnError, parseCardIssuanceLimit } from "@/lib/card-issuance";
@@ -469,6 +468,22 @@ export async function PUT(
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
     }
 
+    // Delete old image if imageUrl is being changed to a different URL
+    // imageUrlが異なるURLに変更される場合、古い画像を削除
+    const oldImageUrl = card.image_url;
+    const isImageChanging = imageUrl !== undefined && imageUrl !== oldImageUrl;
+
+    // #830: 他人のストレージURLを自分のカードへ紐付けることを禁止する。
+    // 紐付けを許すと、以降の差し替え・カード削除のクリーンアップで他人の
+    // オブジェクトが削除される。判定は「実際に変わるとき」だけに限定し、
+    // プレフィックス命名以前の既存画像を持つカードの編集は妨げない。
+    if (isImageChanging && !(await isAssignableImageUrl(imageUrl, session.twitchUserId))) {
+      logger.warn(
+        `Cards API: rejected foreign storage image URL on update by user ${session.twitchUserId}: ${imageUrl}`
+      );
+      return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
+    }
+
     // Issue #393再設計: パック紐付けの変更は、値が実際に変わる場合のみ
     // 事前登録済み(card_pack_names)であることを要求する(#269のプレミアム
     // ゲートは廃止。パック管理モーダルでの追加時のみゲートする設計に変更)。
@@ -516,36 +531,11 @@ export async function PUT(
     if (intraRarityWeight !== undefined) updateData.intra_rarity_weight = intraRarityWeight;
     if (isActive !== undefined) updateData.is_active = isActive;
 
-    // Delete old image if imageUrl is being changed to a different URL
-    // imageUrlが異なるURLに変更される場合、古い画像を削除
-    const oldImageUrl = card.image_url;
-    const isImageChanging = imageUrl !== undefined && imageUrl !== oldImageUrl;
-
-    if (isImageChanging && oldImageUrl && isStorageUrl(oldImageUrl)) {
-      // Remove from DB and update usage
-      // DBから削除し使用量を更新
+    // 旧画像のクリーンアップ (#830: 所有権検証は deleteOwnedStorageImage が担当)
+    // 削除失敗はカード更新を妨げない（ログのみ）
+    if (isImageChanging && oldImageUrl) {
       try {
-        await removeBlobFile(oldImageUrl);
-      } catch (dbError) {
-        logger.warn(`Failed to remove old image from DB: ${oldImageUrl}`, dbError);
-      }
-
-      // Delete from storage (R2)
-      // ストレージから削除（R2）
-      // Note: Vercel Blob deletion removed - only R2 is supported now
-      // 注意: Vercel Blob削除を削除 - R2のみサポート
-      try {
-        if (isR2Url(oldImageUrl)) {
-          const key = getR2KeyFromUrl(oldImageUrl);
-          if (key) {
-            await deleteFromR2(key);
-            logger.info(`Deleted old R2 image on update: ${oldImageUrl}`);
-          }
-        } else if (isVercelBlobUrl(oldImageUrl)) {
-          // Vercel Blob URLs are no longer actively deleted
-          // Migration to R2 should have moved these files
-          logger.warn(`Vercel Blob URL found but deletion skipped: ${oldImageUrl}`);
-        }
+        await deleteOwnedStorageImage(oldImageUrl, session.twitchUserId, "Cards API (update)");
       } catch (storageError) {
         logger.warn(`Failed to delete old storage image: ${oldImageUrl}`, storageError);
       }
@@ -703,34 +693,14 @@ export async function DELETE(
       return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
     }
 
-    // Delete image from storage if it exists (R2 or Vercel Blob)
-    // ストレージから画像を削除（存在する場合、R2またはVercel Blob）
-    if (card.image_url && isStorageUrl(card.image_url)) {
+    // Delete image from storage if it exists
+    // ストレージから画像を削除（#830: 所有権検証は deleteOwnedStorageImage が担当）
+    // Log but don't fail the card deletion if storage deletion fails
+    // ストレージ削除が失敗してもカード削除は続行（ログのみ記録）
+    if (card.image_url) {
       try {
-        // DBからファイル情報を削除し、使用量を減算
-        await removeBlobFile(card.image_url);
-      } catch (dbError) {
-        // DB操作に失敗しても続行
-        logger.warn(`Failed to remove blob file from DB: ${card.image_url}`, dbError);
-      }
-
-      try {
-        if (isR2Url(card.image_url)) {
-          // R2から削除
-          const key = getR2KeyFromUrl(card.image_url);
-          if (key) {
-            await deleteFromR2(key);
-            logger.info(`Deleted R2 image: ${card.image_url}`);
-          }
-        } else if (isVercelBlobUrl(card.image_url)) {
-          // Vercel Blob URLs are no longer actively deleted
-          // Migration to R2 should have moved these files
-          // Vercel Blob URLは削除しない（R2移行済みのはず）
-          logger.warn(`Vercel Blob URL found but deletion skipped: ${card.image_url}`);
-        }
+        await deleteOwnedStorageImage(card.image_url, session.twitchUserId, "Cards API (delete)");
       } catch (storageError) {
-        // Log but don't fail the card deletion if storage deletion fails
-        // ストレージ削除が失敗してもカード削除は続行（ログのみ記録）
         logger.warn(`Failed to delete storage image: ${card.image_url}`, storageError);
       }
     }

--- a/src/app/api/cards/[id]/route.ts
+++ b/src/app/api/cards/[id]/route.ts
@@ -545,10 +545,12 @@ export async function PUT(
     }
 
     // 旧画像のクリーンアップ (#830: 所有権検証は deleteOwnedStorageImage が担当)
-    // UPDATE 成功後に実行する。先に削除すると、card_number 重複(409)などで
-    // UPDATE が失敗したときにカードが旧URLを参照したまま実体だけが消える。
+    // UPDATE が実際に行を更新したあとに実行する。先に削除すると、card_number
+    // 重複(409)などで UPDATE が失敗したときにカードが旧URLを参照したまま実体
+    // だけが消える。updatedCard が null = 0行更新（並行削除など）も同様に
+    // 新しい image_url が永続化されていないため削除しない。
     // 削除失敗はカード更新を妨げない（ログのみ）。
-    if (isImageChanging && oldImageUrl) {
+    if (updatedCard && isImageChanging && oldImageUrl) {
       try {
         await deleteOwnedStorageImage(oldImageUrl, session.twitchUserId, "Cards API (update)");
       } catch (storageError) {

--- a/src/app/api/cards/batch/route.ts
+++ b/src/app/api/cards/batch/route.ts
@@ -12,6 +12,7 @@ import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-l
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
+import { isAssignableImageUrl } from "@/lib/storage-utils";
 import { recalculateIfAutoMode } from "@/lib/recalculate-drop-rates";
 // -----------------------------------------------------------------------------
 // 一括カード作成の所有権確認と書き込みは PlanetScale の単一接続を使う。
@@ -215,6 +216,16 @@ export async function POST(request: NextRequest) {
       const imageUrlValidation = validateImageUrl(card.imageUrl);
       if (!imageUrlValidation.valid) {
         validationErrors.push(`カード${i + 1}: ${imageUrlValidation.error}`);
+        continue;
+      }
+
+      // #830: 他人のストレージURLをカードへ紐付けることを禁止する
+      // （この経路は主にTwitchエモートの取り込みで、外部CDN URLは即座に許可される）
+      if (!(await isAssignableImageUrl(card.imageUrl, session.twitchUserId))) {
+        logger.warn(
+          `Cards Batch API: rejected foreign storage image URL by user ${session.twitchUserId}: ${card.imageUrl}`
+        );
+        validationErrors.push(`カード${i + 1}: ${ERROR_MESSAGES.FORBIDDEN}`);
         continue;
       }
 

--- a/src/app/api/cards/batch/route.ts
+++ b/src/app/api/cards/batch/route.ts
@@ -221,6 +221,8 @@ export async function POST(request: NextRequest) {
 
       // #830: 他人のストレージURLをカードへ紐付けることを禁止する
       // （この経路は主にTwitchエモートの取り込みで、外部CDN URLは即座に許可される）
+      // 単体の POST/PUT は 403 を返すが、このバッチ経路は全カードの検証エラーを
+      // 集約して 400 で返す既存設計に合わせる。
       if (!(await isAssignableImageUrl(card.imageUrl, session.twitchUserId))) {
         logger.warn(
           `Cards Batch API: rejected foreign storage image URL by user ${session.twitchUserId}: ${card.imageUrl}`

--- a/src/app/api/cards/route.ts
+++ b/src/app/api/cards/route.ts
@@ -16,6 +16,7 @@ import { validateContentType } from "@/lib/request-validation";
 import { normalizeDropRate } from "@/lib/card-utils";
 import { getStorageUsage } from "@/lib/storage-usage";
 import { sha256Prefix } from "@/lib/crypto-utils";
+import { isAssignableImageUrl } from "@/lib/storage-utils";
 import { logger } from "@/lib/logger.server";
 import { recalculateIfAutoMode } from "@/lib/recalculate-drop-rates";
 import { CARD_NUMBER_MESSAGES, isCardNumberConflictError, isMissingCardNumberColumnError } from "@/lib/card-number-errors";
@@ -257,6 +258,16 @@ export async function POST(request: NextRequest) {
         { error: imageUrlValidation.error },
         { status: 400 }
       )
+    }
+
+    // #830: 他人のストレージURLをカードへ紐付けることを禁止する。
+    // 紐付けを許すと、以降の画像差し替え・カード削除のクリーンアップで
+    // 他人のオブジェクトが削除される。
+    if (!(await isAssignableImageUrl(imageUrl, session.twitchUserId))) {
+      logger.warn(
+        `Cards API: rejected foreign storage image URL on create by user ${session.twitchUserId}: ${imageUrl}`
+      );
+      return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
     }
 
     const rarityValidation = validateRarity(rarity)

--- a/src/app/api/upload/delete/route.ts
+++ b/src/app/api/upload/delete/route.ts
@@ -5,10 +5,8 @@ import { validateContentType } from "@/lib/request-validation";
 import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
 import { handleApiError } from "@/lib/error-handler";
 import { ERROR_MESSAGES } from "@/lib/constants";
-import { deleteFromR2 } from "@/lib/r2-client";
-import { removeBlobFile } from "@/lib/storage-db";
-import { isR2Url, isVercelBlobUrl, isStorageUrl, getR2KeyFromUrl } from "@/lib/storage-utils";
-import { logger } from "@/lib/logger.server";
+import { deleteOwnedStorageImage } from "@/lib/storage-cleanup";
+import { isStorageUrl } from "@/lib/storage-utils";
 
 export async function POST(request: NextRequest) {
   try {
@@ -77,33 +75,16 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // DBからファイル情報を取得し、削除
-    // これにより使用量も自動的に減算される
-    try {
-      await removeBlobFile(url);
-    } catch (dbError) {
-      // DB操作に失敗しても、ストレージからの削除は続行
-      // 使用量が不整合になる可能性があるが、初期化スクリプトで修正可能
-      logger.warn('Failed to remove blob file from DB:', dbError);
-    }
+    // Ownership validation + deletion
+    // 所有権検証と削除 (#830)
+    // 検証と削除の対象キーがずれないよう、判定は削除処理と同じ場所に閉じている。
+    const outcome = await deleteOwnedStorageImage(url, session.twitchUserId, "Blob Delete API");
 
-    // ストレージから削除（R2のみ）
-    // Note: Vercel Blob deletion removed - only R2 is supported now
-    // 注意: Vercel Blob削除を削除 - R2のみサポート
-    if (isR2Url(url)) {
-      // R2から削除
-      const key = getR2KeyFromUrl(url);
-      if (key) {
-        await deleteFromR2(key);
-        logger.info(`Deleted R2 file: ${key}`);
-      } else {
-        logger.warn(`Could not extract key from R2 URL: ${url}`);
-      }
-    } else if (isVercelBlobUrl(url)) {
-      // Vercel Blob URLs are no longer actively deleted
-      // Migration to R2 should have moved these files
-      // Vercel Blob URLは削除しない（R2移行済みのはず）
-      logger.warn(`Vercel Blob URL found but deletion skipped: ${url}`);
+    if (outcome === "forbidden") {
+      return NextResponse.json(
+        { error: ERROR_MESSAGES.FORBIDDEN },
+        { status: 403 }
+      );
     }
 
     return NextResponse.json({ success: true });

--- a/src/app/api/upload/delete/route.ts
+++ b/src/app/api/upload/delete/route.ts
@@ -6,7 +6,6 @@ import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-l
 import { handleApiError } from "@/lib/error-handler";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { deleteOwnedStorageImage } from "@/lib/storage-cleanup";
-import { isStorageUrl } from "@/lib/storage-utils";
 
 export async function POST(request: NextRequest) {
   try {
@@ -66,19 +65,19 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Ownership validation + deletion
+    // ストレージURL判定・所有権検証・削除 (#830)
+    // 検証と削除の対象キーがずれないよう、判定はすべて削除処理と同じ場所に閉じている。
+    const outcome = await deleteOwnedStorageImage(url, session.twitchUserId, "Blob Delete API");
+
     // Validate that the URL is a storage URL (R2 or Vercel Blob)
     // URLがストレージURL（R2またはVercel Blob）であることを検証
-    if (!isStorageUrl(url)) {
+    if (outcome === "not-storage") {
       return NextResponse.json(
         { error: "Invalid storage URL" },
         { status: 400 }
       );
     }
-
-    // Ownership validation + deletion
-    // 所有権検証と削除 (#830)
-    // 検証と削除の対象キーがずれないよう、判定は削除処理と同じ場所に閉じている。
-    const outcome = await deleteOwnedStorageImage(url, session.twitchUserId, "Blob Delete API");
 
     if (outcome === "forbidden") {
       return NextResponse.json(

--- a/src/lib/storage-cleanup.ts
+++ b/src/lib/storage-cleanup.ts
@@ -56,7 +56,11 @@ export async function deleteOwnedStorageImage(
   }
 
   if (!(await isOwnedStorageUrl(url, twitchUserId))) {
-    logger.warn(`[${context}] Unauthorized delete attempt: ${url} by user ${twitchUserId}`);
+    // 「他人のオブジェクトへの削除要求」と「所有者を判定できないキー」を同じ
+    // fail-closed で扱うため、ログ文言も断定しない。本番/preview の
+    // cards.image_url は実測で 100% が `{prefix}_` 形式（#830 の調査）なので、
+    // 実際にここへ来るのは不正な削除要求だけの想定。
+    logger.warn(`[${context}] Storage ownership mismatch, delete skipped: ${url} (requested by user ${twitchUserId})`);
     return 'forbidden';
   }
 

--- a/src/lib/storage-cleanup.ts
+++ b/src/lib/storage-cleanup.ts
@@ -55,7 +55,11 @@ export async function deleteOwnedStorageImage(
     return 'not-storage';
   }
 
-  if (!(await isOwnedStorageUrl(url, twitchUserId))) {
+  // 検証したキーと削除するキーが同一であることを構造的に保証するため、
+  // キーはここで1度だけ取り出して以降も同じ値を使う。
+  const key = getR2KeyFromUrl(url);
+
+  if (!key || !(await isOwnedStorageUrl(url, twitchUserId))) {
     // 「他人のオブジェクトへの削除要求」と「所有者を判定できないキー」を同じ
     // fail-closed で扱うため、ログ文言も断定しない。本番/preview の
     // cards.image_url は実測で 100% が `{prefix}_` 形式（#830 の調査）なので、
@@ -73,13 +77,8 @@ export async function deleteOwnedStorageImage(
   }
 
   if (isR2Url(url)) {
-    const key = getR2KeyFromUrl(url);
-    if (key) {
-      await deleteFromR2(key);
-      logger.info(`[${context}] Deleted R2 file: ${key}`);
-    } else {
-      logger.warn(`[${context}] Could not extract key from R2 URL: ${url}`);
-    }
+    await deleteFromR2(key);
+    logger.info(`[${context}] Deleted R2 file: ${key}`);
   } else if (isVercelBlobUrl(url)) {
     // Vercel Blob URLs are no longer actively deleted
     // Migration to R2 should have moved these files

--- a/src/lib/storage-cleanup.ts
+++ b/src/lib/storage-cleanup.ts
@@ -1,0 +1,87 @@
+/**
+ * Ownership-checked storage image deletion
+ * 所有権を検証したうえでストレージ画像を削除する共通処理 (#830)
+ *
+ * 画像の削除経路は3箇所ある。
+ *   1. POST /api/upload/delete            （明示的な削除）
+ *   2. PUT  /api/cards/[id]               （画像差し替え時の旧画像クリーンアップ）
+ *   3. DELETE /api/cards/[id]             （カード削除時のクリーンアップ）
+ *
+ * これらは同じ「DB記録の削除 → R2オブジェクトの削除」を行うが、#830 以前は
+ * 3箇所ともコピーで、かつ所有権検証が一切なかった。検証を各所へ書き足すと
+ * 再び抜ける（新しい削除経路が追加されたときに忘れる）ため、削除の入口を
+ * この関数に一本化し、所有権検証を通らない限り削除処理へ進めない構造にする。
+ */
+
+import 'server-only';
+
+import { logger } from './logger.server';
+import { deleteFromR2 } from './r2-client';
+import { removeBlobFile } from './storage-db';
+import {
+  getR2KeyFromUrl,
+  isOwnedStorageUrl,
+  isR2Url,
+  isStorageUrl,
+  isVercelBlobUrl,
+} from './storage-utils';
+
+/**
+ * 削除処理の結果
+ * - `deleted`: 所有権検証を通過し削除処理を実行した
+ *   （Vercel Blob URL の場合は R2 移行済みのため実体削除はせずDB記録のみ削除する）
+ * - `not-storage`: 自前ストレージのURLではないため何もしていない（外部CDN等）
+ * - `forbidden`: 他人の所有物のため何も削除していない
+ */
+export type StorageImageDeleteOutcome = 'deleted' | 'not-storage' | 'forbidden';
+
+/**
+ * 所有権を検証したうえでストレージ画像を削除する
+ *
+ * DB記録の削除は best-effort（失敗しても警告ログのみ。使用量は初期化スクリプトで
+ * 再計算できる）。ストレージ削除の失敗は呼び出し元が扱えるよう throw する。
+ *
+ * @param url - 削除対象のストレージURL
+ * @param twitchUserId - 削除を要求しているTwitchユーザーID
+ * @param context - ログ用のコンテキスト名
+ * @returns 削除処理の結果
+ */
+export async function deleteOwnedStorageImage(
+  url: string,
+  twitchUserId: string,
+  context: string
+): Promise<StorageImageDeleteOutcome> {
+  if (!isStorageUrl(url)) {
+    return 'not-storage';
+  }
+
+  if (!(await isOwnedStorageUrl(url, twitchUserId))) {
+    logger.warn(`[${context}] Unauthorized delete attempt: ${url} by user ${twitchUserId}`);
+    return 'forbidden';
+  }
+
+  // DBからファイル情報を削除（使用量も自動的に減算される）
+  // DB操作に失敗してもストレージからの削除は続行する
+  try {
+    await removeBlobFile(url);
+  } catch (dbError) {
+    logger.warn(`[${context}] Failed to remove blob file from DB: ${url}`, dbError);
+  }
+
+  if (isR2Url(url)) {
+    const key = getR2KeyFromUrl(url);
+    if (key) {
+      await deleteFromR2(key);
+      logger.info(`[${context}] Deleted R2 file: ${key}`);
+    } else {
+      logger.warn(`[${context}] Could not extract key from R2 URL: ${url}`);
+    }
+  } else if (isVercelBlobUrl(url)) {
+    // Vercel Blob URLs are no longer actively deleted
+    // Migration to R2 should have moved these files
+    // Vercel Blob URLは削除しない（R2移行済みのはず）
+    logger.warn(`[${context}] Vercel Blob URL found but deletion skipped: ${url}`);
+  }
+
+  return 'deleted';
+}

--- a/src/lib/storage-utils.ts
+++ b/src/lib/storage-utils.ts
@@ -5,40 +5,65 @@
  * R2とVercel Blobの両方をサポートするための共通ユーティリティ
  */
 
+import { sha256Prefix } from './crypto-utils';
 import { getR2PublicUrl } from './r2-client';
 
 /**
  * URLがR2のURLかどうかを判定
+ *
+ * 判定は `R2_PUBLIC_URL` の origin との完全一致のみで行う (#830)。
+ *
+ * 旧実装は `url.includes('.r2.dev')` / `url.startsWith(r2PublicUrl)` という
+ * 部分一致だったため、`https://attacker.r2.dev/<被害者のキー>` や
+ * `https://<R2_PUBLIC_URLのホスト>.evil.example/...` のような外部URLでも true を
+ * 返した。削除処理 (`deleteFromR2`) は URL のホストに関係なく常に自バケットの
+ * `R2_IMAGES` バインディングへ発行されるため、これは「自バケット内の任意キーを
+ * 指定できる」ことを意味していた。
+ *
+ * `R2_PUBLIC_URL` はバケット直下を指す前提（`uploadToR2` が
+ * `${publicUrl}/${fileName}` を組み立て、`getR2KeyFromUrl` が pathname を
+ * そのままキーとして扱う）なので、origin 一致で必要十分。
+ *
  * @param url - チェックするURL
  * @returns R2のURLの場合はtrue
  */
 export function isR2Url(url: string): boolean {
   if (!url) return false;
 
-  // 環境変数で設定されたR2パブリックURLをチェック
+  let base: URL;
   try {
-    const r2PublicUrl = getR2PublicUrl();
-    if (url.startsWith(r2PublicUrl)) {
-      return true;
-    }
+    base = new URL(getR2PublicUrl());
   } catch {
-    // R2環境変数が設定されていない場合は無視
+    // R2_PUBLIC_URL が未設定/不正な環境では「R2ではない」と判定する（fail-closed）
+    return false;
   }
 
-  // 一般的なR2のURLパターンをチェック
-  // .r2.dev ドメイン または r2.cloudflarestorage.com
-  return url.includes('.r2.dev') || url.includes('r2.cloudflarestorage.com');
+  try {
+    return new URL(url).origin === base.origin;
+  } catch {
+    return false;
+  }
 }
 
 /**
  * URLがVercel BlobのURLかどうかを判定
+ *
+ * `includes()` だとクエリ文字列やパスに文字列を仕込むだけで一致してしまうため、
+ * ホスト名で判定する (#830 / isR2Url と同種の修正)。
+ *
  * @param url - チェックするURL
  * @returns Vercel BlobのURLの場合はtrue
  */
 export function isVercelBlobUrl(url: string): boolean {
   if (!url) return false;
-  return url.includes('blob.vercel-storage.com') ||
-         url.includes('public.blob.vercel-storage.com');
+  try {
+    const { hostname } = new URL(url);
+    // `public.blob.vercel-storage.com` などのサブドメインもサフィックスで一致する
+    return hostname === 'blob.vercel-storage.com' ||
+           hostname.endsWith('.blob.vercel-storage.com');
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -99,34 +124,49 @@ export function getVercelBlobPathFromUrl(url: string): string | null {
 }
 
 /**
- * URLからユーザープレフィックス（8文字のハッシュ）を抽出
- * ファイル名のフォーマット: {userPrefix}_{uniqueSuffix}.{ext}
+ * ストレージURLが指定ユーザーの所有物かを判定する (#830)
+ *
+ * アップロード経路 (`src/app/api/upload/route.ts`) が生成するキーは常に
+ * `{sha256Prefix(twitchUserId)}_{uniqueSuffix}.{ext}` というフラットな形式で、
+ * `blob_files.user_prefix` にも同じプレフィックスが記録される。よってキー先頭の
+ * プレフィックスが所有者を一意に表す（効果音削除 `/api/upload/sound` と同じ判定）。
+ *
+ * 判定対象は「URLのファイル名」ではなく `getR2KeyFromUrl` が返すキーそのもの。
+ * ファイル名（最後のパスセグメント）だけを見ると
+ * `victim-dir/{自分のprefix}_x.png` のようなネストキーで
+ * 「検証した対象」と「削除される対象」がずれるため。
+ *
  * @param url - ストレージURL
- * @returns ユーザープレフィックス（8文字）、または抽出できない場合はnull
+ * @param twitchUserId - 所有者として検証するTwitchユーザーID
+ * @returns 自分の所有物であればtrue
  */
-export function extractUserPrefixFromUrl(url: string): string | null {
-  if (!url) return null;
+export async function isOwnedStorageUrl(url: string, twitchUserId: string): Promise<boolean> {
+  const key = getR2KeyFromUrl(url);
+  if (!key) return false;
 
-  try {
-    const urlObj = new URL(url);
-    const pathname = urlObj.pathname;
-    // パスの最後の部分（ファイル名）を取得
-    const fileName = pathname.split('/').pop();
-    if (!fileName) return null;
+  // アップロード経路が生成するキーは常にフラット。'/' を含むキーは
+  // 自分のプレフィックス配下と断定できないため拒否する。
+  if (key.includes('/')) return false;
 
-    // ファイル名から拡張子を除去
-    const nameWithoutExt = fileName.split('.')[0];
-    if (!nameWithoutExt) return null;
+  const userPrefix = await sha256Prefix(twitchUserId);
+  return key.startsWith(`${userPrefix}_`);
+}
 
-    // ユーザープレフィックスを抽出（最初の8文字）
-    // フォーマット: {userPrefix}_{uniqueSuffix}
-    const prefix = nameWithoutExt.split('_')[0];
-    if (prefix && prefix.length === 8) {
-      return prefix;
-    }
-
-    return null;
-  } catch {
-    return null;
-  }
+/**
+ * 画像URLをカードなどに紐付けてよいかを判定する (#830)
+ *
+ * 他人のストレージURLを自分のカードに設定できると、以降の画像差し替えや
+ * カード削除の「旧画像クリーンアップ」で他人のオブジェクトが削除されるため、
+ * 入口の時点で弾く。ストレージ外のURL（Twitchエモート等の外部CDN）は
+ * `validateImageUrl` の担当なのでここでは許可する。
+ *
+ * @param imageUrl - 紐付けようとしている画像URL
+ * @param twitchUserId - 紐付けを行うTwitchユーザーID
+ * @returns 紐付けてよい場合はtrue
+ */
+export async function isAssignableImageUrl(imageUrl: unknown, twitchUserId: string): Promise<boolean> {
+  // 未指定・空文字（画像なし）は対象外
+  if (typeof imageUrl !== 'string' || imageUrl.trim() === '') return true;
+  if (!isStorageUrl(imageUrl)) return true;
+  return isOwnedStorageUrl(imageUrl, twitchUserId);
 }

--- a/src/lib/storage-utils.ts
+++ b/src/lib/storage-utils.ts
@@ -24,6 +24,12 @@ import { getR2PublicUrl } from './r2-client';
  * `${publicUrl}/${fileName}` を組み立て、`getR2KeyFromUrl` が pathname を
  * そのままキーとして扱う）なので、origin 一致で必要十分。
  *
+ * 運用上の注意: 保存済みURLは組み立て時点の `R2_PUBLIC_URL` を含むため、
+ * ドメインを付け替える場合は `cards.image_url` / `blob_files.url` のデータ移行が
+ * 必須。移行しないと既存URLはすべて「ストレージ外」と判定され、カードの
+ * 差し替え・削除時のクリーンアップが警告も出さずスキップされる（R2オブジェクトと
+ * 使用量カウンタがリークする）。
+ *
  * @param url - チェックするURL
  * @returns R2のURLの場合はtrue
  */
@@ -106,6 +112,12 @@ export function getR2KeyFromUrl(url: string): string | null {
  * ファイル名（最後のパスセグメント）だけを見ると
  * `victim-dir/{自分のprefix}_x.png` のようなネストキーで
  * 「検証した対象」と「削除される対象」がずれるため。
+ *
+ * 既知の限界: プレフィックスは sha256 の先頭8hex（2^32空間）なので、ユーザー数が
+ * 十分に増えれば誕生日衝突でプレフィックスを共有するユーザー同士が現れうる。
+ * 攻撃者は自分の Twitch ID を選べないため能動的な衝突は作れず、効果音削除
+ * (`/api/upload/sound`) や `blob_files.user_prefix` も同じ前提で運用されている。
+ * 規模が変わったら `blob_files.user_prefix` の逆引きへ切り替えること。
  *
  * @param url - ストレージURL
  * @param twitchUserId - 所有者として検証するTwitchユーザーID

--- a/src/lib/storage-utils.ts
+++ b/src/lib/storage-utils.ts
@@ -76,17 +76,6 @@ export function isStorageUrl(url: string): boolean {
 }
 
 /**
- * ストレージの種類を判定
- * @param url - チェックするURL
- * @returns 'r2' | 'vercel' | null
- */
-export function getStorageType(url: string): 'r2' | 'vercel' | null {
-  if (isR2Url(url)) return 'r2';
-  if (isVercelBlobUrl(url)) return 'vercel';
-  return null;
-}
-
-/**
  * R2 URLからキー（ファイル名）を抽出
  * @param url - R2のURL
  * @returns ファイル名（キー）、または抽出できない場合はnull
@@ -101,24 +90,6 @@ export function getR2KeyFromUrl(url: string): string | null {
     return key || null;
   } catch {
     // URLのパースに失敗した場合
-    return null;
-  }
-}
-
-/**
- * Vercel Blob URLからパス名を抽出
- * @param url - Vercel BlobのURL
- * @returns パス名、または抽出できない場合はnull
- */
-export function getVercelBlobPathFromUrl(url: string): string | null {
-  if (!url) return null;
-
-  try {
-    const urlObj = new URL(url);
-    // パスから先頭の '/' を除去
-    const path = urlObj.pathname.slice(1);
-    return path || null;
-  } catch {
     return null;
   }
 }

--- a/tests/unit/api/cards-batch-route-driver-parity.test.ts
+++ b/tests/unit/api/cards-batch-route-driver-parity.test.ts
@@ -11,11 +11,18 @@ import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { validateCSRFToken } from "@/lib/csrf";
 import { getDb } from "@/lib/db/client";
+import { sha256Prefix } from "@/lib/crypto-utils";
 import { CARDS_SAFE_COLUMNS } from "@/lib/db/cards-safe-columns";
+
+// #830: 画像URLの所有権判定は R2 の公開URLに依存するため、テストでは固定値を与える
+const R2_PUBLIC_URL = "https://images.example.test";
 
 vi.mock("@/lib/session");
 vi.mock("@/lib/rate-limit");
 vi.mock("@/lib/csrf");
+vi.mock("@/lib/r2-client", () => ({
+  getR2PublicUrl: vi.fn(() => R2_PUBLIC_URL),
+}));
 vi.mock("@/lib/logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
@@ -311,6 +318,51 @@ describe("POST /api/cards/batch: PlanetScale契約 (#663)", () => {
     expect(pg.insertCalls[1].returningFields).toEqual(CARDS_SAFE_COLUMNS);
     expect(Object.keys(pg.insertCalls[1].returningFields ?? {})).not.toContain("card_number");
     expect(Object.keys(pg.insertCalls[1].returningFields ?? {})).not.toContain("hp");
+  });
+
+  // #830: 他人のストレージURLをカードへ紐付けると、以降のカード削除時の
+  // クリーンアップで他人のR2オブジェクトが消えるため、作成時点で拒否する。
+  it("他人のストレージURLを含むカードは400で拒否しINSERTしない (#830)", async () => {
+    const victimPrefix = await sha256Prefix("victim-user-id");
+    const pg = createDrizzleDbMock({ selects: [{ rows: [STREAMER_ROW] }] });
+    primePgDb(pg);
+
+    const pgRes = await POST(
+      createBatchRequest({
+        streamerId: "streamer-1",
+        cards: [
+          {
+            name: "Card A",
+            imageUrl: `${R2_PUBLIC_URL}/${victimPrefix}_deadbeef.png`,
+            rarity: "common",
+            dropRate: 0.5,
+          },
+        ],
+      })
+    );
+
+    expect(pgRes.status).toBe(400);
+    expect(pg.insertCalls).toHaveLength(0);
+  });
+
+  it("自分のストレージURLを含むカードは従来どおり作成できる (#830)", async () => {
+    const ownPrefix = await sha256Prefix("user1");
+    const imageUrl = `${R2_PUBLIC_URL}/${ownPrefix}_deadbeef.png`;
+    const pg = createDrizzleDbMock({
+      selects: [{ rows: [STREAMER_ROW] }],
+      inserts: [{ rows: [{ id: "card-1", streamer_id: "streamer-1", name: "Card A", image_url: imageUrl }] }],
+    });
+    primePgDb(pg);
+
+    const pgRes = await POST(
+      createBatchRequest({
+        streamerId: "streamer-1",
+        cards: [{ name: "Card A", imageUrl, rarity: "common", dropRate: 0.5 }],
+      })
+    );
+
+    expect(pgRes.status).toBe(200);
+    expect(pg.insertCalls).toHaveLength(1);
   });
 
 });

--- a/tests/unit/api/cards-collection-membership.test.ts
+++ b/tests/unit/api/cards-collection-membership.test.ts
@@ -15,12 +15,23 @@ import { checkRateLimit } from "@/lib/rate-limit";
 import { validateCSRFToken } from "@/lib/csrf";
 import { getStorageUsage } from "@/lib/storage-usage";
 import { getDb } from "@/lib/db/client";
+import { sha256Prefix } from "@/lib/crypto-utils";
 import { DEFAULT_PACK_SENTINEL } from "@/lib/validation/collection-name";
+
+// #830: 画像URLの所有権判定は R2 の公開URLに依存するため、テストでは固定値を与える
+const R2_PUBLIC_URL = "https://images.example.test";
 
 vi.mock("@/lib/session");
 vi.mock("@/lib/rate-limit");
 vi.mock("@/lib/csrf");
 vi.mock("@/lib/storage-usage");
+vi.mock("@/lib/r2-client", () => ({
+  getR2PublicUrl: vi.fn(() => R2_PUBLIC_URL),
+  deleteFromR2: vi.fn(),
+}));
+vi.mock("@/lib/storage-db", () => ({
+  removeBlobFile: vi.fn(),
+}));
 
 const mockGetSession = vi.mocked(getSession);
 const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures);
@@ -319,5 +330,57 @@ describe("PUT /api/cards/[id] card-pack membership validation", () => {
     expect((await response.json()).collectionNameSkippedDeployWindow).toBe(true);
     expect(db.updateCalls[0]).toEqual(expect.objectContaining({ name: "Renamed" }));
     expect(db.updateCalls[0]).not.toHaveProperty("collection_name");
+  });
+});
+
+// #830: 他人のストレージURLをカードへ紐付けると、以降の画像差し替え・カード削除の
+// クリーンアップで他人のR2オブジェクトが削除されるため、作成時点で拒否する。
+describe("POST /api/cards storage image ownership (#830)", () => {
+  it("rejects another streamer's storage URL (403) and does not insert", async () => {
+    const victimPrefix = await sha256Prefix("victim-user-id");
+    const db = createDbMock({ selects: [{ rows: [streamerRow([])] }] });
+
+    const response = await POST(
+      new NextRequest("http://localhost/api/cards", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          streamerId: "streamer1",
+          name: "Sword",
+          imageUrl: `${R2_PUBLIC_URL}/${victimPrefix}_deadbeef.png`,
+          rarity: "common",
+          dropRate: 0.5,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(db.insertCalls).toHaveLength(0);
+  });
+
+  it("accepts the requester's own storage URL", async () => {
+    const ownPrefix = await sha256Prefix(SESSION.twitchUserId);
+    const imageUrl = `${R2_PUBLIC_URL}/${ownPrefix}_deadbeef.png`;
+    const db = createDbMock({
+      selects: [{ rows: [streamerRow([])] }],
+      inserts: [{ rows: [{ id: "card1", image_url: imageUrl }] }],
+    });
+
+    const response = await POST(
+      new NextRequest("http://localhost/api/cards", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          streamerId: "streamer1",
+          name: "Sword",
+          imageUrl,
+          rarity: "common",
+          dropRate: 0.5,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(db.insertCalls[0]).toEqual(expect.objectContaining({ image_url: imageUrl }));
   });
 });

--- a/tests/unit/api/cards-id-route-driver-parity.test.ts
+++ b/tests/unit/api/cards-id-route-driver-parity.test.ts
@@ -3,6 +3,10 @@
  *
  * 現行 Drizzle 実装の所有権・更新・削除・競合応答と、
  * 本番スキーマ移行中の安全な列フォールバックを検証する。
+ *
+ * #830: 画像URLの所有権検証（他人のストレージURLの紐付け拒否・
+ * 他人のオブジェクトを削除しないクリーンアップ）もここで検証する。
+ * 同じルートの PUT/DELETE を対象とし、Drizzle モックを共有するため。
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
@@ -12,12 +16,21 @@ import { checkRateLimit } from "@/lib/rate-limit";
 import { validateCSRFToken } from "@/lib/csrf";
 import { getDb } from "@/lib/db/client";
 import { removeBlobFile } from "@/lib/storage-db";
+import { deleteFromR2 } from "@/lib/r2-client";
+import { sha256Prefix } from "@/lib/crypto-utils";
 import { CARDS_SAFE_COLUMNS } from "@/lib/db/cards-safe-columns";
+
+// #830: 画像削除経路で参照される R2 の公開URL・削除操作を差し替える
+const R2_PUBLIC_URL = "https://images.example.test";
 
 vi.mock("@/lib/session");
 vi.mock("@/lib/rate-limit");
 vi.mock("@/lib/csrf");
 vi.mock("@/lib/storage-db");
+vi.mock("@/lib/r2-client", () => ({
+  getR2PublicUrl: vi.fn(() => R2_PUBLIC_URL),
+  deleteFromR2: vi.fn(),
+}));
 vi.mock("@/lib/logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
@@ -32,6 +45,7 @@ const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures);
 const mockCheckRateLimit = vi.mocked(checkRateLimit);
 const mockValidateCSRFToken = vi.mocked(validateCSRFToken);
 const mockRemoveBlobFile = vi.mocked(removeBlobFile);
+const mockDeleteFromR2 = vi.mocked(deleteFromR2);
 
 const SESSION = {
   twitchUserId: "user1",
@@ -191,6 +205,7 @@ describe("PUT/DELETE /api/cards/[id]: PlanetScale契約 (#663)", () => {
     });
     mockValidateCSRFToken.mockResolvedValue({ valid: true });
     mockRemoveBlobFile.mockResolvedValue(null);
+    mockDeleteFromR2.mockResolvedValue(undefined);
   });
 
   describe("PUT /api/cards/[id]", () => {
@@ -406,5 +421,156 @@ describe("PUT/DELETE /api/cards/[id]: PlanetScale契約 (#663)", () => {
       expect(pgRes.status).toBe(403);
     });
 
+  });
+
+  // -------------------------------------------------------------------------
+  // #830: 画像URLの所有権検証
+  //
+  // 修正前は「他人のR2 URLを自分のカードに紐付ける」→「別URLへ差し替える」
+  // だけで、被害者のオブジェクトがR2から削除できた（復旧不能）。
+  // -------------------------------------------------------------------------
+  describe("画像URLの所有権検証 (#830)", () => {
+    const VICTIM_USER_ID = "victim-user-id";
+
+    const PUT_OWNERSHIP_ROW = {
+      streamer_id: "streamer-1",
+      image_url: null as string | null,
+      rarity: "common",
+      is_active: true,
+      intra_rarity_weight: 1,
+      collection_name: null,
+      twitch_user_id: "user1",
+      rarity_weights: null,
+      card_pack_names: [],
+    };
+
+    const UPDATED_ROW = {
+      id: CARD_ID,
+      streamer_id: "streamer-1",
+      name: "Card",
+      description: null,
+      image_url: null,
+      rarity: "common",
+      card_number: null,
+      max_issuance_count: null,
+      collection_name: null,
+      drop_rate: 0.5,
+      intra_rarity_weight: 1,
+      is_active: true,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-02T00:00:00Z",
+    };
+
+    const DELETE_OWNERSHIP_ROW = {
+      streamer_id: "streamer-1",
+      image_url: null as string | null,
+      twitch_user_id: "user1",
+      rarity_weights: null,
+    };
+
+    async function ownUrl(suffix = "deadbeef"): Promise<string> {
+      return `${R2_PUBLIC_URL}/${await sha256Prefix("user1")}_${suffix}.png`;
+    }
+
+    async function victimUrl(suffix = "cafebabe"): Promise<string> {
+      return `${R2_PUBLIC_URL}/${await sha256Prefix(VICTIM_USER_ID)}_${suffix}.png`;
+    }
+
+    it("PUT: 他人のストレージURLの紐付けは403で拒否しUPDATEしない", async () => {
+      const pg = createDrizzleDbMock({ selects: [{ rows: [PUT_OWNERSHIP_ROW] }] });
+      primePgDb(pg);
+
+      const res = await PUT(createPutRequest({ imageUrl: await victimUrl() }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+
+      expect(res.status).toBe(403);
+      expect(pg.updateCalls).toHaveLength(0);
+      expect(mockRemoveBlobFile).not.toHaveBeenCalled();
+      expect(mockDeleteFromR2).not.toHaveBeenCalled();
+    });
+
+    it("PUT: 自分の画像への差し替えでは旧画像が従来どおり削除される", async () => {
+      const oldUrl = await ownUrl("11111111");
+      const newUrl = await ownUrl("22222222");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [{ ...PUT_OWNERSHIP_ROW, image_url: oldUrl }] }],
+        updates: [{ rows: [{ ...UPDATED_ROW, image_url: newUrl }] }],
+      });
+      primePgDb(pg);
+
+      const res = await PUT(createPutRequest({ imageUrl: newUrl }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockRemoveBlobFile).toHaveBeenCalledWith(oldUrl);
+      expect(mockDeleteFromR2).toHaveBeenCalledWith(`${await sha256Prefix("user1")}_11111111.png`);
+    });
+
+    it("PUT: 旧画像が他人のURLの場合はクリーンアップせず更新は成功する", async () => {
+      const foreignOldUrl = await victimUrl();
+      const newUrl = await ownUrl();
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [{ ...PUT_OWNERSHIP_ROW, image_url: foreignOldUrl }] }],
+        updates: [{ rows: [{ ...UPDATED_ROW, image_url: newUrl }] }],
+      });
+      primePgDb(pg);
+
+      const res = await PUT(createPutRequest({ imageUrl: newUrl }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockRemoveBlobFile).not.toHaveBeenCalled();
+      expect(mockDeleteFromR2).not.toHaveBeenCalled();
+    });
+
+    it("PUT: 画像URLを変更しない編集は所有権判定の対象外（プレフィックス命名以前の画像も編集できる）", async () => {
+      // プレフィックス命名規則より前に保存された画像を持つ既存カードを模す
+      const legacyUrl = `${R2_PUBLIC_URL}/legacy-image.png`;
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [{ ...PUT_OWNERSHIP_ROW, image_url: legacyUrl }] }],
+        updates: [{ rows: [{ ...UPDATED_ROW, name: "Renamed", image_url: legacyUrl }] }],
+      });
+      primePgDb(pg);
+
+      const res = await PUT(createPutRequest({ name: "Renamed", imageUrl: legacyUrl }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockDeleteFromR2).not.toHaveBeenCalled();
+    });
+
+    it("DELETE: カード画像が自分のものなら従来どおり削除される", async () => {
+      const url = await ownUrl();
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [{ ...DELETE_OWNERSHIP_ROW, image_url: url }] }],
+        deletes: [{ rows: [{ id: CARD_ID }] }],
+      });
+      primePgDb(pg);
+
+      const res = await DELETE(createDeleteRequest(), { params: Promise.resolve({ id: CARD_ID }) });
+
+      expect(res.status).toBe(200);
+      expect(mockRemoveBlobFile).toHaveBeenCalledWith(url);
+      expect(mockDeleteFromR2).toHaveBeenCalledWith(`${await sha256Prefix("user1")}_deadbeef.png`);
+    });
+
+    it("DELETE: カード画像が他人のものならR2削除せずカード削除だけ行う", async () => {
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [{ ...DELETE_OWNERSHIP_ROW, image_url: await victimUrl() }] }],
+        deletes: [{ rows: [{ id: CARD_ID }] }],
+      });
+      primePgDb(pg);
+
+      const res = await DELETE(createDeleteRequest(), { params: Promise.resolve({ id: CARD_ID }) });
+
+      expect(res.status).toBe(200);
+      expect(pg.deleteCalls).toHaveLength(1);
+      expect(mockRemoveBlobFile).not.toHaveBeenCalled();
+      expect(mockDeleteFromR2).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/api/cards-id-route-driver-parity.test.ts
+++ b/tests/unit/api/cards-id-route-driver-parity.test.ts
@@ -508,6 +508,54 @@ describe("PUT/DELETE /api/cards/[id]: PlanetScale契約 (#663)", () => {
       expect(mockDeleteFromR2).toHaveBeenCalledWith(`${await sha256Prefix("user1")}_11111111.png`);
     });
 
+    // 旧画像の削除は UPDATE 成功後でなければならない。先に削除すると、
+    // card_number 重複(409)でUPDATEが失敗したときにカードが旧URLを参照した
+    // まま実体だけが消える。
+    it("PUT: UPDATEが409で失敗した場合は旧画像を削除しない", async () => {
+      const oldUrl = await ownUrl("11111111");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [{ ...PUT_OWNERSHIP_ROW, image_url: oldUrl }] }],
+        updates: [
+          {
+            error: {
+              code: "23505",
+              message:
+                'duplicate key value violates unique constraint "cards_streamer_card_number_unique"',
+            },
+          },
+        ],
+      });
+      primePgDb(pg);
+
+      const res = await PUT(
+        createPutRequest({ imageUrl: await ownUrl("22222222"), cardNumber: 3 }),
+        { params: Promise.resolve({ id: CARD_ID }) }
+      );
+
+      expect(res.status).toBe(409);
+      expect(mockRemoveBlobFile).not.toHaveBeenCalled();
+      expect(mockDeleteFromR2).not.toHaveBeenCalled();
+    });
+
+    // 0行更新（並行削除など）では新しい image_url が永続化されていないため、
+    // 旧画像を消すとカードから参照されている実体を失う。
+    it("PUT: UPDATEが0行だった場合は旧画像を削除しない", async () => {
+      const oldUrl = await ownUrl("11111111");
+      const pg = createDrizzleDbMock({
+        selects: [{ rows: [{ ...PUT_OWNERSHIP_ROW, image_url: oldUrl }] }],
+        updates: [{ rows: [] }],
+      });
+      primePgDb(pg);
+
+      const res = await PUT(createPutRequest({ imageUrl: await ownUrl("22222222") }), {
+        params: Promise.resolve({ id: CARD_ID }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockRemoveBlobFile).not.toHaveBeenCalled();
+      expect(mockDeleteFromR2).not.toHaveBeenCalled();
+    });
+
     it("PUT: 旧画像が他人のURLの場合はクリーンアップせず更新は成功する", async () => {
       const foreignOldUrl = await victimUrl();
       const newUrl = await ownUrl();

--- a/tests/unit/api/cards-id-route-driver-parity.test.ts
+++ b/tests/unit/api/cards-id-route-driver-parity.test.ts
@@ -526,8 +526,8 @@ describe("PUT/DELETE /api/cards/[id]: PlanetScale契約 (#663)", () => {
       expect(mockDeleteFromR2).not.toHaveBeenCalled();
     });
 
-    it("PUT: 画像URLを変更しない編集は所有権判定の対象外（プレフィックス命名以前の画像も編集できる）", async () => {
-      // プレフィックス命名規則より前に保存された画像を持つ既存カードを模す
+    it("PUT: 画像URLを変更しない編集は所有権判定の対象外（所有者を判定できないURLでも編集が止まらない）", async () => {
+      // 命名規則に合致せず所有者を判定できないURLを持つ既存カードを模す
       const legacyUrl = `${R2_PUBLIC_URL}/legacy-image.png`;
       const pg = createDrizzleDbMock({
         selects: [{ rows: [{ ...PUT_OWNERSHIP_ROW, image_url: legacyUrl }] }],

--- a/tests/unit/api/upload-delete-ownership.test.ts
+++ b/tests/unit/api/upload-delete-ownership.test.ts
@@ -1,0 +1,123 @@
+/**
+ * #830: POST /api/upload/delete の所有権検証テスト
+ *
+ * 修正前は所有権検証が無く、配信者セッションを持つ任意のユーザーが他配信者の
+ * カード画像をR2から削除できた（IDOR）。ここでは「他人のオブジェクトに対して
+ * DB削除もR2削除も一切実行されない」ことを検証する。
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/upload/delete/route';
+import { getSession, canUseStreamerFeatures } from '@/lib/session';
+import { checkRateLimit } from '@/lib/rate-limit';
+import { validateCSRFToken } from '@/lib/csrf';
+import { removeBlobFile } from '@/lib/storage-db';
+import { deleteFromR2 } from '@/lib/r2-client';
+import { sha256Prefix } from '@/lib/crypto-utils';
+
+vi.mock('@/lib/session');
+vi.mock('@/lib/rate-limit');
+vi.mock('@/lib/csrf');
+vi.mock('@/lib/storage-db', () => ({
+  removeBlobFile: vi.fn(),
+}));
+vi.mock('@/lib/r2-client', () => ({
+  getR2PublicUrl: vi.fn(() => R2_PUBLIC_URL),
+  deleteFromR2: vi.fn(),
+}));
+
+const R2_PUBLIC_URL = 'https://images.example.test';
+
+const mockGetSession = vi.mocked(getSession);
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures);
+const mockCheckRateLimit = vi.mocked(checkRateLimit);
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken);
+const mockRemoveBlobFile = vi.mocked(removeBlobFile);
+const mockDeleteFromR2 = vi.mocked(deleteFromR2);
+
+const SESSION = {
+  twitchUserId: 'attacker-user-id',
+  twitchUsername: 'attacker',
+  twitchDisplayName: 'Attacker',
+  twitchProfileImageUrl: '',
+  broadcasterType: 'affiliate' as const,
+  expiresAt: Date.now() + 60_000,
+  version: 1,
+};
+
+const VICTIM_USER_ID = 'victim-user-id';
+
+function createRequest(url: unknown): NextRequest {
+  return new NextRequest('http://localhost/api/upload/delete', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ url }),
+  });
+}
+
+describe('POST /api/upload/delete: 所有権検証 (#830)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(SESSION);
+    mockCanUseStreamerFeatures.mockReturnValue(true);
+    mockValidateCSRFToken.mockResolvedValue({ valid: true });
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: Date.now() + 60_000,
+    });
+    mockRemoveBlobFile.mockResolvedValue(null);
+    mockDeleteFromR2.mockResolvedValue(undefined);
+  });
+
+  it('他配信者のオブジェクトは403で拒否し、DB削除もR2削除も実行しない', async () => {
+    const victimPrefix = await sha256Prefix(VICTIM_USER_ID);
+    const response = await POST(createRequest(`${R2_PUBLIC_URL}/${victimPrefix}_deadbeef.png`));
+
+    expect(response.status).toBe(403);
+    expect(mockRemoveBlobFile).not.toHaveBeenCalled();
+    expect(mockDeleteFromR2).not.toHaveBeenCalled();
+  });
+
+  it('自分のオブジェクトは従来どおり削除できる', async () => {
+    const ownPrefix = await sha256Prefix(SESSION.twitchUserId);
+    const url = `${R2_PUBLIC_URL}/${ownPrefix}_deadbeef.png`;
+
+    const response = await POST(createRequest(url));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(mockRemoveBlobFile).toHaveBeenCalledWith(url);
+    expect(mockDeleteFromR2).toHaveBeenCalledWith(`${ownPrefix}_deadbeef.png`);
+  });
+
+  it('他バケットの .r2.dev URL はストレージURLとして扱わず400で拒否する', async () => {
+    const victimPrefix = await sha256Prefix(VICTIM_USER_ID);
+    const response = await POST(createRequest(`https://attacker.r2.dev/${victimPrefix}_deadbeef.png`));
+
+    expect(response.status).toBe(400);
+    expect(mockRemoveBlobFile).not.toHaveBeenCalled();
+    expect(mockDeleteFromR2).not.toHaveBeenCalled();
+  });
+
+  it('自分のプレフィックスを含むネストキーでも他キーを削除できない', async () => {
+    const ownPrefix = await sha256Prefix(SESSION.twitchUserId);
+    const response = await POST(
+      createRequest(`${R2_PUBLIC_URL}/victim-dir/${ownPrefix}_deadbeef.png`)
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockDeleteFromR2).not.toHaveBeenCalled();
+  });
+
+  it('配信者権限のないセッションは従来どおり401', async () => {
+    mockCanUseStreamerFeatures.mockReturnValue(false);
+    const ownPrefix = await sha256Prefix(SESSION.twitchUserId);
+
+    const response = await POST(createRequest(`${R2_PUBLIC_URL}/${ownPrefix}_deadbeef.png`));
+
+    expect(response.status).toBe(401);
+    expect(mockDeleteFromR2).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/api/upload-delete-ownership.test.ts
+++ b/tests/unit/api/upload-delete-ownership.test.ts
@@ -25,6 +25,16 @@ vi.mock('@/lib/r2-client', () => ({
   getR2PublicUrl: vi.fn(() => R2_PUBLIC_URL),
   deleteFromR2: vi.fn(),
 }));
+// 同ディレクトリの他ルートテストと同じ境界。500ケースで error-reporter の
+// 実経路が走らないようにする。
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('@/lib/sentry/error-handler', () => ({
+  reportError: vi.fn(),
+  reportApiError: vi.fn(),
+  logErrorFromLogger: vi.fn(),
+}));
 
 const R2_PUBLIC_URL = 'https://images.example.test';
 

--- a/tests/unit/api/upload-delete-ownership.test.ts
+++ b/tests/unit/api/upload-delete-ownership.test.ts
@@ -111,6 +111,40 @@ describe('POST /api/upload/delete: 所有権検証 (#830)', () => {
     expect(mockDeleteFromR2).not.toHaveBeenCalled();
   });
 
+  // R2削除の失敗は握りつぶさず500へ落とす（error-reporter が拾えるようにする）。
+  // 将来 deleteOwnedStorageImage 内で catch すると「削除できていないのに200」に
+  // なるため、その回帰をここで固定する。
+  it('R2削除が失敗した場合は500を返す（成功として握りつぶさない）', async () => {
+    const ownPrefix = await sha256Prefix(SESSION.twitchUserId);
+    mockDeleteFromR2.mockRejectedValue(new Error('R2 unavailable'));
+
+    const response = await POST(createRequest(`${R2_PUBLIC_URL}/${ownPrefix}_deadbeef.png`));
+
+    expect(response.status).toBe(500);
+  });
+
+  // Vercel Blob は R2 へ移行済みで実体削除しない。DB記録だけを削除する既存挙動を固定する。
+  it('自分のVercel Blob URLはDB記録のみ削除しR2削除は行わない', async () => {
+    const ownPrefix = await sha256Prefix(SESSION.twitchUserId);
+    const url = `https://abc.public.blob.vercel-storage.com/${ownPrefix}_deadbeef.png`;
+
+    const response = await POST(createRequest(url));
+
+    expect(response.status).toBe(200);
+    expect(mockRemoveBlobFile).toHaveBeenCalledWith(url);
+    expect(mockDeleteFromR2).not.toHaveBeenCalled();
+  });
+
+  it('ストレージ外のURLは400で拒否する', async () => {
+    const response = await POST(
+      createRequest('https://static-cdn.jtvnw.net/emoticons/v2/1/static/light/3.0')
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockRemoveBlobFile).not.toHaveBeenCalled();
+    expect(mockDeleteFromR2).not.toHaveBeenCalled();
+  });
+
   it('配信者権限のないセッションは従来どおり401', async () => {
     mockCanUseStreamerFeatures.mockReturnValue(false);
     const ownPrefix = await sha256Prefix(SESSION.twitchUserId);

--- a/tests/unit/api/upload-delete-ownership.test.ts
+++ b/tests/unit/api/upload-delete-ownership.test.ts
@@ -145,6 +145,16 @@ describe('POST /api/upload/delete: 所有権検証 (#830)', () => {
     expect(mockDeleteFromR2).not.toHaveBeenCalled();
   });
 
+  // キーを取り出せないストレージURL（パスなし）は fail-closed。
+  // 所有権を判定できない以上、削除には進ませない。
+  it('キーを持たないストレージURLは403で拒否し削除しない', async () => {
+    const response = await POST(createRequest(`${R2_PUBLIC_URL}/`));
+
+    expect(response.status).toBe(403);
+    expect(mockRemoveBlobFile).not.toHaveBeenCalled();
+    expect(mockDeleteFromR2).not.toHaveBeenCalled();
+  });
+
   it('ストレージ外のURLは400で拒否する', async () => {
     const response = await POST(
       createRequest('https://static-cdn.jtvnw.net/emoticons/v2/1/static/light/3.0')

--- a/tests/unit/storage-utils.test.ts
+++ b/tests/unit/storage-utils.test.ts
@@ -1,0 +1,152 @@
+/**
+ * #830: ストレージURL判定と所有権判定のテスト
+ *
+ * `/api/upload/delete` と `/api/cards/[id]` の削除経路は、この2つの判定に
+ * 依存して「自分のオブジェクトだけを削除する」ことを保証している。
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  isR2Url,
+  isVercelBlobUrl,
+  isStorageUrl,
+  getR2KeyFromUrl,
+  isOwnedStorageUrl,
+  isAssignableImageUrl,
+} from '@/lib/storage-utils';
+import { sha256Prefix } from '@/lib/crypto-utils';
+import { getR2PublicUrl } from '@/lib/r2-client';
+
+// storage-utils は R2 の公開URLだけを r2-client から取得する。
+// R2バインディング/S3 SDKを読み込まないようモジュールごと差し替える。
+vi.mock('@/lib/r2-client', () => ({
+  getR2PublicUrl: vi.fn(() => 'https://images.example.test'),
+}));
+
+const mockGetR2PublicUrl = vi.mocked(getR2PublicUrl);
+
+const OWNER = 'owner-user-id';
+const ATTACKER = 'attacker-user-id';
+
+describe('isR2Url (#830)', () => {
+  beforeEach(() => {
+    mockGetR2PublicUrl.mockReturnValue('https://images.example.test');
+  });
+
+  it('R2_PUBLIC_URL と同一originのURLのみ true を返す', () => {
+    expect(isR2Url('https://images.example.test/abc12345_def67890.png')).toBe(true);
+  });
+
+  it('他バケットの .r2.dev URL を拒否する（自バケットの任意キー削除を防ぐ）', () => {
+    expect(isR2Url('https://attacker-bucket.r2.dev/abc12345_def67890.png')).toBe(false);
+    expect(isR2Url('https://any.r2.cloudflarestorage.com/abc12345_def67890.png')).toBe(false);
+  });
+
+  it('公開URLホストを接頭辞に持つだけの別ドメインを拒否する', () => {
+    expect(isR2Url('https://images.example.test.evil.example/abc12345_x.png')).toBe(false);
+  });
+
+  it('公開URLを文字列として含むだけのURLを拒否する', () => {
+    expect(isR2Url('https://evil.example/?u=https://images.example.test/abc12345_x.png')).toBe(false);
+  });
+
+  it('R2_PUBLIC_URL が未設定の環境では false を返す（fail-closed）', () => {
+    mockGetR2PublicUrl.mockImplementation(() => {
+      throw new Error('Missing R2_PUBLIC_URL environment variable');
+    });
+    expect(isR2Url('https://images.example.test/abc12345_x.png')).toBe(false);
+  });
+
+  it('空文字列やURLとして不正な値は false', () => {
+    expect(isR2Url('')).toBe(false);
+    expect(isR2Url('not a url')).toBe(false);
+  });
+});
+
+describe('isVercelBlobUrl (#830)', () => {
+  it('Vercel Blob のホストのみ true を返す', () => {
+    expect(isVercelBlobUrl('https://abc.public.blob.vercel-storage.com/x.png')).toBe(true);
+    expect(isVercelBlobUrl('https://blob.vercel-storage.com/x.png')).toBe(true);
+  });
+
+  it('ホスト名以外に文字列を含むだけのURLを拒否する', () => {
+    expect(isVercelBlobUrl('https://evil.example/?u=blob.vercel-storage.com')).toBe(false);
+    expect(isVercelBlobUrl('https://blob.vercel-storage.com.evil.example/x.png')).toBe(false);
+  });
+});
+
+describe('isStorageUrl (#830)', () => {
+  beforeEach(() => {
+    mockGetR2PublicUrl.mockReturnValue('https://images.example.test');
+  });
+
+  it('外部CDN（Twitchエモート）はストレージURLではない', () => {
+    expect(isStorageUrl('https://static-cdn.jtvnw.net/emoticons/v2/1/static/light/3.0')).toBe(false);
+  });
+});
+
+describe('isOwnedStorageUrl (#830)', () => {
+  beforeEach(() => {
+    mockGetR2PublicUrl.mockReturnValue('https://images.example.test');
+  });
+
+  it('自分のプレフィックスで始まるキーは true', async () => {
+    const prefix = await sha256Prefix(OWNER);
+    expect(await isOwnedStorageUrl(`https://images.example.test/${prefix}_deadbeef.png`, OWNER)).toBe(true);
+  });
+
+  it('他人のプレフィックスのキーは false', async () => {
+    const victimPrefix = await sha256Prefix(OWNER);
+    expect(
+      await isOwnedStorageUrl(`https://images.example.test/${victimPrefix}_deadbeef.png`, ATTACKER)
+    ).toBe(false);
+  });
+
+  it('自分のプレフィックスを含むだけのネストキーは false（検証対象と削除対象のズレを防ぐ）', async () => {
+    const attackerPrefix = await sha256Prefix(ATTACKER);
+    const url = `https://images.example.test/victim-dir/${attackerPrefix}_deadbeef.png`;
+
+    // 削除に渡されるキーはネストされたパス全体であり、攻撃者の所有物ではない
+    expect(getR2KeyFromUrl(url)).toBe(`victim-dir/${attackerPrefix}_deadbeef.png`);
+    expect(await isOwnedStorageUrl(url, ATTACKER)).toBe(false);
+  });
+
+  it('プレフィックスが前方一致するだけでセパレータが無いキーは false', async () => {
+    const prefix = await sha256Prefix(OWNER);
+    expect(await isOwnedStorageUrl(`https://images.example.test/${prefix}deadbeef.png`, OWNER)).toBe(false);
+  });
+
+  it('キーを持たないURLは false', async () => {
+    expect(await isOwnedStorageUrl('https://images.example.test/', OWNER)).toBe(false);
+    expect(await isOwnedStorageUrl('not a url', OWNER)).toBe(false);
+  });
+});
+
+describe('isAssignableImageUrl (#830)', () => {
+  beforeEach(() => {
+    mockGetR2PublicUrl.mockReturnValue('https://images.example.test');
+  });
+
+  it('ストレージ外のURL（外部CDN）は許可する', async () => {
+    expect(
+      await isAssignableImageUrl('https://static-cdn.jtvnw.net/emoticons/v2/1/static/light/3.0', ATTACKER)
+    ).toBe(true);
+  });
+
+  it('未指定・空文字は許可する（画像なし）', async () => {
+    expect(await isAssignableImageUrl(undefined, ATTACKER)).toBe(true);
+    expect(await isAssignableImageUrl(null, ATTACKER)).toBe(true);
+    expect(await isAssignableImageUrl('  ', ATTACKER)).toBe(true);
+  });
+
+  it('自分のストレージURLは許可する', async () => {
+    const prefix = await sha256Prefix(OWNER);
+    expect(await isAssignableImageUrl(`https://images.example.test/${prefix}_deadbeef.png`, OWNER)).toBe(true);
+  });
+
+  it('他人のストレージURLは拒否する', async () => {
+    const victimPrefix = await sha256Prefix(OWNER);
+    expect(
+      await isAssignableImageUrl(`https://images.example.test/${victimPrefix}_deadbeef.png`, ATTACKER)
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #830

## 概要

`POST /api/upload/delete` は削除対象URLがリクエスト者の所有物かを**一切検証していなかった**ため、配信者セッションを持つ任意のユーザーが**他配信者のカード画像をR2から削除**できました（IDOR）。R2からの削除は復旧不能です。

`PUT /api/cards/[id]` の旧画像クリーンアップも同根で、他人のR2 URLを自分のカードの `image_url` に設定してから別URLへ差し替えるだけで、同じ削除が起きました。

## 根本原因

3つの欠陥が重なっていました。

1. **所有権検証の不在** — `/api/upload/delete` は CSRF・セッション・配信者権限・レート制限の4段の防御を持ちながら、「そのファイルが誰のものか」だけを見ていませんでした。同種の `/api/upload/sound` の DELETE は正しく検証しており、画像側だけの実装漏れです。
2. **`isR2Url` の部分一致** — `url.includes('.r2.dev')` で判定していたため `https://attacker.r2.dev/<被害者のキー>` が通過しました。`deleteFromR2` は URL のホストに関係なく**常に自バケットの `R2_IMAGES` バインディング**へ削除を発行するため、これは「自バケット内の任意キーを指定できる」ことを意味していました。`url.startsWith(R2_PUBLIC_URL)` も `https://<R2ホスト>.evil.example/...` を通す穴でした。
3. **入口の未検証** — `validateImageUrl` は https と拡張子しか見ないため、他人のストレージURLをカードに紐付けられました。

## 変更内容

### 削除時の所有権検証（本丸）

`isOwnedStorageUrl(url, twitchUserId)` を新設し、キー先頭が `sha256Prefix(twitchUserId)_` で始まることを検証します。アップロード経路が生成するキーは常に `{prefix}_{suffix}.{ext}` で、`blob_files.user_prefix` にも同じ値が記録されるため、キー先頭が所有者を一意に表します（効果音削除と同じ方式）。

判定対象は **URLのファイル名ではなく、`deleteFromR2` に渡すキーそのもの**です。ファイル名（最後のパスセグメント）だけを見ると `victim-dir/{自分のprefix}_x.png` のようなネストキーで「検証した対象」と「削除される対象」がずれるため、キーは一度だけ取り出して検証と削除の両方に使い、`/` を含むキーは拒否します。

### `isR2Url` / `isVercelBlobUrl` の判定強化

`isR2Url` は `R2_PUBLIC_URL` の origin 完全一致のみに変更し、未設定/不正時は fail-closed。`isVercelBlobUrl` も同種の `includes()` 判定をホスト名一致に修正しました。

### 削除経路の一本化

3箇所にコピーされていた「DB記録の削除 → R2削除」を `src/lib/storage-cleanup.ts` に統合し、**所有権検証を通らない限り削除処理へ進めない構造**にしました。新しい削除経路が増えても検証を書き忘れられません。差分としてはコード削減です。

### 入口での紐付け拒否（多層防御）

`isAssignableImageUrl` で他人のストレージURLをカードに紐付けることを POST `/api/cards`・PUT `/api/cards/[id]`・POST `/api/cards/batch` の3経路で拒否します。既存データを壊さないよう、更新時は**画像URLが実際に変わる場合のみ**判定するため、画像以外のフィールド編集は従来どおり動きます。

### 削除順序の是正

旧画像のクリーンアップを `updateCardPg` の**成功後**に移動しました。従来は先に削除していたため、`card_number` 重複（409）でUPDATEが失敗するとカードが旧URLを参照したまま実体だけが消えていました。0行更新（並行削除など）でも同様にスキップします。

### 整理

`extractUserPrefixFromUrl`（ファイル名ベースの欠陥ある実装）、`getStorageType`、`getVercelBlobPathFromUrl` の参照ゼロのデッドエクスポートを削除しました。

## 本番/preview データの実測（リグレッション検証）

`isR2Url` を origin 完全一致にすると、既存の保存済みURLが「ストレージ外」と判定されて削除・使用量減算ができなくなる懸念があるため、両環境のDBを実測しました。

| 環境 | ストレージホスト | 件数 | `{8hex}_` 形式 | ネストキー |
|---|---|---|---|---|
| prod `cards.image_url` | `https://image.twica.bluemoon.works` の1種のみ | 10,067 | **10,067 (100%)** | 0 |
| preview `cards.image_url` | `https://pub-c02c...r2.dev` の1種のみ | 3 | **3 (100%)** | 0 |

`.r2.dev` / `r2.cloudflarestorage.com` / Vercel Blob のURLは prod に **0件**、プレフィックス命名以前のレガシーキーも **0件**でした。ストレージURLは `${R2_PUBLIC_URL}/${key}` で組み立てられるため、origin 完全一致で全件が従来どおり削除・使用量減算できます。**リグレッションなし**と判断しました。

`blob_files.user_prefix` によるDB逆引きフォールバックは、レガシーキーが実在しないためYAGNIとして実装していません。将来ドメインを付け替える場合は `cards.image_url` / `blob_files.url` のデータ移行が必須である旨を `isR2Url` のコメントに記載しています。

## テスト

追加 **39件**（合計 3,375 passed / 250ファイル全green）。

- `tests/unit/storage-utils.test.ts`（新規18件）— origin一致判定、他バケット `.r2.dev` の拒否、ホスト前方一致偽装の拒否、ネストキーの拒否、所有権判定
- `tests/unit/api/upload-delete-ownership.test.ts`（新規9件）— 他人のオブジェクトで403かつ `removeBlobFile` / `deleteFromR2` が呼ばれない、R2削除失敗時に500へ落ちる（握りつぶし回帰の固定）、Vercel Blob はDB記録のみ削除、キーなしURLの fail-closed
- `cards-id-route-driver-parity.test.ts` / `cards-collection-membership.test.ts` / `cards-batch-route-driver-parity.test.ts` — 紐付け拒否、クリーンアップのスキップ、409/0行時に旧画像を削除しないこと

削除順序の退行テストは、実際に順序を戻して**追加した2件だけが落ちる**ことを確認済みです。

### 検証結果

- `npm run typecheck` = 0 errors
- `npm run lint` = 0 errors（warning 15件はすべて本PR対象外の既存ファイル）
- `npm run test:unit` = 3,375 passed / 34 skipped、250ファイル全green
- `npm run test:integration` = 13 passed
- `npm run workers:build` 成功、`check:supabase-shutdown` / `check:maintenance-surfaces` OK

## レビュー

CLAUDE.md の規約に従い、subagent による厳格なセルフレビューを**4ラウンド**実施し、指摘が完全にクリアされるまで修正とレビューを繰り返しました。最終ラウンドで critical/high/medium/low の指摘ゼロを確認しています。レビュー側でも削除順序の退行実験・パーセントエンコード/バックスラッシュ/ホスト偽装によるバイパス検証・`deleteFromR2` と `image_url` 書き込み経路の全数調査が独立に行われ、迂回経路がないことを確認済みです。

## 備考

`/api/upload/delete` はリポジトリ内にフロントエンドからの呼び出しが存在しません（エンドポイント自体の削除は本PRの範囲を超える製品判断のため #837 のデッドコード整理に委ねます）。ただし公開されている以上は塞ぐ必要があるため、本PRで所有権検証を入れています。

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ghvx5gDDm9t2HisZCHYvT)_