### PR TITLE
Paginate analysis dashboard queries

### DIFF
--- a/analysis/dev/adminApiPg.ts
+++ b/analysis/dev/adminApiPg.ts
@@ -23,10 +23,10 @@
  * 関数名は SQL インジェクション対策として動的に組み立てず、呼び出す関数ごとに
  * 個別のリテラル SQL を書く。
  *
- * gacha chart/table/export（`getGachaChartPg` 以下）は上記と異なり、対応する
+ * gacha table/export（`getGachaTablePg` 以下）は上記と異なり、対応する
  * `get_analysis_*()` SQL 関数が存在しない（絞り込み条件が可変で、既存の
  * `00073_add_analysis_dashboard_rpcs.sql` のような固定引数のRPC化に馴染まないため）。
- * そのため、この3関数のみ postgres.js のフラグメント合成（`sql`` を `${}` でネスト、
+ * そのため、この2機能のみ postgres.js のフラグメント合成（`sql`` を `${}` でネスト、
  * postgres.js README「nesting sql`` fragments」参照）で動的 WHERE 句を組み立てる。
  * 値は必ずバインドパラメータとして渡され文字列連結は一切行わないため、
  * 条件の有無を動的に変えてもインジェクションの余地はない。
@@ -46,7 +46,7 @@ import postgres from 'postgres'
  * `grant service_role to <role>` 済みである必要がある（未付与だと接続自体は成功し、
  * 呼び出し時に "permission denied for function" で失敗する）。
  *
- * `getGachaChartPg` 以下の関数群は SQL 関数を経由せず対象テーブル（gacha_history/
+ * `getGachaTablePg` 以下の関数群は SQL 関数を経由せず対象テーブル（gacha_history/
  * cards/streamers/users/user_cards/support_codes/user_licenses/support_inquiries/
  * support_inquiry_messages 等、増分が進むごとに増える）を直接 SELECT/INSERT/UPDATE
  * するため、上記の EXECUTE 権限に加えてこれらテーブルへの DML 権限も必要
@@ -174,12 +174,56 @@ export async function getStreamerLeaderboardPg(env: Record<string, string>): Pro
   )
 }
 
