### PR TITLE
fix(auth): TwitchLoginButtonがauthUrl/error両方無い応答でローディングに取り残されるのを修正 (#870)

### DIFF
--- a/src/components/TwitchLoginButton.tsx
+++ b/src/components/TwitchLoginButton.tsx
@@ -119,6 +119,17 @@ export function TwitchLoginButton({ className = '', showIcon = false }: TwitchLo
         // APIからのJSONエラーレスポンスを処理
         logger.error('Login API error:', { error: data.error })
         setIsLoading(false)
+      } else {
+        // #870: 応答がauthUrlもerrorも持たない異常系（例: {}）。ここに分岐が
+        // 無いとsetIsLoading(false)が呼ばれず、disabled={isLoading || ...}の
+        // ためボタンが何の表示もないまま恒久的にdisableされたまま取り残される。
+        // ローディング状態を解除して再試行可能に戻す。応答body全体を記録すると
+        // 壊れた/侵害されたAPI応答に含まれる秘密情報がログへ漏れるため、固定
+        // reasonのみを残し生データはログに含めない（#865のポリシーと同じ）。
+        logger.error('Login API returned a response with neither authUrl nor error', {
+          reason: 'malformed-login-response',
+        })
+        setIsLoading(false)
       }
     } catch (error) {
       logger.error('Login error:', { error })

--- a/tests/unit/components/twitch-login-button-maintenance.test.tsx
+++ b/tests/unit/components/twitch-login-button-maintenance.test.tsx
@@ -204,6 +204,54 @@ describe('TwitchLoginButton maintenance integration', () => {
     ).toBe(false)
   })
 
+  // #870: ログインAPIがauthUrlもerrorも持たない応答（例: {}）を返す異常系で、
+  // 従来はどちらのif/else分岐にも入らずsetIsLoading(false)が呼ばれないため、
+  // disabled={isLoading || ...}でボタンが恒久的にdisableのまま取り残される。
+  // フォールバック分岐でローディングを解除し、再度操作可能へ戻ることを検証する。
+  it('ログインAPIがauthUrlもerrorも返さない場合でもローディングから復帰してボタンが再度操作可能になる', async () => {
+    const secretValue = 'should-not-be-logged'
+    const fetchMock = vi.fn((url: string) => {
+      if (String(url).includes('/api/maintenance-status')) {
+        return Promise.resolve(new Response(JSON.stringify({ mode: 'off' }), { status: 200 }))
+      }
+      if (String(url).includes('/api/auth/twitch/login')) {
+        // authUrlもerrorも持たない壊れた/侵害された応答を想定し、秘密情報に
+        // 見えるbodyを返す（ログへ漏れないことの検証に使う）。
+        return Promise.resolve(
+          new Response(JSON.stringify({ secretValue }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        )
+      }
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    vi.mocked(logger.error).mockClear()
+
+    renderButton()
+
+    const button = await screen.findByRole('button', { name: 'Twitchでログイン' })
+    fireEvent.click(button)
+
+    // クリック直後は連打防止のため同期的にローディング（disable）になる。
+    expect(button).toBeDisabled()
+
+    // APIが{}（authUrlもerrorも無い）を返しても、フォールバック分岐の
+    // setIsLoading(false)により最終的に再度操作可能な状態へ戻る。
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Twitchでログイン' })).not.toBeDisabled()
+    })
+
+    // 固定reasonだけをログし、応答body（秘密情報を含みうる）を漏らさない
+    // （#865と同じ非漏洩ポリシー）。
+    expect(logger.error).toHaveBeenCalledWith(
+      'Login API returned a response with neither authUrl nor error',
+      { reason: 'malformed-login-response' }
+    )
+    expect(JSON.stringify(vi.mocked(logger.error).mock.calls)).not.toContain(secretValue)
+  })
+
   // #785 Fableレビュー指摘: setIsLoading(true) を fetchMaintenanceStatus() の
   // await より前（handleLogin冒頭）に移動したことで、クリック直後・非同期処理の
   // 応答を待たずに同期的にボタンがdisableされることを直接検証する。これにより


### PR DESCRIPTION
## Summary
- `TwitchLoginButton` がログインAPI応答に `authUrl` も `error` も持たない場合（例: `{}`）、どちらのif/else分岐にも入らず `setIsLoading(false)` が呼ばれず、`disabled={isLoading || ...}` でボタンが恒久的に disable のまま取り残されるバグを修正（Issue #870）。
- フォールバック分岐（`else`）を追加し、ローディング状態を解除して再試行可能に戻す。
- 応答body全体をログへ記録すると壊れた/侵害されたAPI応答に含まれる秘密情報が漏れるため、固定 `reason: 'malformed-login-response'` のみを記録し生データは含めない（PR #868/#865 のポリシーと同一）。
- 回帰テストを追加: `{}` 応答でもローディングから復帰しボタンが再度操作可能になること、およびログにbodyが漏れないことを検証。

## 変更ファイル
- `src/components/TwitchLoginButton.tsx`: フォールバック分岐追加
- `tests/unit/components/twitch-login-button-maintenance.test.tsx`: 回帰テスト追加

## 検証
- `npx vitest run tests/unit/components/twitch-login-button-maintenance.test.tsx` → 8 passed
- `npm run test:unit` → 3583 passed / 34 skipped
- `npx eslint`（変更ファイル）→ OK
- `npx tsc --noEmit` → OK

Closes #870