### PR TITLE
fix(security): /api/upload に配信者権限チェックを追加し、アップロードキーの推測可能性を解消 (#832)

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getSession } from '@/lib/session';
+import { getSession, canUseStreamerFeatures } from '@/lib/session';
 import { handleApiError, handleBlobError } from '@/lib/error-handler';
 import { validateUpload, getUploadErrorMessage } from '@/lib/upload-validation';
 import { checkRateLimit, rateLimits, getRateLimitIdentifier } from '@/lib/rate-limit';
@@ -11,7 +11,7 @@ import { uploadToR2WithRetry } from '@/lib/r2-client';
 import { retryCloudflareR2Upload } from '@/lib/r2-retry-policy';
 import { recordBlobFile } from '@/lib/storage-db';
 import { getStorageUsage } from '@/lib/storage-usage';
-import { sha256Prefix } from '@/lib/crypto-utils';
+import { sha256Prefix, randomUUID } from '@/lib/crypto-utils';
 import { getUserPlan, PLAN_MAX_UPLOAD_SIZE } from '@/lib/plan';
 import type { Session } from '@/lib/session';
 
@@ -48,6 +48,14 @@ async function validateRequest(request: NextRequest): Promise<ValidateRequestRes
   if (!session) {
     return {
       error: NextResponse.json({ error: ERROR_MESSAGES.NOT_AUTHENTICATED }, { status: 401 }),
+    };
+  }
+
+  // カード画像アップロードは配信者機能なので、配信者権限を必須にする (#832)
+  // これが無いと任意のTwitchアカウントで公開R2への恒久URLを取得できてしまう
+  if (!canUseStreamerFeatures(session)) {
+    return {
+      error: NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 }),
     };
   }
 
@@ -162,10 +170,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     // User prefix for tracking uploads per user (must match storage-db.ts)
-    // ユーザー別アップロード追跡用プレフィックス（storage-db.tsと一致させる）
+    // ユーザー別アップロード追跡用プレフィックス（storage-db.tsと一致させる、公開値でよい）
     // Web Crypto APIを使用（Cloudflare Workers互換）
     const userPrefixForFile = await sha256Prefix(session!.twitchUserId);
-    const uniqueSuffix = await sha256Prefix(`${session!.twitchUserId}-${Date.now()}`);
+    // suffixはtwitchUserId+Date.now()由来のsha256Prefix(8hex)だと、公開情報である
+    // twitchUserIdとミリ秒単位のDate.now()から総当りで再現できた (#832)。
+    // crypto.randomUUID()（128bit・推測不能）に変更する。
+    const uniqueSuffix = randomUUID();
 
     // Format: {userPrefix}_{uniqueSuffix}.{ext}
     fileName = `${userPrefixForFile}_${uniqueSuffix}.${ext}`;

--- a/src/app/api/upload/sound/route.ts
+++ b/src/app/api/upload/sound/route.ts
@@ -7,7 +7,7 @@ import { getSoundFileTypeFromBuffer, getFileExtension, isValidSoundExtension } f
 import { logger } from '@/lib/logger.server';
 import { validateCSRFToken } from '@/lib/csrf';
 import { uploadSoundToR2WithRetry, deleteSoundFromR2 } from '@/lib/r2-client';
