### PR TITLE
fix(security): gacha/demo が無認証で任意cardIdのカード情報を返す問題を修正 (#735)

### DIFF
--- a/src/app/api/gacha/demo/route.ts
+++ b/src/app/api/gacha/demo/route.ts
@@ -13,14 +13,27 @@ import { cards as cardsTable } from "@/lib/db/schema";
 import { CARDS_SAFE_COLUMNS, isMissingCardsBattleColumnError } from "@/lib/db/cards-safe-columns";
 import { publishOverlayDemoEvent } from "@/lib/overlay/demo-event-store";
 
-/** Fetch one card from the authoritative PlanetScale database. */
-async function fetchCardByIdPg(cardId: string): Promise<Card | null> {
+/**
+ * Fetch one card from the authoritative PlanetScale database.
+ *
+ * #735: 元実装は is_active / streamer_id を一切見ずに任意の cardId を返していた
+ * ため、id さえ分かれば非公開(inactive)カードの name/description/image_url を
+ * 誰でも取得できた。デモ用途に必要な範囲(有効カードのみ、可能なら指定
+ * streamerId 配下のみ)に絞る。絞り込みでヒットしない場合は null を返し、
+ * 呼び出し側が streamerId のランダムカード → 組み込みデモカードへ
+ * フォールバックする既存の縮退chainに委ねる。
+ */
+async function fetchCardByIdPg(cardId: string, streamerId: string | null): Promise<Card | null> {
+  const condition = streamerId
+    ? and(eq(cardsTable.id, cardId), eq(cardsTable.streamer_id, streamerId), eq(cardsTable.is_active, true))
+    : and(eq(cardsTable.id, cardId), eq(cardsTable.is_active, true));
+
   async function selectRow(useSafeColumns: boolean) {
     return withDbRetry(
       async () => {
         const { db } = await getDb();
         const query = useSafeColumns ? db.select(CARDS_SAFE_COLUMNS) : db.select();
-        return query.from(cardsTable).where(eq(cardsTable.id, cardId)).limit(1);
+        return query.from(cardsTable).where(condition).limit(1);
       },
       "gacha/demo(fetch card by id)",
       { idempotent: true },
@@ -169,6 +182,29 @@ export async function POST(request: NextRequest) {
       // Treat invalid/empty JSON as a parameterless public demo request.
     }
 
+    // #735: このエンドポイントは意図的に無認証(OBSオーバーレイのデモ表示・
+    // プレビューUIから直接呼ばれる)だが、レートリミットが無いと任意cardIdの
+    // enumerationに使えてしまう。broadcast分岐は専用の制限(gachaDemoBroadcast)
+    // を別途持つため、ここでは全リクエストに共通の低めの制限をIPベースで課す。
+    const generalIdentifier = await getRateLimitIdentifier(request);
+    const generalRateLimitResult = await checkRateLimit(rateLimits.gachaDemoCard, generalIdentifier);
+    if (!generalRateLimitResult.success) {
+      return NextResponse.json<ApiRateLimitResponse>(
+        {
+          error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+          retryAfter: (generalRateLimitResult.reset || 0) - Math.floor(Date.now() / 1000),
+        },
+        {
+          status: 429,
+          headers: {
+            'X-RateLimit-Limit': String(generalRateLimitResult.limit),
+            'X-RateLimit-Remaining': String(generalRateLimitResult.remaining),
+            'X-RateLimit-Reset': String(generalRateLimitResult.reset),
+          },
+        }
+      );
+    }
+
     if (broadcast && streamerId) {
       const session = await getSession();
       if (!session) {
@@ -214,7 +250,7 @@ export async function POST(request: NextRequest) {
     };
 
     if (cardId && cardId !== "random") {
-      const card = await fetchCardByIdPg(cardId);
+      const card = await fetchCardByIdPg(cardId, streamerId);
       if (card) return respondWithCard(card, streamerId);
     }
 

--- a/src/app/api/gacha/demo/route.ts
+++ b/src/app/api/gacha/demo/route.ts
@@ -18,15 +18,21 @@ import { publishOverlayDemoEvent } from "@/lib/overlay/demo-event-store";
  *
  * #735: 元実装は is_active / streamer_id を一切見ずに任意の cardId を返していた
  * ため、id さえ分かれば非公開(inactive)カードの name/description/image_url を
- * 誰でも取得できた。デモ用途に必要な範囲(有効カードのみ、可能なら指定
- * streamerId 配下のみ)に絞る。絞り込みでヒットしない場合は null を返し、
- * 呼び出し側が streamerId のランダムカード → 組み込みデモカードへ
- * フォールバックする既存の縮退chainに委ねる。
+ * 誰でも取得できた。streamerId を必須にし、指定 streamerId 配下の有効カードに
+ * 絞る(streamerId を任意にすると、他streamerのidさえ知っていればactiveな
+ * カードの内容とその所有streamer_idを無認証で引ける横断オラクルになるため)。
+ * 実際の呼び出し元(OverlayPreview.tsx / overlay/[streamerId]/page.tsx)は常に
+ * cardIdとstreamerIdを同時に渡すため、正規の利用を壊さない。
+ * 絞り込みでヒットしない場合は null を返し、呼び出し側が streamerId の
+ * ランダムカード → 組み込みデモカードへフォールバックする既存の縮退chainに
+ * 委ねる。
  */
-async function fetchCardByIdPg(cardId: string, streamerId: string | null): Promise<Card | null> {
-  const condition = streamerId
-    ? and(eq(cardsTable.id, cardId), eq(cardsTable.streamer_id, streamerId), eq(cardsTable.is_active, true))
-    : and(eq(cardsTable.id, cardId), eq(cardsTable.is_active, true));
+async function fetchCardByIdPg(cardId: string, streamerId: string): Promise<Card | null> {
+  const condition = and(
+    eq(cardsTable.id, cardId),
+    eq(cardsTable.streamer_id, streamerId),
+    eq(cardsTable.is_active, true)
+  );
 
   async function selectRow(useSafeColumns: boolean) {
     return withDbRetry(
@@ -184,25 +190,31 @@ export async function POST(request: NextRequest) {
 
     // #735: このエンドポイントは意図的に無認証(OBSオーバーレイのデモ表示・
     // プレビューUIから直接呼ばれる)だが、レートリミットが無いと任意cardIdの
-    // enumerationに使えてしまう。broadcast分岐は専用の制限(gachaDemoBroadcast)
-    // を別途持つため、ここでは全リクエストに共通の低めの制限をIPベースで課す。
-    const generalIdentifier = await getRateLimitIdentifier(request);
-    const generalRateLimitResult = await checkRateLimit(rateLimits.gachaDemoCard, generalIdentifier);
-    if (!generalRateLimitResult.success) {
-      return NextResponse.json<ApiRateLimitResponse>(
-        {
-          error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-          retryAfter: (generalRateLimitResult.reset || 0) - Math.floor(Date.now() / 1000),
-        },
-        {
-          status: 429,
-          headers: {
-            'X-RateLimit-Limit': String(generalRateLimitResult.limit),
-            'X-RateLimit-Remaining': String(generalRateLimitResult.remaining),
-            'X-RateLimit-Reset': String(generalRateLimitResult.reset),
+    // enumerationに使えてしまう。broadcast&&streamerId分岐は認証済みユーザーID
+    // 基準のより厳格な専用制限(gachaDemoBroadcast)を別途持つため、そちらを通る
+    // リクエストにはIPベースの制限を重ねない。同じ数値(30/分)の制限を先に
+    // 無関係な匿名IPベースの枠で課すと、同一IPを共有する別人の連打だけで
+    // 配信者自身のOBSデモボタンがブロックされ得るうえ、専用制限に一度も
+    // 到達しなくなってしまう。
+    if (!(broadcast && streamerId)) {
+      const generalIdentifier = await getRateLimitIdentifier(request);
+      const generalRateLimitResult = await checkRateLimit(rateLimits.gachaDemoCard, generalIdentifier);
+      if (!generalRateLimitResult.success) {
+        return NextResponse.json<ApiRateLimitResponse>(
+          {
+            error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+            retryAfter: (generalRateLimitResult.reset || 0) - Math.floor(Date.now() / 1000),
           },
-        }
-      );
+          {
+            status: 429,
+            headers: {
+              'X-RateLimit-Limit': String(generalRateLimitResult.limit),
+              'X-RateLimit-Remaining': String(generalRateLimitResult.remaining),
+              'X-RateLimit-Reset': String(generalRateLimitResult.reset),
+            },
+          }
+        );
+      }
     }
 
     if (broadcast && streamerId) {
@@ -249,7 +261,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ card, userTwitchUsername: "DemoUser" });
     };
 
-    if (cardId && cardId !== "random") {
+    // #735: streamerId が無いと、他streamerの任意のactiveカードを id だけで
+    // 無認証取得できる横断オラクルになるため streamerId を必須にする。
+    if (cardId && cardId !== "random" && streamerId) {
       const card = await fetchCardByIdPg(cardId, streamerId);
       if (card) return respondWithCard(card, streamerId);
     }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -301,6 +301,12 @@ export const rateLimits = {
   // 制限（1000回/分/IP）までデモイベント配信を叩けてしまう。
   // /api/gacha (rateLimits.gacha) と同じ水準の専用制限を課す。
   gachaDemoBroadcast: createRatelimit("gachaDemoBroadcast", 30, 60 * 1000),
+  // Issue #735: /api/gacha/demo は意図的に無認証(OBSオーバーレイのデモ表示から
+  // 直接呼ばれる)公開エンドポイントだが、従来レートリミットが一切無く、任意の
+  // cardIdに対するカード情報取得（enumeration）に使えた。IPベースで課す
+  // 全リクエスト共通の制限（gachaDemoBroadcastとは別枠。broadcast分岐は
+  // 認証済みユーザー操作でIDベース、こちらは匿名IPベースのため識別子が異なる）。
+  gachaDemoCard: createRatelimit("gachaDemoCard", 30, 60 * 1000),
   authLogin: createRatelimit("authLogin", 5, 60 * 1000),
   authCallback: createRatelimit("authCallback", 10, 60 * 1000),
   authLogout: createRatelimit("authLogout", 10, 60 * 1000),

--- a/tests/unit/api/gacha-demo-route.test.ts
+++ b/tests/unit/api/gacha-demo-route.test.ts
@@ -108,10 +108,11 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
       expect.anything(),
       'twitch-1'
     )
-    // #735: 全リクエスト共通のIPベース制限(gachaDemoCard)がbroadcast専用制限
-    // (gachaDemoBroadcast)より先に追加されたため、broadcastリクエストは2回
-    // checkRateLimitを通る。
-    expect(mockCheckRateLimit).toHaveBeenCalledTimes(2)
+    // #735: 全リクエスト共通のIPベース制限(gachaDemoCard)は、認証済みユーザーID
+    // 基準のより厳格な専用制限(gachaDemoBroadcast)がすでに適用される
+    // broadcast&&streamerIdリクエストには重ねない(重ねると無関係な匿名IPの
+    // 連打だけで専用制限に到達する前にブロックされてしまうため)。
+    expect(mockCheckRateLimit).toHaveBeenCalledTimes(1)
   })
 
   it('returns 429 before publishing when the dedicated limiter is exhausted', async () => {
@@ -161,6 +162,31 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
     expect(body.card).toBeDefined()
     expect(mockGetSession).not.toHaveBeenCalled()
     expect(mockPublishOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockCheckRateLimit).toHaveBeenCalledTimes(1)
+  })
+
+  it('#735: 匿名IPの一般制限が枯渇していても、認証済みユーザーのbroadcastは専用制限のみで判定され成功する', async () => {
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'twitch-1',
+      twitchUsername: 'user1',
+      broadcasterType: 'affiliate',
+    } as Awaited<ReturnType<typeof getSession>>)
+    mockGetStreamerIdByTwitchUserId.mockResolvedValue({ id: 'streamer-1' })
+    mockGetRateLimitIdentifier.mockImplementation(async (_req, twitchUserId) =>
+      twitchUserId ? `user:${twitchUserId}` : 'ip:203.0.113.1'
+    )
+    // 匿名IPベースの識別子に対しては枯渇済みを返す。gachaDemoCard(一般制限)が
+    // broadcast&&streamerId経路でも誤って呼ばれてしまえば、この枯渇で検出できる。
+    mockCheckRateLimit.mockImplementation(async (_limiter, identifier: string) => {
+      if (identifier.startsWith('ip:')) {
+        return { success: false, limit: 30, remaining: 0, reset: Date.now() + 60_000 }
+      }
+      return { success: true, limit: 30, remaining: 29, reset: Date.now() + 60_000 }
+    })
+
+    const response = await POST(makeRequest({ streamerId: 'streamer-1', broadcast: true }))
+
+    expect(response.status).toBe(200)
     expect(mockCheckRateLimit).toHaveBeenCalledTimes(1)
   })
 

--- a/tests/unit/api/gacha-demo-route.test.ts
+++ b/tests/unit/api/gacha-demo-route.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/lib/overlay/demo-event-store', () => ({
 vi.mock('@/lib/rate-limit', () => ({
   checkRateLimit: vi.fn(),
   getRateLimitIdentifier: vi.fn(),
-  rateLimits: { gachaDemoBroadcast: {} },
+  rateLimits: { gachaDemoBroadcast: {}, gachaDemoCard: {} },
 }))
 
 const mockGetSession = vi.mocked(getSession)
@@ -108,7 +108,10 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
       expect.anything(),
       'twitch-1'
     )
-    expect(mockCheckRateLimit).toHaveBeenCalledTimes(1)
+    // #735: 全リクエスト共通のIPベース制限(gachaDemoCard)がbroadcast専用制限
+    // (gachaDemoBroadcast)より先に追加されたため、broadcastリクエストは2回
+    // checkRateLimitを通る。
+    expect(mockCheckRateLimit).toHaveBeenCalledTimes(2)
   })
 
   it('returns 429 before publishing when the dedicated limiter is exhausted', async () => {
@@ -145,7 +148,9 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
     expect(body.card).toBeDefined()
     expect(mockGetSession).not.toHaveBeenCalled()
     expect(mockPublishOverlayDemoEvent).not.toHaveBeenCalled()
-    expect(mockCheckRateLimit).not.toHaveBeenCalled()
+    // #735: broadcast専用の制限は通らないが、全リクエスト共通のIPベース制限は通る
+    expect(mockCheckRateLimit).toHaveBeenCalledTimes(1)
+    expect(mockGetRateLimitIdentifier).toHaveBeenCalledWith(expect.anything())
   })
 
   it('does not publish or authenticate when broadcast=true lacks a streamerId', async () => {
@@ -156,6 +161,22 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
     expect(body.card).toBeDefined()
     expect(mockGetSession).not.toHaveBeenCalled()
     expect(mockPublishOverlayDemoEvent).not.toHaveBeenCalled()
-    expect(mockCheckRateLimit).not.toHaveBeenCalled()
+    expect(mockCheckRateLimit).toHaveBeenCalledTimes(1)
+  })
+
+  it('#735: 全リクエスト共通のレートリミットに達した場合はセッション不要で429を返す', async () => {
+    mockCheckRateLimit.mockResolvedValue({
+      success: false,
+      limit: 30,
+      remaining: 0,
+      reset: Date.now() + 60_000,
+    })
+
+    const response = await POST(makeRequest({ cardId: 'some-card' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(429)
+    expect(body.error).toBe(ERROR_MESSAGES.RATE_LIMIT_EXCEEDED)
+    expect(mockGetSession).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/gacha-demo-driver-parity.test.ts
+++ b/tests/unit/gacha-demo-driver-parity.test.ts
@@ -112,7 +112,8 @@ describe('POST /api/gacha/demo: PlanetScale-only reads', () => {
   it('fetches a requested card from PlanetScale', async () => {
     primePgDb([{ rows: [CARD_ROW] }])
 
-    const response = await POST(request({ cardId: 'card-1' }))
+    // #735: cardId指定の単一カード取得はstreamerId必須(下記の専用テスト参照)
+    const response = await POST(request({ cardId: 'card-1', streamerId: 'streamer-1' }))
     const body = await response.json()
 
     expect(response.status).toBe(200)
@@ -134,12 +135,13 @@ describe('POST /api/gacha/demo: PlanetScale-only reads', () => {
   it('falls back to a built-in demo card when PostgreSQL is unavailable', async () => {
     primePgDb([{ error: new Error('connection failure') }])
 
-    const response = await POST(request({ cardId: 'missing' }))
+    const response = await POST(request({ cardId: 'missing', streamerId: 'streamer-1' }))
     const body = await response.json()
 
     expect(response.status).toBe(200)
     expect(body.card).toBeDefined()
     expect(body.userTwitchUsername).toBe('DemoUser')
+    expect(getDb).toHaveBeenCalled()
   })
 
   it('#735: cardId指定時はis_active=trueかつ指定streamerId配下に絞り込む', async () => {
@@ -157,15 +159,17 @@ describe('POST /api/gacha/demo: PlanetScale-only reads', () => {
     )
   })
 
-  it('#735: streamerId未指定時はis_active=trueのみで絞り込み、streamer_idは条件に含めない', async () => {
+  it('#735: streamerId未指定時はcardIdによる単一カード取得を一切試みない(他streamerのactiveカードを無認証で引ける横断オラクル化を防ぐ)', async () => {
     const pg = primePgDb([{ rows: [CARD_ROW] }])
 
     const response = await POST(request({ cardId: 'card-1' }))
+    const body = await response.json()
 
     expect(response.status).toBe(200)
-    expect(pg.whereConditions[0]).toEqual(
-      and(eq(cardsTable.id, 'card-1'), eq(cardsTable.is_active, true))
-    )
+    // DBへの問い合わせが一切発生しない(streamerId無しではcardId検索もstreamer別
+    // ランダム取得も走らないため、組み込みDEMO_CARDSへ直接フォールバックする)
+    expect(pg.db.select).not.toHaveBeenCalled()
+    expect(body.card.id).not.toBe('card-1')
   })
 
   it('#735: 絞り込みでヒットしない場合(非公開カード等)はエラーにせず組み込みデモカードへフォールバックする', async () => {
@@ -185,7 +189,7 @@ describe('POST /api/gacha/demo: PlanetScale-only reads', () => {
       { rows: [SAFE_CARD_ROW] },
     ])
 
-    const response = await POST(request({ cardId: 'card-1' }))
+    const response = await POST(request({ cardId: 'card-1', streamerId: 'streamer-1' }))
     const body = await response.json()
 
     expect(response.status).toBe(200)

--- a/tests/unit/gacha-demo-driver-parity.test.ts
+++ b/tests/unit/gacha-demo-driver-parity.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
+import { and, eq } from 'drizzle-orm'
 import { POST } from '@/app/api/gacha/demo/route'
 import { getDb } from '@/lib/db/client'
+import { cards as cardsTable } from '@/lib/db/schema'
 
 vi.mock('@/lib/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -61,6 +63,7 @@ interface PgResponse {
 
 function createDrizzleDbMock(selects: PgResponse[]) {
   let selectIndex = 0
+  const whereConditions: unknown[] = []
   const db = {
     select: vi.fn(() => {
       const response = selects[Math.min(selectIndex, selects.length - 1)] ?? { rows: [] }
@@ -70,14 +73,17 @@ function createDrizzleDbMock(selects: PgResponse[]) {
         : Promise.resolve(response.rows ?? [])
       const builder: any = {
         from: vi.fn(() => builder),
-        where: vi.fn(() => builder),
+        where: vi.fn((condition: unknown) => {
+          whereConditions.push(condition)
+          return builder
+        }),
         limit: vi.fn(() => builder),
         then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
       }
       return builder
     }),
   }
-  return { db }
+  return { db, whereConditions }
 }
 
 function primePgDb(selects: PgResponse[]) {
@@ -134,6 +140,43 @@ describe('POST /api/gacha/demo: PlanetScale-only reads', () => {
     expect(response.status).toBe(200)
     expect(body.card).toBeDefined()
     expect(body.userTwitchUsername).toBe('DemoUser')
+  })
+
+  it('#735: cardId指定時はis_active=trueかつ指定streamerId配下に絞り込む', async () => {
+    const pg = primePgDb([{ rows: [CARD_ROW] }])
+
+    const response = await POST(request({ cardId: 'card-1', streamerId: 'streamer-1' }))
+
+    expect(response.status).toBe(200)
+    expect(pg.whereConditions[0]).toEqual(
+      and(
+        eq(cardsTable.id, 'card-1'),
+        eq(cardsTable.streamer_id, 'streamer-1'),
+        eq(cardsTable.is_active, true)
+      )
+    )
+  })
+
+  it('#735: streamerId未指定時はis_active=trueのみで絞り込み、streamer_idは条件に含めない', async () => {
+    const pg = primePgDb([{ rows: [CARD_ROW] }])
+
+    const response = await POST(request({ cardId: 'card-1' }))
+
+    expect(response.status).toBe(200)
+    expect(pg.whereConditions[0]).toEqual(
+      and(eq(cardsTable.id, 'card-1'), eq(cardsTable.is_active, true))
+    )
+  })
+
+  it('#735: 絞り込みでヒットしない場合(非公開カード等)はエラーにせず組み込みデモカードへフォールバックする', async () => {
+    primePgDb([{ rows: [] }])
+
+    const response = await POST(request({ cardId: 'inactive-or-foreign-card', streamerId: 'streamer-1' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.card).toBeDefined()
+    expect(body.card.id).not.toBe('inactive-or-foreign-card')
   })
 
   it('retries with CARDS_SAFE_COLUMNS when production-only battle columns are absent', async () => {


### PR DESCRIPTION
## 概要

#735 の修正。`POST /api/gacha/demo` は `is_active` フィルタ無しで任意の `cardId` のカード（name/description/image_url）を返し、レート制限も一切無かった。

このエンドポイントは OBS オーバーレイのデモ表示・プレビューUIから意図的に無認証で呼ばれる(`overlay/[streamerId]/page.tsx`の "Use demo endpoint which doesn't require authentication" 参照)ため、セッション必須化は行わない。

## 修正内容

1. **`is_active`/`streamer_id` によるスコープ**: `fetchCardByIdPg` は `streamerId` を必須パラメータにし、指定 streamerId 配下の有効カードのみに絞る。絞り込みでヒットしない場合はエラーにせず、既存の縮退chain（streamer別ランダムカード → 組み込みデモカード）にフォールバックする。

2. **レート制限の追加**: 全リクエスト共通のIPベース制限(`gachaDemoCard`, 30/分)を追加。既存の `gachaDemoBroadcast`（認証済みユーザーID基準、broadcast経路専用）とは別枠にし、かつ**互いに排他的**に適用する(`broadcast && streamerId` の時だけ専用制限、それ以外は一般制限)。

## レビューで見つかり追加修正した2点

最初の実装(コミット `336174f`)を独立レビューにかけたところ、実害のある問題が2つ見つかったため追加修正した(コミット `85d631d`)。

- **横断オラクル**: `streamerId` を省略可能にしていたため、`cardId` だけ知っていれば他streamerの有効カードの内容と所有streamer_idを無認証で引けてしまっていた。`streamerId` を必須にし、この経路自体を塞いだ(実際の呼び出し元は常に両方を渡すため実害無し)。
- **レート制限の競合**: 全リクエスト共通のIP制限を無条件に先頭で課していたため、無関係な匿名IPの連打だけで配信者自身のOBSデモボタンが専用制限に到達する前にブロックされ得た。IP制限は非broadcast経路にのみ適用するよう修正。

## 既知の残課題（本PRの対象外）

- broadcast経路で所有権不一致(403)の場合、レート制限チェックより先に403を返すため、その組み合わせ自体は無制限に叩ける(このpre-existingな順序自体は#783時点からの既存挙動で、本PRで新たに導入したものではない)
- レート制限の実体が `setRateLimitStorage` 未呼び出しのため per-isolate のインメモリのみ(KVバインディング`RATE_LIMIT_KV`はあるが未使用)、`getClientIp` が `CF-Connecting-IP` を見ていない、という2点は本PR対象エンドポイントに限らずアプリ全体の既存インフラ課題であり対象外とする

## テスト

- `tests/unit/gacha-demo-driver-parity.test.ts`: is_active/streamer_id絞り込みのSQL条件そのものの検証、streamerId省略時にDB問い合わせが一切発生しないこと、絞り込み不一致時のフォールバック
- `tests/unit/api/gacha-demo-route.test.ts`: 全リクエスト共通レート制限の429、匿名IP側の制限が枯渇していても認証済みbroadcastは専用制限のみで成功すること
- `npm run test:unit` 全体実行済み（バックグラウンドで最終確認中）
- `tsc --noEmit` / `eslint` 変更ファイルともクリーン
- 独立レビューsubagent + 自己検証（コード全文読み直し）で、2つの追加修正が実際に閉じていることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DiUHeoAwCWKdsCsYWezTS