### PR TITLE
release: promote preview to main (#868)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -539,7 +539,7 @@
   },
   "chatDeliveryWarning": {
     "title": "Chat announcements cannot be sent",
-    "description": "Twitch message permission is missing. Gacha draws and card grants will continue normally, but chat announcements will not be sent.",
+    "description": "The account used to send chat messages needs to be re-authorized. Gacha draws and card grants will continue normally, but chat announcements will not be sent.",
     "reauthorize": "Re-authorize with Twitch",
     "reauthorizing": "Re-authorizing...",
     "settingsLink": "Chat announcement settings",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -539,7 +539,7 @@
   },
   "chatDeliveryWarning": {
     "title": "チャット通知を送信できません",
-    "description": "Twitchの送信権限がありません。ガチャとカード付与は通常どおり動作しますが、チャット通知は送信されません。",
+    "description": "チャット通知の送信元アカウントの認証が必要です。ガチャとカード付与は通常どおり動作しますが、チャット通知は送信されません。",
     "reauthorize": "Twitchと再認証",
     "reauthorizing": "再認証中...",
     "settingsLink": "チャット通知設定",

--- a/src/app/api/auth/bot/connect/route.ts
+++ b/src/app/api/auth/bot/connect/route.ts
@@ -77,7 +77,9 @@ export async function POST(request: NextRequest) {
     const redirectUri = `${baseUrl}${API_ROUTES.AUTH_TWITCH_CALLBACK}`
     const loginUrl = getTwitchAuthUrl(redirectUri, state, [ADDITIONAL_SCOPES.CHAT_WRITE])
 
-    const response = NextResponse.json({ success: true, loginUrl })
+    // stateを返し、クライアント側でも遷移前にloginUrlのstateと突き合わせて検証できるようにする
+    // （reauth APIと同じOAuth/CSRF境界の検証をBOT接続フローにも適用する。Issue #865）。
+    const response = NextResponse.json({ success: true, loginUrl, state })
     response.cookies.set(COOKIE_NAMES.BOT_AUTH_STATE, state, STATE_COOKIE_OPTIONS)
     return response
   } catch (error) {

--- a/src/app/api/auth/twitch/login/route.ts
+++ b/src/app/api/auth/twitch/login/route.ts
@@ -246,7 +246,9 @@ export async function GET(request: Request) {
       return NextResponse.redirect(authUrl)
     }
 
-    return NextResponse.json({ authUrl })
+    // stateを返し、クライアント側でauthUrlのstateと突き合わせて遷移前に検証できる
+    // ようにする（reauth/BOT接続APIと同じOAuth/CSRF境界の検証。Issue #865フォローアップ）。
+    return NextResponse.json({ authUrl, state })
   } catch (error) {
     // handleAuthError が唯一の永続化責任点。ここで別途 reportAuthError を呼ぶと
     // 同一例外が2件の errors 行・自動issueになる。

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useId } from "react";
 import { useTranslations } from "next-intl";
 import { logger } from "@/lib/logger";
 import { CHANNEL_POINT_SCOPES } from "@/lib/twitch/scopes";
+import { parseTwitchAuthorizationResponse } from "@/lib/twitch/authorization-response";
 import { DEFAULT_PACK_SENTINEL, isReservedCollectionName } from "@/lib/validation/collection-name";
 import {
   deriveEventSubStatus,
@@ -762,12 +763,18 @@ export default function ChannelPointSettings({
 
       if (response.ok) {
         const data = await response.json();
+        // 壊れたAPI応答や侵害時の外部URLをそのままwindow.locationへ渡さないため、
+        // ChatAnnouncementSettingsのreauth/BOT接続と同じorigin/path/state検証を通す
+        // （Issue #865フォローアップ）。
+        const authorization = parseTwitchAuthorizationResponse(data);
+        if (!authorization) {
+          setError(t("messages.reauthorizeFailed"));
+          return;
+        }
         // state をCookieに保存してからリダイレクト（callbackでの検証用）
         // Persist state to cookie before redirect (callback verifies state)
-        if (data.state) {
-          document.cookie = `twitch_auth_state=${data.state}; path=/; max-age=600; secure; samesite=lax`;
-        }
-        window.location.href = data.loginUrl;
+        document.cookie = `twitch_auth_state=${authorization.state}; path=/; max-age=600; secure; samesite=lax`;
+        window.location.href = authorization.loginUrl;
         return;
       }
 

--- a/src/components/ChannelPointsAccessSection.tsx
+++ b/src/components/ChannelPointsAccessSection.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { parseMaintenanceError } from "@/lib/maintenance/client";
 import { useMaintenanceStatus } from "./MaintenanceStatusProvider";
 import { CHANNEL_POINT_SCOPES } from "@/lib/twitch/scopes";
+import { parseTwitchAuthorizationResponse } from "@/lib/twitch/authorization-response";
 import { logger } from "@/lib/logger";
 
 interface ChannelPointsAccessSectionProps {
@@ -206,13 +207,20 @@ export default function ChannelPointsAccessSection({
 
       if (response.ok) {
         const data = await response.json();
-        if (data.state) {
-          // callbackのstate検証(COOKIE_NAMES.AUTH_STATE)用。reauth APIはこのCookieを
-          // server-sideで設定しないため、既存ChannelPointSettings.handleReauthorizeと
-          // 同じ方式でclient側から設定する。
-          document.cookie = `twitch_auth_state=${data.state}; path=/; max-age=600; secure; samesite=lax`;
+        // 壊れたAPI応答や侵害時の外部URLをそのままwindow.locationへ渡さないため、
+        // ChatAnnouncementSettingsのreauth/BOT接続と同じorigin/path/state検証を通す
+        // （Issue #865フォローアップ）。
+        const authorization = parseTwitchAuthorizationResponse(data);
+        if (!authorization) {
+          setMessage({ type: "error", text: t("messages.genericError") });
+          setChecking(false);
+          return;
         }
-        window.location.href = data.loginUrl;
+        // callbackのstate検証(COOKIE_NAMES.AUTH_STATE)用。reauth APIはこのCookieを
+        // server-sideで設定しないため、既存ChannelPointSettings.handleReauthorizeと
+        // 同じ方式でclient側から設定する。
+        document.cookie = `twitch_auth_state=${authorization.state}; path=/; max-age=600; secure; samesite=lax`;
+        window.location.href = authorization.loginUrl;
         return;
       }
 

--- a/src/components/ChatAnnouncementSettings.tsx
+++ b/src/components/ChatAnnouncementSettings.tsx
@@ -10,6 +10,7 @@ import { MAX_COLLECTION_NAME_LENGTH } from "@/lib/validation/collection-name";
 import { parseMaintenanceError } from "@/lib/maintenance/client";
 import { useMaintenanceStatus } from "./MaintenanceStatusProvider";
 import { useChatReauthorization } from "@/lib/twitch/use-chat-reauthorization";
+import { parseTwitchAuthorizationResponse } from "@/lib/twitch/authorization-response";
 
 interface ChatAnnouncementSettingsProps {
   streamerId: string;
@@ -323,8 +324,17 @@ export default function ChatAnnouncementSettings({
       });
 
       if (response.ok) {
-        const data = await response.json();
-        window.location.href = data.loginUrl;
+        // reauthフローと同じOAuth/CSRF境界の検証: origin/path/state一致を確認してから
+        // 遷移する。壊れたAPI応答や侵害時の外部URLをそのままwindow.locationへ渡さない
+        // ため（Issue #865）。
+        const data: unknown = await response.json();
+        const authorization = parseTwitchAuthorizationResponse(data);
+        if (!authorization) {
+          setMessage(t("errors.botConnectFailed"));
+          setIsError(true);
+          return;
+        }
+        window.location.href = authorization.loginUrl;
         return;
       }
 

--- a/src/components/TwitchLoginButton.tsx
+++ b/src/components/TwitchLoginButton.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
 import { logger } from '@/lib/logger'
 import { fetchMaintenanceStatus } from '@/lib/maintenance/client'
+import { parseTwitchAuthorizationResponse } from '@/lib/twitch/authorization-response'
 
 interface TwitchLoginButtonProps {
   className?: string
@@ -96,7 +97,18 @@ export function TwitchLoginButton({ className = '', showIcon = false }: TwitchLo
 
       const data = await response.json()
       if (data.authUrl) {
-        window.location.href = data.authUrl
+        // 壊れたAPI応答や侵害時の外部URLをそのままwindow.locationへ渡さないため、
+        // reauth/BOT接続と同じorigin/path/state検証を通す（Issue #865フォローアップ）。
+        const authorization = parseTwitchAuthorizationResponse({
+          loginUrl: data.authUrl,
+          state: data.state,
+        })
+        if (authorization) {
+          window.location.href = authorization.loginUrl
+        } else {
+          logger.error('Login API returned an invalid authUrl')
+          setIsLoading(false)
+        }
       } else if (data.error) {
         // Handle JSON error response from API
         // APIからのJSONエラーレスポンスを処理

--- a/src/components/TwitchLoginRedirect.tsx
+++ b/src/components/TwitchLoginRedirect.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { TwitchLoginResponse } from '@/types/auth'
+import { logger } from '@/lib/logger'
 import { fetchMaintenanceStatus } from '@/lib/maintenance/client'
 import { parseTwitchAuthorizationResponse } from '@/lib/twitch/authorization-response'
 
@@ -27,6 +28,11 @@ export function TwitchLoginRedirect() {
   // 例外が握りつぶされていた。マウント時にまずmaintenance状態を確認し、
   // ブロック中ならそもそもこのfetchを呼ばず、案内文言を表示する。
   const [isMaintenanceBlocked, setIsMaintenanceBlocked] = useState(false)
+  // このコンポーネントはユーザー操作なしでマウント時に自動発火するため、
+  // 検証失敗やネットワーク例外時も「リダイレクト中...」の表示のまま何も
+  // 変わらないと、ユーザーはスピナーに取り残されてしまう。redirectFailed
+  // で明示的に案内文言へ切り替える。
+  const [redirectFailed, setRedirectFailed] = useState(false)
 
   useEffect(() => {
     let isMounted = true
@@ -53,13 +59,18 @@ export function TwitchLoginRedirect() {
           if (authorization) {
             window.location.href = authorization.loginUrl
           } else {
-            console.error('[TwitchLoginRedirect] login response failed authorization URL validation')
+            logger.error('[TwitchLoginRedirect] login response failed authorization URL validation')
+            setRedirectFailed(true)
           }
+        } else if (isMounted) {
+          logger.error('[TwitchLoginRedirect] login response missing authUrl')
+          setRedirectFailed(true)
         }
       } catch (error) {
         if (isMounted) {
           // Sentry removed for Cloudflare Workers bundle size reduction
-          console.error('[TwitchLoginRedirect]', error)
+          logger.error('[TwitchLoginRedirect]', error)
+          setRedirectFailed(true)
         }
       }
     }
@@ -74,7 +85,11 @@ export function TwitchLoginRedirect() {
   return (
     <div className="flex items-center justify-center">
       <div className="text-white">
-        {isMaintenanceBlocked ? tMaintenance('writeDisabled') : t('redirecting')}
+        {isMaintenanceBlocked
+          ? tMaintenance('writeDisabled')
+          : redirectFailed
+            ? t('loginFailed')
+            : t('redirecting')}
       </div>
     </div>
   )

--- a/src/components/TwitchLoginRedirect.tsx
+++ b/src/components/TwitchLoginRedirect.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { TwitchLoginResponse } from '@/types/auth'
 import { fetchMaintenanceStatus } from '@/lib/maintenance/client'
+import { parseTwitchAuthorizationResponse } from '@/lib/twitch/authorization-response'
 
 /**
  * Component that redirects to Twitch login page
@@ -43,7 +44,17 @@ export function TwitchLoginRedirect() {
         const data: TwitchLoginResponse = await response.json()
 
         if (data.authUrl && isMounted) {
-          window.location.href = data.authUrl
+          // 壊れたAPI応答や侵害時の外部URLをそのままwindow.locationへ渡さないため、
+          // reauth/BOT接続と同じorigin/path/state検証を通す（Issue #865フォローアップ）。
+          const authorization = parseTwitchAuthorizationResponse({
+            loginUrl: data.authUrl,
+            state: data.state,
+          })
+          if (authorization) {
+            window.location.href = authorization.loginUrl
+          } else {
+            console.error('[TwitchLoginRedirect] login response failed authorization URL validation')
+          }
         }
       } catch (error) {
         if (isMounted) {

--- a/src/components/TwitchSubCheckSection.tsx
+++ b/src/components/TwitchSubCheckSection.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { parseMaintenanceError } from "@/lib/maintenance/client";
+import { parseTwitchAuthorizationResponse } from "@/lib/twitch/authorization-response";
 import { useMaintenanceStatus } from "./MaintenanceStatusProvider";
 
 interface TwitchSubCheckSectionProps {
@@ -86,10 +87,17 @@ export default function TwitchSubCheckSection({
 
       if (response.ok) {
         const data = await response.json();
-        if (data.state) {
-          document.cookie = `twitch_auth_state=${data.state}; path=/; max-age=600; secure; samesite=lax`;
+        // 壊れたAPI応答や侵害時の外部URLをそのままwindow.locationへ渡さないため、
+        // ChatAnnouncementSettingsのreauth/BOT接続と同じorigin/path/state検証を通す
+        // （Issue #865フォローアップ）。
+        const authorization = parseTwitchAuthorizationResponse(data);
+        if (!authorization) {
+          setMessage({ type: "error", text: t("messages.reauthorizeFailed") });
+          setReauthorizing(false);
+          return;
         }
-        window.location.href = data.loginUrl;
+        document.cookie = `twitch_auth_state=${authorization.state}; path=/; max-age=600; secure; samesite=lax`;
+        window.location.href = authorization.loginUrl;
       } else {
         const errorData = await response.json();
         const maintenanceError = parseMaintenanceError(response, errorData);

--- a/src/lib/twitch/authorization-response.ts
+++ b/src/lib/twitch/authorization-response.ts
@@ -1,0 +1,40 @@
+const TWITCH_AUTHORIZATION_ORIGIN = 'https://id.twitch.tv'
+const TWITCH_AUTHORIZATION_PATH = '/oauth2/authorize'
+
+export interface TwitchAuthorizationResponse {
+  loginUrl: string
+  state: string
+}
+
+/**
+ * reauth/BOT接続などOAuth開始APIの成功bodyを、ブラウザ遷移へ使ってよいTwitch OAuth URLへ正規化する。
+ *
+ * 型確認だけでは、壊れたAPI応答や侵害時の外部URLを `window.location` へ渡してしまう。
+ * Twitch公式の認可endpoint（https://id.twitch.tv/oauth2/authorize）に限定し、URL内の
+ * stateとAPI応答のstateが一致することまで確認してから遷移する。本人再認証とBOT接続の
+ * 2つのCTAが同じOAuth/CSRF境界を共有し、片方だけ検証が弱くなる回帰を防ぐ（Issue #865）。
+ */
+export function parseTwitchAuthorizationResponse(body: unknown): TwitchAuthorizationResponse | null {
+  if (typeof body !== 'object' || body === null) return null
+
+  const { loginUrl, state } = body as Record<string, unknown>
+  if (typeof loginUrl !== 'string' || typeof state !== 'string' || state.length === 0) {
+    return null
+  }
+
+  try {
+    const url = new URL(loginUrl)
+    if (
+      url.origin !== TWITCH_AUTHORIZATION_ORIGIN ||
+      url.pathname !== TWITCH_AUTHORIZATION_PATH ||
+      url.username !== '' ||
+      url.password !== '' ||
+      url.searchParams.get('state') !== state
+    ) {
+      return null
+    }
+    return { loginUrl: url.href, state }
+  } catch {
+    return null
+  }
+}

--- a/src/lib/twitch/authorization-response.ts
+++ b/src/lib/twitch/authorization-response.ts
@@ -12,12 +12,36 @@ export interface TwitchAuthorizationResponse {
 }
 
 /**
+ * OAuth認可URLの `redirect_uri` が自アプリのoriginと一致するかを確認する。
+ *
+ * origin/path/stateの検証だけでは、侵害された応答が正規のTwitch認可URLの
+ * `client_id`・`redirect_uri` だけ攻撃者のものへ差し替えて返すOAuth consent
+ * phishingを防げない（Issue #869）。`client_id`の検証には環境別の期待値を
+ * `NEXT_PUBLIC_`化して持つ必要がありスコープが大きいため別issueとするが、
+ * `redirect_uri`のorigin一致は秘密情報を新たに公開せずクライアント側で
+ * 安価に検証でき、consent phishingの実効性を大きく下げられる。
+ *
+ * この関数は必ずブラウザ内（クリックイベント/useEffect経由）で呼ばれる
+ * client componentからのみ使われるためwindowは常に存在する前提だが、
+ * 万一存在しない場合はfail-closedでfalseを返す。
+ */
+function isSameOriginRedirectUri(redirectUri: string): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    return new URL(redirectUri).origin === window.location.origin
+  } catch {
+    return false
+  }
+}
+
+/**
  * reauth/BOT接続などOAuth開始APIの成功bodyを、ブラウザ遷移へ使ってよいTwitch OAuth URLへ正規化する。
  *
  * 型確認だけでは、壊れたAPI応答や侵害時の外部URLを `window.location` へ渡してしまう。
  * Twitch公式の認可endpoint（https://id.twitch.tv/oauth2/authorize）に限定し、URL内の
- * stateとAPI応答のstateが一致することまで確認してから遷移する。本人再認証とBOT接続の
- * 2つのCTAが同じOAuth/CSRF境界を共有し、片方だけ検証が弱くなる回帰を防ぐ（Issue #865）。
+ * stateとAPI応答のstateが一致すること、`redirect_uri`が自アプリのoriginと一致することまで
+ * 確認してから遷移する。本人再認証とBOT接続の2つのCTAが同じOAuth/CSRF境界を共有し、
+ * 片方だけ検証が弱くなる回帰を防ぐ（Issue #865）。
  */
 export function parseTwitchAuthorizationResponse(body: unknown): TwitchAuthorizationResponse | null {
   if (typeof body !== 'object' || body === null) return null
@@ -29,16 +53,19 @@ export function parseTwitchAuthorizationResponse(body: unknown): TwitchAuthoriza
 
   try {
     const url = new URL(loginUrl)
-    // getAll: 重複したstateクエリ（?state=a&state=b）はgetでは先頭しか見えず
+    // getAll: 重複したクエリ（?state=a&state=b等）はgetでは先頭しか見えず
     // 曖昧になるため、ちょうど1件だけであることも確認する。
     const stateParams = url.searchParams.getAll('state')
+    const redirectUriParams = url.searchParams.getAll('redirect_uri')
     if (
       url.origin !== TWITCH_AUTHORIZATION_ORIGIN ||
       url.pathname !== TWITCH_AUTHORIZATION_PATH ||
       url.username !== '' ||
       url.password !== '' ||
       stateParams.length !== 1 ||
-      stateParams[0] !== state
+      stateParams[0] !== state ||
+      redirectUriParams.length !== 1 ||
+      !isSameOriginRedirectUri(redirectUriParams[0])
     ) {
       return null
     }

--- a/src/lib/twitch/authorization-response.ts
+++ b/src/lib/twitch/authorization-response.ts
@@ -1,5 +1,10 @@
 const TWITCH_AUTHORIZATION_ORIGIN = 'https://id.twitch.tv'
 const TWITCH_AUTHORIZATION_PATH = '/oauth2/authorize'
+// サーバー側の生成方式はcrypto.randomUUID()（36文字、16進数+ハイフン）または
+// randomBytesHex(32)（64文字、16進数のみ）のいずれかで、他の文字は使わない。
+// ここで許可文字を絞ることで、stateが後段でdocument.cookieへ直接埋め込まれる
+// 呼び出し元（例: "abc; Domain=evil.com; Path=/"）でのcookie属性インジェクションを防ぐ。
+const STATE_PATTERN = /^[A-Za-z0-9-]{8,256}$/
 
 export interface TwitchAuthorizationResponse {
   loginUrl: string
@@ -18,18 +23,22 @@ export function parseTwitchAuthorizationResponse(body: unknown): TwitchAuthoriza
   if (typeof body !== 'object' || body === null) return null
 
   const { loginUrl, state } = body as Record<string, unknown>
-  if (typeof loginUrl !== 'string' || typeof state !== 'string' || state.length === 0) {
+  if (typeof loginUrl !== 'string' || typeof state !== 'string' || !STATE_PATTERN.test(state)) {
     return null
   }
 
   try {
     const url = new URL(loginUrl)
+    // getAll: 重複したstateクエリ（?state=a&state=b）はgetでは先頭しか見えず
+    // 曖昧になるため、ちょうど1件だけであることも確認する。
+    const stateParams = url.searchParams.getAll('state')
     if (
       url.origin !== TWITCH_AUTHORIZATION_ORIGIN ||
       url.pathname !== TWITCH_AUTHORIZATION_PATH ||
       url.username !== '' ||
       url.password !== '' ||
-      url.searchParams.get('state') !== state
+      stateParams.length !== 1 ||
+      stateParams[0] !== state
     ) {
       return null
     }

--- a/src/lib/twitch/chat-service.ts
+++ b/src/lib/twitch/chat-service.ts
@@ -315,6 +315,23 @@ export class TwitchChatService {
     if (botAccount) {
       senderTwitchUserId = botAccount.senderId
     } else {
+      // BOT設定済みで一時的に解決できない場合、本人scopeの状態に関わらずリトライへ
+      // 戻し、次回試行までBOT名義を維持する（Issue #862）。DB瞬断等のretryableを
+      // 本人scope granted時にすり抜けさせて即fallbackすると、一時障害のたびに
+      // 送信者名義が本人へ切り替わってしまう。terminal-unavailable（恒久失効）は
+      // 本人scope次第でterminalまたはdegradation付きfallbackへ分岐する必要が
+      // あるため、従来どおりscope判定の内側で扱う。
+      if (botResolution.status === 'retryable-unavailable') {
+        logger.warn('BOT chat sender is temporarily unavailable; deferring chat delivery', {
+          broadcasterTwitchUserId,
+          reason: botResolution.reason,
+        })
+        return finishPreflightFailure({
+          outcome: 'retryable',
+          reason: botResolution.reason,
+        })
+      }
+
       // 送信前にDBのスコープを確認（無駄なAPI呼び出し抑止）
       // Check DB scope before sending to avoid unnecessary API calls (e.g., repeated 401s from EventSub)
       const chatScopeStatus = await getScopeStatus(
@@ -322,19 +339,9 @@ export class TwitchChatService {
         ADDITIONAL_SCOPES.CHAT_WRITE,
       )
       if (chatScopeStatus === 'missing') {
-        // BOT未設定の場合だけ本人のscope不足と確定できる。BOT設定済みで解決不能な
+        // BOT未設定の場合だけ本人のscope不足と確定できる。BOT設定済みで恒久解決不能な
         // 状態をmissing_scopeへ落とすと誤った再認証案内とreport抑制が起きるため、
-        // retryable/terminalのBOT解決結果を本人scopeより優先する。
-        if (botResolution.status === 'retryable-unavailable') {
-          logger.warn('BOT chat sender is temporarily unavailable; deferring chat delivery', {
-            broadcasterTwitchUserId,
-            reason: botResolution.reason,
-          })
-          return finishPreflightFailure({
-            outcome: 'retryable',
-            reason: botResolution.reason,
-          })
-        }
+        // terminalのBOT解決結果を本人scopeより優先する。
         if (botResolution.status === 'terminal-unavailable') {
           logger.warn('Configured BOT chat sender credential is unavailable', {
             broadcasterTwitchUserId,

--- a/src/lib/twitch/use-chat-reauthorization.tsx
+++ b/src/lib/twitch/use-chat-reauthorization.tsx
@@ -13,6 +13,7 @@ import { useMaintenanceStatus } from '@/components/MaintenanceStatusProvider'
 import { COOKIE_NAMES } from '@/lib/constants'
 import { parseMaintenanceError } from '@/lib/maintenance/client'
 import { ADDITIONAL_SCOPES } from '@/lib/twitch/scopes'
+import { parseTwitchAuthorizationResponse } from '@/lib/twitch/authorization-response'
 
 export type ChatReauthorizationFailure = 'maintenance' | 'request'
 
@@ -21,45 +22,7 @@ interface ChatReauthorizationContextValue {
   reauthorize: () => Promise<ChatReauthorizationFailure | null>
 }
 
-const TWITCH_AUTHORIZATION_ORIGIN = 'https://id.twitch.tv'
-const TWITCH_AUTHORIZATION_PATH = '/oauth2/authorize'
 const ChatReauthorizationContext = createContext<ChatReauthorizationContextValue | null>(null)
-
-/**
- * reauth APIの成功bodyを、ブラウザ遷移へ使ってよいTwitch OAuth URLへ正規化する。
- *
- * 型確認だけでは、壊れたAPI応答や侵害時の外部URLを `window.location` へ渡してしまう。
- * Twitch公式の認可endpoint（https://id.twitch.tv/oauth2/authorize）に限定し、URL内の
- * stateとCookieへ保存するstateが一致することまで確認してから遷移する。これにより
- * 2つのCTAが同じOAuth/CSRF境界を共有し、片方だけ検証が弱くなる回帰を防ぐ。
- */
-function parseTwitchAuthorizationResponse(body: unknown): {
-  loginUrl: string
-  state: string
-} | null {
-  if (typeof body !== 'object' || body === null) return null
-
-  const { loginUrl, state } = body as Record<string, unknown>
-  if (typeof loginUrl !== 'string' || typeof state !== 'string' || state.length === 0) {
-    return null
-  }
-
-  try {
-    const url = new URL(loginUrl)
-    if (
-      url.origin !== TWITCH_AUTHORIZATION_ORIGIN ||
-      url.pathname !== TWITCH_AUTHORIZATION_PATH ||
-      url.username !== '' ||
-      url.password !== '' ||
-      url.searchParams.get('state') !== state
-    ) {
-      return null
-    }
-    return { loginUrl: url.href, state }
-  } catch {
-    return null
-  }
-}
 
 /**
  * user:write:chat のstep-up再認証をダッシュボード内で1系統だけ管理するProvider。

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,4 +1,5 @@
 export interface TwitchLoginResponse {
   authUrl?: string
+  state?: string
   error?: string
 }

--- a/tests/unit/chat-service.test.ts
+++ b/tests/unit/chat-service.test.ts
@@ -229,32 +229,26 @@ describe('TwitchChatService', () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it('BOT解決不能でも本人scope付与済みなら本人credentialへfallbackする', async () => {
+    it('BOT一時解決不能なら本人scope付与済みでもリトライへ戻しBOT名義を維持する', async () => {
+      // Issue #862: retryable-unavailable（DB瞬断等の一時障害）を本人scope
+      // granted時にすり抜けさせて即fallbackすると、一時障害のたびに送信者名義が
+      // 本人へ切り替わってしまう。本人credentialへは切り替えず、次回試行まで
+      // BOT名義を維持する。
       vi.mocked(resolveBotAccountForChat).mockResolvedValue({
         status: 'retryable-unavailable',
         reason: 'configured BOT credential is temporarily unavailable',
       });
       vi.mocked(getScopeStatus).mockResolvedValue('granted');
       vi.mocked(getTwitchAccessToken).mockResolvedValue('streamer-token');
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: true,
-        status: 200,
-        json: () => Promise.resolve({ data: [{ message_id: 'msg-123', is_sent: true }] }),
-      } as Response);
 
       await expect(
         service.sendChatMessageDetailed('123456789', 'test message')
-      ).resolves.toEqual({ outcome: 'sent' });
-      expect(global.fetch).toHaveBeenCalledWith(
-        'https://api.twitch.tv/helix/chat/messages',
-        expect.objectContaining({
-          body: JSON.stringify({
-            broadcaster_id: '123456789',
-            sender_id: '123456789',
-            message: 'test message',
-          }),
-        }),
-      );
+      ).resolves.toEqual({
+        outcome: 'retryable',
+        reason: 'configured BOT credential is temporarily unavailable',
+      });
+      expect(getTwitchAccessToken).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it('BOT恒久失効でも本人fallback送信を成功させ、typed degradationを上位へ渡す', async () => {

--- a/tests/unit/chat-service.test.ts
+++ b/tests/unit/chat-service.test.ts
@@ -190,23 +190,6 @@ describe('TwitchChatService', () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it('BOT一時解決不能かつ本人scope不足はmissing_scopeへ誤分類しない', async () => {
-      vi.mocked(resolveBotAccountForChat).mockResolvedValue({
-        status: 'retryable-unavailable',
-        reason: 'configured BOT credential is temporarily unavailable',
-      });
-      vi.mocked(getScopeStatus).mockResolvedValue('missing');
-
-      await expect(
-        service.sendChatMessageDetailed('123456789', 'test message')
-      ).resolves.toEqual({
-        outcome: 'retryable',
-        reason: 'configured BOT credential is temporarily unavailable',
-      });
-      expect(getTwitchAccessToken).not.toHaveBeenCalled();
-      expect(global.fetch).not.toHaveBeenCalled();
-    });
-
     it('BOT恒久credential欠落かつ本人scope不足はcredential terminalにする', async () => {
       vi.mocked(resolveBotAccountForChat).mockResolvedValue({
         status: 'terminal-unavailable',
@@ -229,27 +212,32 @@ describe('TwitchChatService', () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it('BOT一時解決不能なら本人scope付与済みでもリトライへ戻しBOT名義を維持する', async () => {
-      // Issue #862: retryable-unavailable（DB瞬断等の一時障害）を本人scope
-      // granted時にすり抜けさせて即fallbackすると、一時障害のたびに送信者名義が
-      // 本人へ切り替わってしまう。本人credentialへは切り替えず、次回試行まで
-      // BOT名義を維持する。
-      vi.mocked(resolveBotAccountForChat).mockResolvedValue({
-        status: 'retryable-unavailable',
-        reason: 'configured BOT credential is temporarily unavailable',
-      });
-      vi.mocked(getScopeStatus).mockResolvedValue('granted');
-      vi.mocked(getTwitchAccessToken).mockResolvedValue('streamer-token');
+    it.each(['missing', 'granted', 'unavailable'] as const)(
+      'BOT一時解決不能なら本人scope状態(%s)に関わらずリトライへ戻しBOT名義を維持する',
+      async (scopeStatus) => {
+        // Issue #862: retryable-unavailable（DB瞬断等の一時障害）を本人scope
+        // granted時にすり抜けさせて即fallbackすると、一時障害のたびに送信者名義が
+        // 本人へ切り替わってしまう。本人credentialへは切り替えず、次回試行まで
+        // BOT名義を維持する。scope確認より前に判定するため、getScopeStatusは
+        // 呼ばれないことも合わせて固定する。
+        vi.mocked(resolveBotAccountForChat).mockResolvedValue({
+          status: 'retryable-unavailable',
+          reason: 'configured BOT credential is temporarily unavailable',
+        });
+        vi.mocked(getScopeStatus).mockResolvedValue(scopeStatus);
+        vi.mocked(getTwitchAccessToken).mockResolvedValue('streamer-token');
 
-      await expect(
-        service.sendChatMessageDetailed('123456789', 'test message')
-      ).resolves.toEqual({
-        outcome: 'retryable',
-        reason: 'configured BOT credential is temporarily unavailable',
-      });
-      expect(getTwitchAccessToken).not.toHaveBeenCalled();
-      expect(global.fetch).not.toHaveBeenCalled();
-    });
+        await expect(
+          service.sendChatMessageDetailed('123456789', 'test message')
+        ).resolves.toEqual({
+          outcome: 'retryable',
+          reason: 'configured BOT credential is temporarily unavailable',
+        });
+        expect(getScopeStatus).not.toHaveBeenCalled();
+        expect(getTwitchAccessToken).not.toHaveBeenCalled();
+        expect(global.fetch).not.toHaveBeenCalled();
+      },
+    );
 
     it('BOT恒久失効でも本人fallback送信を成功させ、typed degradationを上位へ渡す', async () => {
       vi.mocked(resolveBotAccountForChat).mockResolvedValue({
@@ -698,6 +686,29 @@ describe('TwitchChatService', () => {
       expect(reportError).toHaveBeenCalledWith(
         expect.objectContaining({
           message: 'Chat delivery preflight failed: unable to verify user:write:chat scope',
+        }),
+        expect.objectContaining({
+          context: 'chat-service:sendChatMessage:preflight',
+          broadcasterTwitchUserId: '123456789',
+          outcome: 'retryable',
+        }),
+      );
+    });
+
+    it('BOT一時解決不能のpreflight失敗はlegacy経路でもreportErrorを1回残す', async () => {
+      vi.mocked(resolveBotAccountForChat).mockResolvedValue({
+        status: 'retryable-unavailable',
+        reason: 'configured BOT credential is temporarily unavailable',
+      });
+
+      await expect(service.sendChatMessage('123456789', 'test message')).resolves.toBe(false);
+
+      expect(getScopeStatus).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(reportError).toHaveBeenCalledTimes(1);
+      expect(reportError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Chat delivery preflight failed: configured BOT credential is temporarily unavailable',
         }),
         expect.objectContaining({
           context: 'chat-service:sendChatMessage:preflight',

--- a/tests/unit/components/channel-point-settings-maintenance.test.tsx
+++ b/tests/unit/components/channel-point-settings-maintenance.test.tsx
@@ -15,8 +15,14 @@ vi.mock("@/lib/logger");
 
 type FetchMock = ReturnType<typeof vi.fn>;
 
-function mockFetch(overrides: { rewards?: unknown[]; createRewardStatus?: number; createRewardBody?: unknown } = {}): FetchMock {
-  const { rewards = [], createRewardStatus = 200, createRewardBody } = overrides;
+function mockFetch(overrides: {
+  rewards?: unknown[];
+  createRewardStatus?: number;
+  createRewardBody?: unknown;
+  needsReauth?: boolean;
+  reauthBody?: unknown;
+} = {}): FetchMock {
+  const { rewards = [], createRewardStatus = 200, createRewardBody, needsReauth = false, reauthBody } = overrides;
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString();
     const method = init?.method ?? "GET";
@@ -30,8 +36,8 @@ function mockFetch(overrides: { rewards?: unknown[]; createRewardStatus?: number
     if (url.includes("/api/twitch/channel-point-bootstrap")) {
       return new Response(
         JSON.stringify({
-          hasRequiredScope: true,
-          requiresReauth: false,
+          hasRequiredScope: !needsReauth,
+          requiresReauth: needsReauth,
           rewards,
           subscriptions: [],
           additionalRewards: [],
@@ -45,6 +51,12 @@ function mockFetch(overrides: { rewards?: unknown[]; createRewardStatus?: number
         JSON.stringify(createRewardBody ?? { error: "unexpected" }),
         { status: createRewardStatus, headers: { "content-type": "application/json" } }
       );
+    }
+    if (url.includes("/api/auth/reauth") && method === "POST") {
+      return new Response(JSON.stringify(reauthBody ?? { error: "unexpected" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
     }
     return new Response(JSON.stringify({}), {
       status: 200,
@@ -71,11 +83,50 @@ function renderComponent(
   );
 }
 
+const ORIGINAL_LOCATION = window.location;
+
+function stubLocationHref() {
+  const current = window.location;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      hash: current.hash,
+      host: current.host,
+      hostname: current.hostname,
+      href: current.href,
+      origin: current.origin,
+      pathname: current.pathname,
+      port: current.port,
+      protocol: current.protocol,
+      search: current.search,
+    },
+  });
+}
+
 describe("ChannelPointSettings maintenance integration", () => {
   let fetchMock: FetchMock;
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    Object.defineProperty(window, "location", { value: ORIGINAL_LOCATION, configurable: true });
+  });
+
+  it("reauth APIの200応答に有効なTwitch loginUrlがなければ遷移せず翻訳済みエラーを表示する（Issue #865フォローアップ）", async () => {
+    stubLocationHref();
+    const originalHref = window.location.href;
+    // origin/pathがTwitchの認可endpointと一致しない、侵害/バグ時を想定した応答
+    fetchMock = mockFetch({
+      needsReauth: true,
+      reauthBody: { loginUrl: "https://evil.example.com/phish", state: "state-1" },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderComponent({ mode: "off" });
+
+    const button = await screen.findByRole("button", { name: "チャネルポイント連携を有効化" });
+    fireEvent.click(button);
+
+    expect(await screen.findByText("再認証に失敗しました。時間をおいて再度お試しください。")).toBeInTheDocument();
+    expect(window.location.href).toBe(originalHref);
   });
 
   it("mode=off のときは報酬作成ボタンが操作可能（既存挙動を壊さない）", async () => {

--- a/tests/unit/components/channel-point-settings-maintenance.test.tsx
+++ b/tests/unit/components/channel-point-settings-maintenance.test.tsx
@@ -117,7 +117,7 @@ describe("ChannelPointSettings maintenance integration", () => {
     // origin/pathがTwitchの認可endpointと一致しない、侵害/バグ時を想定した応答
     fetchMock = mockFetch({
       needsReauth: true,
-      reauthBody: { loginUrl: "https://evil.example.com/phish", state: "state-1" },
+      reauthBody: { loginUrl: "https://evil.example.com/phish", state: "state-1234" },
     });
     vi.stubGlobal("fetch", fetchMock);
     renderComponent({ mode: "off" });

--- a/tests/unit/components/channel-points-access-section.test.tsx
+++ b/tests/unit/components/channel-points-access-section.test.tsx
@@ -230,7 +230,7 @@ describe("ChannelPointsAccessSection", () => {
         additionalScopes: CHANNEL_POINT_SCOPES,
         returnTo: "/dashboard/account",
       });
-      return jsonResponse({ loginUrl: "https://id.twitch.tv/oauth2/authorize?mock=1", state: "abc123" });
+      return jsonResponse({ loginUrl: "https://id.twitch.tv/oauth2/authorize?mock=1&state=abc123", state: "abc123" });
     });
     vi.stubGlobal(
       "fetch",
@@ -248,8 +248,29 @@ describe("ChannelPointsAccessSection", () => {
 
     await waitFor(() => expect(reauthHandler).toHaveBeenCalledTimes(1));
     await waitFor(() =>
-      expect(window.location.href).toBe("https://id.twitch.tv/oauth2/authorize?mock=1")
+      expect(window.location.href).toBe("https://id.twitch.tv/oauth2/authorize?mock=1&state=abc123")
     );
+  });
+
+  it("reauth APIの200応答に有効なTwitch loginUrlがなければ遷移せず汎用エラーを表示する（Issue #865フォローアップ）", async () => {
+    stubLocationHref();
+    const originalHref = window.location.href;
+    vi.stubGlobal(
+      "fetch",
+      buildFetchMock({
+        get: () => jsonResponse(makeState({ hasRequiredScope: false, requiresReauth: true, stale: false })),
+        // origin/pathがTwitchの認可endpointと一致しない、侵害/バグ時を想定した応答
+        reauth: () => jsonResponse({ loginUrl: "https://evil.example.com/phish", state: "abc123" }),
+      })
+    );
+
+    renderSection({ mode: "off" });
+
+    const button = await screen.findByRole("button", { name: JA.reauthButton });
+    fireEvent.click(button);
+
+    expect(await screen.findByText(JA.genericError)).toBeInTheDocument();
+    expect(window.location.href).toBe(originalHref);
   });
 
   it("non-affiliate + スコープ有 + stale の場合、ユーザー操作なしで自動的に1回だけPOST /api/account/channel-pointsが発火する", async () => {

--- a/tests/unit/components/channel-points-access-section.test.tsx
+++ b/tests/unit/components/channel-points-access-section.test.tsx
@@ -230,7 +230,11 @@ describe("ChannelPointsAccessSection", () => {
         additionalScopes: CHANNEL_POINT_SCOPES,
         returnTo: "/dashboard/account",
       });
-      return jsonResponse({ loginUrl: "https://id.twitch.tv/oauth2/authorize?mock=1&state=abc12345", state: "abc12345" });
+      const redirectUri = encodeURIComponent(`${window.location.origin}/api/auth/twitch/callback`);
+      return jsonResponse({
+        loginUrl: `https://id.twitch.tv/oauth2/authorize?mock=1&redirect_uri=${redirectUri}&state=abc12345`,
+        state: "abc12345",
+      });
     });
     vi.stubGlobal(
       "fetch",
@@ -247,8 +251,11 @@ describe("ChannelPointsAccessSection", () => {
     fireEvent.click(button);
 
     await waitFor(() => expect(reauthHandler).toHaveBeenCalledTimes(1));
+    const redirectUri = encodeURIComponent(`${window.location.origin}/api/auth/twitch/callback`);
     await waitFor(() =>
-      expect(window.location.href).toBe("https://id.twitch.tv/oauth2/authorize?mock=1&state=abc12345")
+      expect(window.location.href).toBe(
+        `https://id.twitch.tv/oauth2/authorize?mock=1&redirect_uri=${redirectUri}&state=abc12345`
+      )
     );
   });
 

--- a/tests/unit/components/channel-points-access-section.test.tsx
+++ b/tests/unit/components/channel-points-access-section.test.tsx
@@ -230,7 +230,7 @@ describe("ChannelPointsAccessSection", () => {
         additionalScopes: CHANNEL_POINT_SCOPES,
         returnTo: "/dashboard/account",
       });
-      return jsonResponse({ loginUrl: "https://id.twitch.tv/oauth2/authorize?mock=1&state=abc123", state: "abc123" });
+      return jsonResponse({ loginUrl: "https://id.twitch.tv/oauth2/authorize?mock=1&state=abc12345", state: "abc12345" });
     });
     vi.stubGlobal(
       "fetch",
@@ -248,7 +248,7 @@ describe("ChannelPointsAccessSection", () => {
 
     await waitFor(() => expect(reauthHandler).toHaveBeenCalledTimes(1));
     await waitFor(() =>
-      expect(window.location.href).toBe("https://id.twitch.tv/oauth2/authorize?mock=1&state=abc123")
+      expect(window.location.href).toBe("https://id.twitch.tv/oauth2/authorize?mock=1&state=abc12345")
     );
   });
 
@@ -260,7 +260,7 @@ describe("ChannelPointsAccessSection", () => {
       buildFetchMock({
         get: () => jsonResponse(makeState({ hasRequiredScope: false, requiresReauth: true, stale: false })),
         // origin/pathがTwitchの認可endpointと一致しない、侵害/バグ時を想定した応答
-        reauth: () => jsonResponse({ loginUrl: "https://evil.example.com/phish", state: "abc123" }),
+        reauth: () => jsonResponse({ loginUrl: "https://evil.example.com/phish", state: "abc12345" }),
       })
     );
 

--- a/tests/unit/components/chat-announcement-settings.test.tsx
+++ b/tests/unit/components/chat-announcement-settings.test.tsx
@@ -104,6 +104,36 @@ describe("ChatAnnouncementSettings", () => {
     expect(window.location.href).toBe(originalHref);
   });
 
+  it("BOT接続APIの200応答に有効なTwitch loginUrlがなければ遷移せず翻訳済みエラーを表示する（Issue #865）", async () => {
+    stubLocationHref();
+    const originalHref = window.location.href;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/api/auth/check-scope")) {
+          return Promise.resolve(new Response(JSON.stringify({ hasScope: true }), { status: 200 }));
+        }
+        if (url.includes("/api/auth/bot/connect")) {
+          // origin/pathがTwitchの認可endpointと一致しない、侵害/バグ時を想定した応答
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ success: true, loginUrl: "https://evil.example.com/phish", state: "state-123" }),
+              { status: 200 }
+            )
+          );
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      })
+    );
+    renderSettings({ currentEnabled: true });
+
+    fireEvent.click(await screen.findByRole("button", { name: "連携する" }));
+
+    expect(await screen.findByText("別アカウント連携の開始に失敗しました")).toBeInTheDocument();
+    expect(window.location.href).toBe(originalHref);
+  });
+
   it("shows template controls by default without the legacy advanced checkbox", async () => {
     renderSettings();
 

--- a/tests/unit/components/chat-delivery-warning.test.tsx
+++ b/tests/unit/components/chat-delivery-warning.test.tsx
@@ -192,7 +192,7 @@ describe('ChatDeliveryWarning', () => {
   it('成功時はOAuth state cookieを保存してTwitchへredirectする', async () => {
     stubLocationHref()
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
-      loginUrl: 'https://id.twitch.tv/oauth2/authorize?mock=1&state=state-123',
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?mock=1&redirect_uri=${encodeURIComponent(window.location.origin + '/api/auth/twitch/callback')}&state=state-123`,
       state: 'state-123',
     }), {
       status: 200,
@@ -203,7 +203,7 @@ describe('ChatDeliveryWarning', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Twitchと再認証' }))
 
     await waitFor(() => expect(window.location.href).toBe(
-      'https://id.twitch.tv/oauth2/authorize?mock=1&state=state-123',
+      `https://id.twitch.tv/oauth2/authorize?mock=1&redirect_uri=${encodeURIComponent(window.location.origin + '/api/auth/twitch/callback')}&state=state-123`,
     ))
     expect(document.cookie).toContain('twitch_auth_state=state-123')
   })

--- a/tests/unit/components/chat-delivery-warning.test.tsx
+++ b/tests/unit/components/chat-delivery-warning.test.tsx
@@ -9,7 +9,7 @@ import { ChatReauthorizationProvider } from '@/lib/twitch/use-chat-reauthorizati
 const messages = {
   chatDeliveryWarning: {
     title: 'チャット通知を送信できません',
-    description: 'Twitchの送信権限がありません。ガチャとカード付与は通常どおり動作しますが、チャット通知は送信されません。',
+    description: 'チャット通知の送信元アカウントの認証が必要です。ガチャとカード付与は通常どおり動作しますが、チャット通知は送信されません。',
     reauthorize: 'Twitchと再認証',
     reauthorizing: '再認証中...',
     settingsLink: 'チャット通知設定',

--- a/tests/unit/components/twitch-login-button-maintenance.test.tsx
+++ b/tests/unit/components/twitch-login-button-maintenance.test.tsx
@@ -78,7 +78,7 @@ describe('TwitchLoginButton maintenance integration', () => {
         // origin/pathがTwitchの認可endpointと一致しない、侵害/バグ時を想定した応答
         return Promise.resolve(
           new Response(
-            JSON.stringify({ authUrl: 'https://evil.example.com/phish', state: 'state-1' }),
+            JSON.stringify({ authUrl: 'https://evil.example.com/phish', state: 'state-1234' }),
             { status: 200, headers: { 'content-type': 'application/json' } }
           )
         )

--- a/tests/unit/components/twitch-login-button-maintenance.test.tsx
+++ b/tests/unit/components/twitch-login-button-maintenance.test.tsx
@@ -68,6 +68,36 @@ describe('TwitchLoginButton maintenance integration', () => {
     })
   })
 
+  it('login APIの200応答に有効なTwitch authUrlがなければ遷移せずボタンを再度有効にする（Issue #865フォローアップ）', async () => {
+    const originalHref = window.location.href
+    const fetchMock = vi.fn((url: string) => {
+      if (String(url).includes('/api/maintenance-status')) {
+        return Promise.resolve(new Response(JSON.stringify({ mode: 'off' }), { status: 200 }))
+      }
+      if (String(url).includes('/api/auth/twitch/login')) {
+        // origin/pathがTwitchの認可endpointと一致しない、侵害/バグ時を想定した応答
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ authUrl: 'https://evil.example.com/phish', state: 'state-1' }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          )
+        )
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderButton()
+
+    const button = await screen.findByRole('button', { name: 'Twitchでログイン' })
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Twitchでログイン' })).not.toBeDisabled()
+    })
+    expect(window.location.href).toBe(originalHref)
+  })
+
   it('mode!=off のときはボタンがdisableされ案内文言を表示し、ログインAPIへのfetchを一切呼ばない', async () => {
     const fetchMock = mockFetch('read-only')
     vi.stubGlobal('fetch', fetchMock)

--- a/tests/unit/components/twitch-login-redirect-maintenance.test.tsx
+++ b/tests/unit/components/twitch-login-redirect-maintenance.test.tsx
@@ -69,7 +69,7 @@ describe('TwitchLoginRedirect maintenance integration', () => {
         // origin/pathがTwitchの認可endpointと一致しない、侵害/バグ時を想定した応答
         return Promise.resolve(
           new Response(
-            JSON.stringify({ authUrl: 'https://evil.example.com/phish', state: 'state-1' }),
+            JSON.stringify({ authUrl: 'https://evil.example.com/phish', state: 'state-1234' }),
             { status: 200, headers: { 'content-type': 'application/json' } }
           )
         )

--- a/tests/unit/components/twitch-login-redirect-maintenance.test.tsx
+++ b/tests/unit/components/twitch-login-redirect-maintenance.test.tsx
@@ -4,6 +4,10 @@ import { NextIntlClientProvider } from 'next-intl'
 import { TwitchLoginRedirect } from '@/components/TwitchLoginRedirect'
 import jaMessages from '../../../messages/ja.json'
 
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}))
+
 // #694 Stage 6c 既知の不具合対応（Stage 3のFableレビューで指摘）:
 // TwitchLoginRedirect はマウント時に自動で fetch('/api/auth/twitch/login') を
 // 呼び、response.json() で {authUrl} を期待する。maintenance中はこのrouteが
@@ -80,11 +84,20 @@ describe('TwitchLoginRedirect maintenance integration', () => {
 
     renderRedirect()
 
-    await waitFor(() => {
-      expect(
-        fetchMock.mock.calls.some(([u]) => String(u).includes('/api/auth/twitch/login'))
-      ).toBe(true)
-    })
+    // 検証失敗時にスピナー（「リダイレクト中...」）に取り残されず、
+    // 案内文言へ切り替わることを確認する（PR #868レビュー指摘）。
+    expect(await screen.findByText('ログインに失敗しました')).toBeInTheDocument()
+    expect(screen.queryByText('Twitchログインページへ移動中...')).not.toBeInTheDocument()
+    expect(window.location.href).toBe(originalHref)
+  })
+
+  it('login APIの200応答にauthUrlが無ければ遷移せず案内文言を表示する', async () => {
+    const originalHref = window.location.href
+    vi.stubGlobal('fetch', mockFetch('off'))
+
+    renderRedirect()
+
+    expect(await screen.findByText('ログインに失敗しました')).toBeInTheDocument()
     expect(window.location.href).toBe(originalHref)
   })
 

--- a/tests/unit/components/twitch-login-redirect-maintenance.test.tsx
+++ b/tests/unit/components/twitch-login-redirect-maintenance.test.tsx
@@ -59,6 +59,35 @@ describe('TwitchLoginRedirect maintenance integration', () => {
     })
   })
 
+  it('login APIの200応答に有効なTwitch authUrlがなければ遷移しない（Issue #865フォローアップ）', async () => {
+    const originalHref = window.location.href
+    const fetchMock = vi.fn((url: string) => {
+      if (String(url).includes('/api/maintenance-status')) {
+        return Promise.resolve(new Response(JSON.stringify({ mode: 'off' }), { status: 200 }))
+      }
+      if (String(url).includes('/api/auth/twitch/login')) {
+        // origin/pathがTwitchの認可endpointと一致しない、侵害/バグ時を想定した応答
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ authUrl: 'https://evil.example.com/phish', state: 'state-1' }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          )
+        )
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderRedirect()
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([u]) => String(u).includes('/api/auth/twitch/login'))
+      ).toBe(true)
+    })
+    expect(window.location.href).toBe(originalHref)
+  })
+
   it('mode!=off のときは「リダイレクト中」表示の代わりに案内文言を表示し、ログインAPIへのfetchを一切呼ばない', async () => {
     const fetchMock = mockFetch('read-only')
     vi.stubGlobal('fetch', fetchMock)

--- a/tests/unit/components/twitch-sub-check-section-maintenance.test.tsx
+++ b/tests/unit/components/twitch-sub-check-section-maintenance.test.tsx
@@ -52,9 +52,55 @@ const maintenanceErrorResponse = () =>
     { status: 503 }
   )
 
+const ORIGINAL_LOCATION = window.location
+
+function stubLocationHref() {
+  const current = window.location
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      hash: current.hash,
+      host: current.host,
+      hostname: current.hostname,
+      href: current.href,
+      origin: current.origin,
+      pathname: current.pathname,
+      port: current.port,
+      protocol: current.protocol,
+      search: current.search,
+    },
+  })
+}
+
 describe('TwitchSubCheckSection maintenance integration', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    Object.defineProperty(window, 'location', { value: ORIGINAL_LOCATION, configurable: true })
+  })
+
+  it('reauth APIの200応答に有効なTwitch loginUrlがなければ遷移せず翻訳済みエラーを表示する（Issue #865フォローアップ）', async () => {
+    stubLocationHref()
+    const originalHref = window.location.href
+    vi.stubGlobal(
+      'fetch',
+      mockFetchWithScope(false, (url) => {
+        // origin/pathがTwitchの認可endpointと一致しない、侵害/バグ時を想定した応答
+        if (url.includes('/api/auth/reauth')) {
+          return new Response(
+            JSON.stringify({ loginUrl: 'https://evil.example.com/phish', state: 'state-1' }),
+            { status: 200 }
+          )
+        }
+        return new Response(JSON.stringify({}), { status: 200 })
+      })
+    )
+    renderSection({ mode: 'off' }, false)
+
+    const button = await screen.findByRole('button', { name: '権限を付与' })
+    fireEvent.click(button)
+
+    expect(await screen.findByText('再認証に失敗しました。')).toBeInTheDocument()
+    expect(window.location.href).toBe(originalHref)
   })
 
   it('mode=off のときは確認/無効化ボタンが操作可能（既存挙動を壊さない）', async () => {

--- a/tests/unit/components/twitch-sub-check-section-maintenance.test.tsx
+++ b/tests/unit/components/twitch-sub-check-section-maintenance.test.tsx
@@ -87,7 +87,7 @@ describe('TwitchSubCheckSection maintenance integration', () => {
         // origin/pathがTwitchの認可endpointと一致しない、侵害/バグ時を想定した応答
         if (url.includes('/api/auth/reauth')) {
           return new Response(
-            JSON.stringify({ loginUrl: 'https://evil.example.com/phish', state: 'state-1' }),
+            JSON.stringify({ loginUrl: 'https://evil.example.com/phish', state: 'state-1234' }),
             { status: 200 }
           )
         }

--- a/tests/unit/twitch-authorization-response.test.ts
+++ b/tests/unit/twitch-authorization-response.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { parseTwitchAuthorizationResponse } from '@/lib/twitch/authorization-response'
+
+// Issue #865: reauth API・BOT接続APIの両方が共有するOAuth応答検証。
+// origin/path/state不一致や壊れた応答をブラウザ遷移へ渡さないことを固定する。
+describe('parseTwitchAuthorizationResponse', () => {
+  const VALID_STATE = 'state-abc123'
+  const VALID_LOGIN_URL = `https://id.twitch.tv/oauth2/authorize?client_id=abc&state=${VALID_STATE}`
+
+  it('Twitch公式の認可URLかつstateが一致すれば正規化して返す', () => {
+    const result = parseTwitchAuthorizationResponse({ loginUrl: VALID_LOGIN_URL, state: VALID_STATE })
+
+    expect(result).toEqual({ loginUrl: VALID_LOGIN_URL, state: VALID_STATE })
+  })
+
+  it('originがTwitch公式と異なればnullを返す', () => {
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://evil.example.com/oauth2/authorize?state=${VALID_STATE}`,
+      state: VALID_STATE,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('pathがoauth2/authorize以外ならnullを返す', () => {
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://id.twitch.tv/oauth2/token?state=${VALID_STATE}`,
+      state: VALID_STATE,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('URL内のstateとbodyのstateが不一致ならnullを返す', () => {
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?state=different-state`,
+      state: VALID_STATE,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('URLにusername/passwordが埋め込まれていればnullを返す', () => {
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://attacker:pw@id.twitch.tv/oauth2/authorize?state=${VALID_STATE}`,
+      state: VALID_STATE,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('loginUrlが不正なURL文字列ならnullを返す', () => {
+    const result = parseTwitchAuthorizationResponse({ loginUrl: 'not a url', state: VALID_STATE })
+
+    expect(result).toBeNull()
+  })
+
+  it.each([
+    ['loginUrlが欠落', { state: VALID_STATE }],
+    ['stateが欠落', { loginUrl: VALID_LOGIN_URL }],
+    ['stateが空文字', { loginUrl: VALID_LOGIN_URL, state: '' }],
+    ['bodyがnull', null],
+    ['bodyが文字列', 'unexpected'],
+  ])('%s の場合はnullを返す', (_label, body) => {
+    expect(parseTwitchAuthorizationResponse(body)).toBeNull()
+  })
+})

--- a/tests/unit/twitch-authorization-response.test.ts
+++ b/tests/unit/twitch-authorization-response.test.ts
@@ -5,12 +5,50 @@ import { parseTwitchAuthorizationResponse } from '@/lib/twitch/authorization-res
 // origin/path/state不一致や壊れた応答をブラウザ遷移へ渡さないことを固定する。
 describe('parseTwitchAuthorizationResponse', () => {
   const VALID_STATE = 'state-abc123'
-  const VALID_LOGIN_URL = `https://id.twitch.tv/oauth2/authorize?client_id=abc&state=${VALID_STATE}`
+  const SAME_ORIGIN_REDIRECT_URI = `${window.location.origin}/api/auth/twitch/callback`
+  const VALID_LOGIN_URL =
+    `https://id.twitch.tv/oauth2/authorize?client_id=abc&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${VALID_STATE}`
 
   it('Twitch公式の認可URLかつstateが一致すれば正規化して返す', () => {
     const result = parseTwitchAuthorizationResponse({ loginUrl: VALID_LOGIN_URL, state: VALID_STATE })
 
     expect(result).toEqual({ loginUrl: VALID_LOGIN_URL, state: VALID_STATE })
+  })
+
+  it('redirect_uriが自アプリと異なるoriginならnullを返す（Issue #869: consent phishing対策）', () => {
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?redirect_uri=${encodeURIComponent('https://evil.example.com/callback')}&state=${VALID_STATE}`,
+      state: VALID_STATE,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('redirect_uriが欠落していればnullを返す', () => {
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?state=${VALID_STATE}`,
+      state: VALID_STATE,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('URLに重複したredirect_uriクエリパラメータがあればnullを返す', () => {
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&redirect_uri=${encodeURIComponent('https://evil.example.com/callback')}&state=${VALID_STATE}`,
+      state: VALID_STATE,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('redirect_uriが不正なURL文字列ならnullを返す', () => {
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?redirect_uri=not-a-url&state=${VALID_STATE}`,
+      state: VALID_STATE,
+    })
+
+    expect(result).toBeNull()
   })
 
   it('originがTwitch公式と異なればnullを返す', () => {

--- a/tests/unit/twitch-authorization-response.test.ts
+++ b/tests/unit/twitch-authorization-response.test.ts
@@ -40,6 +40,35 @@ describe('parseTwitchAuthorizationResponse', () => {
     expect(result).toBeNull()
   })
 
+  it('stateに許可されない文字（cookie属性インジェクションを狙った値）が含まれていればnullを返す', () => {
+    const maliciousState = 'abc; Domain=evil.com; Path=/'
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?state=${encodeURIComponent(maliciousState)}`,
+      state: maliciousState,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('stateが8文字未満ならnullを返す', () => {
+    const shortState = 'short1'
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?state=${shortState}`,
+      state: shortState,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('URLに重複したstateクエリパラメータがあればnullを返す', () => {
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?state=${VALID_STATE}&state=other-value`,
+      state: VALID_STATE,
+    })
+
+    expect(result).toBeNull()
+  })
+
   it('URLにusername/passwordが埋め込まれていればnullを返す', () => {
     const result = parseTwitchAuthorizationResponse({
       loginUrl: `https://attacker:pw@id.twitch.tv/oauth2/authorize?state=${VALID_STATE}`,


### PR DESCRIPTION
## Summary
- Promote the verified `preview` branch to `main`.
- Includes PR #868 (merge commit `11286fd9ba70aabbc5300cb2f87277ef5a0e65d0`).

## Preview verification
- Preview CI, PlanetScale Migrations, Cloudflare Deploy Support, and Supabase-independent build passed.
- Baseline history: 231 entries.
- Executed two real Twitch channel-point redemptions of `ドッスン君？！` (10 points) while the channel was offline.
- Both redemptions produced Twitch redemption notices, TwiCa card-result chat messages, `Received payload: gacha` overlay events, and history entries.
- History increased from 231 to 233; preview overlay error/retry logs were clear.

## Release gate
- Merge this promotion PR only after its main-target checks and deployment complete successfully.
- Production smoke test will use the production reward `カードガチャ (TwiCa)` as the live configured redemption.