### PR TITLE
fix(security): /api/streamer/additional-rewards の DELETE に CSRF 検証を追加 (#736)

### DIFF
--- a/src/app/api/streamer/additional-rewards/route.ts
+++ b/src/app/api/streamer/additional-rewards/route.ts
@@ -681,6 +681,16 @@ async function deleteAdditionalRewardByIdPg(streamerId: string, rewardId: string
  * - ?deleteAll=true: Delete all additional rewards for the streamer
  */
 export async function DELETE(request: NextRequest) {
+  // 状態変更 API のため CSRF 検証を最初に行う (#736)。POST には既に存在するが
+  // DELETE ハンドラだけ検証漏れがあった。
+  const csrfValidation = await validateCSRFToken(request);
+  if (!csrfValidation.valid) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.FORBIDDEN },
+      { status: 403 }
+    );
+  }
+
   const session = await getSession();
 
   const identifier = await getRateLimitIdentifier(request, session?.twitchUserId);

--- a/tests/unit/additional-rewards-driver-parity.test.ts
+++ b/tests/unit/additional-rewards-driver-parity.test.ts
@@ -12,6 +12,7 @@ import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
 import { getDb } from "@/lib/db/client";
 import { streamerAdditionalGachaRewards as streamerAdditionalGachaRewardsTable } from "@/lib/db/schema";
+import { ERROR_MESSAGES } from "@/lib/constants";
 
 vi.mock("@/lib/session");
 vi.mock("@/lib/rate-limit");
@@ -615,6 +616,23 @@ describe("streamer/additional-rewards: PlanetScale契約 (#663)", () => {
         new NextRequest("http://localhost/api/streamer/additional-rewards?deleteAll=true", { method: "DELETE" })
       );
       expect(response.status).toBe(404);
+    });
+
+    it("CSRF検証が無効な場合は403を返し、レートリミット/セッション取得/DB削除にも到達しない (#736)", async () => {
+      mockValidateCSRFToken.mockResolvedValue({ valid: false, error: "bad csrf" } as any);
+      const pg = createDrizzleDbMock({ selects: [{ rows: [{ id: "streamer-1" }] }] });
+      primePgDb(pg);
+
+      const { DELETE } = await loadRoute();
+      const response = await DELETE(
+        new NextRequest("http://localhost/api/streamer/additional-rewards?deleteAll=true", { method: "DELETE" })
+      );
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({ error: ERROR_MESSAGES.FORBIDDEN });
+      expect(mockCheckRateLimit).not.toHaveBeenCalled();
+      expect(mockGetSession).not.toHaveBeenCalled();
+      expect(pg.deleteCalls).toHaveLength(0);
     });
 
   });


### PR DESCRIPTION
## 概要

#736 の修正。`DELETE /api/streamer/additional-rewards` に CSRF 検証が無く、POST には既に存在していたため非対称だった。悪意あるサイトが、ログイン中の配信者のセッションCookieを利用して追加ガチャ報酬設定を無断削除できる状態だった（クロスサイトのフォームPOST/fetchで、ブラウザが自動的にセッションCookieを送信するため到達可能）。

## 修正内容

DELETEハンドラの先頭に`validateCSRFToken(request)`を追加。POST（同ファイル）、`eventsub/subscribe`・`eventsub/debug`のDELETEと同じ順序（CSRF → session取得 → レートリミット）。

## テスト

- `tests/unit/additional-rewards-driver-parity.test.ts` にCSRF検証失敗時403・`getSession`/`checkRateLimit`/DB削除いずれにも到達しないことを確認する回帰テストを追加
- 既存のDELETEテスト3件（`deleteAll`/`rewardId`単体/404）は`beforeEach`でCSRF検証が`valid:true`にモックされているため、有効なCSRFトークンでの正常系も引き続き検証される
- `npm run test:unit` 全体実行: 3391 passed / 34 skipped / 0 failed
- `tsc --noEmit` / `eslint` 変更ファイルともクリーン
- 独立レビューsubagentによる検証済み: CSRF検証が実際に他の全チェックより先に実行され、失敗時はsession取得・DB呼び出しに一切到達しないことをコードリーディングとテスト差分（フィックス適用前にrevertして`1 failed`→適用後`16 passed`)で確認

## 横断確認について

issueのチェックリストにある「他ルートのDELETE/PUTハンドラにも同種の漏れがないか横断確認」を独立レビューで実施。`src/app/api/streamer/`配下は本PRで解消済み。他に見つかった残存ギャップ:

- `tos/accept` POST のCSRF欠落 → 既に issue #836 で追跡済み
- `gacha/demo` POST の `broadcast=true` 分岐のCSRF欠落 → 影響は軽微(cosmetic)、未追跡。必要なら別issueで対応

なお `eventsub/debug` DELETE のCSRF欠落は、レビュー実行時点でこのブランチ(main起点)にまだ反映されていなかったため未修正として検出されたが、これは別PR(#846, #831対応)で既に修正済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DiUHeoAwCWKdsCsYWezTS