### PR TITLE
fix(stats): aggregate channel point fallback in SQL

### DIFF
--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -26,7 +26,10 @@ import {
   ilike,
   inArray,
   lt,
+  max,
   notLike,
+  sql,
+  sum,
 } from "drizzle-orm";
 import { getDb, type DbHandle } from "@/lib/db/client";
 import { isPgFunctionNotFoundError, isPgMissingColumnError, isPgUniqueViolationError } from "@/lib/db/errors";
@@ -1149,11 +1152,13 @@ interface ChannelPointUsageStatsRpcRow {
   last_redeemed_at: string | null;
 }
 
-interface ChannelPointUsageHistoryRow {
+interface ChannelPointUsageHistoryRankingRow {
   user_twitch_id: string;
-  user_twitch_username: string | null;
-  reward_cost: number | string | null;
-  redeemed_at: string | null;
+  username: string | null;
+  total_points: number | string | null;
+  redemption_count: number | string;
+  last_redeemed_at: string | null;
+  total_points_all_users: number | string | null;
 }
 
 interface GachaDropStatsRpcDrawerRow {
@@ -1307,27 +1312,46 @@ async function fetchChannelPointUsageStatsFromHistory(
   streamerId: string,
   limit = 10
 ): Promise<GachaStatsResult["channelPointStats"]> {
-  let data: ChannelPointUsageHistoryRow[];
+  const historyFilter = and(
+    eq(gachaHistoryTable.streamer_id, streamerId),
+    gt(gachaHistoryTable.reward_cost, 0),
+  );
+  let rankingRows: ChannelPointUsageHistoryRankingRow[];
   try {
-    data = await withDbRetry(
+    rankingRows = await withDbRetry(
       async () => {
         const { db } = await getDb();
+        const totalPoints = sum(gachaHistoryTable.reward_cost);
+        const redemptionCount = countRows();
+        const lastRedeemedAt = max(gachaHistoryTable.redeemed_at);
+        // GROUP BY後のユーザー別SUMをwindow SUMすることで、ランキングLIMITの
+        // 対象外ユーザーも含む全ポイントを同じ1 statement内で算出する。
+        // PostgreSQLではwindow関数はGROUP BY集計後・ORDER BY/LIMIT前に評価される
+        // ため、上位N行だけを返しても値は全ユーザー分の合計になる。総合計と順位を
+        // 別SQLにすると更新の途中で異なるsnapshotを読む可能性と二重走査が生じるが、
+        // この形なら単一snapshot・単一走査でRPC migration 00036/00039と同じ集計を
+        // 得られる。該当行が0件なら結果行自体が無く、呼び出し側で0/空配列へ戻す。
+        const totalPointsAllUsers =
+          sql<number | string>`sum(sum(${gachaHistoryTable.reward_cost})) over ()`;
         return db
           .select({
             user_twitch_id: gachaHistoryTable.user_twitch_id,
-            user_twitch_username: gachaHistoryTable.user_twitch_username,
-            reward_cost: gachaHistoryTable.reward_cost,
-            redeemed_at: gachaHistoryTable.redeemed_at,
+            username: sql<string>`coalesce(max(${gachaHistoryTable.user_twitch_username}), ${gachaHistoryTable.user_twitch_id})`,
+            total_points: totalPoints,
+            redemption_count: redemptionCount,
+            last_redeemed_at: lastRedeemedAt,
+            total_points_all_users: totalPointsAllUsers,
           })
           .from(gachaHistoryTable)
-          .where(
-            and(
-              eq(gachaHistoryTable.streamer_id, streamerId),
-              gt(gachaHistoryTable.reward_cost, 0),
-            ),
+          .where(historyFilter)
+          .groupBy(gachaHistoryTable.user_twitch_id)
+          .orderBy(
+            desc(totalPoints),
+            desc(redemptionCount),
+            desc(lastRedeemedAt),
           )
-          .orderBy(desc(gachaHistoryTable.redeemed_at))
-          .limit(10000);
+          // LIMITは必ずGROUP BY・window集計・順位確定後にだけ適用する。
+          .limit(Math.max(1, limit));
       },
       "dashboard:channelPointUsageHistory",
       { idempotent: true },
@@ -1337,52 +1361,15 @@ async function fetchChannelPointUsageStatsFromHistory(
     return EMPTY_CHANNEL_POINT_STATS;
   }
 
-  const usageByUser = new Map<string, {
-    username: string;
-    totalPoints: number;
-    redemptionCount: number;
-    lastRedeemedAt: string | null;
-  }>();
-  let totalPoints = 0;
-
-  for (const row of data) {
-    const rewardCost = Number(row.reward_cost || 0);
-    if (!row.user_twitch_id || rewardCost <= 0) continue;
-
-    totalPoints += rewardCost;
-    const existing = usageByUser.get(row.user_twitch_id);
-    if (existing) {
-      existing.totalPoints += rewardCost;
-      existing.redemptionCount += 1;
-      if (row.user_twitch_username) {
-        existing.username = row.user_twitch_username;
-      }
-      if (
-        row.redeemed_at &&
-        (!existing.lastRedeemedAt || row.redeemed_at > existing.lastRedeemedAt)
-      ) {
-        existing.lastRedeemedAt = row.redeemed_at;
-      }
-    } else {
-      usageByUser.set(row.user_twitch_id, {
-        username: row.user_twitch_username || row.user_twitch_id,
-        totalPoints: rewardCost,
-        redemptionCount: 1,
-        lastRedeemedAt: row.redeemed_at,
-      });
-    }
-  }
-
   return {
-    totalPoints,
-    ranking: Array.from(usageByUser.entries())
-      .map(([userTwitchId, usage]) => ({ userTwitchId, ...usage }))
-      .sort((a, b) => {
-              if (b.totalPoints !== a.totalPoints) return b.totalPoints - a.totalPoints;
-        if (b.redemptionCount !== a.redemptionCount) return b.redemptionCount - a.redemptionCount;
-        return (b.lastRedeemedAt || "").localeCompare(a.lastRedeemedAt || "");
-      })
-      .slice(0, Math.max(1, limit)),
+    totalPoints: Number(rankingRows[0]?.total_points_all_users ?? 0),
+    ranking: rankingRows.map((row) => ({
+      userTwitchId: row.user_twitch_id,
+      username: row.username || row.user_twitch_id,
+      totalPoints: Number(row.total_points ?? 0),
+      redemptionCount: Number(row.redemption_count),
+      lastRedeemedAt: row.last_redeemed_at,
+    })),
   };
 }
 

--- a/tests/unit/dashboard-data-rpc-driver-parity.test.ts
+++ b/tests/unit/dashboard-data-rpc-driver-parity.test.ts
@@ -6,6 +6,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Column, SQL, Table, is } from 'drizzle-orm'
+import { drizzle as drizzleProxy } from 'drizzle-orm/pg-proxy'
 import {
   getGachaCardOwnerStats,
   getGachaStats,
@@ -268,6 +269,24 @@ function primeDb(
   const db = createFallbackDb(rowsByTable)
   vi.mocked(getDb).mockResolvedValue({ db, sql } as any)
   return { sql, db }
+}
+
+/**
+ * 実DBへ接続せず、DrizzleのPostgreSQL dialectが生成したSQL/paramsを捕捉する。
+ * 手製builderは完成済み行しか検証できないため、Issue #849の集計SQL契約に限って
+ * pg-proxyを使い、実際のquery builder生成結果と行デコードの両方を固定する。
+ */
+function createCapturingPgProxyDb(rows: unknown[][]) {
+  const queries: Array<{
+    sql: string
+    params: unknown[]
+    method: 'all' | 'execute'
+  }> = []
+  const db = drizzleProxy(async (query, params, method) => {
+    queries.push({ sql: query, params: [...params], method })
+    return { rows }
+  })
+  return { db, queries }
 }
 
 describe('dashboard-data: PlanetScale読み取りRPC契約 (#803)', () => {
@@ -638,28 +657,19 @@ describe('dashboard-data: PlanetScale読み取りRPC契約 (#803)', () => {
   })
 
   it('channel point統計RPC障害時は履歴からポイントと順位を集約する', async () => {
-    primeDb(
-      [
-        { rows: [{ result: dropStatsResult }] },
-        { error: pgError('42883', 'get_channel_point_usage_stats does not exist') },
-      ],
-      new Map<Table, Array<Record<string, unknown>>>([
-        [gachaHistoryTable, [
-          {
-            user_twitch_id: 'viewer-1',
-            user_twitch_username: 'viewer_one',
-            reward_cost: 100,
-            redeemed_at: '2026-03-01T00:00:00+00:00',
-          },
-          {
-            user_twitch_id: 'viewer-1',
-            user_twitch_username: 'Viewer New',
-            reward_cost: '250',
-            redeemed_at: '2026-03-03T00:00:00+00:00',
-          },
-        ]],
-      ])
-    )
+    const sql = createSqlMock([
+      { rows: [{ result: dropStatsResult }] },
+      { error: pgError('42883', 'get_channel_point_usage_stats does not exist') },
+    ])
+    const { db } = createCapturingPgProxyDb([[
+      'viewer-1',
+      'Viewer New',
+      '350',
+      2,
+      '2026-03-03T00:00:00+00:00',
+      '350',
+    ]])
+    vi.mocked(getDb).mockResolvedValue({ db, sql } as any)
 
     const result = await getGachaStats('streamer-1', '30d')
 
@@ -687,6 +697,74 @@ describe('dashboard-data: PlanetScale読み取りRPC契約 (#803)', () => {
         streamerId: 'streamer-1',
       }),
     )
+  })
+
+  it('channel point fallbackは10000件超でもDB集計値の上位Nとusername fallbackを返す', async () => {
+    // 10,000件の明細取得上限とは独立して、DBが返したwindow総計とユーザー別SUMを
+    // 採用する。pg-proxy経由で実際の生成SQLも検証し、完成済みmock値だけを返して
+    // 誤ったクエリを見逃さないようにする。
+    const sql = createSqlMock([
+      { rows: [{ result: dropStatsResult }] },
+      { error: pgError('42883', 'get_channel_point_usage_stats does not exist') },
+    ])
+    const { db, queries } = createCapturingPgProxyDb([
+      [
+        'viewer-top', 'Top Viewer', '1500000', '15000',
+        '2026-03-03T00:00:00+00:00', '2500000',
+      ],
+      [
+        'viewer-fallback', null, '1000000', '12000',
+        '2026-03-02T00:00:00+00:00', '2500000',
+      ],
+    ])
+    vi.mocked(getDb).mockResolvedValue({ db, sql } as any)
+
+    const result = await getGachaStats('streamer-1', '30d')
+
+    expect(result.channelPointStats).toEqual({
+      totalPoints: 2500000,
+      ranking: [
+        {
+          userTwitchId: 'viewer-top', username: 'Top Viewer', totalPoints: 1500000,
+          redemptionCount: 15000, lastRedeemedAt: '2026-03-03T00:00:00+00:00',
+        },
+        {
+          userTwitchId: 'viewer-fallback', username: 'viewer-fallback', totalPoints: 1000000,
+          redemptionCount: 12000, lastRedeemedAt: '2026-03-02T00:00:00+00:00',
+        },
+      ],
+    })
+    expect(queries).toHaveLength(1)
+    const generated = queries[0]
+    expect(generated.method).toBe('all')
+    expect(generated.params).toEqual(['streamer-1', 0, 10])
+    expect(generated.sql).toMatch(/from "gacha_history"/i)
+    expect(generated.sql).toMatch(/"gacha_history"\."streamer_id" = \$1/i)
+    expect(generated.sql).toMatch(/"gacha_history"\."reward_cost" > \$2/i)
+    // PostgreSQL dialectはSELECT式の同一テーブル列を非修飾で出力する一方、
+    // WHERE/GROUP BY/ORDER BYでは修飾する。実際の生成SQLをそのまま固定する。
+    expect(generated.sql).toMatch(/coalesce\(max\("user_twitch_username"\), "user_twitch_id"\)/i)
+    expect(generated.sql).toMatch(/sum\("reward_cost"\)/i)
+    expect(generated.sql).toMatch(/count\(\*\)/i)
+    expect(generated.sql).toMatch(/max\("redeemed_at"\)/i)
+    expect(generated.sql).toMatch(/sum\(sum\("reward_cost"\)\) over \(\)/i)
+    expect(generated.sql).toMatch(/group by "gacha_history"\."user_twitch_id"/i)
+    expect(generated.sql).toMatch(/order by sum\("gacha_history"\."reward_cost"\) desc, count\(\*\) desc, max\("gacha_history"\."redeemed_at"\) desc/i)
+    expect(generated.sql).toMatch(/limit \$3/i)
+  })
+
+  it('channel point fallbackは対象履歴が空なら0ポイント・空ランキングを返す', async () => {
+    const sql = createSqlMock([
+      { rows: [{ result: dropStatsResult }] },
+      { error: pgError('42883', 'get_channel_point_usage_stats does not exist') },
+    ])
+    const { db, queries } = createCapturingPgProxyDb([])
+    vi.mocked(getDb).mockResolvedValue({ db, sql } as any)
+
+    const result = await getGachaStats('streamer-1', '30d')
+
+    expect(result.channelPointStats).toEqual({ totalPoints: 0, ranking: [] })
+    expect(queries).toHaveLength(1)
   })
 
   it('card owner RPCをuuid引数で実行し、owner値を正規化する', async () => {


### PR DESCRIPTION
## 概要

Issue #849 のチャンネルポイント統計フォールバックを、明細10,000件取得後のJavaScript集計からPostgreSQL集約へ変更します。

## 変更内容

- ユーザー別のポイント合計・引換回数・最終引換日時をDBで集約
- `sum(sum(reward_cost)) over ()` により、ランキングのLIMIT外も含む総ポイントを同一statement・同一snapshotで算出
- RPC未配備時のフォールバック経路が、履歴件数10,000件を超えても正確な値を返す回帰テストを追加
- 実際のDrizzle PostgreSQL dialectが生成するSQL・params・行デコードを `pg-proxy` で検証

## 検証

- `npx vitest run tests/unit/dashboard-data-rpc-driver-parity.test.ts`: 17 passed
- `npm run test:unit`: 3434 passed / 34 skipped
- `npm run typecheck`: passed
- 対象2ファイルのESLint: passed
- tracked source全体のESLint: 0 errors（既存warnings 44）
- `git diff --check`: passed
- 独立Solレビュー: 初回P2 2件を修正後、再レビュー指摘なし

補足: リポジトリ全体の `npm run lint` は、保存対象の未追跡隔離worktree群まで再帰走査する既存ノイズで失敗します。今回のtracked sourceおよび変更対象にはerrorはありません。

Closes #849