### PR TITLE
fix(stats): ガチャ統計JSフォールバックがRPCとパリティを失う問題を修正 (#833)

### DIFF
--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -4,6 +4,7 @@ import { unstable_cache } from "next/cache";
 import { logger } from "@/lib/logger.server";
 import { normalizeDropRate } from "@/lib/card-utils";
 import { reportError } from "@/lib/sentry/error-handler";
+import { RARITY_ORDER } from "@/lib/constants";
 
 import { logPerf, perfStart } from "@/lib/perf";
 // ---------------------------------------------------------------------------
@@ -16,6 +17,7 @@ import {
   and,
   asc,
   count as countRows,
+  countDistinct,
   desc,
   eq,
   getTableColumns,
@@ -1416,8 +1418,7 @@ async function fetchGachaDropStatsFromHistory(
   streamerId: string,
   fromDateIso: string
 ): Promise<Omit<GachaStatsResult, "channelPointStats">> {
-  const FIXED_RARITIES = ["legendary", "epic", "rare", "common"] as const;
-  const emptyRarityStats = FIXED_RARITIES.map((rarity) => ({
+  const emptyRarityStats = RARITY_ORDER.map((rarity) => ({
     rarity,
     count: 0,
     rate: 0,
@@ -1429,12 +1430,14 @@ async function fetchGachaDropStatsFromHistory(
     notLike(gachaHistoryTable.event_id, "manual:%"),
   );
   let totalDraws: number;
+  // カード別/レアリティ別の「排出数」自体は下記の GROUP BY 集計（打ち切り無し）
+  // から取る。history はドロワー明細（ユーザー名・引いた日時）の表示専用で、
+  // 1カードあたり上限件数で打ち切って良い付随情報のみに使う (#833)。
   let history: Array<{
     card_id: string;
     user_twitch_id: string;
     user_twitch_username: string | null;
     redeemed_at: string | null;
-    cards: { rarity: string } | null;
   }>;
   let cards: Array<{
     id: string;
@@ -1444,8 +1447,16 @@ async function fetchGachaDropStatsFromHistory(
     drop_rate: number | string | null;
     created_at: string | null;
   }>;
+  let drawCountsByCardRows: Array<{ card_id: string; count: number | string }>;
+  let rarityCountsRows: Array<{ rarity: string; count: number | string }>;
   try {
-    const [countResultRows, historyRows, cardRows] = await Promise.all([
+    const [
+      countResultRows,
+      historyRows,
+      cardRows,
+      drawCountRows,
+      rarityCountRows,
+    ] = await Promise.all([
       withDbRetry(
         async () => {
           const { db } = await getDb();
@@ -1466,10 +1477,8 @@ async function fetchGachaDropStatsFromHistory(
               user_twitch_id: gachaHistoryTable.user_twitch_id,
               user_twitch_username: gachaHistoryTable.user_twitch_username,
               redeemed_at: gachaHistoryTable.redeemed_at,
-              cards: { rarity: cardsTable.rarity },
             })
             .from(gachaHistoryTable)
-            .leftJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
             .where(historyFilter)
             .limit(10000);
         },
@@ -1495,22 +1504,57 @@ async function fetchGachaDropStatsFromHistory(
         "dashboard:gachaDropStats:cards",
         { idempotent: true },
       ),
+      // カード別の排出数はSQL側でGROUP BYして正確に取る（#833: 以前はhistoryの
+      // LIMIT 10000サンプルから数えていたため、期間内の総排出数が10000件を超える
+      // 配信者では全カードのactualRateが黙って過小表示されていた）。
+      withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          return db
+            .select({ card_id: gachaHistoryTable.card_id, count: countRows() })
+            .from(gachaHistoryTable)
+            .where(historyFilter)
+            .groupBy(gachaHistoryTable.card_id);
+        },
+        "dashboard:gachaDropStats:drawCountsByCard",
+        { idempotent: true },
+      ),
+      // レアリティ別の排出数もSQL側でGROUP BY。RPC(migration 00050)のrarity_counts
+      // CTEと同じくcardsとのINNER JOINで、参照先カードが存在しない履歴行(想定外)は
+      // レアリティ別集計から除外する(total_drawsには含まれる)。
+      withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          return db
+            .select({ rarity: cardsTable.rarity, count: countRows() })
+            .from(gachaHistoryTable)
+            .innerJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
+            .where(historyFilter)
+            .groupBy(cardsTable.rarity);
+        },
+        "dashboard:gachaDropStats:rarityCounts",
+        { idempotent: true },
+      ),
     ]);
     totalDraws = Number(countResultRows[0]?.count ?? 0);
     history = historyRows;
     cards = cardRows;
+    drawCountsByCardRows = drawCountRows;
+    rarityCountsRows = rarityCountRows;
   } catch (error) {
     reportError(error, { context: "dashboard:gachaDropStats:fallback", streamerId });
     return { totalDraws: 0, cardStats: [], rarityStats: emptyRarityStats };
   }
 
   const drawCounts = new Map<string, number>();
-  // 期間内にそのカードを引いたユーザーをカード×ユーザーで集計。
-  // RPC(get_gacha_drop_stats)と同じく1カードあたり上限件数で打ち切る。
+  for (const row of drawCountsByCardRows) {
+    drawCounts.set(row.card_id, Number(row.count));
+  }
+
+  // ドロワー明細(誰が引いたか)はhistoryサンプルからのみ構築する付随情報。
+  // actualCount/actualRateの算出には使わない。
   const drawersByCard = new Map<string, Map<string, GachaStatsDrawer>>();
   for (const row of history) {
-    drawCounts.set(row.card_id, (drawCounts.get(row.card_id) || 0) + 1);
-
     if (!row.user_twitch_id) continue;
     const cardDrawers = drawersByCard.get(row.card_id) || new Map();
     const existing = cardDrawers.get(row.user_twitch_id);
@@ -1563,16 +1607,21 @@ async function fetchGachaDropStatsFromHistory(
     };
   });
 
-  // レアリティ別集計は履歴←cards の join から引く（RPC migration 00038 と同じく
-  // is_active 非依存）。非アクティブ化済みカードの過去排出も RPC と同様に計上される。
+  // レアリティ集合はデフォルト4種(常に表示、排出0でも含む)＋実際に排出された
+  // カスタムレアリティ(RPC migration 00050のrarity_universeと同じ構成)。
+  // 以前はデフォルト4種の固定リストのみで、カスタムレアリティのカードが
+  // 排出されてもrarityStatsに一切現れず、内訳合計がtotal_drawsと一致
+  // しなかった (#833)。
   const rarityCounts = new Map<string, number>();
-  for (const row of history) {
-    const rarity = row.cards?.rarity;
-    if (rarity) {
-      rarityCounts.set(rarity, (rarityCounts.get(rarity) || 0) + 1);
-    }
+  for (const row of rarityCountsRows) {
+    rarityCounts.set(row.rarity, Number(row.count));
   }
-  const rarityStats = FIXED_RARITIES.map((rarity) => {
+  const customRarities = Array.from(rarityCounts.keys())
+    .filter((rarity) => !RARITY_ORDER.includes(rarity))
+    .sort((a, b) => a.localeCompare(b));
+  const rarityUniverse = [...RARITY_ORDER, ...customRarities];
+
+  const rarityStats = rarityUniverse.map((rarity) => {
       const count = rarityCounts.get(rarity) || 0;
     return {
       rarity,
@@ -1773,8 +1822,9 @@ async function fetchCardOwnerStatsFromUserCards(
     image_url: string | null;
   }>;
   let ownerRows: GachaCardOwnerStatsOwnerRow[];
+  let ownerCountRows: Array<{ card_id: string; count: number | string }>;
   try {
-    [cards, ownerRows] = await Promise.all([
+    [cards, ownerRows, ownerCountRows] = await Promise.all([
       withDbRetry(
         async () => {
           const { db } = await getDb();
@@ -1814,12 +1864,37 @@ async function fetchCardOwnerStatsFromUserCards(
         "dashboard:cardOwnerStats:owners",
         { idempotent: true },
       ),
+      // カード別の所有者数(ユニークユーザー数)はSQL側でGROUP BYして正確に取る
+      // (#833: 以前はownerRowsのLIMIT 10000サンプルから数えていたため、streamer
+      // 全体のuser_cards行数が10000件を超えると人気カードのownerCountが黙って
+      // 過小になっていた)。1ユーザーが同一カードを複数所持しうるため
+      // COUNT(DISTINCT user_id) で重複を除く。
+      withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          return db
+            .select({ card_id: userCardsTable.card_id, count: countDistinct(userCardsTable.user_id) })
+            .from(userCardsTable)
+            .innerJoin(cardsTable, eq(userCardsTable.card_id, cardsTable.id))
+            .where(and(eq(cardsTable.streamer_id, streamerId), eq(cardsTable.is_active, true)))
+            .groupBy(userCardsTable.card_id);
+        },
+        "dashboard:cardOwnerStats:ownerCounts",
+        { idempotent: true },
+      ),
     ]);
   } catch (error) {
     reportError(error, { context: "dashboard:cardOwnerStats:fallback", streamerId });
     return { cardStats: [] };
   }
 
+  const ownerCounts = new Map<string, number>();
+  for (const row of ownerCountRows) {
+    ownerCounts.set(row.card_id, Number(row.count));
+  }
+
+  // owners一覧(表示用の個別ユーザー明細)はownerRowsのサンプルからのみ構築する
+  // 付随情報。ownerCountの算出には使わない。
   const ownersByCard = new Map<string, Map<string, GachaCardOwner>>();
   for (const row of ownerRows) {
     const user = Array.isArray(row.users) ? row.users[0] : row.users;
@@ -1868,8 +1943,9 @@ async function fetchCardOwnerStatsFromUserCards(
         cardName: card.name,
         rarity: card.rarity,
         imageUrl: card.image_url,
-        // ownerCount は総数（打ち切り前）、owners はRPCと同じく上限件数で打ち切る
-        ownerCount: owners.length,
+        // ownerCount はGROUP BY集計による正確な総数、owners はRPCと同じく
+        // 上限件数で打ち切る (#833)
+        ownerCount: ownerCounts.get(card.id) || 0,
         owners: owners.slice(0, STATS_USERS_PER_CARD_LIMIT),
       };
     }),

--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -1449,6 +1449,7 @@ async function fetchGachaDropStatsFromHistory(
   }>;
   let drawCountsByCardRows: Array<{ card_id: string; count: number | string }>;
   let rarityCountsRows: Array<{ rarity: string; count: number | string }>;
+  let drawerCountsByCardRows: Array<{ card_id: string; count: number | string }>;
   try {
     const [
       countResultRows,
@@ -1456,6 +1457,7 @@ async function fetchGachaDropStatsFromHistory(
       cardRows,
       drawCountRows,
       rarityCountRows,
+      drawerCountRows,
     ] = await Promise.all([
       withDbRetry(
         async () => {
@@ -1535,12 +1537,31 @@ async function fetchGachaDropStatsFromHistory(
         "dashboard:gachaDropStats:rarityCounts",
         { idempotent: true },
       ),
+      // カード別のユニーク排出ユーザー数(drawerCount)もSQL側でGROUP BYして正確に
+      // 取る(#833レビュー指摘: drawersリスト表示用の明細はhistoryサンプルの
+      // ままで良いが、drawerCount自体をそこから数えるとactualCountだけが
+      // 正確になり「actualCountは大きいのにdrawerCountは0人」のような矛盾した
+      // 表示になりうる)。COUNT(DISTINCT ...)はNULLを自動的に除外するため、
+      // user_twitch_idがNULLの行を弾くdrawersByCard構築時のガードと整合する。
+      withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          return db
+            .select({ card_id: gachaHistoryTable.card_id, count: countDistinct(gachaHistoryTable.user_twitch_id) })
+            .from(gachaHistoryTable)
+            .where(historyFilter)
+            .groupBy(gachaHistoryTable.card_id);
+        },
+        "dashboard:gachaDropStats:drawerCountsByCard",
+        { idempotent: true },
+      ),
     ]);
     totalDraws = Number(countResultRows[0]?.count ?? 0);
     history = historyRows;
     cards = cardRows;
     drawCountsByCardRows = drawCountRows;
     rarityCountsRows = rarityCountRows;
+    drawerCountsByCardRows = drawerCountRows;
   } catch (error) {
     reportError(error, { context: "dashboard:gachaDropStats:fallback", streamerId });
     return { totalDraws: 0, cardStats: [], rarityStats: emptyRarityStats };
@@ -1550,9 +1571,13 @@ async function fetchGachaDropStatsFromHistory(
   for (const row of drawCountsByCardRows) {
     drawCounts.set(row.card_id, Number(row.count));
   }
+  const drawerCounts = new Map<string, number>();
+  for (const row of drawerCountsByCardRows) {
+    drawerCounts.set(row.card_id, Number(row.count));
+  }
 
-  // ドロワー明細(誰が引いたか)はhistoryサンプルからのみ構築する付随情報。
-  // actualCount/actualRateの算出には使わない。
+  // drawersリスト(誰が引いたか上位N件の明細)はhistoryサンプルからのみ構築する
+  // 付随情報。drawerCount(人数)の算出には使わない(上記GROUP BY集計を使う)。
   const drawersByCard = new Map<string, Map<string, GachaStatsDrawer>>();
   for (const row of history) {
     if (!row.user_twitch_id) continue;
@@ -1602,7 +1627,7 @@ async function fetchGachaDropStatsFromHistory(
         totalWeight > 0 ? (Number(card.drop_rate || 0) / totalWeight) * 100 : 0,
       actualCount,
       actualRate: totalDraws > 0 ? (actualCount / totalDraws) * 100 : 0,
-      drawerCount: allDrawers.length,
+      drawerCount: drawerCounts.get(card.id) || 0,
       drawers: allDrawers.slice(0, STATS_USERS_PER_CARD_LIMIT),
     };
   });

--- a/tests/unit/dashboard-data-rpc-driver-parity.test.ts
+++ b/tests/unit/dashboard-data-rpc-driver-parity.test.ts
@@ -462,6 +462,37 @@ describe('dashboard-data: PlanetScale読み取りRPC契約 (#803)', () => {
     expect(pointCall.values).toEqual(['streamer-1', null, 10])
   })
 
+  it('#833: RPC経路はカスタムレアリティをそのまま(固定4種にハードコードせず)返す', async () => {
+    // #833の本質的な原因はJSフォールバック側が固定4レアリティにハードコード
+    // していたことで、RPC側(parseGachaDropStatsRpc)は元々rarity_statsの
+    // 内容をそのまま透過するだけで正しい。両経路が同じ入力に同じ結果を
+    // 返すことを固定し、将来どちらかにハードコードが再導入されたら
+    // このテストで検知できるようにする。
+    const dropStatsWithCustomRarity = {
+      ...dropStatsResult,
+      rarity_stats: [
+        { rarity: 'legendary', count: '0', rate: '0' },
+        { rarity: 'epic', count: '0', rate: '0' },
+        { rarity: 'rare', count: '0', rate: '0' },
+        { rarity: 'common', count: '6', rate: '60' },
+        { rarity: 'mythic', count: '4', rate: '40' },
+      ],
+    }
+    primeDb([
+      { rows: [{ result: dropStatsWithCustomRarity }] },
+      { rows: [{ result: channelPointResult }] },
+    ])
+
+    const result = await getGachaStats('streamer-1', '7d')
+
+    const mythicStat = result.rarityStats.find((row) => row.rarity === 'mythic')
+    expect(mythicStat).toMatchObject({ count: 4, rate: 40 })
+    expect(result.rarityStats).toHaveLength(5)
+    const sumOfCounts = result.rarityStats.reduce((sum, row) => sum + row.count, 0)
+    expect(sumOfCounts).toBe(10)
+    expect(sumOfCounts).toBe(result.totalDraws)
+  })
+
   it('drop統計RPC未デプロイ時は履歴から件数・排出ユーザー・レアリティを集約する', async () => {
     // rarity は #833 以降 cardsTable.rarity への INNER JOIN + GROUP BY で
     // 取得するため、fixture側もフラットな rarity フィールドを持たせる
@@ -560,6 +591,7 @@ describe('dashboard-data: PlanetScale読み取りRPC契約 (#803)', () => {
       }],
       [{ card_id: 'card-a', count: 25000 }], // drawCountsByCard(GROUP BY)
       [{ rarity: 'mythic', count: 25000 }], // rarityCounts(GROUP BY)
+      [{ card_id: 'card-a', count: 500 }], // drawerCountsByCard(GROUP BY COUNT DISTINCT)
     ]
     const db = {
       select: vi.fn(() => {
@@ -588,8 +620,11 @@ describe('dashboard-data: PlanetScale読み取りRPC契約 (#803)', () => {
       cardId: 'card-a',
       actualCount: 25000,
       actualRate: 100,
-      drawerCount: 0,
-      drawers: [],
+      // drawerCountはGROUP BY集計(500)から取り、空の履歴サンプルから0と
+      // 誤って数え直されない(レビュー指摘: actualCountだけ大きくdrawerCountが
+      // 0のままだと矛盾した表示になる)
+      drawerCount: 500,
+      drawers: [], // 明細一覧は履歴サンプル(空)のまま=付随情報として空でよい
     })
     const mythicStat = result.rarityStats.find((row) => row.rarity === 'mythic')
     expect(mythicStat).toMatchObject({ count: 25000, rate: 100 })

--- a/tests/unit/dashboard-data-rpc-driver-parity.test.ts
+++ b/tests/unit/dashboard-data-rpc-driver-parity.test.ts
@@ -183,21 +183,63 @@ function createFallbackDb(
   return {
     select: vi.fn((fields: Record<string, unknown>) => ({
       from: vi.fn((table: Table) => {
+        let groupByColumns: Column[] = []
         const evaluate = () => {
           const rows = rowsByTable.get(table) ?? []
-          const hasAggregate = Object.values(fields).some((field) => is(field, SQL))
-          if (hasAggregate) return [{ count: rows.length }]
+          const aggregateEntries = Object.entries(fields).filter(([, field]) => is(field, SQL))
+          const columnEntries = Object.entries(fields).filter(([, field]) => is(field, Column))
 
-          return rows.map((row) =>
-            Object.fromEntries(
-              Object.entries(fields).map(([key, field]) => {
-                if (is(field, Column)) return [key, row[field.name] ?? null]
-                // JOIN後のネスト値はfixture側でキー名どおりに保持する。
-                // SQL条件の再実装を避けつつ、公開結果のネスト形状は厳密に検証できる。
-                return [key, row[key] ?? null]
-              })
+          if (aggregateEntries.length === 0) {
+            return rows.map((row) =>
+              Object.fromEntries(
+                Object.entries(fields).map(([key, field]) => {
+                  if (is(field, Column)) return [key, row[field.name] ?? null]
+                  // JOIN後のネスト値はfixture側でキー名どおりに保持する。
+                  // SQL条件の再実装を避けつつ、公開結果のネスト形状は厳密に検証できる。
+                  return [key, row[key] ?? null]
+                })
+              )
             )
-          )
+          }
+
+          // groupBy() 呼び出しが無い集計 = 全体件数のみ(既存の挙動)。
+          if (groupByColumns.length === 0) {
+            return [{ count: rows.length }]
+          }
+
+          // groupBy() 呼び出しあり = GROUP BY をシミュレートする。groupBy対象の
+          // カラム値でグループ化し、各グループの行をまとめて保持する
+          // (#833のGROUP BY集計テスト用)。
+          const groups = new Map<string, { keyValues: Record<string, unknown>; rowsInGroup: Record<string, unknown>[] }>()
+          for (const row of rows) {
+            const keyValues: Record<string, unknown> = {}
+            for (const [key, field] of columnEntries) {
+              if (is(field, Column)) keyValues[key] = row[field.name] ?? null
+            }
+            const groupKey = groupByColumns.map((col) => String(row[col.name] ?? '')).join('|')
+            const existing = groups.get(groupKey)
+            if (existing) {
+              existing.rowsInGroup.push(row)
+            } else {
+              groups.set(groupKey, { keyValues, rowsInGroup: [row] })
+            }
+          }
+          return Array.from(groups.values()).map(({ keyValues, rowsInGroup }) => {
+            const result: Record<string, unknown> = { ...keyValues }
+            for (const [key, field] of aggregateEntries) {
+              // count()はsql`count(${sql.raw("*")})`、countDistinct(col)は
+              // sql`count(distinct ${col})`として表現される(drizzle-orm/sql/
+              // functions/aggregate.js)。queryChunks内にColumnが含まれるかで
+              // 両者を判別し、distinct集計ならグループ内のユニーク値数を返す。
+              const distinctColumn = (field as SQL).queryChunks.find((chunk) => is(chunk, Column)) as
+                | Column
+                | undefined
+              result[key] = distinctColumn
+                ? new Set(rowsInGroup.map((r) => r[distinctColumn.name])).size
+                : rowsInGroup.length
+            }
+            return result
+          })
         }
         const builder: any = {
           leftJoin: vi.fn(() => builder),
@@ -205,6 +247,10 @@ function createFallbackDb(
           where: vi.fn(() => builder),
           orderBy: vi.fn(() => builder),
           limit: vi.fn(() => builder),
+          groupBy: vi.fn((...columns: Column[]) => {
+            groupByColumns = columns
+            return builder
+          }),
           then: (onFulfilled: any, onRejected: any) =>
             Promise.resolve().then(evaluate).then(onFulfilled, onRejected),
         }
@@ -417,20 +463,24 @@ describe('dashboard-data: PlanetScale読み取りRPC契約 (#803)', () => {
   })
 
   it('drop統計RPC未デプロイ時は履歴から件数・排出ユーザー・レアリティを集約する', async () => {
+    // rarity は #833 以降 cardsTable.rarity への INNER JOIN + GROUP BY で
+    // 取得するため、fixture側もフラットな rarity フィールドを持たせる
+    // (createFallbackDb の GROUP BY シミュレーションが row[column.name] で
+    // 引くため、ネストした cards.rarity では解決できない)。
     const historyRows = [
       {
         card_id: 'card-a',
         user_twitch_id: 'viewer-1',
         user_twitch_username: 'viewer_one',
         redeemed_at: '2026-03-02T00:00:00+00:00',
-        cards: { rarity: 'common' },
+        rarity: 'common',
       },
       {
         card_id: 'card-a',
         user_twitch_id: 'viewer-1',
         user_twitch_username: 'Viewer New',
         redeemed_at: '2026-03-03T00:00:00+00:00',
-        cards: { rarity: 'common' },
+        rarity: 'common',
       },
     ]
     primeDb(
@@ -484,6 +534,72 @@ describe('dashboard-data: PlanetScale読み取りRPC契約 (#803)', () => {
         streamerId: 'streamer-1',
       }),
     )
+  })
+
+  it('#833: カスタムレアリティを含み、履歴サンプル上限を超える件数でも件数・レアリティ内訳が正確', async () => {
+    // 実運用では10000件超の履歴サンプルで actualCount/rarityStats が黙って
+    // 過小になっていた(#833)。ここではGROUP BY集計(count=25000)が
+    // 履歴サンプル(空配列=0件)から独立していることを直接検証する:
+    // もし実装がhistory配列から数え直す旧ロジックに戻れば、actualCount/
+    // rarityStatsのcountは0になりこのテストは失敗する。
+    const sql = createSqlMock([
+      { error: pgError('42883', 'get_gacha_drop_stats does not exist') },
+      { rows: [{ result: channelPointResult }] },
+    ])
+    let selectCallIndex = 0
+    const groupByResponses = [
+      [{ count: 25000 }], // count-only
+      [], // history detail sample(空でも件数計算に影響しないことを示す)
+      [{
+        id: 'card-a',
+        name: 'Card A',
+        rarity: 'mythic', // デフォルト4種に無いカスタムレアリティ
+        image_url: null,
+        drop_rate: 1,
+        created_at: '2026-01-01T00:00:00+00:00',
+      }],
+      [{ card_id: 'card-a', count: 25000 }], // drawCountsByCard(GROUP BY)
+      [{ rarity: 'mythic', count: 25000 }], // rarityCounts(GROUP BY)
+    ]
+    const db = {
+      select: vi.fn(() => {
+        const response = groupByResponses[Math.min(selectCallIndex, groupByResponses.length - 1)]
+        selectCallIndex += 1
+        const builder: any = {
+          from: vi.fn(() => builder),
+          innerJoin: vi.fn(() => builder),
+          leftJoin: vi.fn(() => builder),
+          where: vi.fn(() => builder),
+          orderBy: vi.fn(() => builder),
+          limit: vi.fn(() => builder),
+          groupBy: vi.fn(() => builder),
+          then: (onFulfilled: any, onRejected: any) =>
+            Promise.resolve(response).then(onFulfilled, onRejected),
+        }
+        return builder
+      }),
+    }
+    vi.mocked(getDb).mockResolvedValue({ db, sql } as any)
+
+    const result = await getGachaStats('streamer-1', '7d')
+
+    expect(result.totalDraws).toBe(25000)
+    expect(result.cardStats[0]).toMatchObject({
+      cardId: 'card-a',
+      actualCount: 25000,
+      actualRate: 100,
+      drawerCount: 0,
+      drawers: [],
+    })
+    const mythicStat = result.rarityStats.find((row) => row.rarity === 'mythic')
+    expect(mythicStat).toMatchObject({ count: 25000, rate: 100 })
+    // デフォルト4種(排出0でも表示)+実際に排出されたカスタムレアリティの順で並ぶ
+    expect(result.rarityStats.map((row) => row.rarity)).toEqual([
+      'legendary', 'epic', 'rare', 'common', 'mythic',
+    ])
+    // rarityStatsの内訳合計がtotal_drawsと一致する(カスタムレアリティ込み)
+    const sumOfCounts = result.rarityStats.reduce((sum, row) => sum + row.count, 0)
+    expect(sumOfCounts).toBe(25000)
   })
 
   it('channel point統計RPC障害時は履歴からポイントと順位を集約する', async () => {
@@ -629,5 +745,45 @@ describe('dashboard-data: PlanetScale読み取りRPC契約 (#803)', () => {
         streamerId: 'streamer-1',
       }),
     )
+  })
+
+  it('#833: 所持ユーザー明細サンプル件数を超えても、ownerCountはGROUP BY集計から正確な値を返す', async () => {
+    // 実運用ではownerRowsのLIMIT 10000サンプルからownerCountを数えていたため、
+    // streamer全体のuser_cards行数が10000件を超えると人気カードのownerCountが
+    // 黙って過小になっていた(#833)。ここではownerRows(明細サンプル)を空にし、
+    // 別のGROUP BY集計(COUNT DISTINCT)だけがownerCountを決めることを直接示す。
+    let selectCallIndex = 0
+    const responses = [
+      [{ id: 'card-a', name: 'Card A', rarity: 'common', image_url: null }], // cards
+      [], // ownerRows(明細サンプル、空でもownerCountに影響しないことを示す)
+      [{ card_id: 'card-a', count: 3000 }], // ownerCounts(GROUP BY COUNT DISTINCT)
+    ]
+    const db = {
+      select: vi.fn(() => {
+        const response = responses[Math.min(selectCallIndex, responses.length - 1)]
+        selectCallIndex += 1
+        const builder: any = {
+          from: vi.fn(() => builder),
+          innerJoin: vi.fn(() => builder),
+          where: vi.fn(() => builder),
+          orderBy: vi.fn(() => builder),
+          limit: vi.fn(() => builder),
+          groupBy: vi.fn(() => builder),
+          then: (onFulfilled: any, onRejected: any) =>
+            Promise.resolve(response).then(onFulfilled, onRejected),
+        }
+        return builder
+      }),
+    }
+    const sql = createSqlMock([{ error: pgError('42883', 'get_card_owner_stats does not exist') }])
+    vi.mocked(getDb).mockResolvedValue({ db, sql } as any)
+
+    const result = await getGachaCardOwnerStats('streamer-1')
+
+    expect(result.cardStats[0]).toMatchObject({
+      cardId: 'card-a',
+      ownerCount: 3000,
+      owners: [],
+    })
   })
 })


### PR DESCRIPTION
## 概要

#833 の修正。`get_gacha_drop_stats` / `get_card_owner_stats` RPCが未デプロイ・実行時エラーの際に使われるJSフォールバック（`fetchGachaDropStatsFromHistory` / `fetchCardOwnerStatsFromUserCards`）に2つの問題があった。

1. **カスタムレアリティの欠落**: `rarityStats` が固定4レアリティ(legendary/epic/rare/common)のみを対象としていたため、カスタムレアリティのカードが排出されても一切現れず、内訳合計が `total_draws` と一致しなかった。RPC側(migration 00050)は排出実績のあるカスタムレアリティも含める`rarity_universe`構成に既に対応済みで、フォールバック側だけが取り残されていた。
2. **打ち切りサンプルによる過小算出**: `actualCount`/`actualRate`（カード別）、`rarityStats.count`/`.rate`（レアリティ別）、`ownerCount`（所持ユーザー数）が、上限10000件のJS側サンプルから数えていたため、期間内の総件数がその上限を超える配信者では実際より小さく表示されていた。`totalDraws`自体は別のCOUNT-onlyクエリで常に正確だったため、この乖離は気づきにくい。

## 修正内容

- `rarityStats`の対象を、デフォルト4種(排出0でも常に表示)+実際に排出されたカスタムレアリティの集合に拡張(RPC migration 00050の`rarity_universe`と同じ構成: デフォルトを先頭固定、カスタムはレアリティ名昇順で後続)
- カード別排出数・レアリティ別排出数・カード別ユニーク所持者数(`COUNT DISTINCT`)をSQL側のGROUP BYで正確に取得するよう変更し、JS側サンプルの件数上限から独立させた
- レアリティ別集計のINNER JOINはRPC(`rarity_counts` CTE)と同じセマンティクス(参照先カードが存在しない履歴行は集計から除外、`total_draws`には含まれる)
- ドロワー明細(誰が引いたか)・所持者明細(表示用の個別ユーザー一覧)は付随情報として上限付きサンプルのまま(数値の算出には使わない)
- 独立レビューで見つかった追加の同型問題も修正: `drawerCount`(ユニーク排出ユーザー数)も同じ理由で打ち切りサンプル依存だったため、`ownerCount`と同じ`COUNT(DISTINCT)`のGROUP BY集計に切り替え

## 対象外(フォローアップ)

- `fetchChannelPointUsageStatsFromHistory`(チャネルポイント利用状況の別フォールバック)にも同型の問題があることをレビューで発見。#833が対象とするRPCとは別物のため、フォローアップ issue #849 として起票済み

## テスト

- 両フォールバック関数に、RPCと同じ期待値を当てるパリティテストを追加:
  - カスタムレアリティを含む場合の内訳合計一致
  - サンプル上限を超える件数でも `actualCount`/`rarityStats`/`ownerCount`/`drawerCount` が正確なままであることの直接検証(空の詳細サンプルでもGROUP BY集計側の値が使われることを確認)
- RPC経路にも、カスタムレアリティをハードコードせず透過することを固定するパリティテストを追加(将来どちらかの経路にのみ固定レアリティが再導入された場合に検知できるようにする)
- 共有Drizzleモックヘルパー(`createFallbackDb`)を拡張し、`GROUP BY`と`count()`/`countDistinct()`の違い(SQL式の`queryChunks`内にColumnが含まれるかで判別)を実際にシミュレートするようにした
- `npm run test:unit` 全体実行済み(バックグラウンドで最終確認中)、`tsc --noEmit`/`eslint` 変更ファイルともクリーン
- 独立レビューsubagentによる厳格レビュー2回実施: 1回目でRPCとの意味論的な一致(rarity_universeの順序・INNER JOINセマンティクス・countDistinct判別ロジックの妥当性)を確認、新規テストが実際にfixなしでは失敗することを実測で検証。指摘のうち本PRの範囲内のもの(drawerCountの打ち切り依存、RPC側パリティテスト不足)は反映済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DiUHeoAwCWKdsCsYWezTS