### PR TITLE
ci: Claude Code 自動レビューを一時停止

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,11 +36,17 @@ concurrency:
 
 jobs:
   claude-review:
+    # Claude Code が --max-turns 30 に繰り返し到達し、レビューコメントを投稿しないまま
+    # 終了しているため、原因と実行条件を見直すまでこの job 全体を一時停止する。
+    # 先頭の false により runner の割り当て前に job がスキップされるため、checkout や
+    # Claude Code Action は起動せず、不要な API 利用・サブスクリプション消費・課金も発生しない。
+    # 再開時は max-turns、プロンプト、権限を見直したうえで、次行の `false &&` だけを削除する。
     # - draft PR は作業途中のためレビューしない(ready_for_review で拾う)。
     # - fork からの PR では GitHub がシークレットを渡さないため CLAUDE_CODE_OAUTH_TOKEN が使えず
     #   必ず失敗する。head.repo.full_name の比較で除外する(fork 判定と異なり、
     #   fork リポジトリが削除済みで head.repo が null の場合もまとめて除外できる)。
     if: >-
+      false &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要

Claude Code Review の自動実行を一時停止します。

## 背景・原因

- PR #860 の Claude Code Review が `--max-turns 30` に繰り返し到達して失敗しました。
- いずれもレビューコメントを投稿できず、補助レビューとしての成果がないまま赤いチェックだけが残る状態でした。

## 変更内容

- `claude-review` job の既存 `if` 条件先頭へ `false &&` を追加しました。
- job 全体が runner 割り当て前に skipped となるため、checkout、Claude Code Action、OIDC交換、Claude API利用は起動しません。
- 既存トリガー・認証・権限・レビュー設定は残し、再開時は `false &&` の1行だけを削除できる可逆な構成です。
- 再開前に max-turns、プロンプト、権限制限を別途見直します。

## 影響

- `preview` 向けPRの Claude Code 自動レビューだけが停止します。
- アプリ本体、デプロイ、手動レビュー、その他のCIには影響しません。
- GitHub Actions仕様上、条件でskipされたjobはSuccess扱いで、マージを妨げません。

## 検証

- Node `yaml` によるYAML構文解析: 成功
- job条件文字列が `false && ...` で始まることを検証: 成功
- `git diff --check`: 成功
- 変更範囲がworkflow 1ファイルのみであることを確認
- 独立Solレビュー: BLOCKER/HIGH/MEDIUM/LOW すべて0件