-import { sha256Prefix } from '@/lib/crypto-utils';
+import { sha256Prefix, randomUUID } from '@/lib/crypto-utils';
 import type { Session } from '@/lib/session';
 
 interface ValidateRequestResult {
@@ -148,7 +148,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // "sound_"プレフィックスで画像ファイルと区別
     // Web Crypto APIを使用（Cloudflare Workers互換）
     const userPrefix = await sha256Prefix(session!.twitchUserId);
-    const uniqueSuffix = await sha256Prefix(`${session!.twitchUserId}-sound-${Date.now()}`);
+    // suffixはtwitchUserId+Date.now()由来のsha256Prefix(8hex)だと総当りで再現できた
+    // (#832、画像アップロードと同型)。crypto.randomUUID()（推測不能）に変更する。
+    const uniqueSuffix = randomUUID();
 
     fileName = `sound_${userPrefix}_${uniqueSuffix}.${ext}`;
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -380,9 +380,12 @@ export const UPLOAD_CONFIG = {
   // Storage limits
   // ストレージ制限
   USER_STORAGE_LIMIT: 10 * 1024 * 1024, // 10MB per user (increased from 5MB)
-  // Global storage limit disabled - set to very large value
-  // グローバルストレージ制限を撤廃 - 非常に大きな値を設定
-  GLOBAL_STORAGE_LIMIT: Number.MAX_SAFE_INTEGER, // No global limit
+  // グローバル上限が実質無制限(Number.MAX_SAFE_INTEGER)だったため、認証さえ
+  // 通れば無制限に書き込める状態だった (#832)。ユーザー上限(10MB)+全プラン最大の
+  // ストレージボーナス(500MB, plan-constants.ts)を踏まえても、現在の運用規模で
+  // 現実的にありえない50GBを運用上の上限として設定する。unreachableではなく実際に
+  // 効くガードなので、規模が拡大したら見直すこと。
+  GLOBAL_STORAGE_LIMIT: 50 * 1024 * 1024 * 1024, // 50GB operational cap
 } as const
 
 /**

--- a/tests/unit/upload.test.ts
+++ b/tests/unit/upload.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { cookies } from 'next/headers'
 import { POST } from '@/app/api/upload/route'
-import { getSession } from '@/lib/session'
+import { getSession, canUseStreamerFeatures } from '@/lib/session'
 import { checkRateLimit } from '@/lib/rate-limit'
 import { getFileTypeFromBuffer } from '@/lib/file-utils'
 import { validateCSRFToken } from '@/lib/csrf'
@@ -37,6 +37,7 @@ vi.mock('@/lib/storage-usage', () => ({
 
 const mockCookies = vi.mocked(cookies)
 const mockGetSession = vi.mocked(getSession)
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)
 const mockCheckRateLimit = vi.mocked(checkRateLimit)
 const mockUploadToR2WithRetry = vi.mocked(uploadToR2WithRetry)
 const mockValidateCSRFToken = vi.mocked(validateCSRFToken)
@@ -46,6 +47,9 @@ describe('POST /api/upload', () => {
     vi.clearAllMocks()
     // Mock CSRF validation to pass by default
     mockValidateCSRFToken.mockResolvedValue({ valid: true })
+    // 既存テストは配信者セッションを前提としているため、デフォルトはtrueにする
+    // （配信者権限なしのケースは専用テストで個別にfalseへ上書きする）
+    mockCanUseStreamerFeatures.mockReturnValue(true)
     // Mock cookies to return empty store
     mockCookies.mockResolvedValue({
       get: vi.fn().mockReturnValue(undefined),
@@ -99,6 +103,39 @@ describe('POST /api/upload', () => {
       expect(response.status).toBe(401)
       const body = await response.json()
       expect(body.error).toBe('Not authenticated')
+    })
+  })
+
+  describe('配信者権限のないセッション', () => {
+    it('403 エラーを返す(#832: 誰でも公開R2へアップロードできる問題の修正)', async () => {
+      mockGetSession.mockResolvedValue({
+        twitchUserId: 'test-user-id',
+        twitchUsername: 'test-user',
+        twitchDisplayName: 'Test User',
+        twitchProfileImageUrl: 'https://example.com/avatar.jpg',
+        broadcasterType: '',
+        expiresAt: Date.now() + 3600000,
+        version: 1,
+      })
+      mockCanUseStreamerFeatures.mockReturnValue(false)
+
+      const imageFile = new File([createMinimalJpegBuffer()], 'test.jpg', {
+        type: 'image/jpeg',
+      })
+      const formData = new FormData()
+      formData.append('file', imageFile)
+
+      const request = new NextRequest('http://localhost:3000/api/upload', {
+        method: 'POST',
+        body: formData,
+      })
+
+      const response = await POST(request)
+
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body.error).toBe('Forbidden')
+      expect(mockUploadToR2WithRetry).not.toHaveBeenCalled()
     })
   })
 
@@ -289,9 +326,12 @@ describe('POST /api/upload', () => {
       expect(body.url).toBe('https://blob.vercel-storage.com/test-image.jpg')
       expect(mockUploadToR2WithRetry).toHaveBeenCalled()
       // First argument should be the filename pattern
-      // Filename format: {userPrefix(8chars)}_{uniqueSuffix(8chars)}.{ext}
+      // Filename format: {userPrefix(8chars)}_{uniqueSuffix(UUID)}.{ext}
+      // uniqueSuffixはcrypto.randomUUID()で生成する推測不能な値 (#832)
       // 第1引数はファイル名パターン
-      expect(mockUploadToR2WithRetry.mock.calls[0][0]).toMatch(/^[a-f0-9]{8}_[a-f0-9]{8}\.jpg$/)
+      expect(mockUploadToR2WithRetry.mock.calls[0][0]).toMatch(
+        /^[a-f0-9]{8}_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jpg$/
+      )
       // Second argument should be Buffer or Uint8Array-like (file contents)
       // 第2引数はファイル内容のBuffer
       const fileArg = mockUploadToR2WithRetry.mock.calls[0][1]


### PR DESCRIPTION
## 概要

#832 の修正。2つの問題を修正する。

### 1. 配信者権限チェックの欠落

`POST /api/upload` は `getSession()` のみで `canUseStreamerFeatures(session)` を呼んでいなかった。任意のTwitchアカウントでログインすれば、配信者機能であるカード画像アップロードを実行し、公開R2の恒久URLを取得できた。`/api/upload/sound` は既にこのチェックを持っており、非対称だった。

→ `validateRequest` に `canUseStreamerFeatures` チェックを追加（sound routeと同じパターン）。

### 2. アップロードキーの推測可能性

ファイル名suffixが `sha256Prefix(twitchUserId + Date.now())` だったため、公開値の `twitchUserId` とミリ秒精度の `Date.now()` から1日分のアップロードを総当りで再現できた（画像・効果音の両方が同型）。

→ suffixを `crypto.randomUUID()`（128bit・推測不能）に変更。ユーザープレフィックス（`sha256Prefix(twitchUserId)`）は元々公開値の8hexで秘匿性は不要なため変更していない。所有権検証（`isOwnedStorageUrl`、`key.startsWith(userPrefix + '_')`）はsuffixの形式に依存しないため影響なし。

### 3. グローバルストレージ上限

`GLOBAL_STORAGE_LIMIT` が `Number.MAX_SAFE_INTEGER`（実質無制限）だったため、認証さえ通れば無制限に書き込める状態だった。ユーザー上限(10MB)+全プラン最大ボーナス(500MB)を踏まえ、現在の運用規模でありえない50GBを運用上限として設定。

**未検証事項**: 本番の実際のR2/blob_files使用量は、利用可能なMCP経由のPlanetScale読み取りがRLSでブロックされ確認できなかった（`blob_files`/`storage_usage` とも0行返却だが、RLSブロックによる偽陰性の可能性があり実際に空とは断定できない）。50GBという値は既存の上限定数から妥当と判断したが、実測での裏付けは取れていない。もし実際の使用量が既にこれに近い場合、新規アップロードが507で弾かれるだけで、データ破壊や既存機能の停止は起きない（定数を上げて再デプロイすれば即復旧できる）。念のため、マージ後に実際の使用量を確認することを推奨する。

## 対象外(フォローアップ)

- 既存アップロード済みキーのリネーム移行(旧predictable形式のまま) — 本番データ移行のリスクが大きいため別issueで対応。issue側も段階移行(新規のみ新方式)を提案済み。
- 未参照 `blob_files` 行のGC — issue側も「検討する」（必須ではない）扱い。
- 効果音アップロードは元々ストレージ使用量トラッキング(`recordBlobFile`)の対象外で、`GLOBAL_STORAGE_LIMIT` チェックの対象にもなっていない（画像アップロードのみ計測される、pre-existing）。#832 は画像アップロードの無認証書き込みが主題であり、効果音は既に `canUseStreamerFeatures` 必須だったため深刻度は低いが、別issueで計測範囲拡大を検討する。

## テスト

- `tests/unit/upload.test.ts` に配信者権限なしセッションで403を返すテストを追加、ファイル名フォーマットのアサーションをUUID形式に更新
- `npm run test:unit` 全体実行: 3391 passed / 34 skipped / 0 failed
- `tsc --noEmit` / `eslint` 変更ファイルともクリーン
- 独立レビューsubagentによる厳格レビュー実施済み(所有権検証ロジック・CSRF/レート制限との順序・他の未保護R2経路の横断確認・テストカバレッジ)。指摘のうち本PRの範囲内のものは反映済み、範囲外の指摘は上記フォローアップとして記載

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DiUHeoAwCWKdsCsYWezTS