### PR TITLE
fix(auth): complete PR #871 follow-up review fixes

### DIFF
--- a/src/components/TwitchLoginButton.tsx
+++ b/src/components/TwitchLoginButton.tsx
@@ -106,16 +106,12 @@ export function TwitchLoginButton({ className = '', showIcon = false }: TwitchLo
         if (authorization) {
           window.location.href = authorization.loginUrl
         } else {
-          // origin/pathnameのみ記録（クエリ文字列にPIIが含まれ得るため除外）。
-          // 検証拒否の原因切り分け用（本番での設定ミス調査など）。
-          let rejectedUrlSummary = 'unparsable'
-          try {
-            const rejected = new URL(String(data.authUrl))
-            rejectedUrlSummary = `${rejected.origin}${rejected.pathname}`
-          } catch {
-            // rejectedUrlSummary は 'unparsable' のまま
-          }
-          logger.error('Login API returned an invalid authUrl', { authUrl: rejectedUrlSummary })
+          // URLのorigin/pathnameも攻撃者制御値であり、クエリを除外しても
+          // pathnameへPIIや秘密情報が含まれる可能性があるため記録しない。
+          // 固定reasonだけを残し、拒否されたURLをブラウザconsoleへ漏らさない。
+          logger.error('Login API returned an invalid authUrl', {
+            reason: 'authorization-url-validation-failed',
+          })
           setIsLoading(false)
         }
       } else if (data.error) {

--- a/tests/unit/components/chat-delivery-warning.test.tsx
+++ b/tests/unit/components/chat-delivery-warning.test.tsx
@@ -5,24 +5,11 @@ import ChatDeliveryWarning from '@/components/ChatDeliveryWarning'
 import { MaintenanceStatusContext } from '@/components/MaintenanceStatusProvider'
 import type { MaintenanceMode } from '@/lib/maintenance/state'
 import { ChatReauthorizationProvider } from '@/lib/twitch/use-chat-reauthorization'
-
-const messages = {
-  chatDeliveryWarning: {
-    title: 'チャット通知を送信できません',
-    description: 'チャット通知の送信元アカウントの再認証が必要です。ガチャとカード付与は通常どおり動作しますが、チャット通知は送信されません。',
-    reauthorize: 'Twitchと再認証',
-    reauthorizing: '再認証中...',
-    settingsLink: 'チャット通知設定',
-    reauthFailed: '再認証を開始できませんでした。',
-  },
-  maintenance: {
-    writeDisabled: 'メンテナンス中は変更できません',
-  },
-}
+import jaMessages from '../../../messages/ja.json'
 
 function renderWarning(needsAttention: boolean, maintenanceMode: MaintenanceMode = 'off') {
   return render(
-    <NextIntlClientProvider locale="ja" messages={messages}>
+    <NextIntlClientProvider locale="ja" messages={jaMessages}>
       <MaintenanceStatusContext.Provider value={{ mode: maintenanceMode }}>
         <ChatReauthorizationProvider>
           <ChatDeliveryWarning needsAttention={needsAttention} />
@@ -68,6 +55,7 @@ describe('ChatDeliveryWarning', () => {
     const warning = screen.getByTestId('chat-delivery-warning')
     expect(warning).toHaveAttribute('aria-live', 'polite')
     expect(screen.getByText('チャット通知を送信できません')).toBeInTheDocument()
+    expect(screen.getByText(/送信元アカウントの再認証が必要/)).toBeInTheDocument()
     expect(screen.getByText(/ガチャとカード付与は通常どおり動作/)).toBeInTheDocument()
     expect(screen.getByRole('link', { name: 'チャット通知設定' })).toHaveAttribute(
       'href',
@@ -95,7 +83,7 @@ describe('ChatDeliveryWarning', () => {
         body: JSON.stringify({ additionalScopes: ['user:write:chat'] }),
       }),
     ))
-    expect(screen.getByText('再認証を開始できませんでした。')).toBeInTheDocument()
+    expect(screen.getByText('再認証を開始できませんでした。しばらくしてから再度お試しください。')).toBeInTheDocument()
   })
 
   it('同じProvider配下の別CTAを連続操作してもreauth requestは1本だけ発行する', async () => {
@@ -106,7 +94,7 @@ describe('ChatDeliveryWarning', () => {
       }),
     )
     render(
-      <NextIntlClientProvider locale="ja" messages={messages}>
+      <NextIntlClientProvider locale="ja" messages={jaMessages}>
         <MaintenanceStatusContext.Provider value={{ mode: 'off' }}>
           <ChatReauthorizationProvider>
             <ChatDeliveryWarning needsAttention />
@@ -137,7 +125,7 @@ describe('ChatDeliveryWarning', () => {
 
     const button = screen.getByRole('button', { name: 'Twitchと再認証' })
     expect(button).toBeDisabled()
-    expect(button).toHaveAttribute('title', 'メンテナンス中は変更できません')
+    expect(button).toHaveAttribute('title', 'メンテナンス中は操作できません')
     fireEvent.click(button)
     expect(fetchMock).not.toHaveBeenCalled()
   })
@@ -148,7 +136,7 @@ describe('ChatDeliveryWarning', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Twitchと再認証' }))
 
-    expect(await screen.findByText('再認証を開始できませんでした。')).toBeInTheDocument()
+    expect(await screen.findByText('再認証を開始できませんでした。しばらくしてから再度お試しください。')).toBeInTheDocument()
     expect(screen.queryByText(/Failed to fetch/)).toBeNull()
   })
 
@@ -164,7 +152,7 @@ describe('ChatDeliveryWarning', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Twitchと再認証' }))
 
-    expect(await screen.findByText('再認証を開始できませんでした。')).toBeInTheDocument()
+    expect(await screen.findByText('再認証を開始できませんでした。しばらくしてから再度お試しください。')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Twitchと再認証' })).not.toBeDisabled()
     expect(window.location.href).toBe(originalHref)
     expect(document.cookie).toBe(originalCookie)
@@ -185,7 +173,7 @@ describe('ChatDeliveryWarning', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Twitchと再認証' }))
 
-    expect(await screen.findByText('メンテナンス中は変更できません')).toBeInTheDocument()
+    expect(await screen.findByText('メンテナンス中は操作できません')).toBeInTheDocument()
     expect(screen.queryByText('server locale message')).toBeNull()
   })
 
@@ -229,7 +217,7 @@ describe('ChatDeliveryWarning', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Twitchと再認証' }))
 
-    expect(await screen.findByText('再認証を開始できませんでした。')).toBeInTheDocument()
+    expect(await screen.findByText('再認証を開始できませんでした。しばらくしてから再度お試しください。')).toBeInTheDocument()
     expect(window.location.href).toBe(originalHref)
   })
 })

--- a/tests/unit/components/twitch-login-button-maintenance.test.tsx
+++ b/tests/unit/components/twitch-login-button-maintenance.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { NextIntlClientProvider } from 'next-intl'
 import { TwitchLoginButton } from '@/components/TwitchLoginButton'
+import { logger } from '@/lib/logger'
 import jaMessages from '../../../messages/ja.json'
 
 vi.mock('@/lib/logger', () => ({
@@ -96,6 +97,39 @@ describe('TwitchLoginButton maintenance integration', () => {
       expect(screen.getByRole('button', { name: 'Twitchでログイン' })).not.toBeDisabled()
     })
     expect(window.location.href).toBe(originalHref)
+  })
+
+  it('不正なauthUrlを拒否したときはURLをログへ渡さず固定reasonだけ記録する', async () => {
+    const rejectedUrl = 'https://evil.example.com/users/alice@example.com/reset/secret?token=should-not-log'
+    const fetchMock = vi.fn((url: string) => {
+      if (String(url).includes('/api/maintenance-status')) {
+        return Promise.resolve(new Response(JSON.stringify({ mode: 'off' }), { status: 200 }))
+      }
+      if (String(url).includes('/api/auth/twitch/login')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ authUrl: rejectedUrl, state: 'state-1234' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        )
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    vi.mocked(logger.error).mockClear()
+
+    renderButton()
+
+    const button = await screen.findByRole('button', { name: 'Twitchでログイン' })
+    fireEvent.click(button)
+
+    await waitFor(() => expect(button).not.toBeDisabled())
+    expect(logger.error).toHaveBeenCalledTimes(1)
+    expect(logger.error).toHaveBeenCalledWith('Login API returned an invalid authUrl', {
+      reason: 'authorization-url-validation-failed',
+    })
+    expect(JSON.stringify(vi.mocked(logger.error).mock.calls)).not.toContain('alice@example.com')
+    expect(JSON.stringify(vi.mocked(logger.error).mock.calls)).not.toContain('should-not-log')
   })
 
   it('mode!=off のときはボタンがdisableされ案内文言を表示し、ログインAPIへのfetchを一切呼ばない', async () => {


### PR DESCRIPTION
## 概要
PR #871 の独立レビューで見つかった残課題を解消します。

## 修正内容
- 不正な `authUrl` を拒否した際、攻撃者制御のURL由来情報をログへ渡さず、固定の `reason` のみ記録する。
- チャット通知警告テストが手書きfixtureではなく `messages/ja.json` を実際に参照するようにし、実カタログの再認証文言を検証する。
- 上記のURL情報非出力を回帰テストで固定する。

## 背景
独立レビューで、URLのorigin/pathnameもPIIや秘密情報を含み得ること、手書きfixtureでは翻訳カタログの変更を検知できないことが指摘されました。

## 検証
- `npm run typecheck`
- `npx vitest run tests/unit/components/twitch-login-button-maintenance.test.tsx tests/unit/components/chat-delivery-warning.test.tsx tests/unit/twitch-authorization-response.test.ts`（40 tests passed）
- 対象3ファイルの `npx eslint`
- `git diff --check`
- PR #871 のpreviewマージ後CI（unit/integration/typecheck/build/PlanetScale migration）passed

PR #871 のフォローアップとして、previewへマージ後に再レビュー・実経路確認を行います。