-export async function listUsersPg(env: Record<string, string>): Promise<unknown> {
-  return callAnalysisJsonFunction(env, (sql) => sql`select get_analysis_users() as result`)
+export async function listUsersPg(
+  env: Record<string, string>,
+  params: {
+    page: number
+    pageSize: number
+    search?: string | null
+    sort?: string
+    hideZeroCards?: boolean
+  } = { page: 1, pageSize: 20 }
+): Promise<unknown> {
+  return callAnalysisJsonFunction(
+    env,
+    (sql) =>
+      sql`select get_analysis_users_page(${params.page}, ${params.pageSize}, ${params.search ?? null}, ${params.sort ?? 'card_count_desc'}, ${params.hideZeroCards ?? false}) as result`
+  )
 }
 
-export async function listStreamersWithStatsPg(env: Record<string, string>): Promise<unknown> {
-  return callAnalysisJsonFunction(env, (sql) => sql`select get_analysis_streamers() as result`)
+export async function listStreamersWithStatsPg(
+  env: Record<string, string>,
+  params: {
+    page: number
+    pageSize: number
+    search?: string | null
+    sort?: string
+    hideZeroCards?: boolean
+    filterChatEnabled?: boolean
+    filterHasTemplate?: boolean
+    filterMissingScope?: boolean
+    filterVoteCampaign?: boolean
+  } = { page: 1, pageSize: 20 }
+): Promise<unknown> {
+  return callAnalysisJsonFunction(
+    env,
+    (sql) =>
+      sql`select get_analysis_streamers_page(${params.page}, ${params.pageSize}, ${params.search ?? null}, ${params.sort ?? 'card_count_desc'}, ${params.hideZeroCards ?? false}, ${params.filterChatEnabled ?? false}, ${params.filterHasTemplate ?? false}, ${params.filterMissingScope ?? false}, ${params.filterVoteCampaign ?? false}) as result`
+  )
+}
+
+export async function getStreamerOptionsPg(
+  env: Record<string, string>,
+  params: { page: number; pageSize: number; search?: string | null } = {
+    page: 1,
+    pageSize: 50,
+  }
+): Promise<unknown> {
+  return callAnalysisJsonFunction(
+    env,
+    (sql) =>
+      sql`select get_analysis_streamer_options_page(${params.page}, ${params.pageSize}, ${params.search ?? null}) as result`
+  )
 }
 
 /**
@@ -231,7 +275,7 @@ export async function getGachaSummaryPg(
   )
 }
 
-/** getGachaChartPg/getGachaTablePg/getGachaExportRowsPg が共有する絞り込み条件。 */
+/** getGachaTablePg/getGachaExportRowsPg が共有する絞り込み条件。 */
 export interface GachaHistoryFilters {
   streamerId?: string
   /** ISO文字列。範囲の下限（含む）。未指定なら絞り込まない。 */
@@ -273,50 +317,6 @@ export function gachaHistoryFromWhere(sql: postgres.Sql, filters: GachaHistoryFi
 }
 
 /**
- * ダッシュボードのガチャチャートが期待する行を返す（GachaChartRow 相当）。
- * `getGachaChart()`（PostgREST版）は `.limit(10000)` を指定しているが、
- * Supabase の max-rows API 設定（既定 1000）により実際には最大1000件しか
- * 返っていない（`docs/db-driver-migration.md` 参照、`getGachaExportRows` の
- * fetchAllPaged 導入理由と同じ制約）。pg 直結には PostgREST の max-rows は
- * 適用されないため、ここではコードが本来意図している10000件の上限をそのまま使う
- * （既存の実挙動＝1000件を人為的に再現するのではなく、コードの記述どおりの
- * 上限に揃える。管理者用の内部チャートであり、より完全なデータが出ることは
- * リスクではない）。
- *
- * timestamp/timestamptz を生列として SELECT すると postgres.js が JS Date
- * オブジェクトへ変換してしまい、呼び出し元が期待する ISO 文字列と型が
- * 食い違う（かつファイル冒頭の「jsonb 列1本しかSELECTしない」前提も崩れる）。
- * そのため jsonb_build_object() で個々の値を明示的に組み立てる
- * （timestamptz を jsonb_build_object の値として渡すと to_jsonb() と同じ
- * ISO 8601 変換が適用される）。
- */
-export async function getGachaChartPg(
-  env: Record<string, string>,
-  filters: Pick<GachaHistoryFilters, 'streamerId' | 'fromDate'>
-): Promise<unknown> {
-  return callAnalysisJsonFunction(env, (sql) => sql`
-    SELECT COALESCE(jsonb_agg(row_json ORDER BY sort_redeemed_at DESC), '[]'::jsonb) AS result
-    FROM (
-      SELECT
-        jsonb_build_object(
-          'id', gh.id,
-          'redeemed_at', gh.redeemed_at,
-          'card_id', gh.card_id,
-          'user_twitch_id', gh.user_twitch_id,
-          'streamer_id', gh.streamer_id,
-          'cards', jsonb_build_object(
-            'id', c.id, 'name', c.name, 'rarity', c.rarity, 'image_url', c.image_url
-          ),
-          'streamers', to_jsonb(s.*)
-        ) AS row_json,
-        gh.redeemed_at AS sort_redeemed_at
-      ${gachaHistoryFromWhere(sql, filters)}
-      ORDER BY gh.redeemed_at DESC
-      LIMIT 10000
-    ) chart
-  `)
-}
-
 /**
  * 件数のみを取得する（`getGachaTablePg` 専用）。`count(*) OVER()` ウィンドウ関数で
  * 1クエリに統合する案もあったが、要求ページが最終ページを超えて0行になった場合に
@@ -383,8 +383,8 @@ const GACHA_EXPORT_ROW_LIMIT_PG = 50000
 
 /**
  * CSVエクスポート用の行を返す（`getGachaExportRows()` 相当）。PostgREST版は
- * max-rows制約により `fetchAllPaged` で1000件ずつバッチ取得しているが、
- * pg直結にはその制約がないため単発の `LIMIT` クエリで完結する。
+ * max-rows制約により `fetchAllPaged` で1000件ずつバッチ取得していた旧経路だが、
+ * pg直結では明示的な安全上限を持つ単発の `LIMIT` クエリで完結する。
  */
 export async function getGachaExportRowsPg(
   env: Record<string, string>,
@@ -570,7 +570,7 @@ export async function getStreamerCardsPagePg(
  * サポートコード一覧を作成日降順で返す（`GET /support-codes` 相当）。
  *
  * PostgREST版は `.range()` を指定しない単発 `select()` のため、Supabase の
- * max-rows API 設定（既定1000件、`getGachaChartPg` のコメント参照）で
+ * max-rows API 設定（既定1000件）で
  * 実際には最大1000件に打ち切られている可能性があるが、pg直結にはこの制約が
  * 適用されないためLIMITなしで全件返す。support_codes/user_licenses/
  * twitch_has_sub ユーザーはいずれも管理対象データとして現実的には

--- a/analysis/dev/localAdminApi.ts
+++ b/analysis/dev/localAdminApi.ts
@@ -6,7 +6,6 @@ import {
   createSupportInquiryMessagePg,
   deleteAnnouncementPg,
   getDropRateStatsPg,
-  getGachaChartPg,
   getGachaExportRowsPg,
   getGachaSummaryPg,
   getGachaTablePg,
@@ -19,6 +18,7 @@ import {
   getUserCardsTablePg,
   listAnnouncementsPg,
   listLicensesPg,
+  getStreamerOptionsPg,
   listStreamersWithStatsPg,
   listSupportCodesPg,
   listSupportInquiryMessagesPg,
@@ -33,6 +33,13 @@ import {
 type Env = Record<string, string>
 
 type TimeRange = '7d' | '30d' | '90d' | 'all'
+type UserListSortOrder = 'card_count_desc' | 'card_count_asc' | 'created_at_desc' | 'name_asc'
+type StreamerListSortOrder =
+  | 'card_count_desc'
+  | 'card_count_asc'
+  | 'created_at_desc'
+  | 'name_asc'
+  | 'storage_desc'
 
 type RouteContext = {
   req: IncomingMessage
@@ -116,7 +123,10 @@ const VALID_TIME_RANGES: readonly TimeRange[] = ['7d', '30d', '90d', 'all']
 // getFromDateForRange() 内で NaN 経由の Invalid Date → toISOString() 例外という
 // 分かりにくい500になる。ここで早期にバリデーションして400を返す
 function parseTimeRange(raw: string | null): TimeRange {
-  if (raw === null) return 'all'
+  // ガチャ画面の初期表示は直近7日を基準にする。期間未指定を全期間に
+  // フォールバックすると、古い履歴が増えるほど集計・テーブルの初回コストが
+  // 増えるため、明示的に「全期間」を選んだ場合だけ all を許可する。
+  if (raw === null) return '7d'
   if ((VALID_TIME_RANGES as readonly string[]).includes(raw))
     return raw as TimeRange
   throw Object.assign(new Error(`Invalid range: ${raw}`), { statusCode: 400 })
@@ -124,7 +134,7 @@ function parseTimeRange(raw: string | null): TimeRange {
 
 // page/pageSizeが未検証だと負のOFFSETや過大なLIMITがDBまで届く。
 // 予測可能な4xxへ正規化し、DBドライバ由来のエラーを露出させない。
-function parsePagination(url: URL): { page: number; pageSize: number } {
+function parsePagination(url: URL, maxPageSize = 1000): { page: number; pageSize: number } {
   const page = Number(url.searchParams.get('page') || '1')
   const pageSize = Number(url.searchParams.get('pageSize') || '20')
   if (!Number.isInteger(page) || page < 1) {
@@ -132,15 +142,51 @@ function parsePagination(url: URL): { page: number; pageSize: number } {
       statusCode: 400,
     })
   }
-  if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 1000) {
+  if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > maxPageSize) {
     throw Object.assign(
-      new Error('pageSize must be a positive integer up to 1000'),
+      new Error(`pageSize must be a positive integer up to ${maxPageSize}`),
       {
         statusCode: 400,
       }
     )
   }
   return { page, pageSize }
+}
+
+function parseBooleanParam(raw: string | null): boolean {
+  if (raw === null || raw === '') return false
+  if (raw === 'true') return true
+  if (raw === 'false') return false
+  throw Object.assign(new Error(`Invalid boolean: ${raw}`), { statusCode: 400 })
+}
+
+function parseUserListSort(raw: string | null): UserListSortOrder {
+  const value = raw || 'card_count_desc'
+  const valid: readonly UserListSortOrder[] = [
+    'card_count_desc',
+    'card_count_asc',
+    'created_at_desc',
+    'name_asc',
+  ]
+  if (!valid.includes(value as UserListSortOrder)) {
+    throw Object.assign(new Error(`Invalid user sort: ${value}`), { statusCode: 400 })
+  }
+  return value as UserListSortOrder
+}
+
+function parseStreamerListSort(raw: string | null): StreamerListSortOrder {
+  const value = raw || 'card_count_desc'
+  const valid: readonly StreamerListSortOrder[] = [
+    'card_count_desc',
+    'card_count_asc',
+    'created_at_desc',
+    'name_asc',
+    'storage_desc',
+  ]
+  if (!valid.includes(value as StreamerListSortOrder)) {
+    throw Object.assign(new Error(`Invalid streamer sort: ${value}`), { statusCode: 400 })
+  }
+  return value as StreamerListSortOrder
 }
 
 export async function listLicenses(env: Env) {
@@ -231,18 +277,45 @@ export async function getOverview(env: Env) {
 export const USER_SAFE_COLUMNS =
   'id, twitch_user_id, twitch_username, twitch_display_name, twitch_profile_image_url, tos_accepted_at, twitch_scopes, created_at, updated_at'
 
-// ユーザー一覧（カード所持数付き）を返す。集計は get_analysis_users()
-// （00073_add_analysis_dashboard_rpcs.sql）がDB側で行い、関数未適用時はfail-fastする。
-export async function listUsers(env: Env) {
-  return listUsersPg(env)
+// ユーザー一覧はDB側で検索・集計・ページングを済ませ、現在ページと全体サマリーだけを返す。
+// これによりNodeプロセスがusers全件を保持してからブラウザへ渡す経路を廃止する。
+export async function listUsers(
+  params: {
+    page: number
+    pageSize: number
+    search?: string
+    sort?: UserListSortOrder
+    hideZeroCards?: boolean
+  },
+  env: Env
+) {
+  return listUsersPg(env, params)
 }
 
-// analysis/src/pages/Streamers.tsx の fetchStreamers() が期待する、カード数・
-// ストレージ使用量・チャット送信可否・投票キャンペーン特典を含む配信者一覧を返す。
-// 集計は get_analysis_streamers()（00073_add_analysis_dashboard_rpcs.sql）がDB側で行い、
-// 関数未適用時はfail-fastする。
-export async function listStreamersWithStats(env: Env) {
-  return listStreamersWithStatsPg(env)
+// Streamersも同じ契約に統一する。重いカード数・ストレージ・チャット設定の
+// 集計はDB側で行うが、JSON化するのは要求されたページの行だけに限定する。
+export async function listStreamersWithStats(
+  params: {
+    page: number
+    pageSize: number
+    search?: string
+    sort?: StreamerListSortOrder
+    hideZeroCards?: boolean
+    filterChatEnabled?: boolean
+    filterHasTemplate?: boolean
+    filterMissingScope?: boolean
+    filterVoteCampaign?: boolean
+  },
+  env: Env
+) {
+  return listStreamersWithStatsPg(env, params)
+}
+
+export async function getStreamerOptions(
+  params: { page: number; pageSize: number; search?: string },
+  env: Env
+) {
+  return getStreamerOptionsPg(env, params)
 }
 
 // #701: StreamerCards.tsx/StreamerGachaHistory.tsxのブラウザDB直接アクセスを
@@ -259,18 +332,6 @@ export async function getStreamerById(id: string, env: Env) {
   return getStreamerByIdPg(env, id)
 }
 
-// analysis/src/pages/StreamerGachaHistory.tsx のチャート用クエリと同一ロジック。
-// streamerId未指定時は全ストリーマー横断(analysis/src/pages/Gacha.tsx相当)になるため
-// streamers(*) も併せて埋め込む
-export async function getGachaChart(
-  params: { range: TimeRange; streamerId?: string },
-  env: Env
-) {
-  const fromDate = getFromDateForRange(params.range)
-
-  return getGachaChartPg(env, { streamerId: params.streamerId, fromDate })
-}
-
 export async function getGachaSummary(
   params: { range: TimeRange; streamerId?: string },
   env: Env
@@ -283,10 +344,12 @@ export async function getGachaSummary(
   })
 }
 
-// ILIKE 部分一致用のパターン文字エスケープ（%/_）。
+// ILIKE 部分一致用のパターン文字エスケープ（\\/%/_）。
 // テーブル表示とCSVエクスポートで同一の検索条件を保証する。
 export function escapeIlikePattern(value: string): string {
-  return value.replace(/%/g, '\\%').replace(/_/g, '\\_')
+  // バックスラッシュ自身を先にエスケープしないと、後続の %/_ 用エスケープが
+  // 検索文字列中のバックスラッシュをLIKEの制御文字として解釈してしまう。
+  return value.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_')
 }
 
 // to（YYYY-MM-DD）を「翌日0時（exclusive上限）」のISO文字列に変換する。
@@ -563,22 +626,58 @@ async function handleRoute(ctx: RouteContext): Promise<unknown> {
   }
 
   if (req.method === 'GET' && path === '/users') {
-    return listUsers(env)
+    const { page, pageSize } = parsePagination(url, 100)
+    const rawSearch = url.searchParams.get('search')?.trim() || ''
+    return listUsers(
+      {
+        page,
+        pageSize,
+        search: rawSearch ? `%${escapeIlikePattern(rawSearch)}%` : undefined,
+        sort: parseUserListSort(url.searchParams.get('sort')),
+        hideZeroCards: parseBooleanParam(url.searchParams.get('hideZeroCards')),
+      },
+      env
+    )
   }
 
   if (req.method === 'GET' && path === '/streamers') {
-    return listStreamersWithStats(env)
+    const { page, pageSize } = parsePagination(url, 100)
+    const rawSearch = url.searchParams.get('search')?.trim() || ''
+    return listStreamersWithStats(
+      {
+        page,
+        pageSize,
+        search: rawSearch ? `%${escapeIlikePattern(rawSearch)}%` : undefined,
+        sort: parseStreamerListSort(url.searchParams.get('sort')),
+        hideZeroCards: parseBooleanParam(url.searchParams.get('hideZeroCards')),
+        filterChatEnabled: parseBooleanParam(url.searchParams.get('filterChatEnabled')),
+        filterHasTemplate: parseBooleanParam(url.searchParams.get('filterHasTemplate')),
+        filterMissingScope: parseBooleanParam(url.searchParams.get('filterMissingScope')),
+        filterVoteCampaign: parseBooleanParam(url.searchParams.get('filterVoteCampaign')),
+      },
+      env
+    )
+  }
+
+  // Gachaの配信者選択肢は一覧全件ではなく、表示に必要な軽量な候補だけ取得する。
+  // 検索入力がある場合も同じbounded endpointを使い、ドロップダウンのために
+  // StreamerWithStats全体（カード数・ストレージ・Bot設定）を転送しない。
+  if (req.method === 'GET' && path === '/streamers/options') {
+    const { page, pageSize } = parsePagination(url, 100)
+    const rawSearch = url.searchParams.get('search')?.trim() || ''
+    return getStreamerOptions(
+      {
+        page,
+        pageSize,
+        search: rawSearch ? `%${escapeIlikePattern(rawSearch)}%` : undefined,
+      },
+      env
+    )
   }
 
   const streamerByIdMatch = path.match(/^\/streamers\/([^/]+)$/)
   if (req.method === 'GET' && streamerByIdMatch) {
     return getStreamerById(streamerByIdMatch[1], env)
-  }
-
-  if (req.method === 'GET' && path === '/gacha/chart') {
-    const range = parseTimeRange(url.searchParams.get('range'))
-    const streamerId = url.searchParams.get('streamerId') || undefined
-    return getGachaChart({ range, streamerId }, env)
   }
 
   if (req.method === 'GET' && path === '/gacha/summary') {
@@ -589,7 +688,10 @@ async function handleRoute(ctx: RouteContext): Promise<unknown> {
 
   if (req.method === 'GET' && path === '/gacha/table') {
     const range = parseTimeRange(url.searchParams.get('range'))
-    const { page, pageSize } = parsePagination(url)
+    // ガチャ履歴テーブルも画面の選択肢（20/50/100）に合わせ、1回のレスポンスを
+    // 最大100行に固定する。デフォルトの1000行上限をそのまま使うと、画面外から
+    // 大きなpageSizeを指定した場合に「サーバー側ページング」でも過大取得できる。
+    const { page, pageSize } = parsePagination(url, 100)
     const username = url.searchParams.get('username') || ''
     const rarity = url.searchParams.get('rarity') || ''
     const from = url.searchParams.get('from') || ''

--- a/analysis/src/App.tsx
+++ b/analysis/src/App.tsx
@@ -1,15 +1,70 @@
+import { lazy, Suspense, type ReactNode } from 'react'
 import { Routes, Route } from 'react-router-dom'
 import { Layout } from './components/Layout'
-import { Overview } from './pages/Overview'
-import { Users } from './pages/Users'
-import { UserCards } from './pages/UserCards'
-import { Streamers } from './pages/Streamers'
-import { StreamerCards } from './pages/StreamerCards'
-import { StreamerGachaHistory } from './pages/StreamerGachaHistory'
-import { Gacha } from './pages/Gacha'
-import { Announcements } from './pages/Announcements'
-import { Licenses } from './pages/Licenses'
-import { SupportInquiries } from './pages/SupportInquiries'
+
+// 各画面はOverviewの初回表示には不要で、Gacha画面はrechartsも読み込むため、
+// 全ページを静的importすると初回JSにすべての画面コードが含まれてしまう。
+// React.lazyのdynamic importに切り替えることで、Viteがルートごとのチャンクを
+// 生成し、ユーザーが実際に遷移した画面だけをダウンロードできる。
+// named exportのページをReact.lazyで扱うにはdefault exportへの変換が必要なため、
+// 各loaderのthenでページコンポーネントをdefaultとして返す。
+const Overview = lazy(() =>
+  import('./pages/Overview').then(({ Overview: Page }) => ({ default: Page }))
+)
+const Users = lazy(() => import('./pages/Users').then(({ Users: Page }) => ({ default: Page })))
+const UserCards = lazy(() =>
+  import('./pages/UserCards').then(({ UserCards: Page }) => ({ default: Page }))
+)
+const Streamers = lazy(() =>
+  import('./pages/Streamers').then(({ Streamers: Page }) => ({ default: Page }))
+)
+const StreamerCards = lazy(() =>
+  import('./pages/StreamerCards').then(({ StreamerCards: Page }) => ({ default: Page }))
+)
+const StreamerGachaHistory = lazy(() =>
+  import('./pages/StreamerGachaHistory').then(({ StreamerGachaHistory: Page }) => ({
+    default: Page,
+  }))
+)
+const Gacha = lazy(() => import('./pages/Gacha').then(({ Gacha: Page }) => ({ default: Page })))
+const Announcements = lazy(() =>
+  import('./pages/Announcements').then(({ Announcements: Page }) => ({ default: Page }))
+)
+const Licenses = lazy(() =>
+  import('./pages/Licenses').then(({ Licenses: Page }) => ({ default: Page }))
+)
+const SupportInquiries = lazy(() =>
+  import('./pages/SupportInquiries').then(({ SupportInquiries: Page }) => ({ default: Page }))
+)
+
+/**
+ * 画面チャンク取得中に表示する軽量なfallback。
+ * Layoutの外側ではなくRoutesの内側に置くことで、ナビゲーションを維持したまま
+ * 画面領域だけを置き換える。ユーザーが通信完了を待つ間も現在の操作対象が分かる
+ * ように、単なる空白ではなく画面見出し相当のスケルトンを表示する。
+ */
+function RouteLoadingFallback() {
+  return (
+    <div className="space-y-6" role="status" aria-live="polite" aria-label="画面を読み込み中">
+      <div className="h-8 w-48 rounded bg-gray-200 animate-pulse" />
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        {[0, 1, 2].map((item) => (
+          <div key={item} className="h-24 rounded-lg bg-white shadow animate-pulse" />
+        ))}
+      </div>
+      <div className="h-64 rounded-lg bg-white shadow animate-pulse" />
+    </div>
+  )
+}
+
+/**
+ * すべての遅延ルートで同じSuspense境界を使う。
+ * ルートごとにfallbackの実装を複製すると画面追加時に表示仕様がずれるため、
+ * チャンク読み込み中のUXをここで一元化する。
+ */
+function LazyPage({ children }: { children: ReactNode }) {
+  return <Suspense fallback={<RouteLoadingFallback />}>{children}</Suspense>
+}
 
 /**
  * Main App component with routing configuration
@@ -20,19 +75,89 @@ function App() {
     <Routes>
       <Route path="/" element={<Layout />}>
         {/* Overview is the default landing page (index route) */}
-        <Route index element={<Overview />} />
-        <Route path="users" element={<Users />} />
+        <Route
+          index
+          element={
+            <LazyPage>
+              <Overview />
+            </LazyPage>
+          }
+        />
+        <Route
+          path="users"
+          element={
+            <LazyPage>
+              <Users />
+            </LazyPage>
+          }
+        />
         {/* ユーザーごとのカード一覧ページ */}
-        <Route path="users/:userId/cards" element={<UserCards />} />
-        <Route path="streamers" element={<Streamers />} />
+        <Route
+          path="users/:userId/cards"
+          element={
+            <LazyPage>
+              <UserCards />
+            </LazyPage>
+          }
+        />
+        <Route
+          path="streamers"
+          element={
+            <LazyPage>
+              <Streamers />
+            </LazyPage>
+          }
+        />
         {/* ストリーマーごとのカード一覧ページ */}
-        <Route path="streamers/:streamerId/cards" element={<StreamerCards />} />
+        <Route
+          path="streamers/:streamerId/cards"
+          element={
+            <LazyPage>
+              <StreamerCards />
+            </LazyPage>
+          }
+        />
         {/* ストリーマーごとのガチャ履歴ページ */}
-        <Route path="streamers/:streamerId/gacha" element={<StreamerGachaHistory />} />
-        <Route path="gacha" element={<Gacha />} />
-        <Route path="announcements" element={<Announcements />} />
-        <Route path="licenses" element={<Licenses />} />
-        <Route path="inquiries" element={<SupportInquiries />} />
+        <Route
+          path="streamers/:streamerId/gacha"
+          element={
+            <LazyPage>
+              <StreamerGachaHistory />
+            </LazyPage>
+          }
+        />
+        <Route
+          path="gacha"
+          element={
+            <LazyPage>
+              <Gacha />
+            </LazyPage>
+          }
+        />
+        <Route
+          path="announcements"
+          element={
+            <LazyPage>
+              <Announcements />
+            </LazyPage>
+          }
+        />
+        <Route
+          path="licenses"
+          element={
+            <LazyPage>
+              <Licenses />
+            </LazyPage>
+          }
+        />
+        <Route
+          path="inquiries"
+          element={
+            <LazyPage>
+              <SupportInquiries />
+            </LazyPage>
+          }
+        />
       </Route>
     </Routes>
   )

--- a/analysis/src/components/DropRateStats.tsx
+++ b/analysis/src/components/DropRateStats.tsx
@@ -53,7 +53,7 @@ export function DropRateStats({ streamerId, timeRange }: DropRateStatsProps) {
 
     try {
       // __admin/drop-rate-stats 経由で get_gacha_drop_stats RPC を呼び出す。
-      // DBサイドの正確なCOUNT/GROUP BY集計のため、10000件キャップや近似値の懸念はない。
+      // DBサイドの正確なCOUNT/GROUP BY集計のため、履歴行数に依存した近似値の懸念はない。
       const data = await adminApi.getDropRateStats({ streamerId, range: timeRange })
 
       const stats: CardStat[] = data.card_stats.map((c) => ({

--- a/analysis/src/hooks/useDebouncedValue.ts
+++ b/analysis/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * 指定した値の通知を遅延させ、保留中の通知を取り消す関数を返す。
+ *
+ * タイマーのライフサイクルをhook本体から分離しておくと、Reactのrendererを
+ * 必要とせずに「古い値のタイマーをcleanupして最新値だけ通知する」という
+ * デバウンスの本体を検証できる。hookはこのcleanupをuseEffectの戻り値として
+ * そのまま返すため、再レンダー時とアンマウント時の既存の動作も維持される。
+ */
+export function scheduleDebouncedValue<T>(
+  value: T,
+  delayMs: number,
+  onValue: (value: T) => void,
+): () => void {
+  const timer = setTimeout(() => onValue(value), delayMs)
+  return () => clearTimeout(timer)
+}
+
+/**
+ * 値が最後に変更されてから指定時間が経過したときだけ、最新値を返す。
+ *
+ * 検索入力をそのままDB検索の依存値にすると、1文字入力するたびに
+ * `get_analysis_*_page` が実行される。これらのRPCはページ行だけでなく正確な
+ * countと全体summaryも計算するため、入力中の中間値を毎回検索するのはDB負荷と
+ * レスポンス競合を不必要に増やす。hook側でタイマーを一元管理し、入力が続く間は
+ * 保留、入力が止まった後の最新値だけを一覧APIへ渡す。
+ *
+ * cleanupで前回のタイマーを必ず破棄するため、連続入力中に古い検索語が後から
+ * stateへ反映されることも防ぐ。呼び出し側がアンマウントされた場合も同じcleanupが
+ * 走り、アンマウント後のstate更新を発生させない。
+ */
+export function useDebouncedValue<T>(value: T, delayMs = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(
+    () => scheduleDebouncedValue(value, delayMs, setDebouncedValue),
+    [value, delayMs]
+  )
+
+  return debouncedValue
+}

--- a/analysis/src/lib/adminApi.ts
+++ b/analysis/src/lib/adminApi.ts
@@ -97,6 +97,10 @@ export interface Paginated<T> {
   count: number
 }
 
+export interface PaginatedWithSummary<T, S> extends Paginated<T> {
+  summary: S
+}
+
 // analysis/src/pages/Users.tsx の fetchUsers() が読む形（user.user_cards?.[0]?.count）と一致
 export type UserWithCardCount = User & { user_cards: { count: number }[] }
 
@@ -118,18 +122,76 @@ export interface StreamerWithStats extends Streamer {
   has_vote_campaign_bonus: boolean
 }
 
-// チャート用ガチャ履歴行 - cards は最小フィールドのみ
-export type GachaChartCard = Pick<Card, 'id' | 'name' | 'rarity' | 'image_url'>
+export type UserListSortOrder =
+  | 'card_count_desc'
+  | 'card_count_asc'
+  | 'created_at_desc'
+  | 'name_asc'
 
-export interface GachaChartRow {
-  id: string
-  redeemed_at: string
-  card_id: string
-  user_twitch_id: string
-  streamer_id: string
-  cards: GachaChartCard | null
-  streamers: Streamer | null
+export type StreamerListSortOrder =
+  | 'card_count_desc'
+  | 'card_count_asc'
+  | 'created_at_desc'
+  | 'name_asc'
+  | 'storage_desc'
+
+export interface UserListSummary {
+  totalUsers: number
+  totalCards: number
+  usersWithTos: number
+  usersWithCards: number
 }
+
+export interface StreamerListSummary {
+  totalStreamers: number
+  activeStreamers: number
+  configuredStreamers: number
+  totalCards: number
+  totalStorage: number
+  streamersWithCards: number
+  chatEnabledStreamers: number
+  customTemplateStreamers: number
+  chatEnabledNoSender: number
+  voteCampaignUsers: number
+}
+
+export interface StreamerOption {
+  id: string
+  twitch_username: string
+  twitch_display_name: string
+}
+
+export type UserListResponse = PaginatedWithSummary<UserWithCardCount, UserListSummary>
+export type StreamerListResponse = PaginatedWithSummary<StreamerWithStats, StreamerListSummary>
+
+export interface UserListParams {
+  page: number
+  pageSize: number
+  search?: string
+  sort?: UserListSortOrder
+  hideZeroCards?: boolean
+}
+
+export interface StreamerListParams {
+  page: number
+  pageSize: number
+  search?: string
+  sort?: StreamerListSortOrder
+  hideZeroCards?: boolean
+  filterChatEnabled?: boolean
+  filterHasTemplate?: boolean
+  filterMissingScope?: boolean
+  filterVoteCampaign?: boolean
+}
+
+export interface StreamerOptionParams {
+  page: number
+  pageSize: number
+  search?: string
+}
+
+// DB側集計RPCが返す人気カードの最小フィールド
+export type GachaChartCard = Pick<Card, 'id' | 'name' | 'rarity' | 'image_url'>
 
 export interface GachaSummary {
   totalGacha: number
@@ -226,10 +288,9 @@ function buildQueryString(params: Record<string, string | number | undefined>): 
 }
 
 // リクエストがハングしたまま返ってこない事故(サーバープロセスの停止・ネットワーク
-// 断等)を防ぐデフォルトタイムアウト。getStreamerLeaderboard()はgacha_history全件
-// (~65,000行超)をNode側でfetchAllPagedしながら集計するため既知で約20秒かかる
-// (Overview.tsx/localAdminApi.tsのコメント参照)。誤って正常な低速リクエストを
-// 打ち切らないよう、その3倍程度の余裕を持たせた値にする
+// 断等)を防ぐデフォルトタイムアウト。Overviewや一覧の集計はDB側で完結するが、
+// ネットワーク障害やDBの一時的な遅延でリクエストが無期限に残らないよう、
+// UIが再試行できる十分な余裕を持たせた値にする。
 const DEFAULT_TIMEOUT_MS = 60_000
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -296,12 +357,35 @@ export const adminApi = {
   getOverview: (options?: RequestOptions) => request<OverviewData>('/overview', options),
   getOverviewLeaderboard: (options?: RequestOptions) =>
     request<StreamerLeaderboardEntry[]>('/overview/leaderboard', options),
-  getUsers: (options?: RequestOptions) => request<UserWithCardCount[]>('/users', options),
-  getStreamers: (options?: RequestOptions) => request<StreamerWithStats[]>('/streamers', options),
+  getUsers: (params: UserListParams = { page: 1, pageSize: 20 }, options?: RequestOptions) =>
+    request<UserListResponse>(`/users?${buildQueryString({
+      ...params,
+      search: params.search?.trim() || undefined,
+      sort: params.sort || 'card_count_desc',
+      hideZeroCards: params.hideZeroCards ? 'true' : undefined,
+    })}`, options),
+  getStreamers: (
+    params: StreamerListParams = { page: 1, pageSize: 20 },
+    options?: RequestOptions
+  ) =>
+    request<StreamerListResponse>(`/streamers?${buildQueryString({
+      ...params,
+      search: params.search?.trim() || undefined,
+      sort: params.sort || 'card_count_desc',
+      hideZeroCards: params.hideZeroCards ? 'true' : undefined,
+      filterChatEnabled: params.filterChatEnabled ? 'true' : undefined,
+      filterHasTemplate: params.filterHasTemplate ? 'true' : undefined,
+      filterMissingScope: params.filterMissingScope ? 'true' : undefined,
+      filterVoteCampaign: params.filterVoteCampaign ? 'true' : undefined,
+    })}`, options),
+  getStreamerOptions: (params: StreamerOptionParams, options?: RequestOptions) =>
+    request<Paginated<StreamerOption>>(`/streamers/options?${buildQueryString({
+      page: params.page,
+      pageSize: params.pageSize,
+      search: params.search,
+    })}`, options),
   getStreamer: (id: string, options?: RequestOptions) =>
     request<Streamer>(`/streamers/${id}`, options),
-  getGachaChart: (params: { range: TimeRange; streamerId?: string }, options?: RequestOptions) =>
-    request<GachaChartRow[]>(`/gacha/chart?${buildQueryString(params)}`, options),
   getGachaSummary: (params: { range: TimeRange; streamerId?: string }, options?: RequestOptions) =>
     request<GachaSummary>(`/gacha/summary?${buildQueryString(params)}`, options),
   getGachaTable: (params: GachaTableParams, options?: RequestOptions) =>

--- a/analysis/src/pages/Gacha.tsx
+++ b/analysis/src/pages/Gacha.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, useCallback, useRef } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { DataTable } from '../components/DataTable'
 import { ErrorBanner } from '../components/ErrorBanner'
 import { RarityBadge } from '../components/RarityBadge'
@@ -9,7 +9,7 @@ import {
   TimeRange,
   GachaSummary,
   GachaTableRow,
-  StreamerWithStats,
+  StreamerOption,
 } from '../lib/adminApi'
 import {
   LineChart,
@@ -53,15 +53,17 @@ const PAGE_SIZE_OPTIONS = [20, 50, 100]
  * filter, and a paginated/filterable history table (server-side, via /__admin/gacha/*)
  */
 export function Gacha() {
-  const [timeRange, setTimeRange] = useState<TimeRange>('all')
+  // 全期間は明示選択時だけ許可し、初回の集計・履歴取得は直近7日に限定する。
+  const [timeRange, setTimeRange] = useState<TimeRange>('7d')
   const [chartError, setChartError] = useState<string | null>(null)
   const [tableError, setTableError] = useState<string | null>(null)
   // 再試行ボタン用のトリガー（値自体に意味は無く、変更するとeffectを再実行させる）
   const [chartRetryToken, setChartRetryToken] = useState(0)
   const [tableRetryToken, setTableRetryToken] = useState(0)
 
-  // --- 全ストリーマー一覧（ストリーマーフィルタのドロップダウン用、マウント時に一度だけ取得） ---
-  const [streamers, setStreamers] = useState<StreamerWithStats[]>([])
+  // --- ストリーマー選択肢（軽量・最大100件。検索で候補を絞り込む） ---
+  const [streamers, setStreamers] = useState<StreamerOption[]>([])
+  const [streamerSearchInput, setStreamerSearchInput] = useState('')
   const [selectedStreamerId, setSelectedStreamerId] = useState('')
 
   // --- チャート/統計用集計データ（/__admin/gacha/summary でDB側GROUP BY済み） ---
@@ -89,22 +91,32 @@ export function Gacha() {
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // ========================================
-  // fetchStreamers: ストリーマーフィルタ用の一覧取得（マウント時に一度だけ）
+  // fetchStreamerOptions: ドロップダウン専用の軽量候補をbounded取得する。
+  // StreamerWithStats全件を取得してから並べ替える旧経路を廃止し、検索時も
+  // 100件以内の候補だけを保持する。
   // ========================================
   useEffect(() => {
     const controller = new AbortController()
-    ;(async () => {
-      try {
-        const data = await adminApi.getStreamers({ signal: controller.signal })
-        setStreamers(data)
-      } catch (err) {
-        if (controller.signal.aborted) return
-        // ドロップダウンが空のままになるだけなので致命的ではない
-        console.error('Failed to fetch streamers:', err)
-      }
-    })()
-    return () => controller.abort()
-  }, [])
+    const timer = setTimeout(() => {
+      ;(async () => {
+        try {
+          const { rows } = await adminApi.getStreamerOptions(
+            { page: 1, pageSize: 100, search: streamerSearchInput },
+            { signal: controller.signal }
+          )
+          setStreamers(rows)
+        } catch (err) {
+          if (controller.signal.aborted) return
+          // 候補だけの取得失敗は集計・履歴テーブルをブロックさせない。
+          console.error('Failed to fetch streamer options:', err)
+        }
+      })()
+    }, 250)
+    return () => {
+      clearTimeout(timer)
+      controller.abort()
+    }
+  }, [streamerSearchInput])
 
   // ========================================
   // fetchSummary: チャート/統計用集計データ取得（timeRange/selectedStreamerId変更時）
@@ -220,11 +232,6 @@ export function Gacha() {
   }, [])
 
   // ストリーマーフィルタ用ドロップダウンの選択肢（カード数の多い順）
-  const sortedStreamers = useMemo(
-    () => [...streamers].sort((a, b) => b.card_count - a.card_count),
-    [streamers]
-  )
-
   // CSVエクスポート: window.location.href によるフルページ遷移だと、サーバーが
   // エラー(JSON/500)を返した場合にSPAの状態(フィルタ等)が失われた上にエラーも
   // 画面に表示されない。fetch + blobダウンロードに切り替え、失敗時はtableErrorに出す
@@ -503,13 +510,20 @@ export function Gacha() {
             {/* Streamer Filter */}
             <div>
               <label className="block text-xs text-gray-500 mb-1">Streamer</label>
+              <input
+                type="text"
+                value={streamerSearchInput}
+                onChange={(e) => setStreamerSearchInput(e.target.value)}
+                placeholder="候補を検索..."
+                className="border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 w-40 mb-1"
+              />
               <select
                 value={selectedStreamerId}
                 onChange={(e) => handleStreamerChange(e.target.value)}
                 className="border border-gray-300 rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
                 <option value="">All Streamers</option>
-                {sortedStreamers.map((s) => (
+                {streamers.map((s) => (
                   <option key={s.id} value={s.id}>
                     {s.twitch_display_name}
                   </option>

--- a/analysis/src/pages/Gacha.tsx
+++ b/analysis/src/pages/Gacha.tsx
@@ -104,7 +104,17 @@ export function Gacha() {
             { page: 1, pageSize: 100, search: streamerSearchInput },
             { signal: controller.signal }
           )
-          setStreamers(rows)
+          setStreamers((previousRows) => {
+            // 検索結果を置き換えるだけだと、100件目以降の配信者を検索して
+            // 選択した後に検索文字を消した際、その選択肢が先頭100件から外れて
+            // selectの表示が空になる。現在選択中の候補だけは軽量な1行として
+            // 次の結果にも残し、選択状態とサーバー側の集計条件を一致させる。
+            const selected = previousRows.find((row) => row.id === selectedStreamerId)
+            if (selected && !rows.some((row) => row.id === selected.id)) {
+              return [selected, ...rows]
+            }
+            return rows
+          })
         } catch (err) {
           if (controller.signal.aborted) return
           // 候補だけの取得失敗は集計・履歴テーブルをブロックさせない。
@@ -116,7 +126,7 @@ export function Gacha() {
       clearTimeout(timer)
       controller.abort()
     }
-  }, [streamerSearchInput])
+  }, [streamerSearchInput, selectedStreamerId])
 
   // ========================================
   // fetchSummary: チャート/統計用集計データ取得（timeRange/selectedStreamerId変更時）

--- a/analysis/src/pages/StreamerGachaHistory.tsx
+++ b/analysis/src/pages/StreamerGachaHistory.tsx
@@ -1,11 +1,9 @@
-import { useEffect, useState, useMemo, useCallback, useRef } from 'react'
+import { useEffect, useState, useCallback, useRef } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import {
   adminApi,
-  DropRateStatsResponse,
+  GachaSummary,
   TimeRange,
-  GachaChartRow,
-  GachaChartCard,
   GachaTableRow,
 } from '../lib/adminApi'
 import { DataTable } from '../components/DataTable'
@@ -72,7 +70,8 @@ export function StreamerGachaHistory() {
 
   // --- 基本 state ---
   const [streamer, setStreamer] = useState<Streamer | null>(null)
-  const [timeRange, setTimeRange] = useState<TimeRange>('all')
+  // 初回表示は直近7日。全期間はユーザーが明示的に選択したときだけ集計する。
+  const [timeRange, setTimeRange] = useState<TimeRange>('7d')
   // streamer本体のエラーはchartErrorに相乗りさせず専用のstateで持つ。
   // 相乗りさせるとtimeRange変更時のsetChartError(null)で「streamer取得は
   // 再試行されていないのに」エラー表示だけが消え、ヘッダーが黙って空のまま残る
@@ -84,17 +83,16 @@ export function StreamerGachaHistory() {
   const [chartRetryToken, setChartRetryToken] = useState(0)
   const [tableRetryToken, setTableRetryToken] = useState(0)
 
-  // --- チャート用データ（bounded 10000件、timeRange で再取得。/__admin/gacha/chart 経由） ---
-  const [chartData, setChartData] = useState<GachaChartRow[]>([])
+  // --- チャート用集計（DB側GROUP BY済み。履歴行をクライアントへ持ち込まない） ---
+  const [chartSummary, setChartSummary] = useState<GachaSummary>({
+    totalGacha: 0,
+    uniqueUsers: 0,
+    legendaryCount: 0,
+    dailyGachaData: [],
+    rarityDistribution: [],
+    popularCards: [],
+  })
   const [chartLoading, setChartLoading] = useState(true)
-
-  // --- サマリー統計用データ（get_gacha_drop_stats RPC、正確な集計） ---
-  // <DropRateStats> も内部で同じRPCを呼ぶが、props経由で状態を共有せず
-  // あえて独立に取得する（疎結合を優先。DB側は軽量なインデックス集計のため許容）
-  const [dropRateStats, setDropRateStats] = useState<DropRateStatsResponse | null>(null)
-  const [dropRateStatsLoading, setDropRateStatsLoading] = useState(true)
-  const [dropRateStatsError, setDropRateStatsError] = useState<string | null>(null)
-  const [dropRateStatsRetryToken, setDropRateStatsRetryToken] = useState(0)
 
   // --- テーブル用データ（ページネーション + フィルタ） ---
   const [tableData, setTableData] = useState<GachaTableRow[]>([])
@@ -131,8 +129,9 @@ export function StreamerGachaHistory() {
   }, [streamerId, streamerRetryToken])
 
   // ========================================
-  // fetchChartData: チャート用bounded(10000件)データ取得（streamerId/timeRange変更時）
-  // /__admin/gacha/chart 経由（anon keyではRLSによりgacha_historyを直接読めないため）
+  // fetchChartData: DB側で集計済みのチャート値を取得（streamerId/timeRange変更時）。
+  // 大量の履歴行を取得してからブラウザで集計する経路を廃止し、日別・レアリティ・
+  // 人気カード・ユニークユーザー数を1つの集計レスポンスで受け取る。
   // ========================================
   useEffect(() => {
     if (!streamerId) return
@@ -144,11 +143,11 @@ export function StreamerGachaHistory() {
       setChartLoading(true)
       setChartError(null)
       try {
-        const data = await adminApi.getGachaChart(
+        const data = await adminApi.getGachaSummary(
           { range: timeRange, streamerId },
           { signal: controller.signal }
         )
-        setChartData(data)
+        setChartSummary(data)
       } catch (err) {
         if (controller.signal.aborted) return
         setChartError(`Chart data error: ${(err instanceof Error && err.message) || 'Unknown error'}`)
@@ -160,36 +159,6 @@ export function StreamerGachaHistory() {
     fetchChartData()
     return () => controller.abort()
   }, [streamerId, timeRange, chartRetryToken])
-
-  // ========================================
-  // fetchDropRateStats: サマリー統計用の正確な集計取得（streamerId/timeRange変更時）
-  // get_gacha_drop_stats RPC（10000件キャップなし、DB側で正確なCOUNT/GROUP BY）から
-  // totalGacha/legendaryCount/legendaryRate を導出する。<DropRateStats> とは独立に取得。
-  // ========================================
-  useEffect(() => {
-    if (!streamerId) return
-    const controller = new AbortController()
-
-    const fetchDropRateStats = async () => {
-      setDropRateStatsLoading(true)
-      setDropRateStatsError(null)
-      try {
-        const data = await adminApi.getDropRateStats(
-          { streamerId, range: timeRange },
-          { signal: controller.signal }
-        )
-        setDropRateStats(data)
-      } catch (err) {
-        if (controller.signal.aborted) return
-        setDropRateStatsError((err instanceof Error && err.message) || 'Unknown error')
-      } finally {
-        if (!controller.signal.aborted) setDropRateStatsLoading(false)
-      }
-    }
-
-    fetchDropRateStats()
-    return () => controller.abort()
-  }, [streamerId, timeRange, dropRateStatsRetryToken])
 
   // ========================================
   // fetchTableData: テーブル用データ取得（ページ/フィルタ/timeRange変更時）
@@ -262,62 +231,15 @@ export function StreamerGachaHistory() {
     setCurrentPage(1)
   }, [])
 
-  // ========================================
-  // チャート用の集計データ（useMemo）
-  // ========================================
-
-  /** 日別ガチャ数を集計（折れ線チャート用） */
-  const dailyGachaData = useMemo(() => {
-    // ISO日付文字列（YYYY-MM-DD）をキーに集計し、ロケール依存のパース問題を回避
-    const dailyCounts = new Map<string, number>()
-    chartData.forEach((gacha) => {
-      const isoDate = gacha.redeemed_at.slice(0, 10) // "2024-01-05"
-      dailyCounts.set(isoDate, (dailyCounts.get(isoDate) || 0) + 1)
-    })
-    return Array.from(dailyCounts.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([isoDate, count]) => ({
-        date: new Date(isoDate).toLocaleDateString('ja-JP'),
-        count,
-      }))
-  }, [chartData])
-
-  /** レアリティ分布を集計（円チャート用） */
-  const rarityDistribution = useMemo(() => {
-    const counts: Record<Rarity, number> = { common: 0, rare: 0, epic: 0, legendary: 0 }
-    chartData.forEach((gacha) => {
-      if (gacha.cards?.rarity) counts[gacha.cards.rarity]++
-    })
-    return Object.entries(counts)
-      .filter(([, count]) => count > 0)
-      .map(([rarity, count]) => ({
-        name: rarity.charAt(0).toUpperCase() + rarity.slice(1),
-        value: count,
-        rarity: rarity as Rarity,
-      }))
-  }, [chartData])
-
-  /** 人気カードランキング（TOP10） */
-  const popularCards = useMemo(() => {
-    const cardCounts = new Map<string, { card: GachaChartCard; count: number }>()
-    chartData.forEach((gacha) => {
-      if (gacha.cards) {
-        const existing = cardCounts.get(gacha.cards.id)
-        if (existing) existing.count++
-        else cardCounts.set(gacha.cards.id, { card: gacha.cards, count: 1 })
-      }
-    })
-    return Array.from(cardCounts.values())
-      .sort((a, b) => b.count - a.count)
-      .slice(0, 10)
-  }, [chartData])
-
-  // サマリー統計（get_gacha_drop_stats RPCの正確な集計から算出。10000件キャップなし）
-  const totalGacha = dropRateStats?.total_draws ?? 0
-  const legendaryCount = dropRateStats?.rarity_stats.find((r) => r.rarity === 'legendary')?.count ?? 0
+  // サマリーはDBのCOUNT/GROUP BY結果をそのまま表示する。履歴全件をブラウザで
+  // Set/Map集計しないため、7日を超えるデータ量に初回表示が比例しない。
+  const totalGacha = chartSummary.totalGacha
+  const uniqueUsers = chartSummary.uniqueUsers
+  const legendaryCount = chartSummary.legendaryCount
   const legendaryRate = totalGacha > 0 ? ((legendaryCount / totalGacha) * 100).toFixed(2) : '0'
-  // uniqueUsers はRPCに対応フィールドがないため、引き続きチャートデータ（10000件上限）から近似算出
-  const uniqueUsers = new Set(chartData.map((g) => g.user_twitch_id)).size
+  const dailyGachaData = chartSummary.dailyGachaData
+  const rarityDistribution = chartSummary.rarityDistribution
+  const popularCards = chartSummary.popularCards
 
   /** ガチャ履歴テーブルのカラム定義 */
   const columns = [
@@ -418,12 +340,10 @@ export function StreamerGachaHistory() {
           streamerError,
           chartError,
           tableError,
-          dropRateStatsError && `Summary stats error: ${dropRateStatsError}`,
         ]}
         onRetry={() => {
           setStreamerRetryToken((t) => t + 1)
           setChartRetryToken((t) => t + 1)
-          setDropRateStatsRetryToken((t) => t + 1)
           setTableRetryToken((t) => t + 1)
         }}
       />
@@ -432,7 +352,7 @@ export function StreamerGachaHistory() {
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <div className="bg-white rounded-lg shadow p-4">
           <p className="text-sm text-gray-500">総ガチャ数</p>
-          {dropRateStatsLoading ? (
+          {chartLoading ? (
             <div className="h-7 w-20 bg-gray-100 animate-pulse rounded mt-1" />
           ) : (
             <p className="text-2xl font-bold">{totalGacha.toLocaleString()}</p>
@@ -445,14 +365,10 @@ export function StreamerGachaHistory() {
           ) : (
             <p className="text-2xl font-bold">{uniqueUsers.toLocaleString()}</p>
           )}
-          {/* uniqueUsers に対応する正確な集計RPCがないため、引き続きチャートの10000件上限からの近似値 */}
-          {chartData.length >= 10000 && (
-            <p className="text-xs text-amber-600 mt-1">※ 直近10,000件からの概算です</p>
-          )}
         </div>
         <div className="bg-white rounded-lg shadow p-4">
           <p className="text-sm text-gray-500">レジェンダリー獲得数</p>
-          {dropRateStatsLoading ? (
+          {chartLoading ? (
             <div className="h-7 w-16 bg-gray-100 animate-pulse rounded mt-1" />
           ) : (
             <p className="text-2xl font-bold text-amber-600">{legendaryCount.toLocaleString()}</p>
@@ -460,20 +376,13 @@ export function StreamerGachaHistory() {
         </div>
         <div className="bg-white rounded-lg shadow p-4">
           <p className="text-sm text-gray-500">レジェンダリー率</p>
-          {dropRateStatsLoading ? (
+          {chartLoading ? (
             <div className="h-7 w-14 bg-gray-100 animate-pulse rounded mt-1" />
           ) : (
             <p className="text-2xl font-bold">{legendaryRate}%</p>
           )}
         </div>
       </div>
-      {/* チャート（日別推移・レアリティ分布・人気カード）は10000件上限のため、超過時は近似値であることを注記 */}
-      {chartData.length >= 10000 && (
-        <p className="text-xs text-amber-600">
-          ※ 下記チャートは直近10,000件からの算出です。正確な総回数は下部の排出率統計を参照してください。
-        </p>
-      )}
-
       {/* チャートセクション */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* 日別ガチャ数 折れ線チャート */}

--- a/analysis/src/pages/Streamers.tsx
+++ b/analysis/src/pages/Streamers.tsx
@@ -8,6 +8,7 @@ import {
 } from '../lib/adminApi'
 import { DataTable } from '../components/DataTable'
 import { ErrorBanner } from '../components/ErrorBanner'
+import { useDebouncedValue } from '../hooks/useDebouncedValue'
 import { StreamerPopup } from '../components/StreamerPopup'
 
 /**
@@ -37,6 +38,10 @@ export function Streamers() {
   const [loading, setLoading] = useState(true)
   // 検索クエリ（ユーザー名・表示名・Twitch User IDでフィルタリング）
   const [searchQuery, setSearchQuery] = useState('')
+  // Streamers RPCはカード数・ストレージ・チャット設定を集計するため、検索入力の
+  // 中間値ごとに実行すると全体集計を連続して起動してしまう。最後の入力から300ms
+  // 待ってからAPIへ渡し、入力中の不要なDB処理をまとめる。
+  const debouncedSearchQuery = useDebouncedValue(searchQuery)
   // ソート順（デフォルト: カード数の多い順）
   const [sortOrder, setSortOrder] = useState<SortOrder>('card_count_desc')
   // カード数0のストリーマーを非表示にするフラグ
@@ -81,7 +86,7 @@ export function Streamers() {
           {
             page: currentPage,
             pageSize,
-            search: searchQuery,
+            search: debouncedSearchQuery,
             sort: sortOrder,
             hideZeroCards,
             filterChatEnabled,
@@ -103,7 +108,7 @@ export function Streamers() {
       }
     })()
     return () => controller.abort()
-  }, [currentPage, pageSize, searchQuery, sortOrder, hideZeroCards, filterChatEnabled, filterHasTemplate, filterMissingScope, filterVoteCampaign, retryToken])
+  }, [currentPage, pageSize, debouncedSearchQuery, sortOrder, hideZeroCards, filterChatEnabled, filterHasTemplate, filterMissingScope, filterVoteCampaign, retryToken])
 
   // フィルター条件が変わったらページを1に戻す
   useEffect(() => {

--- a/analysis/src/pages/Streamers.tsx
+++ b/analysis/src/pages/Streamers.tsx
@@ -1,6 +1,11 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { adminApi, type StreamerWithStats } from '../lib/adminApi'
+import {
+  adminApi,
+  type StreamerListSortOrder,
+  type StreamerListSummary,
+  type StreamerWithStats,
+} from '../lib/adminApi'
 import { DataTable } from '../components/DataTable'
 import { ErrorBanner } from '../components/ErrorBanner'
 import { StreamerPopup } from '../components/StreamerPopup'
@@ -18,7 +23,7 @@ function formatBytes(bytes: number): string {
 }
 
 // ソート順の定義
-type SortOrder = 'card_count_desc' | 'card_count_asc' | 'created_at_desc' | 'name_asc' | 'storage_desc'
+type SortOrder = StreamerListSortOrder
 
 /**
  * Streamers page - Displays all registered streamers with their card collections
@@ -47,21 +52,48 @@ export function Streamers() {
   // ページネーション状態
   const [currentPage, setCurrentPage] = useState(1)
   const [pageSize, setPageSize] = useState(20)
+  const [totalCount, setTotalCount] = useState(0)
+  const [summary, setSummary] = useState<StreamerListSummary>({
+    totalStreamers: 0,
+    activeStreamers: 0,
+    configuredStreamers: 0,
+    totalCards: 0,
+    totalStorage: 0,
+    streamersWithCards: 0,
+    chatEnabledStreamers: 0,
+    customTemplateStreamers: 0,
+    chatEnabledNoSender: 0,
+    voteCampaignUsers: 0,
+  })
   const [error, setError] = useState<string | null>(null)
   // 再試行ボタン用のトリガー（値自体に意味は無く、変更するとeffectを再実行させる）
   const [retryToken, setRetryToken] = useState(0)
 
-  // Fetches all streamers with card counts and storage usage
-  // カード数・ストレージ使用量・チャット送信可否・投票キャンペーン適用状況は
-  // すべてサーバーサイド（/__admin/streamers）で集計済みのため、1回のAPI呼び出しで完結する
+  // 検索・フィルタ・ソートをDB側へ渡し、カード数・ストレージ等の重い集計結果も
+  // 現在ページの行だけ受け取る。画面側のページャーは全件配列をsliceしない。
   useEffect(() => {
     const controller = new AbortController()
     ;(async () => {
       setLoading(true)
       setError(null)
       try {
-        const streamers = await adminApi.getStreamers({ signal: controller.signal })
-        setStreamers(streamers)
+        const { rows, count, summary: nextSummary } = await adminApi.getStreamers(
+          {
+            page: currentPage,
+            pageSize,
+            search: searchQuery,
+            sort: sortOrder,
+            hideZeroCards,
+            filterChatEnabled,
+            filterHasTemplate,
+            filterMissingScope,
+            filterVoteCampaign,
+          },
+          { signal: controller.signal }
+        )
+        setStreamers(rows)
+        setTotalCount(count)
+        setSummary(nextSummary)
       } catch (err) {
         if (controller.signal.aborted) return
         console.error('Error fetching streamers:', err)
@@ -71,7 +103,7 @@ export function Streamers() {
       }
     })()
     return () => controller.abort()
-  }, [retryToken])
+  }, [currentPage, pageSize, searchQuery, sortOrder, hideZeroCards, filterChatEnabled, filterHasTemplate, filterMissingScope, filterVoteCampaign, retryToken])
 
   // フィルター条件が変わったらページを1に戻す
   useEffect(() => {
@@ -271,87 +303,6 @@ export function Streamers() {
     },
   ]
 
-  // Calculate summary statistics including total storage usage
-  // 全ストリーマーの統計情報を計算（ストレージ使用量を含む）
-  const activeStreamers = streamers.filter((s) => s.is_active).length
-  const configuredStreamers = streamers.filter((s) => s.channel_point_reward_id).length
-  const totalCards = streamers.reduce((sum, s) => sum + s.card_count, 0)
-  const totalStorage = streamers.reduce((sum, s) => sum + s.storage_bytes, 0)
-  const streamersWithCards = streamers.filter((s) => s.card_count > 0).length
-  // チャット通知ONのストリーマー数
-  const chatEnabledStreamers = streamers.filter((s) => s.chat_announcement_enabled).length
-  // カスタムテンプレート設定済みのストリーマー数
-  const customTemplateStreamers = streamers.filter((s) => s.chat_announcement_template).length
-  // Chat通知ONだが現在の送信方式で送信できないストリーマー数（要対応）
-  const chatEnabledNoSender = streamers.filter((s) => s.chat_announcement_enabled && !s.chat_send_available).length
-  // 投票キャンペーンボーナスを有効化したユーザー数
-  const voteCampaignUsers = streamers.filter((s) => s.has_vote_campaign_bonus).length
-
-  /**
-   * フィルターとソートを適用したストリーマー一覧を生成
-   * 検索クエリ、カード数フィルター、ソート順を適用
-   * パフォーマンス最適化のためuseMemoでメモ化
-   */
-  const filteredAndSortedStreamers = useMemo(() => {
-    let result = streamers
-
-    // フィルター: 検索クエリ（ユーザー名、表示名、またはTwitch User IDに部分一致）
-    // broadcasterTwitchUserIdで配信者を特定する運用ケースに対応
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase().trim()
-      result = result.filter(
-        (s) =>
-          s.twitch_username.toLowerCase().includes(query) ||
-          s.twitch_display_name.toLowerCase().includes(query) ||
-          s.twitch_user_id.includes(query)
-      )
-    }
-
-    // フィルター: カード数0を非表示にする場合
-    if (hideZeroCards) {
-      result = result.filter((s) => s.card_count > 0)
-    }
-
-    // フィルター: チャット通知ONのストリーマーのみ表示
-    if (filterChatEnabled) {
-      result = result.filter((s) => s.chat_announcement_enabled)
-    }
-
-    // フィルター: カスタムテンプレート設定済みのストリーマーのみ表示
-    if (filterHasTemplate) {
-      result = result.filter((s) => s.chat_announcement_template)
-    }
-
-    // フィルター: Chat通知ONだが現在の送信方式で送信できないストリーマーのみ表示
-    if (filterMissingScope) {
-      result = result.filter((s) => s.chat_announcement_enabled && !s.chat_send_available)
-    }
-
-    // フィルター: 投票キャンペーン有効化済みのストリーマーのみ表示
-    if (filterVoteCampaign) {
-      result = result.filter((s) => s.has_vote_campaign_bonus)
-    }
-
-    // ソート
-    result = [...result].sort((a, b) => {
-      switch (sortOrder) {
-        case 'card_count_desc':
-          return b.card_count - a.card_count
-        case 'card_count_asc':
-          return a.card_count - b.card_count
-        case 'storage_desc':
-          return b.storage_bytes - a.storage_bytes
-        case 'name_asc':
-          return a.twitch_display_name.localeCompare(b.twitch_display_name)
-        case 'created_at_desc':
-        default:
-          return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-      }
-    })
-
-    return result
-  }, [streamers, searchQuery, hideZeroCards, filterChatEnabled, filterHasTemplate, filterMissingScope, filterVoteCampaign, sortOrder])
-
   return (
     <div className="space-y-6">
       {/* Page Header */}
@@ -366,48 +317,48 @@ export function Streamers() {
       <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-8 gap-4">
         <div className="bg-white rounded-lg shadow p-4">
           <p className="text-sm text-gray-500">Total Streamers</p>
-          <p className="text-2xl font-bold">{streamers.length}</p>
+          <p className="text-2xl font-bold">{summary.totalStreamers}</p>
         </div>
         <div className="bg-white rounded-lg shadow p-4">
           <p className="text-sm text-gray-500">Active</p>
-          <p className="text-2xl font-bold text-green-600">{activeStreamers}</p>
+          <p className="text-2xl font-bold text-green-600">{summary.activeStreamers}</p>
         </div>
         <div className="bg-white rounded-lg shadow p-4">
           <p className="text-sm text-gray-500">EventSub Configured</p>
-          <p className="text-2xl font-bold text-blue-600">{configuredStreamers}</p>
+          <p className="text-2xl font-bold text-blue-600">{summary.configuredStreamers}</p>
         </div>
         <div className="bg-white rounded-lg shadow p-4">
           <p className="text-sm text-gray-500">Total Cards</p>
-          <p className="text-2xl font-bold">{totalCards}</p>
+          <p className="text-2xl font-bold">{summary.totalCards}</p>
         </div>
         <div className="bg-white rounded-lg shadow p-4">
           <p className="text-sm text-gray-500">Total Storage</p>
-          <p className="text-2xl font-bold text-purple-600">{formatBytes(totalStorage)}</p>
+          <p className="text-2xl font-bold text-purple-600">{formatBytes(summary.totalStorage)}</p>
         </div>
         {/* チャット通知をONにしているストリーマー数 */}
         <div className="bg-white rounded-lg shadow p-4">
           <p className="text-sm text-gray-500">Chat通知 ON</p>
-          <p className="text-2xl font-bold text-green-600">{chatEnabledStreamers}</p>
+          <p className="text-2xl font-bold text-green-600">{summary.chatEnabledStreamers}</p>
         </div>
         {/* カスタムテンプレートを設定済みのストリーマー数 */}
         <div className="bg-white rounded-lg shadow p-4">
           <p className="text-sm text-gray-500">カスタムテンプレート</p>
-          <p className="text-2xl font-bold text-purple-600">{customTemplateStreamers}</p>
+          <p className="text-2xl font-bold text-purple-600">{summary.customTemplateStreamers}</p>
         </div>
         {/* 投票キャンペーンボーナスを有効化したユーザー数 */}
         <div className="bg-white rounded-lg shadow p-4">
           <p className="text-sm text-gray-500">投票キャンペーン</p>
-          <p className="text-2xl font-bold text-pink-600">{voteCampaignUsers}</p>
+          <p className="text-2xl font-bold text-pink-600">{summary.voteCampaignUsers}</p>
         </div>
       </div>
 
       {/* Chat通知ONなのに現在の送信方式で送信できないストリーマーがいる場合に警告バナーを表示 */}
-      {chatEnabledNoSender > 0 && (
+      {summary.chatEnabledNoSender > 0 && (
         <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 flex items-center gap-3">
           <span className="text-amber-500 text-xl">⚠</span>
           <div>
             <p className="text-sm font-medium text-amber-800">
-              Chat通知ONだが現在の送信方式では送信不可: {chatEnabledNoSender}件
+              Chat通知ONだが現在の送信方式では送信不可: {summary.chatEnabledNoSender}件
             </p>
             <p className="text-xs text-amber-600 mt-0.5">
               配信者本人の再認証、または有効なBOT送信設定が必要です。
@@ -545,9 +496,9 @@ export function Streamers() {
 
           {/* 表示件数 */}
           <div className="text-sm text-gray-500 ml-auto">
-            表示: {filteredAndSortedStreamers.length} / {streamers.length} 件
+            表示: {streamers.length} / {totalCount} 件
             {searchQuery && ` (検索: "${searchQuery}")`}
-            {hideZeroCards && ` (カードあり: ${streamersWithCards}件)`}
+            {hideZeroCards && ` (カードあり: ${summary.streamersWithCards}件)`}
           </div>
         </div>
       </div>
@@ -555,13 +506,14 @@ export function Streamers() {
       {/* Streamers Table */}
       <DataTable
         columns={columns}
-        data={filteredAndSortedStreamers}
+        data={streamers}
         keyExtractor={(streamer) => streamer.id}
         loading={loading}
         emptyMessage="No streamers registered"
         pagination={{
           currentPage,
           pageSize,
+          totalItems: totalCount,
           onPageChange: setCurrentPage,
           onPageSizeChange: (size) => {
             setPageSize(size)

--- a/analysis/src/pages/Streamers.tsx
+++ b/analysis/src/pages/Streamers.tsx
@@ -77,6 +77,11 @@ export function Streamers() {
   // 検索・フィルタ・ソートをDB側へ渡し、カード数・ストレージ等の重い集計結果も
   // 現在ページの行だけ受け取る。画面側のページャーは全件配列をsliceしない。
   useEffect(() => {
+    // 検索入力中にページを1へ戻すeffectも別に走るため、ここで旧debounced値を
+    // 使った中間リクエストを止める。入力が止まって両値が一致したrenderだけが
+    // page 1の確定検索を開始し、カード・ストレージ等の全体集計を重複実行しない。
+    if (searchQuery !== debouncedSearchQuery) return
+
     const controller = new AbortController()
     ;(async () => {
       setLoading(true)
@@ -108,7 +113,7 @@ export function Streamers() {
       }
     })()
     return () => controller.abort()
-  }, [currentPage, pageSize, debouncedSearchQuery, sortOrder, hideZeroCards, filterChatEnabled, filterHasTemplate, filterMissingScope, filterVoteCampaign, retryToken])
+  }, [currentPage, pageSize, searchQuery, debouncedSearchQuery, sortOrder, hideZeroCards, filterChatEnabled, filterHasTemplate, filterMissingScope, filterVoteCampaign, retryToken])
 
   // フィルター条件が変わったらページを1に戻す
   useEffect(() => {

--- a/analysis/src/pages/Users.tsx
+++ b/analysis/src/pages/Users.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { adminApi, type UserListSortOrder, type UserListSummary } from '../lib/adminApi'
 import { DataTable } from '../components/DataTable'
 import { ErrorBanner } from '../components/ErrorBanner'
+import { useDebouncedValue } from '../hooks/useDebouncedValue'
 import { User } from '../types/database'
 
 // Extended user type with aggregated statistics
@@ -21,6 +22,10 @@ export function Users() {
   const [users, setUsers] = useState<UserWithStats[]>([])
   const [loading, setLoading] = useState(true)
   const [searchTerm, setSearchTerm] = useState('')
+  // 入力中の中間文字列ではRPCを発火させず、最後の入力から300ms後に検索する。
+  // UsersのRPCは正確な件数と全体summaryも再計算するため、キー入力ごとの実行を
+  // 抑えてDBの全体集計とレスポンス競合を減らす。
+  const debouncedSearchTerm = useDebouncedValue(searchTerm)
   // ソート順（デフォルト: カード数の多い順）
   const [sortOrder, setSortOrder] = useState<SortOrder>('card_count_desc')
   // カード数0のユーザーを非表示にするフラグ
@@ -52,7 +57,7 @@ export function Users() {
           {
             page: currentPage,
             pageSize,
-            search: searchTerm,
+            search: debouncedSearchTerm,
             sort: sortOrder,
             hideZeroCards,
           },
@@ -88,7 +93,7 @@ export function Users() {
       }
     })()
     return () => controller.abort()
-  }, [currentPage, pageSize, searchTerm, sortOrder, hideZeroCards, retryToken])
+  }, [currentPage, pageSize, debouncedSearchTerm, sortOrder, hideZeroCards, retryToken])
 
   // フィルター条件が変わったらページを1に戻す
   useEffect(() => {

--- a/analysis/src/pages/Users.tsx
+++ b/analysis/src/pages/Users.tsx
@@ -48,6 +48,11 @@ export function Users() {
   // 以前はこの後にローカルfilter/sortを行っていたため、画面のページャーが
   // 全件取得を隠してしまっていた。rowsは1ページ分、count/summaryは集計値である。
   useEffect(() => {
+    // 検索入力中にページを1へ戻すeffectも別に走るため、ここで旧debounced値を
+    // 使った中間リクエストを止める。入力が止まって両値が一致したrenderだけが
+    // page 1の確定検索を開始し、1文字ごとの全体集計RPCを発生させない。
+    if (searchTerm !== debouncedSearchTerm) return
+
     const controller = new AbortController()
     ;(async () => {
       setLoading(true)
@@ -93,7 +98,7 @@ export function Users() {
       }
     })()
     return () => controller.abort()
-  }, [currentPage, pageSize, debouncedSearchTerm, sortOrder, hideZeroCards, retryToken])
+  }, [currentPage, pageSize, searchTerm, debouncedSearchTerm, sortOrder, hideZeroCards, retryToken])
 
   // フィルター条件が変わったらページを1に戻す
   useEffect(() => {

--- a/analysis/src/pages/Users.tsx
+++ b/analysis/src/pages/Users.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { adminApi } from '../lib/adminApi'
+import { adminApi, type UserListSortOrder, type UserListSummary } from '../lib/adminApi'
 import { DataTable } from '../components/DataTable'
 import { ErrorBanner } from '../components/ErrorBanner'
 import { User } from '../types/database'
@@ -11,7 +11,7 @@ interface UserWithStats extends User {
 }
 
 // ソート順の定義
-type SortOrder = 'card_count_desc' | 'card_count_asc' | 'created_at_desc' | 'name_asc'
+type SortOrder = UserListSortOrder
 
 /**
  * Users page - Displays all registered users with their statistics
@@ -28,22 +28,39 @@ export function Users() {
   // ページネーション状態
   const [currentPage, setCurrentPage] = useState(1)
   const [pageSize, setPageSize] = useState(20)
+  const [totalCount, setTotalCount] = useState(0)
+  const [summary, setSummary] = useState<UserListSummary>({
+    totalUsers: 0,
+    totalCards: 0,
+    usersWithTos: 0,
+    usersWithCards: 0,
+  })
   const [error, setError] = useState<string | null>(null)
   // 再試行ボタン用のトリガー（値自体に意味は無く、変更するとeffectを再実行させる）
   const [retryToken, setRetryToken] = useState(0)
 
-  // Fetches all users with their card counts
-  // サーバーサイド（/__admin/users）でカード数を集計済みのデータを取得
+  // 検索・ソート・フィルタをDB側へ渡し、現在ページだけを取得する。
+  // 以前はこの後にローカルfilter/sortを行っていたため、画面のページャーが
+  // 全件取得を隠してしまっていた。rowsは1ページ分、count/summaryは集計値である。
   useEffect(() => {
     const controller = new AbortController()
     ;(async () => {
       setLoading(true)
       setError(null)
       try {
-        const rawData = await adminApi.getUsers({ signal: controller.signal })
+        const { rows, count, summary: nextSummary } = await adminApi.getUsers(
+          {
+            page: currentPage,
+            pageSize,
+            search: searchTerm,
+            sort: sortOrder,
+            hideZeroCards,
+          },
+          { signal: controller.signal }
+        )
 
         // Combine users with their statistics
-        const usersWithStats: UserWithStats[] = rawData.map((user) => {
+        const usersWithStats: UserWithStats[] = rows.map((user) => {
           const cardCount = user.user_cards?.[0]?.count ?? 0
           return {
             id: user.id,
@@ -60,6 +77,8 @@ export function Users() {
         })
 
         setUsers(usersWithStats)
+        setTotalCount(count)
+        setSummary(nextSummary)
       } catch (err) {
         if (controller.signal.aborted) return
         console.error('Error fetching users:', err)
@@ -69,40 +88,12 @@ export function Users() {
       }
     })()
     return () => controller.abort()
-  }, [retryToken])
+  }, [currentPage, pageSize, searchTerm, sortOrder, hideZeroCards, retryToken])
 
   // フィルター条件が変わったらページを1に戻す
   useEffect(() => {
     setCurrentPage(1)
   }, [searchTerm, sortOrder, hideZeroCards])
-
-  // Filter users based on search term and hideZeroCards flag
-  const filteredUsers = users.filter((user) => {
-    // 検索フィルター
-    const matchesSearch =
-      user.twitch_username.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      user.twitch_display_name.toLowerCase().includes(searchTerm.toLowerCase())
-    // カード0件フィルター
-    const matchesCardFilter = hideZeroCards ? user.card_count > 0 : true
-    return matchesSearch && matchesCardFilter
-  })
-
-  /**
-   * ソートを適用したユーザー一覧を生成
-   */
-  const sortedUsers = [...filteredUsers].sort((a, b) => {
-    switch (sortOrder) {
-      case 'card_count_desc':
-        return b.card_count - a.card_count
-      case 'card_count_asc':
-        return a.card_count - b.card_count
-      case 'name_asc':
-        return a.twitch_display_name.localeCompare(b.twitch_display_name)
-      case 'created_at_desc':
-      default:
-        return new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
-    }
-  })
 
   // Table column definitions
   const columns = [
@@ -169,11 +160,6 @@ export function Users() {
     },
   ]
 
-  // Calculate summary statistics（全データに基づく）
-  const totalCards = users.reduce((sum, u) => sum + u.card_count, 0)
-  const usersWithTos = users.filter((u) => u.tos_accepted_at).length
-  const usersWithCards = users.filter((u) => u.card_count > 0).length
-
   return (
     <div className="space-y-6">
       {/* Page Header */}
@@ -188,18 +174,18 @@ export function Users() {
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div className="bg-white rounded-lg shadow p-4">
           <p className="text-sm text-gray-500">Total Users</p>
-          <p className="text-2xl font-bold">{users.length}</p>
+          <p className="text-2xl font-bold">{summary.totalUsers}</p>
         </div>
         <div className="bg-white rounded-lg shadow p-4">
           <p className="text-sm text-gray-500">Total Cards Owned</p>
-          <p className="text-2xl font-bold">{totalCards}</p>
+          <p className="text-2xl font-bold">{summary.totalCards}</p>
         </div>
         <div className="bg-white rounded-lg shadow p-4">
           <p className="text-sm text-gray-500">ToS Accepted</p>
           <p className="text-2xl font-bold">
-            {usersWithTos}
+            {summary.usersWithTos}
             <span className="text-sm font-normal text-gray-500 ml-1">
-              ({users.length > 0 ? ((usersWithTos / users.length) * 100).toFixed(1) : 0}%)
+              ({summary.totalUsers > 0 ? ((summary.usersWithTos / summary.totalUsers) * 100).toFixed(1) : 0}%)
             </span>
           </p>
         </div>
@@ -252,8 +238,8 @@ export function Users() {
 
           {/* 表示件数 */}
           <div className="text-sm text-gray-500">
-            表示: {sortedUsers.length} / {users.length} 件
-            {hideZeroCards && ` (カード所持: ${usersWithCards}件)`}
+            表示: {users.length} / {totalCount} 件
+            {hideZeroCards && ` (カード所持: ${summary.usersWithCards}件)`}
           </div>
         </div>
       </div>
@@ -261,13 +247,14 @@ export function Users() {
       {/* Users Table */}
       <DataTable
         columns={columns}
-        data={sortedUsers}
+        data={users}
         keyExtractor={(user) => user.id}
         loading={loading}
         emptyMessage="No users found"
         pagination={{
           currentPage,
           pageSize,
+          totalItems: totalCount,
           onPageChange: setCurrentPage,
           onPageSizeChange: (size) => {
             setPageSize(size)

--- a/src/app/api/gacha/demo/route.ts
+++ b/src/app/api/gacha/demo/route.ts
@@ -13,14 +13,33 @@ import { cards as cardsTable } from "@/lib/db/schema";
 import { CARDS_SAFE_COLUMNS, isMissingCardsBattleColumnError } from "@/lib/db/cards-safe-columns";
 import { publishOverlayDemoEvent } from "@/lib/overlay/demo-event-store";
 
-/** Fetch one card from the authoritative PlanetScale database. */
-async function fetchCardByIdPg(cardId: string): Promise<Card | null> {
+/**
+ * Fetch one card from the authoritative PlanetScale database.
+ *
+ * #735: 元実装は is_active / streamer_id を一切見ずに任意の cardId を返していた
+ * ため、id さえ分かれば非公開(inactive)カードの name/description/image_url を
+ * 誰でも取得できた。streamerId を必須にし、指定 streamerId 配下の有効カードに
+ * 絞る(streamerId を任意にすると、他streamerのidさえ知っていればactiveな
+ * カードの内容とその所有streamer_idを無認証で引ける横断オラクルになるため)。
+ * 実際の呼び出し元(OverlayPreview.tsx / overlay/[streamerId]/page.tsx)は常に
+ * cardIdとstreamerIdを同時に渡すため、正規の利用を壊さない。
+ * 絞り込みでヒットしない場合は null を返し、呼び出し側が streamerId の
+ * ランダムカード → 組み込みデモカードへフォールバックする既存の縮退chainに
+ * 委ねる。
+ */
+async function fetchCardByIdPg(cardId: string, streamerId: string): Promise<Card | null> {
+  const condition = and(
+    eq(cardsTable.id, cardId),
+    eq(cardsTable.streamer_id, streamerId),
+    eq(cardsTable.is_active, true)
+  );
+
   async function selectRow(useSafeColumns: boolean) {
     return withDbRetry(
       async () => {
         const { db } = await getDb();
         const query = useSafeColumns ? db.select(CARDS_SAFE_COLUMNS) : db.select();
-        return query.from(cardsTable).where(eq(cardsTable.id, cardId)).limit(1);
+        return query.from(cardsTable).where(condition).limit(1);
       },
       "gacha/demo(fetch card by id)",
       { idempotent: true },
@@ -169,6 +188,35 @@ export async function POST(request: NextRequest) {
       // Treat invalid/empty JSON as a parameterless public demo request.
     }
 
+    // #735: このエンドポイントは意図的に無認証(OBSオーバーレイのデモ表示・
+    // プレビューUIから直接呼ばれる)だが、レートリミットが無いと任意cardIdの
+    // enumerationに使えてしまう。broadcast&&streamerId分岐は認証済みユーザーID
+    // 基準のより厳格な専用制限(gachaDemoBroadcast)を別途持つため、そちらを通る
+    // リクエストにはIPベースの制限を重ねない。同じ数値(30/分)の制限を先に
+    // 無関係な匿名IPベースの枠で課すと、同一IPを共有する別人の連打だけで
+    // 配信者自身のOBSデモボタンがブロックされ得るうえ、専用制限に一度も
+    // 到達しなくなってしまう。
+    if (!(broadcast && streamerId)) {
+      const generalIdentifier = await getRateLimitIdentifier(request);
+      const generalRateLimitResult = await checkRateLimit(rateLimits.gachaDemoCard, generalIdentifier);
+      if (!generalRateLimitResult.success) {
+        return NextResponse.json<ApiRateLimitResponse>(
+          {
+            error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
+            retryAfter: (generalRateLimitResult.reset || 0) - Math.floor(Date.now() / 1000),
+          },
+          {
+            status: 429,
+            headers: {
+              'X-RateLimit-Limit': String(generalRateLimitResult.limit),
+              'X-RateLimit-Remaining': String(generalRateLimitResult.remaining),
+              'X-RateLimit-Reset': String(generalRateLimitResult.reset),
+            },
+          }
+        );
+      }
+    }
+
     if (broadcast && streamerId) {
       const session = await getSession();
       if (!session) {
@@ -213,8 +261,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ card, userTwitchUsername: "DemoUser" });
     };
 
-    if (cardId && cardId !== "random") {
-      const card = await fetchCardByIdPg(cardId);
+    // #735: streamerId が無いと、他streamerの任意のactiveカードを id だけで
+    // 無認証取得できる横断オラクルになるため streamerId を必須にする。
+    if (cardId && cardId !== "random" && streamerId) {
+      const card = await fetchCardByIdPg(cardId, streamerId);
       if (card) return respondWithCard(card, streamerId);
     }
 

--- a/src/app/api/streamer/additional-rewards/route.ts
+++ b/src/app/api/streamer/additional-rewards/route.ts
@@ -681,6 +681,16 @@ async function deleteAdditionalRewardByIdPg(streamerId: string, rewardId: string
  * - ?deleteAll=true: Delete all additional rewards for the streamer
  */
 export async function DELETE(request: NextRequest) {
+  // 状態変更 API のため CSRF 検証を最初に行う (#736)。POST には既に存在するが
+  // DELETE ハンドラだけ検証漏れがあった。
+  const csrfValidation = await validateCSRFToken(request);
+  if (!csrfValidation.valid) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.FORBIDDEN },
+      { status: 403 }
+    );
+  }
+
   const session = await getSession();
 
   const identifier = await getRateLimitIdentifier(request, session?.twitchUserId);

--- a/src/app/api/twitch/eventsub/debug/route.ts
+++ b/src/app/api/twitch/eventsub/debug/route.ts
@@ -3,6 +3,8 @@ import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { handleApiError } from "@/lib/error-handler";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { logger } from "@/lib/logger.server";
+import { validateCSRFToken } from "@/lib/csrf";
+import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
 
 const TWITCH_API_URL = "https://api.twitch.tv/helix";
 
@@ -72,6 +74,42 @@ async function getAllSubscriptions(appAccessToken: string): Promise<EventSubSubs
   return allData;
 }
 
+// 指定broadcasterのEventSubサブスクリプションのみを取得（デバッグ用・ページネーション対応）
+// subscribe/route.ts の getSubscriptionsByUserId と同じ方式: Twitch APIの
+// user_idパラメータで絞り込むことで全件取得より効率的に取得する (#831)。
+// user_idフィルタは broadcaster_user_id 以外(to_broadcaster_user_id等)にも
+// マッチするため、呼び出し側で condition.broadcaster_user_id の一致を
+// 別途確認すること。
+async function getSubscriptionsByBroadcaster(
+  appAccessToken: string,
+  broadcasterUserId: string
+): Promise<EventSubSubscription[]> {
+  const allData: EventSubSubscription[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const baseUrl = `${TWITCH_API_URL}/eventsub/subscriptions?user_id=${broadcasterUserId}`;
+    const url = cursor ? `${baseUrl}&after=${cursor}` : baseUrl;
+
+    const response = await fetch(url, {
+      headers: {
+        "Authorization": `Bearer ${appAccessToken}`,
+        "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch subscriptions: ${response.status}`);
+    }
+
+    const data = await response.json();
+    allData.push(...data.data);
+    cursor = data.pagination?.cursor;
+  } while (cursor);
+
+  return allData;
+}
+
 export async function GET(request: NextRequest) {
   const session = await getSession();
 
@@ -113,7 +151,36 @@ export async function GET(request: NextRequest) {
 
 // 特定のEventSubサブスクリプションを削除
 export async function DELETE(request: NextRequest) {
+  // 状態変更 API（EventSub 解除）のため CSRF 検証を最初に行う (#831)。
+  // 認証済みユーザーの Cookie を悪用したクロスサイト削除を防止する。
+  const csrfValidation = await validateCSRFToken(request);
+  if (!csrfValidation.valid) {
+    return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
+  }
+
   const session = await getSession();
+
+  // レートリミットチェック (#831: 従来未設定だったため追加)。
+  // このエンドポイントは subscribe/route.ts の DELETE と同じEventSub購読を
+  // 操作するため、専用キーで別枠にすると合計の変更可能回数が実質2倍になって
+  // しまう。同じ rateLimits.eventsubSubscribePost バケットを共有し、Twitch側の
+  // 実質的な変更レート予算を一本化する。
+  const identifier = await getRateLimitIdentifier(request, session?.twitchUserId);
+  const rateLimitResult = await checkRateLimit(rateLimits.eventsubSubscribePost, identifier);
+
+  if (!rateLimitResult.success) {
+    return NextResponse.json(
+      { error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
+      {
+        status: 429,
+        headers: {
+          "X-RateLimit-Limit": String(rateLimitResult.limit),
+          "X-RateLimit-Remaining": String(rateLimitResult.remaining),
+          "X-RateLimit-Reset": String(rateLimitResult.reset),
+        },
+      }
+    );
+  }
 
   if (!session || !canUseStreamerFeatures(session)) {
     return NextResponse.json({ error: ERROR_MESSAGES.UNAUTHORIZED }, { status: 401 });
@@ -128,24 +195,13 @@ export async function DELETE(request: NextRequest) {
 
     if (deleteAll) {
       // すべてのサブスクリプションを削除
-      const listResponse = await fetch(
-        `${TWITCH_API_URL}/eventsub/subscriptions`,
-        {
-          headers: {
-            "Authorization": `Bearer ${appAccessToken}`,
-            "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-          },
-        }
-      );
-
-      if (!listResponse.ok) {
-        return NextResponse.json({ error: "Failed to list subscriptions" }, { status: 500 });
-      }
-
-      const listData = await listResponse.json();
-      const mySubscriptions = listData.data.filter(
-        (sub: { condition: { broadcaster_user_id: string } }) =>
-          sub.condition.broadcaster_user_id === session.twitchUserId
+      // user_idで絞り込んだページネーション対応の取得を使う (#831)。旧実装は
+      // 1ページ分の生fetchのみで、購読数がページ上限を超えると一部しか削除
+      // されないのに成功報告してしまっていた。また全app分を取得してから
+      // クライアント側フィルタするより、Twitch API側で絞り込む方が効率的。
+      const candidateSubscriptions = await getSubscriptionsByBroadcaster(appAccessToken, session.twitchUserId);
+      const mySubscriptions = candidateSubscriptions.filter(
+        (sub) => sub.condition.broadcaster_user_id === session.twitchUserId
       );
 
       const results = [];
@@ -176,6 +232,20 @@ export async function DELETE(request: NextRequest) {
 
     if (!subscriptionId) {
       return NextResponse.json({ error: "Missing subscription id" }, { status: 400 });
+    }
+
+    // 所有権検証 (#831): このbroadcasterの購読であることをTwitch側の実データで
+    // 確認してから削除する。旧実装はid以外を一切検証しておらず、他broadcasterの
+    // subscriptionIdが分かれば（ログ・スクショ等の別経路での漏出が前提だが）
+    // app access tokenで削除できてしまっていた。
+    // user_idで絞り込んだ取得を使うことで、削除対象のid1件を探すためだけに
+    // app全体(全streamer分)のサブスクリプションを毎回列挙することを避ける。
+    const candidateSubscriptions = await getSubscriptionsByBroadcaster(appAccessToken, session.twitchUserId);
+    const targetSubscription = candidateSubscriptions.find((sub) => sub.id === subscriptionId);
+
+    if (!targetSubscription || targetSubscription.condition.broadcaster_user_id !== session.twitchUserId) {
+      logger.warn(`[EventSub Debug DELETE] Ownership mismatch or not found: id=${subscriptionId} requested by ${session.twitchUserId}`);
+      return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
     }
 
     // 単一のサブスクリプションを削除

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getSession } from '@/lib/session';
+import { getSession, canUseStreamerFeatures } from '@/lib/session';
 import { handleApiError, handleBlobError } from '@/lib/error-handler';
 import { validateUpload, getUploadErrorMessage } from '@/lib/upload-validation';
 import { checkRateLimit, rateLimits, getRateLimitIdentifier } from '@/lib/rate-limit';
@@ -11,7 +11,7 @@ import { uploadToR2WithRetry } from '@/lib/r2-client';
 import { retryCloudflareR2Upload } from '@/lib/r2-retry-policy';
 import { recordBlobFile } from '@/lib/storage-db';
 import { getStorageUsage } from '@/lib/storage-usage';
-import { sha256Prefix } from '@/lib/crypto-utils';
+import { sha256Prefix, randomUUID } from '@/lib/crypto-utils';
 import { getUserPlan, PLAN_MAX_UPLOAD_SIZE } from '@/lib/plan';
 import type { Session } from '@/lib/session';
 
@@ -48,6 +48,14 @@ async function validateRequest(request: NextRequest): Promise<ValidateRequestRes
   if (!session) {
     return {
       error: NextResponse.json({ error: ERROR_MESSAGES.NOT_AUTHENTICATED }, { status: 401 }),
+    };
+  }
+
+  // カード画像アップロードは配信者機能なので、配信者権限を必須にする (#832)
+  // これが無いと任意のTwitchアカウントで公開R2への恒久URLを取得できてしまう
+  if (!canUseStreamerFeatures(session)) {
+    return {
+      error: NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 }),
     };
   }
 
@@ -162,10 +170,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     // User prefix for tracking uploads per user (must match storage-db.ts)
-    // ユーザー別アップロード追跡用プレフィックス（storage-db.tsと一致させる）
+    // ユーザー別アップロード追跡用プレフィックス（storage-db.tsと一致させる、公開値でよい）
     // Web Crypto APIを使用（Cloudflare Workers互換）
     const userPrefixForFile = await sha256Prefix(session!.twitchUserId);
-    const uniqueSuffix = await sha256Prefix(`${session!.twitchUserId}-${Date.now()}`);
+    // suffixはtwitchUserId+Date.now()由来のsha256Prefix(8hex)だと、公開情報である
+    // twitchUserIdとミリ秒単位のDate.now()から総当りで再現できた (#832)。
+    // crypto.randomUUID()（128bit・推測不能）に変更する。
+    const uniqueSuffix = randomUUID();
 
     // Format: {userPrefix}_{uniqueSuffix}.{ext}
     fileName = `${userPrefixForFile}_${uniqueSuffix}.${ext}`;

--- a/src/app/api/upload/sound/route.ts
+++ b/src/app/api/upload/sound/route.ts
@@ -7,7 +7,7 @@ import { getSoundFileTypeFromBuffer, getFileExtension, isValidSoundExtension } f
 import { logger } from '@/lib/logger.server';
 import { validateCSRFToken } from '@/lib/csrf';
 import { uploadSoundToR2WithRetry, deleteSoundFromR2 } from '@/lib/r2-client';
-import { sha256Prefix } from '@/lib/crypto-utils';
+import { sha256Prefix, randomUUID } from '@/lib/crypto-utils';
 import type { Session } from '@/lib/session';
 
 interface ValidateRequestResult {
@@ -148,7 +148,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // "sound_"プレフィックスで画像ファイルと区別
     // Web Crypto APIを使用（Cloudflare Workers互換）
     const userPrefix = await sha256Prefix(session!.twitchUserId);
-    const uniqueSuffix = await sha256Prefix(`${session!.twitchUserId}-sound-${Date.now()}`);
+    // suffixはtwitchUserId+Date.now()由来のsha256Prefix(8hex)だと総当りで再現できた
+    // (#832、画像アップロードと同型)。crypto.randomUUID()（推測不能）に変更する。
+    const uniqueSuffix = randomUUID();
 
     fileName = `sound_${userPrefix}_${uniqueSuffix}.${ext}`;
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -380,9 +380,12 @@ export const UPLOAD_CONFIG = {
   // Storage limits
   // ストレージ制限
   USER_STORAGE_LIMIT: 10 * 1024 * 1024, // 10MB per user (increased from 5MB)
-  // Global storage limit disabled - set to very large value
-  // グローバルストレージ制限を撤廃 - 非常に大きな値を設定
-  GLOBAL_STORAGE_LIMIT: Number.MAX_SAFE_INTEGER, // No global limit
+  // グローバル上限が実質無制限(Number.MAX_SAFE_INTEGER)だったため、認証さえ
+  // 通れば無制限に書き込める状態だった (#832)。ユーザー上限(10MB)+全プラン最大の
+  // ストレージボーナス(500MB, plan-constants.ts)を踏まえても、現在の運用規模で
+  // 現実的にありえない50GBを運用上の上限として設定する。unreachableではなく実際に
+  // 効くガードなので、規模が拡大したら見直すこと。
+  GLOBAL_STORAGE_LIMIT: 50 * 1024 * 1024 * 1024, // 50GB operational cap
 } as const
 
 /**

--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -4,6 +4,7 @@ import { unstable_cache } from "next/cache";
 import { logger } from "@/lib/logger.server";
 import { normalizeDropRate } from "@/lib/card-utils";
 import { reportError } from "@/lib/sentry/error-handler";
+import { RARITY_ORDER } from "@/lib/constants";
 
 import { logPerf, perfStart } from "@/lib/perf";
 // ---------------------------------------------------------------------------
@@ -16,6 +17,7 @@ import {
   and,
   asc,
   count as countRows,
+  countDistinct,
   desc,
   eq,
   getTableColumns,
@@ -1416,8 +1418,7 @@ async function fetchGachaDropStatsFromHistory(
   streamerId: string,
   fromDateIso: string
 ): Promise<Omit<GachaStatsResult, "channelPointStats">> {
-  const FIXED_RARITIES = ["legendary", "epic", "rare", "common"] as const;
-  const emptyRarityStats = FIXED_RARITIES.map((rarity) => ({
+  const emptyRarityStats = RARITY_ORDER.map((rarity) => ({
     rarity,
     count: 0,
     rate: 0,
@@ -1429,12 +1430,14 @@ async function fetchGachaDropStatsFromHistory(
     notLike(gachaHistoryTable.event_id, "manual:%"),
   );
   let totalDraws: number;
+  // カード別/レアリティ別の「排出数」自体は下記の GROUP BY 集計（打ち切り無し）
+  // から取る。history はドロワー明細（ユーザー名・引いた日時）の表示専用で、
+  // 1カードあたり上限件数で打ち切って良い付随情報のみに使う (#833)。
   let history: Array<{
     card_id: string;
     user_twitch_id: string;
     user_twitch_username: string | null;
     redeemed_at: string | null;
-    cards: { rarity: string } | null;
   }>;
   let cards: Array<{
     id: string;
@@ -1444,8 +1447,18 @@ async function fetchGachaDropStatsFromHistory(
     drop_rate: number | string | null;
     created_at: string | null;
   }>;
+  let drawCountsByCardRows: Array<{ card_id: string; count: number | string }>;
+  let rarityCountsRows: Array<{ rarity: string; count: number | string }>;
+  let drawerCountsByCardRows: Array<{ card_id: string; count: number | string }>;
   try {
-    const [countResultRows, historyRows, cardRows] = await Promise.all([
+    const [
+      countResultRows,
+      historyRows,
+      cardRows,
+      drawCountRows,
+      rarityCountRows,
+      drawerCountRows,
+    ] = await Promise.all([
       withDbRetry(
         async () => {
           const { db } = await getDb();
@@ -1466,10 +1479,8 @@ async function fetchGachaDropStatsFromHistory(
               user_twitch_id: gachaHistoryTable.user_twitch_id,
               user_twitch_username: gachaHistoryTable.user_twitch_username,
               redeemed_at: gachaHistoryTable.redeemed_at,
-              cards: { rarity: cardsTable.rarity },
             })
             .from(gachaHistoryTable)
-            .leftJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
             .where(historyFilter)
             .limit(10000);
         },
@@ -1495,22 +1506,80 @@ async function fetchGachaDropStatsFromHistory(
         "dashboard:gachaDropStats:cards",
         { idempotent: true },
       ),
+      // カード別の排出数はSQL側でGROUP BYして正確に取る（#833: 以前はhistoryの
+      // LIMIT 10000サンプルから数えていたため、期間内の総排出数が10000件を超える
+      // 配信者では全カードのactualRateが黙って過小表示されていた）。
+      withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          return db
+            .select({ card_id: gachaHistoryTable.card_id, count: countRows() })
+            .from(gachaHistoryTable)
+            .where(historyFilter)
+            .groupBy(gachaHistoryTable.card_id);
+        },
+        "dashboard:gachaDropStats:drawCountsByCard",
+        { idempotent: true },
+      ),
+      // レアリティ別の排出数もSQL側でGROUP BY。RPC(migration 00050)のrarity_counts
+      // CTEと同じくcardsとのINNER JOINで、参照先カードが存在しない履歴行(想定外)は
+      // レアリティ別集計から除外する(total_drawsには含まれる)。
+      withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          return db
+            .select({ rarity: cardsTable.rarity, count: countRows() })
+            .from(gachaHistoryTable)
+            .innerJoin(cardsTable, eq(gachaHistoryTable.card_id, cardsTable.id))
+            .where(historyFilter)
+            .groupBy(cardsTable.rarity);
+        },
+        "dashboard:gachaDropStats:rarityCounts",
+        { idempotent: true },
+      ),
+      // カード別のユニーク排出ユーザー数(drawerCount)もSQL側でGROUP BYして正確に
+      // 取る(#833レビュー指摘: drawersリスト表示用の明細はhistoryサンプルの
+      // ままで良いが、drawerCount自体をそこから数えるとactualCountだけが
+      // 正確になり「actualCountは大きいのにdrawerCountは0人」のような矛盾した
+      // 表示になりうる)。COUNT(DISTINCT ...)はNULLを自動的に除外するため、
+      // user_twitch_idがNULLの行を弾くdrawersByCard構築時のガードと整合する。
+      withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          return db
+            .select({ card_id: gachaHistoryTable.card_id, count: countDistinct(gachaHistoryTable.user_twitch_id) })
+            .from(gachaHistoryTable)
+            .where(historyFilter)
+            .groupBy(gachaHistoryTable.card_id);
+        },
+        "dashboard:gachaDropStats:drawerCountsByCard",
+        { idempotent: true },
+      ),
     ]);
     totalDraws = Number(countResultRows[0]?.count ?? 0);
     history = historyRows;
     cards = cardRows;
+    drawCountsByCardRows = drawCountRows;
+    rarityCountsRows = rarityCountRows;
+    drawerCountsByCardRows = drawerCountRows;
   } catch (error) {
     reportError(error, { context: "dashboard:gachaDropStats:fallback", streamerId });
     return { totalDraws: 0, cardStats: [], rarityStats: emptyRarityStats };
   }
 
   const drawCounts = new Map<string, number>();
-  // 期間内にそのカードを引いたユーザーをカード×ユーザーで集計。
-  // RPC(get_gacha_drop_stats)と同じく1カードあたり上限件数で打ち切る。
+  for (const row of drawCountsByCardRows) {
+    drawCounts.set(row.card_id, Number(row.count));
+  }
+  const drawerCounts = new Map<string, number>();
+  for (const row of drawerCountsByCardRows) {
+    drawerCounts.set(row.card_id, Number(row.count));
+  }
+
+  // drawersリスト(誰が引いたか上位N件の明細)はhistoryサンプルからのみ構築する
+  // 付随情報。drawerCount(人数)の算出には使わない(上記GROUP BY集計を使う)。
   const drawersByCard = new Map<string, Map<string, GachaStatsDrawer>>();
   for (const row of history) {
-    drawCounts.set(row.card_id, (drawCounts.get(row.card_id) || 0) + 1);
-
     if (!row.user_twitch_id) continue;
     const cardDrawers = drawersByCard.get(row.card_id) || new Map();
     const existing = cardDrawers.get(row.user_twitch_id);
@@ -1558,21 +1627,26 @@ async function fetchGachaDropStatsFromHistory(
         totalWeight > 0 ? (Number(card.drop_rate || 0) / totalWeight) * 100 : 0,
       actualCount,
       actualRate: totalDraws > 0 ? (actualCount / totalDraws) * 100 : 0,
-      drawerCount: allDrawers.length,
+      drawerCount: drawerCounts.get(card.id) || 0,
       drawers: allDrawers.slice(0, STATS_USERS_PER_CARD_LIMIT),
     };
   });
 
-  // レアリティ別集計は履歴←cards の join から引く（RPC migration 00038 と同じく
-  // is_active 非依存）。非アクティブ化済みカードの過去排出も RPC と同様に計上される。
+  // レアリティ集合はデフォルト4種(常に表示、排出0でも含む)＋実際に排出された
+  // カスタムレアリティ(RPC migration 00050のrarity_universeと同じ構成)。
+  // 以前はデフォルト4種の固定リストのみで、カスタムレアリティのカードが
+  // 排出されてもrarityStatsに一切現れず、内訳合計がtotal_drawsと一致
+  // しなかった (#833)。
   const rarityCounts = new Map<string, number>();
-  for (const row of history) {
-    const rarity = row.cards?.rarity;
-    if (rarity) {
-      rarityCounts.set(rarity, (rarityCounts.get(rarity) || 0) + 1);
-    }
+  for (const row of rarityCountsRows) {
+    rarityCounts.set(row.rarity, Number(row.count));
   }
-  const rarityStats = FIXED_RARITIES.map((rarity) => {
+  const customRarities = Array.from(rarityCounts.keys())
+    .filter((rarity) => !RARITY_ORDER.includes(rarity))
+    .sort((a, b) => a.localeCompare(b));
+  const rarityUniverse = [...RARITY_ORDER, ...customRarities];
+
+  const rarityStats = rarityUniverse.map((rarity) => {
       const count = rarityCounts.get(rarity) || 0;
     return {
       rarity,
@@ -1773,8 +1847,9 @@ async function fetchCardOwnerStatsFromUserCards(
     image_url: string | null;
   }>;
   let ownerRows: GachaCardOwnerStatsOwnerRow[];
+  let ownerCountRows: Array<{ card_id: string; count: number | string }>;
   try {
-    [cards, ownerRows] = await Promise.all([
+    [cards, ownerRows, ownerCountRows] = await Promise.all([
       withDbRetry(
         async () => {
           const { db } = await getDb();
@@ -1814,12 +1889,37 @@ async function fetchCardOwnerStatsFromUserCards(
         "dashboard:cardOwnerStats:owners",
         { idempotent: true },
       ),
+      // カード別の所有者数(ユニークユーザー数)はSQL側でGROUP BYして正確に取る
+      // (#833: 以前はownerRowsのLIMIT 10000サンプルから数えていたため、streamer
+      // 全体のuser_cards行数が10000件を超えると人気カードのownerCountが黙って
+      // 過小になっていた)。1ユーザーが同一カードを複数所持しうるため
+      // COUNT(DISTINCT user_id) で重複を除く。
+      withDbRetry(
+        async () => {
+          const { db } = await getDb();
+          return db
+            .select({ card_id: userCardsTable.card_id, count: countDistinct(userCardsTable.user_id) })
+            .from(userCardsTable)
+            .innerJoin(cardsTable, eq(userCardsTable.card_id, cardsTable.id))
+            .where(and(eq(cardsTable.streamer_id, streamerId), eq(cardsTable.is_active, true)))
+            .groupBy(userCardsTable.card_id);
+        },
+        "dashboard:cardOwnerStats:ownerCounts",
+        { idempotent: true },
+      ),
     ]);
   } catch (error) {
     reportError(error, { context: "dashboard:cardOwnerStats:fallback", streamerId });
     return { cardStats: [] };
   }
 
+  const ownerCounts = new Map<string, number>();
+  for (const row of ownerCountRows) {
+    ownerCounts.set(row.card_id, Number(row.count));
+  }
+
+  // owners一覧(表示用の個別ユーザー明細)はownerRowsのサンプルからのみ構築する
+  // 付随情報。ownerCountの算出には使わない。
   const ownersByCard = new Map<string, Map<string, GachaCardOwner>>();
   for (const row of ownerRows) {
     const user = Array.isArray(row.users) ? row.users[0] : row.users;
@@ -1868,8 +1968,9 @@ async function fetchCardOwnerStatsFromUserCards(
         cardName: card.name,
         rarity: card.rarity,
         imageUrl: card.image_url,
-        // ownerCount は総数（打ち切り前）、owners はRPCと同じく上限件数で打ち切る
-        ownerCount: owners.length,
+        // ownerCount はGROUP BY集計による正確な総数、owners はRPCと同じく
+        // 上限件数で打ち切る (#833)
+        ownerCount: ownerCounts.get(card.id) || 0,
         owners: owners.slice(0, STATS_USERS_PER_CARD_LIMIT),
       };
     }),

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -301,6 +301,12 @@ export const rateLimits = {
   // 制限（1000回/分/IP）までデモイベント配信を叩けてしまう。
   // /api/gacha (rateLimits.gacha) と同じ水準の専用制限を課す。
   gachaDemoBroadcast: createRatelimit("gachaDemoBroadcast", 30, 60 * 1000),
+  // Issue #735: /api/gacha/demo は意図的に無認証(OBSオーバーレイのデモ表示から
+  // 直接呼ばれる)公開エンドポイントだが、従来レートリミットが一切無く、任意の
+  // cardIdに対するカード情報取得（enumeration）に使えた。IPベースで課す
+  // 全リクエスト共通の制限（gachaDemoBroadcastとは別枠。broadcast分岐は
+  // 認証済みユーザー操作でIDベース、こちらは匿名IPベースのため識別子が異なる）。
+  gachaDemoCard: createRatelimit("gachaDemoCard", 30, 60 * 1000),
   authLogin: createRatelimit("authLogin", 5, 60 * 1000),
   authCallback: createRatelimit("authCallback", 10, 60 * 1000),
   authLogout: createRatelimit("authLogout", 10, 60 * 1000),

--- a/supabase/migrations/20260731120000_paginate_analysis_dashboard.sql
+++ b/supabase/migrations/20260731120000_paginate_analysis_dashboard.sql
@@ -1,0 +1,407 @@
+-- analysis dashboard の初回取得を、全件JSON配列からDB側ページングへ移行する。
+--
+-- 以前の get_analysis_users()/get_analysis_streamers() は、一覧用の全行を
+-- jsonb_agg() してからNode.jsとブラウザへ転送していた。画面側にページャーが
+-- あっても、ページャーは既に全件取得した配列をsliceしているだけだったため、
+-- データ量に比例してDBメモリ、Node.jsメモリ、転送量、ブラウザの保持量が増えていた。
+--
+-- 新しい関数は検索・フィルタ・ソート・LIMIT/OFFSETをDB側で適用し、JSON化するのは
+-- 現在ページの行だけに限定する。summaryは配列ではなくCOUNT/SUMのスカラーで返し、
+-- UIの全体統計を維持しながら大量レコードの転送を避ける。
+
+CREATE INDEX IF NOT EXISTS idx_users_created_at_analysis
+  ON users(created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_gacha_history_redeemed_at_analysis
+  ON gacha_history(redeemed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_streamers_created_at_analysis
+  ON streamers(created_at DESC);
+
+-- Overviewの30日推移は日ごとのLATERAL COUNTを30回実行していたため、対象期間を
+-- 先に一度だけGROUP BYしてから日付系列へLEFT JOINする。返却件数は従来どおり
+-- 30日分 + 最新10件であり、契約を変えずにDBスキャン回数を減らす。
+CREATE OR REPLACE FUNCTION get_analysis_overview()
+RETURNS JSONB
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+WITH bounds AS (
+  SELECT
+    date_trunc('day', now()) AS today_start,
+    now() - interval '7 days' AS week_start,
+    date_trunc('month', now()) AS month_start
+),
+day_series AS (
+  SELECT generate_series(
+    date_trunc('day', now()) - interval '29 days',
+    date_trunc('day', now()),
+    interval '1 day'
+  ) AS day_start
+),
+user_growth_counts AS (
+  SELECT date_trunc('day', u.created_at) AS day_start, COUNT(*)::INTEGER AS count
+  FROM users u
+  WHERE u.created_at >= date_trunc('day', now()) - interval '29 days'
+  GROUP BY date_trunc('day', u.created_at)
+),
+gacha_growth_counts AS (
+  SELECT date_trunc('day', gh.redeemed_at) AS day_start, COUNT(*)::INTEGER AS count
+  FROM gacha_history gh
+  WHERE gh.redeemed_at >= date_trunc('day', now()) - interval '29 days'
+  GROUP BY date_trunc('day', gh.redeemed_at)
+),
+user_growth AS (
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'date', to_char(ds.day_start, 'YYYY-MM-DD'),
+      'count', COALESCE(ugc.count, 0)
+    )
+    ORDER BY ds.day_start
+  ) AS rows
+  FROM day_series ds
+  LEFT JOIN user_growth_counts ugc ON ugc.day_start = ds.day_start
+),
+gacha_growth AS (
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'date', to_char(ds.day_start, 'YYYY-MM-DD'),
+      'count', COALESCE(ggc.count, 0)
+    )
+    ORDER BY ds.day_start
+  ) AS rows
+  FROM day_series ds
+  LEFT JOIN gacha_growth_counts ggc ON ggc.day_start = ds.day_start
+),
+recent_gacha AS (
+  SELECT COALESCE(jsonb_agg(row_json ORDER BY redeemed_at DESC), '[]'::jsonb) AS rows
+  FROM (
+    SELECT
+      gh.redeemed_at,
+      to_jsonb(gh.*)
+        || jsonb_build_object(
+          'cards', to_jsonb(c.*),
+          'streamers', to_jsonb(s.*)
+        ) AS row_json
+    FROM gacha_history gh
+    LEFT JOIN cards c ON c.id = gh.card_id
+    LEFT JOIN streamers s ON s.id = gh.streamer_id
+    ORDER BY gh.redeemed_at DESC
+    LIMIT 10
+  ) recent
+)
+SELECT jsonb_build_object(
+  'stats', jsonb_build_object(
+    'totalUsers', (SELECT COUNT(*)::INTEGER FROM users),
+    'totalStreamers', (SELECT COUNT(*)::INTEGER FROM streamers),
+    'totalCards', (SELECT COUNT(*)::INTEGER FROM cards),
+    'todayGacha', (
+      SELECT COUNT(*)::INTEGER FROM gacha_history gh, bounds b
+      WHERE gh.redeemed_at >= b.today_start
+    ),
+    'weekGacha', (
+      SELECT COUNT(*)::INTEGER FROM gacha_history gh, bounds b
+      WHERE gh.redeemed_at >= b.week_start
+    ),
+    'monthGacha', (
+      SELECT COUNT(*)::INTEGER FROM gacha_history gh, bounds b
+      WHERE gh.redeemed_at >= b.month_start
+    )
+  ),
+  'recentGacha', (SELECT rows FROM recent_gacha),
+  'userGrowth', (SELECT rows FROM user_growth),
+  'gachaGrowth', (SELECT rows FROM gacha_growth)
+);
+$$;
+
+CREATE OR REPLACE FUNCTION get_analysis_users_page(
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 20,
+  p_search TEXT DEFAULT NULL,
+  p_sort TEXT DEFAULT 'card_count_desc',
+  p_hide_zero_cards BOOLEAN DEFAULT FALSE
+)
+RETURNS JSONB
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+WITH card_counts AS MATERIALIZED (
+  SELECT user_id, COUNT(*)::INTEGER AS card_count
+  FROM user_cards
+  GROUP BY user_id
+),
+all_users AS MATERIALIZED (
+  SELECT
+    u.id,
+    u.twitch_user_id,
+    u.twitch_username,
+    u.twitch_display_name,
+    u.twitch_profile_image_url,
+    u.tos_accepted_at,
+    COALESCE(u.twitch_scopes, '{}'::TEXT[]) AS twitch_scopes,
+    u.created_at,
+    u.updated_at,
+    COALESCE(cc.card_count, 0)::INTEGER AS card_count
+  FROM users u
+  LEFT JOIN card_counts cc ON cc.user_id = u.id
+),
+filtered_users AS MATERIALIZED (
+  SELECT au.*
+  FROM all_users au
+  WHERE (p_search IS NULL OR p_search = ''
+    OR au.twitch_username ILIKE p_search ESCAPE E'\\'
+    OR au.twitch_display_name ILIKE p_search ESCAPE E'\\')
+    AND (NOT COALESCE(p_hide_zero_cards, FALSE) OR au.card_count > 0)
+),
+paged_users AS (
+  SELECT fu.*
+  FROM filtered_users fu
+  ORDER BY
+    CASE WHEN p_sort = 'card_count_desc' THEN fu.card_count END DESC NULLS LAST,
+    CASE WHEN p_sort = 'card_count_asc' THEN fu.card_count END ASC NULLS LAST,
+    CASE WHEN p_sort = 'name_asc' THEN fu.twitch_display_name END ASC NULLS LAST,
+    fu.created_at DESC,
+    fu.id ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_page_size, 20), 1), 100)
+  OFFSET (GREATEST(COALESCE(p_page, 1), 1)::BIGINT - 1)
+    * LEAST(GREATEST(COALESCE(p_page_size, 20), 1), 100)::BIGINT
+),
+summary AS (
+  SELECT
+    COUNT(*)::INTEGER AS total_users,
+    COALESCE(SUM(au.card_count), 0)::INTEGER AS total_cards,
+    COUNT(*) FILTER (WHERE au.tos_accepted_at IS NOT NULL)::INTEGER AS users_with_tos,
+    COUNT(*) FILTER (WHERE au.card_count > 0)::INTEGER AS users_with_cards
+  FROM all_users au
+)
+SELECT jsonb_build_object(
+  'rows', COALESCE((
+    SELECT jsonb_agg(
+      jsonb_build_object(
+        'id', pu.id,
+        'twitch_user_id', pu.twitch_user_id,
+        'twitch_username', pu.twitch_username,
+        'twitch_display_name', pu.twitch_display_name,
+        'twitch_profile_image_url', pu.twitch_profile_image_url,
+        'tos_accepted_at', pu.tos_accepted_at,
+        'twitch_scopes', pu.twitch_scopes,
+        'created_at', pu.created_at,
+        'updated_at', pu.updated_at,
+        'user_cards', jsonb_build_array(jsonb_build_object('count', pu.card_count))
+      )
+      ORDER BY
+        CASE WHEN p_sort = 'card_count_desc' THEN pu.card_count END DESC NULLS LAST,
+        CASE WHEN p_sort = 'card_count_asc' THEN pu.card_count END ASC NULLS LAST,
+        CASE WHEN p_sort = 'name_asc' THEN pu.twitch_display_name END ASC NULLS LAST,
+        pu.created_at DESC,
+        pu.id ASC
+    )
+    FROM paged_users pu
+  ), '[]'::JSONB),
+  'count', (SELECT COUNT(*)::INTEGER FROM filtered_users),
+  'summary', jsonb_build_object(
+    'totalUsers', (SELECT total_users FROM summary),
+    'totalCards', (SELECT total_cards FROM summary),
+    'usersWithTos', (SELECT users_with_tos FROM summary),
+    'usersWithCards', (SELECT users_with_cards FROM summary)
+  )
+);
+$$;
+
+CREATE OR REPLACE FUNCTION get_analysis_streamers_page(
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 20,
+  p_search TEXT DEFAULT NULL,
+  p_sort TEXT DEFAULT 'card_count_desc',
+  p_hide_zero_cards BOOLEAN DEFAULT FALSE,
+  p_filter_chat_enabled BOOLEAN DEFAULT FALSE,
+  p_filter_has_template BOOLEAN DEFAULT FALSE,
+  p_filter_missing_scope BOOLEAN DEFAULT FALSE,
+  p_filter_vote_campaign BOOLEAN DEFAULT FALSE
+)
+RETURNS JSONB
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+WITH card_counts AS MATERIALIZED (
+  SELECT streamer_id, COUNT(*)::INTEGER AS card_count
+  FROM cards
+  GROUP BY streamer_id
+),
+vote_campaign_bonus AS MATERIALIZED (
+  SELECT DISTINCT streamer_id
+  FROM streamer_storage_bonus
+  WHERE type = 'campaign'
+    AND memo = '2026選挙応援'
+),
+system_bot AS (
+  SELECT EXISTS (
+    SELECT 1
+    FROM twitch_bot_accounts
+    WHERE owner_type = 'system'
+      AND status = 'active'
+  ) AS has_active_system_bot
+),
+streamer_base AS MATERIALIZED (
+  SELECT
+    s.*,
+    COALESCE(cc.card_count, 0)::INTEGER AS card_count,
+    COALESCE(su.bytes_used, 0)::BIGINT AS storage_bytes,
+    COALESCE(u.twitch_scopes, '{}'::TEXT[]) @> ARRAY['user:write:chat']::TEXT[] AS has_chat_scope,
+    COALESCE(css.sender_mode, 'streamer') AS chat_sender_mode,
+    CASE
+      WHEN COALESCE(css.sender_mode, 'streamer') = 'custom_bot' THEN
+        COALESCE(bot.owner_type = 'streamer'
+          AND bot.streamer_id = s.id
+          AND bot.status = 'active', FALSE)
+      WHEN COALESCE(css.sender_mode, 'streamer') = 'official_bot' THEN
+        (SELECT has_active_system_bot FROM system_bot)
+      ELSE FALSE
+    END AS has_active_bot_sender,
+    (
+      (COALESCE(u.twitch_scopes, '{}'::TEXT[]) @> ARRAY['user:write:chat']::TEXT[])
+      OR CASE
+        WHEN COALESCE(css.sender_mode, 'streamer') = 'custom_bot' THEN
+          COALESCE(bot.owner_type = 'streamer'
+            AND bot.streamer_id = s.id
+            AND bot.status = 'active', FALSE)
+        WHEN COALESCE(css.sender_mode, 'streamer') = 'official_bot' THEN
+          (SELECT has_active_system_bot FROM system_bot)
+        ELSE FALSE
+      END
+    ) AS chat_send_available,
+    vcb.streamer_id IS NOT NULL AS has_vote_campaign_bonus
+  FROM streamers s
+  LEFT JOIN card_counts cc ON cc.streamer_id = s.id
+  LEFT JOIN users u ON u.twitch_user_id = s.twitch_user_id
+  LEFT JOIN streamer_chat_sender_settings css ON css.streamer_id = s.id
+  LEFT JOIN twitch_bot_accounts bot ON bot.id = css.custom_bot_account_id
+  LEFT JOIN storage_usage su
+    ON su.user_prefix = substring(encode(extensions.digest(s.twitch_user_id, 'sha256'), 'hex') from 1 for 8)
+  LEFT JOIN vote_campaign_bonus vcb ON vcb.streamer_id = s.id
+),
+filtered_streamers AS MATERIALIZED (
+  SELECT sb.*
+  FROM streamer_base sb
+  WHERE (p_search IS NULL OR p_search = ''
+    OR sb.twitch_username ILIKE p_search ESCAPE E'\\'
+    OR sb.twitch_display_name ILIKE p_search ESCAPE E'\\'
+    OR sb.twitch_user_id ILIKE p_search ESCAPE E'\\')
+    AND (NOT COALESCE(p_hide_zero_cards, FALSE) OR sb.card_count > 0)
+    AND (NOT COALESCE(p_filter_chat_enabled, FALSE) OR sb.chat_announcement_enabled)
+    AND (NOT COALESCE(p_filter_has_template, FALSE)
+      OR COALESCE(length(sb.chat_announcement_template), 0) > 0)
+    AND (NOT COALESCE(p_filter_missing_scope, FALSE)
+      OR (sb.chat_announcement_enabled AND NOT sb.chat_send_available))
+    AND (NOT COALESCE(p_filter_vote_campaign, FALSE) OR sb.has_vote_campaign_bonus)
+),
+paged_streamers AS (
+  SELECT fs.*
+  FROM filtered_streamers fs
+  ORDER BY
+    CASE WHEN p_sort = 'card_count_desc' THEN fs.card_count END DESC NULLS LAST,
+    CASE WHEN p_sort = 'card_count_asc' THEN fs.card_count END ASC NULLS LAST,
+    CASE WHEN p_sort = 'storage_desc' THEN fs.storage_bytes END DESC NULLS LAST,
+    CASE WHEN p_sort = 'name_asc' THEN fs.twitch_display_name END ASC NULLS LAST,
+    fs.created_at DESC,
+    fs.id ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_page_size, 20), 1), 100)
+  OFFSET (GREATEST(COALESCE(p_page, 1), 1)::BIGINT - 1)
+    * LEAST(GREATEST(COALESCE(p_page_size, 20), 1), 100)::BIGINT
+),
+summary AS (
+  SELECT
+    COUNT(*)::INTEGER AS total_streamers,
+    COUNT(*) FILTER (WHERE sb.is_active)::INTEGER AS active_streamers,
+    COUNT(*) FILTER (WHERE COALESCE(length(sb.channel_point_reward_id), 0) > 0)::INTEGER
+      AS configured_streamers,
+    COALESCE(SUM(sb.card_count), 0)::INTEGER AS total_cards,
+    COALESCE(SUM(sb.storage_bytes), 0)::BIGINT AS total_storage,
+    COUNT(*) FILTER (WHERE sb.card_count > 0)::INTEGER AS streamers_with_cards,
+    COUNT(*) FILTER (WHERE sb.chat_announcement_enabled)::INTEGER AS chat_enabled_streamers,
+    COUNT(*) FILTER (WHERE COALESCE(length(sb.chat_announcement_template), 0) > 0)::INTEGER
+      AS custom_template_streamers,
+    COUNT(*) FILTER (WHERE sb.chat_announcement_enabled AND NOT sb.chat_send_available)::INTEGER
+      AS chat_enabled_no_sender,
+    COUNT(*) FILTER (WHERE sb.has_vote_campaign_bonus)::INTEGER AS vote_campaign_users
+  FROM streamer_base sb
+)
+SELECT jsonb_build_object(
+  'rows', COALESCE((
+    SELECT jsonb_agg(to_jsonb(ps) ORDER BY
+      CASE WHEN p_sort = 'card_count_desc' THEN ps.card_count END DESC NULLS LAST,
+      CASE WHEN p_sort = 'card_count_asc' THEN ps.card_count END ASC NULLS LAST,
+      CASE WHEN p_sort = 'storage_desc' THEN ps.storage_bytes END DESC NULLS LAST,
+      CASE WHEN p_sort = 'name_asc' THEN ps.twitch_display_name END ASC NULLS LAST,
+      ps.created_at DESC,
+      ps.id ASC
+    ) FROM paged_streamers ps
+  ), '[]'::JSONB),
+  'count', (SELECT COUNT(*)::INTEGER FROM filtered_streamers),
+  'summary', jsonb_build_object(
+    'totalStreamers', (SELECT total_streamers FROM summary),
+    'activeStreamers', (SELECT active_streamers FROM summary),
+    'configuredStreamers', (SELECT configured_streamers FROM summary),
+    'totalCards', (SELECT total_cards FROM summary),
+    'totalStorage', (SELECT total_storage FROM summary),
+    'streamersWithCards', (SELECT streamers_with_cards FROM summary),
+    'chatEnabledStreamers', (SELECT chat_enabled_streamers FROM summary),
+    'customTemplateStreamers', (SELECT custom_template_streamers FROM summary),
+    'chatEnabledNoSender', (SELECT chat_enabled_no_sender FROM summary),
+    'voteCampaignUsers', (SELECT vote_campaign_users FROM summary)
+  )
+);
+$$;
+
+CREATE OR REPLACE FUNCTION get_analysis_streamer_options_page(
+  p_page INTEGER DEFAULT 1,
+  p_page_size INTEGER DEFAULT 50,
+  p_search TEXT DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+WITH filtered AS MATERIALIZED (
+  SELECT s.id, s.twitch_username, s.twitch_display_name
+  FROM streamers s
+  WHERE (p_search IS NULL OR p_search = ''
+    OR s.twitch_username ILIKE p_search ESCAPE E'\\'
+    OR s.twitch_display_name ILIKE p_search ESCAPE E'\\'
+    OR s.twitch_user_id ILIKE p_search ESCAPE E'\\')
+),
+paged AS (
+  SELECT f.*
+  FROM filtered f
+  ORDER BY f.twitch_display_name ASC, f.id ASC
+  LIMIT LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 100)
+  OFFSET (GREATEST(COALESCE(p_page, 1), 1)::BIGINT - 1)
+    * LEAST(GREATEST(COALESCE(p_page_size, 50), 1), 100)::BIGINT
+)
+SELECT jsonb_build_object(
+  'rows', COALESCE((
+    SELECT jsonb_agg(
+      jsonb_build_object(
+        'id', p.id,
+        'twitch_username', p.twitch_username,
+        'twitch_display_name', p.twitch_display_name
+      ) ORDER BY p.twitch_display_name ASC, p.id ASC
+    ) FROM paged p
+  ), '[]'::JSONB),
+  'count', (SELECT COUNT(*)::INTEGER FROM filtered)
+);
+$$;
+
+REVOKE ALL ON FUNCTION get_analysis_overview() FROM PUBLIC;
+REVOKE ALL ON FUNCTION get_analysis_users_page(INTEGER, INTEGER, TEXT, TEXT, BOOLEAN) FROM PUBLIC;
+REVOKE ALL ON FUNCTION get_analysis_streamers_page(INTEGER, INTEGER, TEXT, TEXT, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN) FROM PUBLIC;
+REVOKE ALL ON FUNCTION get_analysis_streamer_options_page(INTEGER, INTEGER, TEXT) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION get_analysis_overview() TO service_role;
+GRANT EXECUTE ON FUNCTION get_analysis_users_page(INTEGER, INTEGER, TEXT, TEXT, BOOLEAN) TO service_role;
+GRANT EXECUTE ON FUNCTION get_analysis_streamers_page(INTEGER, INTEGER, TEXT, TEXT, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN, BOOLEAN) TO service_role;
+GRANT EXECUTE ON FUNCTION get_analysis_streamer_options_page(INTEGER, INTEGER, TEXT) TO service_role;

--- a/tests/unit/additional-rewards-driver-parity.test.ts
+++ b/tests/unit/additional-rewards-driver-parity.test.ts
@@ -12,6 +12,7 @@ import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
 import { getDb } from "@/lib/db/client";
 import { streamerAdditionalGachaRewards as streamerAdditionalGachaRewardsTable } from "@/lib/db/schema";
+import { ERROR_MESSAGES } from "@/lib/constants";
 
 vi.mock("@/lib/session");
 vi.mock("@/lib/rate-limit");
@@ -615,6 +616,23 @@ describe("streamer/additional-rewards: PlanetScale契約 (#663)", () => {
         new NextRequest("http://localhost/api/streamer/additional-rewards?deleteAll=true", { method: "DELETE" })
       );
       expect(response.status).toBe(404);
+    });
+
+    it("CSRF検証が無効な場合は403を返し、レートリミット/セッション取得/DB削除にも到達しない (#736)", async () => {
+      mockValidateCSRFToken.mockResolvedValue({ valid: false, error: "bad csrf" } as any);
+      const pg = createDrizzleDbMock({ selects: [{ rows: [{ id: "streamer-1" }] }] });
+      primePgDb(pg);
+
+      const { DELETE } = await loadRoute();
+      const response = await DELETE(
+        new NextRequest("http://localhost/api/streamer/additional-rewards?deleteAll=true", { method: "DELETE" })
+      );
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({ error: ERROR_MESSAGES.FORBIDDEN });
+      expect(mockCheckRateLimit).not.toHaveBeenCalled();
+      expect(mockGetSession).not.toHaveBeenCalled();
+      expect(pg.deleteCalls).toHaveLength(0);
     });
 
   });

--- a/tests/unit/analysis-admin-api-client.test.ts
+++ b/tests/unit/analysis-admin-api-client.test.ts
@@ -107,7 +107,7 @@ describe('adminApi: request()のタイムアウト/AbortSignal', () => {
 // キャンセルできるように、読み取り系メソッドは末尾にoptions?: RequestOptionsを
 // 受け取り、渡されたsignalをrequest()へそのまま渡す(既定のタイムアウトsignalで
 // 上書きしない)。読み取り系20メソッド全てを網羅的にテストする意味は薄いため、
-// 引数の形が異なる代表2パターン(引数無し/paramsあり)のみ検証する
+// 引数の形が異なる代表2パターン(ページparams付き/既存params付き)のみ検証する
 describe('adminApi: RequestOptionsによるsignal透過(#701 UI state/UX)', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
@@ -118,12 +118,12 @@ describe('adminApi: RequestOptionsによるsignal透過(#701 UI state/UX)', () =
   // 失わないようにするため)。そのため合成後のsignalへの参照同一性ではなく、
   // 呼び出し元のcontrollerをabortすると実際にfetchへ渡ったsignalも
   // abortされるという振る舞いで検証する(実装の内部詳細に依存しない)
-  it('引数無しメソッド(getUsers)へ渡したsignalをabortするとfetchのsignalもabortされる', async () => {
+  it('ページparams付きメソッド(getUsers)へ渡したsignalをabortするとfetchのsignalもabortされる', async () => {
     const fetchMock = vi.fn().mockResolvedValue(fakeFetchResponse({ ok: true, json: [] }))
     vi.stubGlobal('fetch', fetchMock)
     const controller = new AbortController()
 
-    await adminApi.getUsers({ signal: controller.signal })
+    await adminApi.getUsers({ page: 1, pageSize: 20 }, { signal: controller.signal })
 
     const [, options] = fetchMock.mock.calls[0]
     expect(options.signal).toBeInstanceOf(AbortSignal)
@@ -156,7 +156,7 @@ describe('adminApi: RequestOptionsによるsignal透過(#701 UI state/UX)', () =
     const anySpy = vi.spyOn(AbortSignal, 'any')
     const controller = new AbortController()
 
-    await adminApi.getUsers({ signal: controller.signal })
+    await adminApi.getUsers({ page: 1, pageSize: 20 }, { signal: controller.signal })
 
     expect(anySpy).toHaveBeenCalledWith([controller.signal, expect.any(AbortSignal)])
     anySpy.mockRestore()

--- a/tests/unit/analysis-admin-db-driver.test.ts
+++ b/tests/unit/analysis-admin-db-driver.test.ts
@@ -120,26 +120,69 @@ describe('adminApiPg: pg直結クエリ', () => {
     expect(calls[0].text).toContain('get_analysis_streamer_leaderboard()')
   })
 
-  it('listUsersPg: get_analysis_users() を呼ぶ', async () => {
-    const { tag, calls } = fakeSqlTag([{ id: 'u1' }])
+  it('listUsersPg: ページとフィルタをget_analysis_users_page()へバインドする', async () => {
+    const expected = { rows: [{ id: 'u1' }], count: 1, summary: {} }
+    const { tag, calls } = fakeSqlTag(expected)
     const mod = await importAdminApiPg()
     mod.__setAnalysisSqlFactoryForTests(() => tag as never)
 
-    const data = await mod.listUsersPg({})
+    const data = await mod.listUsersPg({}, {
+      page: 2,
+      pageSize: 10,
+      search: '%alice%',
+      sort: 'name_asc',
+      hideZeroCards: true,
+    })
 
-    expect(data).toEqual([{ id: 'u1' }])
-    expect(calls[0].text).toContain('get_analysis_users()')
+    expect(data).toEqual(expected)
+    expect(calls[0].text).toContain('get_analysis_users_page(')
+    expect(calls[0].values).toEqual([2, 10, '%alice%', 'name_asc', true])
   })
 
-  it('listStreamersWithStatsPg: get_analysis_streamers() を呼ぶ', async () => {
-    const { tag, calls } = fakeSqlTag([{ id: 'st1' }])
+  it('listStreamersWithStatsPg: ページとフィルタをget_analysis_streamers_page()へバインドする', async () => {
+    const expected = { rows: [{ id: 'st1' }], count: 1, summary: {} }
+    const { tag, calls } = fakeSqlTag(expected)
     const mod = await importAdminApiPg()
     mod.__setAnalysisSqlFactoryForTests(() => tag as never)
 
-    const data = await mod.listStreamersWithStatsPg({})
+    const data = await mod.listStreamersWithStatsPg({}, {
+      page: 1,
+      pageSize: 20,
+      search: '%channel%',
+      sort: 'storage_desc',
+      hideZeroCards: true,
+      filterChatEnabled: true,
+      filterHasTemplate: false,
+      filterMissingScope: true,
+      filterVoteCampaign: false,
+    })
 
-    expect(data).toEqual([{ id: 'st1' }])
-    expect(calls[0].text).toContain('get_analysis_streamers()')
+    expect(data).toEqual(expected)
+    expect(calls[0].text).toContain('get_analysis_streamers_page(')
+    expect(calls[0].values).toEqual([
+      1,
+      20,
+      '%channel%',
+      'storage_desc',
+      true,
+      true,
+      false,
+      true,
+      false,
+    ])
+  })
+
+  it('getStreamerOptionsPg: 軽量候補をページングして取得する', async () => {
+    const expected = { rows: [{ id: 'st1' }], count: 1 }
+    const { tag, calls } = fakeSqlTag(expected)
+    const mod = await importAdminApiPg()
+    mod.__setAnalysisSqlFactoryForTests(() => tag as never)
+
+    const data = await mod.getStreamerOptionsPg({}, { page: 1, pageSize: 50, search: '%chan%' })
+
+    expect(data).toEqual(expected)
+    expect(calls[0].text).toContain('get_analysis_streamer_options_page(')
+    expect(calls[0].values).toEqual([1, 50, '%chan%'])
   })
 
   // 5関数とも callAnalysisJsonFunction() を共有しているため、エラー伝播の検証は
@@ -314,28 +357,6 @@ describe('adminApiPg: gachaHistoryFromWhere（動的WHERE句の組み立て）',
   })
 })
 
-describe('adminApiPg: getGachaChartPg', () => {
-  it('LIMIT 10000・jsonb整形した行配列を返し、フィルタがバインドされる', async () => {
-    const { tag, calls } = fakeSqlTag([{ id: 'g1' }])
-    const mod = await importAdminApiPg()
-    mod.__setAnalysisSqlFactoryForTests(() => tag as never)
-
-    const data = await mod.getGachaChartPg(
-      {},
-      { streamerId: 'streamer-1', fromDate: '2024-01-01T00:00:00Z' }
-    )
-
-    expect(data).toEqual([{ id: 'g1' }])
-    expect(calls).toHaveLength(1)
-    // 外側の jsonb_agg にも明示 ORDER BY を持たせている（サブクエリの
-    // ORDER BY + LIMIT の並び順に暗黙で依存しない防御的な集約）
-    expect(calls[0].text).toContain('jsonb_agg(row_json ORDER BY sort_redeemed_at DESC)')
-    expect(calls[0].text).toContain('LIMIT 10000')
-    expect(calls[0].text).toContain('AND gh.streamer_id = ')
-    expect(calls[0].values).toEqual(['streamer-1', '2024-01-01T00:00:00Z'])
-  })
-})
-
 describe('adminApiPg: getGachaTablePg', () => {
   it('件数クエリとデータクエリを共有WHEREで別々に発行し、{rows, count}を返す', async () => {
     const { tag, calls } = fakeSqlTag([{ id: 'g1' }], 42)
@@ -385,7 +406,7 @@ describe('adminApiPg: getGachaExportRowsPg', () => {
     const data = await mod.getGachaExportRowsPg({}, { rarity: 'legendary' })
 
     expect(data).toEqual([{ redeemed_at: '2024-01-01T00:00:00Z' }])
-    // getGachaChartPg/getGachaTablePgと違いページングやcountクエリを伴わない単発クエリ
+    // getGachaTablePgと違いページングやcountクエリを伴わない単発クエリ
     expect(calls).toHaveLength(1)
     // LIMIT はバインドパラメータとして渡すため（GACHA_EXPORT_ROW_LIMIT_PG）、
     // テキストではなく values の末尾を確認する
@@ -865,13 +886,13 @@ describe('localAdminApi: Postgres専用wrapper', () => {
     },
     {
       name: 'listUsers',
-      sql: 'get_analysis_users()',
-      call: (mod: any) => mod.listUsers({}),
+      sql: 'get_analysis_users_page(',
+      call: (mod: any) => mod.listUsers({ page: 1, pageSize: 20 }, {}),
     },
     {
       name: 'listStreamersWithStats',
-      sql: 'get_analysis_streamers()',
-      call: (mod: any) => mod.listStreamersWithStats({}),
+      sql: 'get_analysis_streamers_page(',
+      call: (mod: any) => mod.listStreamersWithStats({ page: 1, pageSize: 20 }, {}),
     },
   ]
 
@@ -999,9 +1020,10 @@ describe('localAdminApi: Postgres専用wrapper', () => {
 })
 
 describe('localAdminApi: pure helper', () => {
-  it('escapeIlikePattern は % と _ をエスケープする', async () => {
+  it('escapeIlikePattern は LIKEの制御文字をエスケープする', async () => {
     const { escapeIlikePattern } = await importLocalAdminApi()
     expect(escapeIlikePattern('100%_off')).toBe('100\\%\\_off')
+    expect(escapeIlikePattern('back\\slash')).toBe('back\\\\slash')
   })
 
   it('computeExclusiveToDateIso は翌日0時UTCを返す', async () => {

--- a/tests/unit/analysis-dashboard-pagination.test.ts
+++ b/tests/unit/analysis-dashboard-pagination.test.ts
@@ -42,6 +42,7 @@ describe('analysis dashboard: bounded data contract', () => {
   it('Gacha系の初回期間は7日で、チャートは行取得ではなく集計RPCを使う', () => {
     expect(gachaPage).toContain("useState<TimeRange>('7d')")
     expect(gachaPage).toContain('adminApi.getStreamerOptions(')
+    expect(gachaPage).toContain('const selected = previousRows.find')
     expect(gachaPage).not.toContain('adminApi.getStreamers(')
     expect(streamerGachaPage).toContain("useState<TimeRange>('7d')")
     expect(streamerGachaPage).toContain('adminApi.getGachaSummary(')

--- a/tests/unit/analysis-dashboard-pagination.test.ts
+++ b/tests/unit/analysis-dashboard-pagination.test.ts
@@ -33,10 +33,12 @@ describe('analysis dashboard: bounded data contract', () => {
   it('一覧ページは現在ページのrowsとDB countをDataTableへ渡し、全件をローカルsliceしない', () => {
     expect(usersPage).toContain('page: currentPage')
     expect(usersPage).toContain('debouncedSearchTerm')
+    expect(usersPage).toContain('if (searchTerm !== debouncedSearchTerm) return')
     expect(usersPage).toContain('totalItems: totalCount')
     expect(usersPage).not.toContain('data={sortedUsers}')
     expect(streamersPage).toContain('page: currentPage')
     expect(streamersPage).toContain('debouncedSearchQuery')
+    expect(streamersPage).toContain('if (searchQuery !== debouncedSearchQuery) return')
     expect(streamersPage).toContain('totalItems: totalCount')
     expect(streamersPage).not.toContain('data={filteredAndSortedStreamers}')
   })

--- a/tests/unit/analysis-dashboard-pagination.test.ts
+++ b/tests/unit/analysis-dashboard-pagination.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const repoRoot = resolve(__dirname, '../..')
+const migration = readFileSync(
+  resolve(repoRoot, 'supabase/migrations/20260731120000_paginate_analysis_dashboard.sql'),
+  'utf8'
+)
+const usersPage = readFileSync(resolve(repoRoot, 'analysis/src/pages/Users.tsx'), 'utf8')
+const streamersPage = readFileSync(resolve(repoRoot, 'analysis/src/pages/Streamers.tsx'), 'utf8')
+const gachaPage = readFileSync(resolve(repoRoot, 'analysis/src/pages/Gacha.tsx'), 'utf8')
+const localAdminApi = readFileSync(resolve(repoRoot, 'analysis/dev/localAdminApi.ts'), 'utf8')
+const streamerGachaPage = readFileSync(
+  resolve(repoRoot, 'analysis/src/pages/StreamerGachaHistory.tsx'),
+  'utf8'
+)
+
+describe('analysis dashboard: bounded data contract', () => {
+  it('DB RPCは一覧を最大100行に制限し、安定したid tie-breakerを持つ', () => {
+    expect(migration).toContain('CREATE OR REPLACE FUNCTION get_analysis_users_page(')
+    expect(migration).toContain('CREATE OR REPLACE FUNCTION get_analysis_streamers_page(')
+    expect(migration).toContain('CREATE OR REPLACE FUNCTION get_analysis_streamer_options_page(')
+    expect(migration.match(/LIMIT LEAST\(GREATEST\(COALESCE\(p_page_size/g)).toHaveLength(3)
+    expect(migration).toContain('), 100)')
+    expect(migration).toContain('fu.id ASC')
+    expect(migration).toContain('fs.id ASC')
+    expect(migration).toContain('p.id ASC')
+    expect(migration).toContain('GRANT EXECUTE ON FUNCTION get_analysis_users_page')
+    expect(migration).toContain('GRANT EXECUTE ON FUNCTION get_analysis_streamers_page')
+  })
+
+  it('一覧ページは現在ページのrowsとDB countをDataTableへ渡し、全件をローカルsliceしない', () => {
+    expect(usersPage).toContain('page: currentPage')
+    expect(usersPage).toContain('totalItems: totalCount')
+    expect(usersPage).not.toContain('data={sortedUsers}')
+    expect(streamersPage).toContain('page: currentPage')
+    expect(streamersPage).toContain('totalItems: totalCount')
+    expect(streamersPage).not.toContain('data={filteredAndSortedStreamers}')
+  })
+
+  it('Gacha系の初回期間は7日で、チャートは行取得ではなく集計RPCを使う', () => {
+    expect(gachaPage).toContain("useState<TimeRange>('7d')")
+    expect(gachaPage).toContain('adminApi.getStreamerOptions(')
+    expect(gachaPage).not.toContain('adminApi.getStreamers(')
+    expect(streamerGachaPage).toContain("useState<TimeRange>('7d')")
+    expect(streamerGachaPage).toContain('adminApi.getGachaSummary(')
+    expect(streamerGachaPage).not.toContain('adminApi.getGachaChart(')
+    expect(streamerGachaPage).not.toContain('new Set(chartData')
+    expect(localAdminApi).toContain("path === '/gacha/table'")
+    expect(localAdminApi).toContain('parsePagination(url, 100)')
+  })
+})

--- a/tests/unit/analysis-dashboard-pagination.test.ts
+++ b/tests/unit/analysis-dashboard-pagination.test.ts
@@ -32,9 +32,11 @@ describe('analysis dashboard: bounded data contract', () => {
 
   it('一覧ページは現在ページのrowsとDB countをDataTableへ渡し、全件をローカルsliceしない', () => {
     expect(usersPage).toContain('page: currentPage')
+    expect(usersPage).toContain('debouncedSearchTerm')
     expect(usersPage).toContain('totalItems: totalCount')
     expect(usersPage).not.toContain('data={sortedUsers}')
     expect(streamersPage).toContain('page: currentPage')
+    expect(streamersPage).toContain('debouncedSearchQuery')
     expect(streamersPage).toContain('totalItems: totalCount')
     expect(streamersPage).not.toContain('data={filteredAndSortedStreamers}')
   })

--- a/tests/unit/analysis-dashboard-search-debounce.test.tsx
+++ b/tests/unit/analysis-dashboard-search-debounce.test.tsx
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { scheduleDebouncedValue } from '../../analysis/src/hooks/useDebouncedValue'
+
+describe('analysis dashboard search debounce', () => {
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('連続入力中は検索語を更新せず、最後の値だけを反映する', () => {
+    vi.useFakeTimers()
+    const receivedValues: string[] = []
+    let cleanup = () => {}
+
+    const schedule = (value: string) => {
+      cleanup()
+      cleanup = scheduleDebouncedValue(value, 300, (nextValue) => {
+        receivedValues.push(nextValue)
+      })
+    }
+
+    schedule('')
+    schedule('a')
+    schedule('ab')
+    expect(receivedValues).toEqual([])
+
+    vi.advanceTimersByTime(299)
+    expect(receivedValues).toEqual([])
+
+    vi.advanceTimersByTime(1)
+    expect(receivedValues).toEqual(['ab'])
+    cleanup()
+  })
+
+  it('cleanup後は保留中の検索語を反映しない', () => {
+    vi.useFakeTimers()
+    const onValue = vi.fn()
+    const cleanup = scheduleDebouncedValue('stale', 300, onValue)
+
+    cleanup()
+    vi.advanceTimersByTime(300)
+
+    expect(onValue).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/api/eventsub-debug-delete-ownership.test.ts
+++ b/tests/unit/api/eventsub-debug-delete-ownership.test.ts
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { DELETE } from '@/app/api/twitch/eventsub/debug/route'
+import { validateCSRFToken } from '@/lib/csrf'
+import { getSession, canUseStreamerFeatures } from '@/lib/session'
+import { checkRateLimit, getRateLimitIdentifier } from '@/lib/rate-limit'
+import { ERROR_MESSAGES } from '@/lib/constants'
+
+// Issue #831: DELETE /api/twitch/eventsub/debug の
+// (1) 所有権検証欠落、(2) CSRF/レートリミット欠落、(3) 全削除のページネーション未対応
+// を検証する回帰テスト。
+
+vi.mock('@/lib/csrf')
+vi.mock('@/lib/session')
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: vi.fn(),
+  getRateLimitIdentifier: vi.fn(),
+  rateLimits: { eventsubSubscribePost: {} },
+}))
+vi.mock('@/lib/logger.server', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken)
+const mockGetSession = vi.mocked(getSession)
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)
+const mockCheckRateLimit = vi.mocked(checkRateLimit)
+const mockGetRateLimitIdentifier = vi.mocked(getRateLimitIdentifier)
+
+function createDeleteRequest(query = ''): NextRequest {
+  return new NextRequest(`http://localhost:3000/api/twitch/eventsub/debug${query}`, {
+    method: 'DELETE',
+  })
+}
+
+function mockAppAccessTokenFetch() {
+  return new Response(JSON.stringify({ access_token: 'app-token' }), { status: 200 })
+}
+
+describe('DELETE /api/twitch/eventsub/debug (#831)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'client-id'
+    process.env.TWITCH_CLIENT_SECRET = 'client-secret'
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'my-user-id',
+      twitchUsername: 'streamer',
+      twitchDisplayName: 'Streamer',
+      twitchProfileImageUrl: 'https://example.com/avatar.png',
+      broadcasterType: 'affiliate',
+      expiresAt: Date.now() + 60_000,
+      version: 1,
+    })
+    mockCanUseStreamerFeatures.mockReturnValue(true)
+    mockValidateCSRFToken.mockResolvedValue({ valid: true })
+    mockGetRateLimitIdentifier.mockResolvedValue('user:my-user-id')
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: Date.now() + 60_000,
+    })
+  })
+
+  it('CSRF不正時は403を返し、レートリミット/セッション取得にも到達しない', async () => {
+    mockValidateCSRFToken.mockResolvedValue({ valid: false, error: 'bad csrf' })
+
+    const response = await DELETE(createDeleteRequest('?id=sub-1'))
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: ERROR_MESSAGES.FORBIDDEN })
+    expect(mockCheckRateLimit).not.toHaveBeenCalled()
+    expect(mockGetSession).not.toHaveBeenCalled()
+  })
+
+  it('レートリミット超過時は429を返す', async () => {
+    mockCheckRateLimit.mockResolvedValue({
+      success: false,
+      limit: 10,
+      remaining: 0,
+      reset: Date.now() + 60_000,
+    })
+
+    const response = await DELETE(createDeleteRequest('?id=sub-1'))
+
+    expect(response.status).toBe(429)
+  })
+
+  it('配信者権限のないセッションは401を返す', async () => {
+    mockCanUseStreamerFeatures.mockReturnValue(false)
+
+    const response = await DELETE(createDeleteRequest('?id=sub-1'))
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: ERROR_MESSAGES.UNAUTHORIZED })
+  })
+
+  it('他broadcasterが所有するsubscriptionIdの削除は403で拒否し、Twitchへの削除リクエストを送らない', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockAppAccessTokenFetch())
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          data: [
+            {
+              id: 'victim-sub',
+              status: 'enabled',
+              type: 'channel.channel_points_custom_reward_redemption.add',
+              condition: { broadcaster_user_id: 'other-user-id' },
+              transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+              created_at: '2026-01-01T00:00:00Z',
+            },
+          ],
+          pagination: {},
+        }), { status: 200 }),
+      )
+
+    const response = await DELETE(createDeleteRequest('?id=victim-sub'))
+    const body = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(body).toEqual({ error: ERROR_MESSAGES.FORBIDDEN })
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('?id=victim-sub'),
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+
+    fetchMock.mockRestore()
+  })
+
+  it('存在しないsubscriptionIdの削除は403で拒否する', async () => {
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockAppAccessTokenFetch())
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: [], pagination: {} }), { status: 200 }),
+      )
+
+    const response = await DELETE(createDeleteRequest('?id=nonexistent-sub'))
+
+    expect(response.status).toBe(403)
+  })
+
+  it('自分が所有するsubscriptionIdの削除は成功する', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockAppAccessTokenFetch())
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          data: [
+            {
+              id: 'my-sub',
+              status: 'enabled',
+              type: 'channel.channel_points_custom_reward_redemption.add',
+              condition: { broadcaster_user_id: 'my-user-id' },
+              transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+              created_at: '2026-01-01T00:00:00Z',
+            },
+          ],
+          pagination: {},
+        }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+
+    const response = await DELETE(createDeleteRequest('?id=my-sub'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual({ success: true, message: 'Subscription deleted' })
+    // 所有権確認の一覧取得はuser_idで絞り込む（app全体を毎回列挙しない） (#831)
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('user_id=my-user-id'),
+      expect.objectContaining({ headers: expect.anything() }),
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.twitch.tv/helix/eventsub/subscriptions?id=my-sub',
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+
+    fetchMock.mockRestore()
+  })
+
+  it('idもall=trueも指定しない場合は400を返す', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockAppAccessTokenFetch())
+
+    const response = await DELETE(createDeleteRequest())
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'Missing subscription id' })
+
+    fetchMock.mockRestore()
+  })
+
+  it('所有権確認の一覧取得がTwitch API側で失敗した場合は500を返し、削除リクエストを送らない(fail-closed)', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockAppAccessTokenFetch())
+      .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'server error' }), { status: 500 }))
+
+    const response = await DELETE(createDeleteRequest('?id=my-sub'))
+
+    expect(response.status).toBe(500)
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining('?id=my-sub'),
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+
+    fetchMock.mockRestore()
+  })
+
+  it('全削除(?all=true)は複数ページに渡る購読を全て取得し、自分の分のみ削除する', async () => {
+    // getAllSubscriptions() のページネーションを検証: 1ページ目にカーソルがあり、
+    // 2ページ目まで辿って初めて全件が揃う。旧実装（生fetch1回）ではこの2ページ目の
+    // 購読が黙って削除対象から漏れていた。
+    const fetchMock = vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(mockAppAccessTokenFetch())
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          data: [
+            {
+              id: 'my-sub-page1',
+              status: 'enabled',
+              type: 'channel.channel_points_custom_reward_redemption.add',
+              condition: { broadcaster_user_id: 'my-user-id' },
+              transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+              created_at: '2026-01-01T00:00:00Z',
+            },
+          ],
+          pagination: { cursor: 'next-page-cursor' },
+        }), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          data: [
+            {
+              id: 'my-sub-page2',
+              status: 'enabled',
+              type: 'channel.channel_points_custom_reward_redemption.add',
+              condition: { broadcaster_user_id: 'my-user-id' },
+              transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+              created_at: '2026-01-01T00:00:00Z',
+            },
+            {
+              id: 'other-user-sub',
+              status: 'enabled',
+              type: 'channel.channel_points_custom_reward_redemption.add',
+              condition: { broadcaster_user_id: 'other-user-id' },
+              transport: { method: 'webhook', callback: 'https://twica.example/api/twitch/eventsub' },
+              created_at: '2026-01-01T00:00:00Z',
+            },
+          ],
+          pagination: {},
+        }), { status: 200 }),
+      )
+      .mockResolvedValue(new Response(null, { status: 204 }))
+
+    const response = await DELETE(createDeleteRequest('?all=true'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.message).toBe('Deleted 2/2 subscriptions')
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.twitch.tv/helix/eventsub/subscriptions?id=my-sub-page1',
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.twitch.tv/helix/eventsub/subscriptions?id=my-sub-page2',
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      'https://api.twitch.tv/helix/eventsub/subscriptions?id=other-user-sub',
+      expect.anything(),
+    )
+
+    fetchMock.mockRestore()
+  })
+})

--- a/tests/unit/api/gacha-demo-route.test.ts
+++ b/tests/unit/api/gacha-demo-route.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/lib/overlay/demo-event-store', () => ({
 vi.mock('@/lib/rate-limit', () => ({
   checkRateLimit: vi.fn(),
   getRateLimitIdentifier: vi.fn(),
-  rateLimits: { gachaDemoBroadcast: {} },
+  rateLimits: { gachaDemoBroadcast: {}, gachaDemoCard: {} },
 }))
 
 const mockGetSession = vi.mocked(getSession)
@@ -108,6 +108,10 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
       expect.anything(),
       'twitch-1'
     )
+    // #735: 全リクエスト共通のIPベース制限(gachaDemoCard)は、認証済みユーザーID
+    // 基準のより厳格な専用制限(gachaDemoBroadcast)がすでに適用される
+    // broadcast&&streamerIdリクエストには重ねない(重ねると無関係な匿名IPの
+    // 連打だけで専用制限に到達する前にブロックされてしまうため)。
     expect(mockCheckRateLimit).toHaveBeenCalledTimes(1)
   })
 
@@ -145,7 +149,9 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
     expect(body.card).toBeDefined()
     expect(mockGetSession).not.toHaveBeenCalled()
     expect(mockPublishOverlayDemoEvent).not.toHaveBeenCalled()
-    expect(mockCheckRateLimit).not.toHaveBeenCalled()
+    // #735: broadcast専用の制限は通らないが、全リクエスト共通のIPベース制限は通る
+    expect(mockCheckRateLimit).toHaveBeenCalledTimes(1)
+    expect(mockGetRateLimitIdentifier).toHaveBeenCalledWith(expect.anything())
   })
 
   it('does not publish or authenticate when broadcast=true lacks a streamerId', async () => {
@@ -156,6 +162,47 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
     expect(body.card).toBeDefined()
     expect(mockGetSession).not.toHaveBeenCalled()
     expect(mockPublishOverlayDemoEvent).not.toHaveBeenCalled()
-    expect(mockCheckRateLimit).not.toHaveBeenCalled()
+    expect(mockCheckRateLimit).toHaveBeenCalledTimes(1)
+  })
+
+  it('#735: 匿名IPの一般制限が枯渇していても、認証済みユーザーのbroadcastは専用制限のみで判定され成功する', async () => {
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'twitch-1',
+      twitchUsername: 'user1',
+      broadcasterType: 'affiliate',
+    } as Awaited<ReturnType<typeof getSession>>)
+    mockGetStreamerIdByTwitchUserId.mockResolvedValue({ id: 'streamer-1' })
+    mockGetRateLimitIdentifier.mockImplementation(async (_req, twitchUserId) =>
+      twitchUserId ? `user:${twitchUserId}` : 'ip:203.0.113.1'
+    )
+    // 匿名IPベースの識別子に対しては枯渇済みを返す。gachaDemoCard(一般制限)が
+    // broadcast&&streamerId経路でも誤って呼ばれてしまえば、この枯渇で検出できる。
+    mockCheckRateLimit.mockImplementation(async (_limiter, identifier: string) => {
+      if (identifier.startsWith('ip:')) {
+        return { success: false, limit: 30, remaining: 0, reset: Date.now() + 60_000 }
+      }
+      return { success: true, limit: 30, remaining: 29, reset: Date.now() + 60_000 }
+    })
+
+    const response = await POST(makeRequest({ streamerId: 'streamer-1', broadcast: true }))
+
+    expect(response.status).toBe(200)
+    expect(mockCheckRateLimit).toHaveBeenCalledTimes(1)
+  })
+
+  it('#735: 全リクエスト共通のレートリミットに達した場合はセッション不要で429を返す', async () => {
+    mockCheckRateLimit.mockResolvedValue({
+      success: false,
+      limit: 30,
+      remaining: 0,
+      reset: Date.now() + 60_000,
+    })
+
+    const response = await POST(makeRequest({ cardId: 'some-card' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(429)
+    expect(body.error).toBe(ERROR_MESSAGES.RATE_LIMIT_EXCEEDED)
+    expect(mockGetSession).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/dashboard-data-rpc-driver-parity.test.ts
+++ b/tests/unit/dashboard-data-rpc-driver-parity.test.ts
@@ -183,21 +183,63 @@ function createFallbackDb(
   return {
     select: vi.fn((fields: Record<string, unknown>) => ({
       from: vi.fn((table: Table) => {
+        let groupByColumns: Column[] = []
         const evaluate = () => {
           const rows = rowsByTable.get(table) ?? []
-          const hasAggregate = Object.values(fields).some((field) => is(field, SQL))
-          if (hasAggregate) return [{ count: rows.length }]
+          const aggregateEntries = Object.entries(fields).filter(([, field]) => is(field, SQL))
+          const columnEntries = Object.entries(fields).filter(([, field]) => is(field, Column))
 
-          return rows.map((row) =>
-            Object.fromEntries(
-              Object.entries(fields).map(([key, field]) => {
-                if (is(field, Column)) return [key, row[field.name] ?? null]
-                // JOIN後のネスト値はfixture側でキー名どおりに保持する。
-                // SQL条件の再実装を避けつつ、公開結果のネスト形状は厳密に検証できる。
-                return [key, row[key] ?? null]
-              })
+          if (aggregateEntries.length === 0) {
+            return rows.map((row) =>
+              Object.fromEntries(
+                Object.entries(fields).map(([key, field]) => {
+                  if (is(field, Column)) return [key, row[field.name] ?? null]
+                  // JOIN後のネスト値はfixture側でキー名どおりに保持する。
+                  // SQL条件の再実装を避けつつ、公開結果のネスト形状は厳密に検証できる。
+                  return [key, row[key] ?? null]
+                })
+              )
             )
-          )
+          }
+
+          // groupBy() 呼び出しが無い集計 = 全体件数のみ(既存の挙動)。
+          if (groupByColumns.length === 0) {
+            return [{ count: rows.length }]
+          }
+
+          // groupBy() 呼び出しあり = GROUP BY をシミュレートする。groupBy対象の
+          // カラム値でグループ化し、各グループの行をまとめて保持する
+          // (#833のGROUP BY集計テスト用)。
+          const groups = new Map<string, { keyValues: Record<string, unknown>; rowsInGroup: Record<string, unknown>[] }>()
+          for (const row of rows) {
+            const keyValues: Record<string, unknown> = {}
+            for (const [key, field] of columnEntries) {
+              if (is(field, Column)) keyValues[key] = row[field.name] ?? null
+            }
+            const groupKey = groupByColumns.map((col) => String(row[col.name] ?? '')).join('|')
+            const existing = groups.get(groupKey)
+            if (existing) {
+              existing.rowsInGroup.push(row)
+            } else {
+              groups.set(groupKey, { keyValues, rowsInGroup: [row] })
+            }
+          }
+          return Array.from(groups.values()).map(({ keyValues, rowsInGroup }) => {
+            const result: Record<string, unknown> = { ...keyValues }
+            for (const [key, field] of aggregateEntries) {
+              // count()はsql`count(${sql.raw("*")})`、countDistinct(col)は
+              // sql`count(distinct ${col})`として表現される(drizzle-orm/sql/
+              // functions/aggregate.js)。queryChunks内にColumnが含まれるかで
+              // 両者を判別し、distinct集計ならグループ内のユニーク値数を返す。
+              const distinctColumn = (field as SQL).queryChunks.find((chunk) => is(chunk, Column)) as
+                | Column
+                | undefined
+              result[key] = distinctColumn
+                ? new Set(rowsInGroup.map((r) => r[distinctColumn.name])).size
+                : rowsInGroup.length
+            }
+            return result
+          })
         }
         const builder: any = {
           leftJoin: vi.fn(() => builder),
@@ -205,6 +247,10 @@ function createFallbackDb(
           where: vi.fn(() => builder),
           orderBy: vi.fn(() => builder),
           limit: vi.fn(() => builder),
+          groupBy: vi.fn((...columns: Column[]) => {
+            groupByColumns = columns
+            return builder
+          }),
           then: (onFulfilled: any, onRejected: any) =>
             Promise.resolve().then(evaluate).then(onFulfilled, onRejected),
         }
@@ -416,21 +462,56 @@ describe('dashboard-data: PlanetScale読み取りRPC契約 (#803)', () => {
     expect(pointCall.values).toEqual(['streamer-1', null, 10])
   })
 
+  it('#833: RPC経路はカスタムレアリティをそのまま(固定4種にハードコードせず)返す', async () => {
+    // #833の本質的な原因はJSフォールバック側が固定4レアリティにハードコード
+    // していたことで、RPC側(parseGachaDropStatsRpc)は元々rarity_statsの
+    // 内容をそのまま透過するだけで正しい。両経路が同じ入力に同じ結果を
+    // 返すことを固定し、将来どちらかにハードコードが再導入されたら
+    // このテストで検知できるようにする。
+    const dropStatsWithCustomRarity = {
+      ...dropStatsResult,
+      rarity_stats: [
+        { rarity: 'legendary', count: '0', rate: '0' },
+        { rarity: 'epic', count: '0', rate: '0' },
+        { rarity: 'rare', count: '0', rate: '0' },
+        { rarity: 'common', count: '6', rate: '60' },
+        { rarity: 'mythic', count: '4', rate: '40' },
+      ],
+    }
+    primeDb([
+      { rows: [{ result: dropStatsWithCustomRarity }] },
+      { rows: [{ result: channelPointResult }] },
+    ])
+
+    const result = await getGachaStats('streamer-1', '7d')
+
+    const mythicStat = result.rarityStats.find((row) => row.rarity === 'mythic')
+    expect(mythicStat).toMatchObject({ count: 4, rate: 40 })
+    expect(result.rarityStats).toHaveLength(5)
+    const sumOfCounts = result.rarityStats.reduce((sum, row) => sum + row.count, 0)
+    expect(sumOfCounts).toBe(10)
+    expect(sumOfCounts).toBe(result.totalDraws)
+  })
+
   it('drop統計RPC未デプロイ時は履歴から件数・排出ユーザー・レアリティを集約する', async () => {
+    // rarity は #833 以降 cardsTable.rarity への INNER JOIN + GROUP BY で
+    // 取得するため、fixture側もフラットな rarity フィールドを持たせる
+    // (createFallbackDb の GROUP BY シミュレーションが row[column.name] で
+    // 引くため、ネストした cards.rarity では解決できない)。
     const historyRows = [
       {
         card_id: 'card-a',
         user_twitch_id: 'viewer-1',
         user_twitch_username: 'viewer_one',
         redeemed_at: '2026-03-02T00:00:00+00:00',
-        cards: { rarity: 'common' },
+        rarity: 'common',
       },
       {
         card_id: 'card-a',
         user_twitch_id: 'viewer-1',
         user_twitch_username: 'Viewer New',
         redeemed_at: '2026-03-03T00:00:00+00:00',
-        cards: { rarity: 'common' },
+        rarity: 'common',
       },
     ]
     primeDb(
@@ -484,6 +565,76 @@ describe('dashboard-data: PlanetScale読み取りRPC契約 (#803)', () => {
         streamerId: 'streamer-1',
       }),
     )
+  })
+
+  it('#833: カスタムレアリティを含み、履歴サンプル上限を超える件数でも件数・レアリティ内訳が正確', async () => {
+    // 実運用では10000件超の履歴サンプルで actualCount/rarityStats が黙って
+    // 過小になっていた(#833)。ここではGROUP BY集計(count=25000)が
+    // 履歴サンプル(空配列=0件)から独立していることを直接検証する:
+    // もし実装がhistory配列から数え直す旧ロジックに戻れば、actualCount/
+    // rarityStatsのcountは0になりこのテストは失敗する。
+    const sql = createSqlMock([
+      { error: pgError('42883', 'get_gacha_drop_stats does not exist') },
+      { rows: [{ result: channelPointResult }] },
+    ])
+    let selectCallIndex = 0
+    const groupByResponses = [
+      [{ count: 25000 }], // count-only
+      [], // history detail sample(空でも件数計算に影響しないことを示す)
+      [{
+        id: 'card-a',
+        name: 'Card A',
+        rarity: 'mythic', // デフォルト4種に無いカスタムレアリティ
+        image_url: null,
+        drop_rate: 1,
+        created_at: '2026-01-01T00:00:00+00:00',
+      }],
+      [{ card_id: 'card-a', count: 25000 }], // drawCountsByCard(GROUP BY)
+      [{ rarity: 'mythic', count: 25000 }], // rarityCounts(GROUP BY)
+      [{ card_id: 'card-a', count: 500 }], // drawerCountsByCard(GROUP BY COUNT DISTINCT)
+    ]
+    const db = {
+      select: vi.fn(() => {
+        const response = groupByResponses[Math.min(selectCallIndex, groupByResponses.length - 1)]
+        selectCallIndex += 1
+        const builder: any = {
+          from: vi.fn(() => builder),
+          innerJoin: vi.fn(() => builder),
+          leftJoin: vi.fn(() => builder),
+          where: vi.fn(() => builder),
+          orderBy: vi.fn(() => builder),
+          limit: vi.fn(() => builder),
+          groupBy: vi.fn(() => builder),
+          then: (onFulfilled: any, onRejected: any) =>
+            Promise.resolve(response).then(onFulfilled, onRejected),
+        }
+        return builder
+      }),
+    }
+    vi.mocked(getDb).mockResolvedValue({ db, sql } as any)
+
+    const result = await getGachaStats('streamer-1', '7d')
+
+    expect(result.totalDraws).toBe(25000)
+    expect(result.cardStats[0]).toMatchObject({
+      cardId: 'card-a',
+      actualCount: 25000,
+      actualRate: 100,
+      // drawerCountはGROUP BY集計(500)から取り、空の履歴サンプルから0と
+      // 誤って数え直されない(レビュー指摘: actualCountだけ大きくdrawerCountが
+      // 0のままだと矛盾した表示になる)
+      drawerCount: 500,
+      drawers: [], // 明細一覧は履歴サンプル(空)のまま=付随情報として空でよい
+    })
+    const mythicStat = result.rarityStats.find((row) => row.rarity === 'mythic')
+    expect(mythicStat).toMatchObject({ count: 25000, rate: 100 })
+    // デフォルト4種(排出0でも表示)+実際に排出されたカスタムレアリティの順で並ぶ
+    expect(result.rarityStats.map((row) => row.rarity)).toEqual([
+      'legendary', 'epic', 'rare', 'common', 'mythic',
+    ])
+    // rarityStatsの内訳合計がtotal_drawsと一致する(カスタムレアリティ込み)
+    const sumOfCounts = result.rarityStats.reduce((sum, row) => sum + row.count, 0)
+    expect(sumOfCounts).toBe(25000)
   })
 
   it('channel point統計RPC障害時は履歴からポイントと順位を集約する', async () => {
@@ -629,5 +780,45 @@ describe('dashboard-data: PlanetScale読み取りRPC契約 (#803)', () => {
         streamerId: 'streamer-1',
       }),
     )
+  })
+
+  it('#833: 所持ユーザー明細サンプル件数を超えても、ownerCountはGROUP BY集計から正確な値を返す', async () => {
+    // 実運用ではownerRowsのLIMIT 10000サンプルからownerCountを数えていたため、
+    // streamer全体のuser_cards行数が10000件を超えると人気カードのownerCountが
+    // 黙って過小になっていた(#833)。ここではownerRows(明細サンプル)を空にし、
+    // 別のGROUP BY集計(COUNT DISTINCT)だけがownerCountを決めることを直接示す。
+    let selectCallIndex = 0
+    const responses = [
+      [{ id: 'card-a', name: 'Card A', rarity: 'common', image_url: null }], // cards
+      [], // ownerRows(明細サンプル、空でもownerCountに影響しないことを示す)
+      [{ card_id: 'card-a', count: 3000 }], // ownerCounts(GROUP BY COUNT DISTINCT)
+    ]
+    const db = {
+      select: vi.fn(() => {
+        const response = responses[Math.min(selectCallIndex, responses.length - 1)]
+        selectCallIndex += 1
+        const builder: any = {
+          from: vi.fn(() => builder),
+          innerJoin: vi.fn(() => builder),
+          where: vi.fn(() => builder),
+          orderBy: vi.fn(() => builder),
+          limit: vi.fn(() => builder),
+          groupBy: vi.fn(() => builder),
+          then: (onFulfilled: any, onRejected: any) =>
+            Promise.resolve(response).then(onFulfilled, onRejected),
+        }
+        return builder
+      }),
+    }
+    const sql = createSqlMock([{ error: pgError('42883', 'get_card_owner_stats does not exist') }])
+    vi.mocked(getDb).mockResolvedValue({ db, sql } as any)
+
+    const result = await getGachaCardOwnerStats('streamer-1')
+
+    expect(result.cardStats[0]).toMatchObject({
+      cardId: 'card-a',
+      ownerCount: 3000,
+      owners: [],
+    })
   })
 })

--- a/tests/unit/gacha-demo-driver-parity.test.ts
+++ b/tests/unit/gacha-demo-driver-parity.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
+import { and, eq } from 'drizzle-orm'
 import { POST } from '@/app/api/gacha/demo/route'
 import { getDb } from '@/lib/db/client'
+import { cards as cardsTable } from '@/lib/db/schema'
 
 vi.mock('@/lib/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -61,6 +63,7 @@ interface PgResponse {
 
 function createDrizzleDbMock(selects: PgResponse[]) {
   let selectIndex = 0
+  const whereConditions: unknown[] = []
   const db = {
     select: vi.fn(() => {
       const response = selects[Math.min(selectIndex, selects.length - 1)] ?? { rows: [] }
@@ -70,14 +73,17 @@ function createDrizzleDbMock(selects: PgResponse[]) {
         : Promise.resolve(response.rows ?? [])
       const builder: any = {
         from: vi.fn(() => builder),
-        where: vi.fn(() => builder),
+        where: vi.fn((condition: unknown) => {
+          whereConditions.push(condition)
+          return builder
+        }),
         limit: vi.fn(() => builder),
         then: (onFulfilled: any, onRejected: any) => resolve().then(onFulfilled, onRejected),
       }
       return builder
     }),
   }
-  return { db }
+  return { db, whereConditions }
 }
 
 function primePgDb(selects: PgResponse[]) {
@@ -106,7 +112,8 @@ describe('POST /api/gacha/demo: PlanetScale-only reads', () => {
   it('fetches a requested card from PlanetScale', async () => {
     primePgDb([{ rows: [CARD_ROW] }])
 
-    const response = await POST(request({ cardId: 'card-1' }))
+    // #735: cardId指定の単一カード取得はstreamerId必須(下記の専用テスト参照)
+    const response = await POST(request({ cardId: 'card-1', streamerId: 'streamer-1' }))
     const body = await response.json()
 
     expect(response.status).toBe(200)
@@ -128,12 +135,52 @@ describe('POST /api/gacha/demo: PlanetScale-only reads', () => {
   it('falls back to a built-in demo card when PostgreSQL is unavailable', async () => {
     primePgDb([{ error: new Error('connection failure') }])
 
-    const response = await POST(request({ cardId: 'missing' }))
+    const response = await POST(request({ cardId: 'missing', streamerId: 'streamer-1' }))
     const body = await response.json()
 
     expect(response.status).toBe(200)
     expect(body.card).toBeDefined()
     expect(body.userTwitchUsername).toBe('DemoUser')
+    expect(getDb).toHaveBeenCalled()
+  })
+
+  it('#735: cardId指定時はis_active=trueかつ指定streamerId配下に絞り込む', async () => {
+    const pg = primePgDb([{ rows: [CARD_ROW] }])
+
+    const response = await POST(request({ cardId: 'card-1', streamerId: 'streamer-1' }))
+
+    expect(response.status).toBe(200)
+    expect(pg.whereConditions[0]).toEqual(
+      and(
+        eq(cardsTable.id, 'card-1'),
+        eq(cardsTable.streamer_id, 'streamer-1'),
+        eq(cardsTable.is_active, true)
+      )
+    )
+  })
+
+  it('#735: streamerId未指定時はcardIdによる単一カード取得を一切試みない(他streamerのactiveカードを無認証で引ける横断オラクル化を防ぐ)', async () => {
+    const pg = primePgDb([{ rows: [CARD_ROW] }])
+
+    const response = await POST(request({ cardId: 'card-1' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    // DBへの問い合わせが一切発生しない(streamerId無しではcardId検索もstreamer別
+    // ランダム取得も走らないため、組み込みDEMO_CARDSへ直接フォールバックする)
+    expect(pg.db.select).not.toHaveBeenCalled()
+    expect(body.card.id).not.toBe('card-1')
+  })
+
+  it('#735: 絞り込みでヒットしない場合(非公開カード等)はエラーにせず組み込みデモカードへフォールバックする', async () => {
+    primePgDb([{ rows: [] }])
+
+    const response = await POST(request({ cardId: 'inactive-or-foreign-card', streamerId: 'streamer-1' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.card).toBeDefined()
+    expect(body.card.id).not.toBe('inactive-or-foreign-card')
   })
 
   it('retries with CARDS_SAFE_COLUMNS when production-only battle columns are absent', async () => {
@@ -142,7 +189,7 @@ describe('POST /api/gacha/demo: PlanetScale-only reads', () => {
       { rows: [SAFE_CARD_ROW] },
     ])
 
-    const response = await POST(request({ cardId: 'card-1' }))
+    const response = await POST(request({ cardId: 'card-1', streamerId: 'streamer-1' }))
     const body = await response.json()
 
     expect(response.status).toBe(200)

--- a/tests/unit/upload.test.ts
+++ b/tests/unit/upload.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { cookies } from 'next/headers'
 import { POST } from '@/app/api/upload/route'
-import { getSession } from '@/lib/session'
+import { getSession, canUseStreamerFeatures } from '@/lib/session'
 import { checkRateLimit } from '@/lib/rate-limit'
 import { getFileTypeFromBuffer } from '@/lib/file-utils'
 import { validateCSRFToken } from '@/lib/csrf'
@@ -37,6 +37,7 @@ vi.mock('@/lib/storage-usage', () => ({
 
 const mockCookies = vi.mocked(cookies)
 const mockGetSession = vi.mocked(getSession)
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)
 const mockCheckRateLimit = vi.mocked(checkRateLimit)
 const mockUploadToR2WithRetry = vi.mocked(uploadToR2WithRetry)
 const mockValidateCSRFToken = vi.mocked(validateCSRFToken)
@@ -46,6 +47,9 @@ describe('POST /api/upload', () => {
     vi.clearAllMocks()
     // Mock CSRF validation to pass by default
     mockValidateCSRFToken.mockResolvedValue({ valid: true })
+    // 既存テストは配信者セッションを前提としているため、デフォルトはtrueにする
+    // （配信者権限なしのケースは専用テストで個別にfalseへ上書きする）
+    mockCanUseStreamerFeatures.mockReturnValue(true)
     // Mock cookies to return empty store
     mockCookies.mockResolvedValue({
       get: vi.fn().mockReturnValue(undefined),
@@ -99,6 +103,39 @@ describe('POST /api/upload', () => {
       expect(response.status).toBe(401)
       const body = await response.json()
       expect(body.error).toBe('Not authenticated')
+    })
+  })
+
+  describe('配信者権限のないセッション', () => {
+    it('403 エラーを返す(#832: 誰でも公開R2へアップロードできる問題の修正)', async () => {
+      mockGetSession.mockResolvedValue({
+        twitchUserId: 'test-user-id',
+        twitchUsername: 'test-user',
+        twitchDisplayName: 'Test User',
+        twitchProfileImageUrl: 'https://example.com/avatar.jpg',
+        broadcasterType: '',
+        expiresAt: Date.now() + 3600000,
+        version: 1,
+      })
+      mockCanUseStreamerFeatures.mockReturnValue(false)
+
+      const imageFile = new File([createMinimalJpegBuffer()], 'test.jpg', {
+        type: 'image/jpeg',
+      })
+      const formData = new FormData()
+      formData.append('file', imageFile)
+
+      const request = new NextRequest('http://localhost:3000/api/upload', {
+        method: 'POST',
+        body: formData,
+      })
+
+      const response = await POST(request)
+
+      expect(response.status).toBe(403)
+      const body = await response.json()
+      expect(body.error).toBe('Forbidden')
+      expect(mockUploadToR2WithRetry).not.toHaveBeenCalled()
     })
   })
 
@@ -289,9 +326,12 @@ describe('POST /api/upload', () => {
       expect(body.url).toBe('https://blob.vercel-storage.com/test-image.jpg')
       expect(mockUploadToR2WithRetry).toHaveBeenCalled()
       // First argument should be the filename pattern
-      // Filename format: {userPrefix(8chars)}_{uniqueSuffix(8chars)}.{ext}
+      // Filename format: {userPrefix(8chars)}_{uniqueSuffix(UUID)}.{ext}
+      // uniqueSuffixはcrypto.randomUUID()で生成する推測不能な値 (#832)
       // 第1引数はファイル名パターン
-      expect(mockUploadToR2WithRetry.mock.calls[0][0]).toMatch(/^[a-f0-9]{8}_[a-f0-9]{8}\.jpg$/)
+      expect(mockUploadToR2WithRetry.mock.calls[0][0]).toMatch(
+        /^[a-f0-9]{8}_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jpg$/
+      )
       // Second argument should be Buffer or Uint8Array-like (file contents)
       // 第2引数はファイル内容のBuffer
       const fileArg = mockUploadToR2WithRetry.mock.calls[0][1]


### PR DESCRIPTION
## Summary

- Replace full users/streamers list fetches plus browser-side filtering/sorting/paging with database-side page RPCs.
- Limit users, streamers, and gacha history table responses to 100 rows per request.
- Use a lightweight, searchable streamer-options endpoint for the Gacha selector while preserving the selected streamer outside the bounded result window.
- Make Gacha views default to the last 7 days and use aggregate results instead of fetching raw history rows for charts.
- Debounce Users/Streamers search input and skip stale intermediate queries so each completed search term issues only the final aggregate request.
- Optimize the Overview 30-day growth query with grouped counts.
- Add the PostgreSQL migration and contract tests.

## Why

The previous dashboard loaded large result sets into Node.js and the browser, then applied pagination locally. This made response size, memory usage, and rendering cost grow with the total record count. The new contract returns only the requested page while keeping exact counts and summary metrics as database aggregates.

## Promotion plan

This PR targets `preview` first. After the preview-targeted CI passes, the PR is merged into `preview`, and the resulting preview deployment and preview database migration are validated. Only after that validation will a separate `preview → main` promotion PR be opened and reviewed.

## Migration / CI

The new migration is additive and is included in this PR. The preview branch push applies the migration to the preview logical database through `planetscale-migrate.yml`; the preview branch deployment publishes the preview Worker. The main promotion is kept separate so production is not changed until preview validation succeeds.

## Validation

- Repository unit tests: 254 files passed, 1 skipped; 3,414 tests passed, 34 skipped.
- Focused dashboard pagination/search tests: 2 files, 5 tests passed.
- `npm run typecheck`
- `npm run build` in `analysis/`
- `npm run check:migration-order`
- `npm run check:analysis-browser-supabase`
- Targeted ESLint: 0 errors (existing image optimization warnings only).
- Fresh PostgreSQL migration/RPC application smoke test completed locally.
- Preview-targeted CI will be re-run after retargeting this PR; production/main promotion is intentionally not part of this PR.

The repository-wide lint command currently scans unrelated dirty worktrees in this checkout and reports pre-existing errors; the changed files were linted separately.