### PR TITLE
fix(auth): validate client_id in OAuth authorize URL against expected value (#869)

### DIFF
--- a/src/lib/twitch/authorization-response.ts
+++ b/src/lib/twitch/authorization-response.ts
@@ -1,5 +1,10 @@
 const TWITCH_AUTHORIZATION_ORIGIN = 'https://id.twitch.tv'
 const TWITCH_AUTHORIZATION_PATH = '/oauth2/authorize'
+// 環境ごとの期待client_id。NEXT_PUBLIC_プレフィックスのためビルド時にクライアント
+// バンドルへリテラルとして埋め込まれ、preview/本番で値が異なっても各環境のビルドが
+// 正しい期待値を持つ（Issue #869）。サーバー側のgetTwitchAuthUrl()と同じ変数から
+// URLを生成するため、正当な応答は常にこの値と一致する。
+const EXPECTED_CLIENT_ID = process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID
 // サーバー側の生成方式はcrypto.randomUUID()（36文字、16進数+ハイフン）または
 // randomBytesHex(32)（64文字、16進数のみ）のいずれかで、他の文字は使わない。
 // ここで許可文字を絞ることで、stateが後段でdocument.cookieへ直接埋め込まれる
@@ -16,10 +21,9 @@ export interface TwitchAuthorizationResponse {
  *
  * origin/path/stateの検証だけでは、侵害された応答が正規のTwitch認可URLの
  * `client_id`・`redirect_uri` だけ攻撃者のものへ差し替えて返すOAuth consent
- * phishingを防げない（Issue #869）。`client_id`の検証には環境別の期待値を
- * `NEXT_PUBLIC_`化して持つ必要がありスコープが大きいため別issueとするが、
- * `redirect_uri`のorigin一致は秘密情報を新たに公開せずクライアント側で
- * 安価に検証でき、consent phishingの実効性を大きく下げられる。
+ * phishingを防げない。`client_id`は EXPECTED_CLIENT_ID で、`redirect_uri`の
+ * origin一致はここでそれぞれ検証し、consent phishingの実効性を下げる
+ * （Issue #869）。
  *
  * この関数は必ずブラウザ内（クリックイベント/useEffect経由）で呼ばれる
  * client componentからのみ使われるためwindowは常に存在する前提だが、
@@ -39,9 +43,15 @@ function isSameOriginRedirectUri(redirectUri: string): boolean {
  *
  * 型確認だけでは、壊れたAPI応答や侵害時の外部URLを `window.location` へ渡してしまう。
  * Twitch公式の認可endpoint（https://id.twitch.tv/oauth2/authorize）に限定し、URL内の
- * stateとAPI応答のstateが一致すること、`redirect_uri`が自アプリのoriginと一致することまで
+ * stateとAPI応答のstateが一致すること、`redirect_uri`が自アプリのoriginと一致すること、
+ * `client_id`が自アプリのもの（NEXT_PUBLIC_TWITCH_CLIENT_ID）と一致することまで
  * 確認してから遷移する。本人再認証とBOT接続の2つのCTAが同じOAuth/CSRF境界を共有し、
  * 片方だけ検証が弱くなる回帰を防ぐ（Issue #865）。
+ *
+ * client_idの照合はOAuth consent phishingへの最終防衛線のひとつ。同一originのJSON応答が
+ * 侵害され、正規のTwitch認可URLのclient_idだけ攻撃者のものへ差し替えられた場合、
+ * ユーザーが同意すれば認可コードが攻撃者アプリのredirect_uriへ流れる。期待値が未設定の
+ * 場合は fail-closed でnullを返す（ビルド時にインライン化されるため実質常に設定済み）。
  */
 export function parseTwitchAuthorizationResponse(body: unknown): TwitchAuthorizationResponse | null {
   if (typeof body !== 'object' || body === null) return null
@@ -57,6 +67,7 @@ export function parseTwitchAuthorizationResponse(body: unknown): TwitchAuthoriza
     // 曖昧になるため、ちょうど1件だけであることも確認する。
     const stateParams = url.searchParams.getAll('state')
     const redirectUriParams = url.searchParams.getAll('redirect_uri')
+    const clientIdParams = url.searchParams.getAll('client_id')
     if (
       url.origin !== TWITCH_AUTHORIZATION_ORIGIN ||
       url.pathname !== TWITCH_AUTHORIZATION_PATH ||
@@ -65,7 +76,9 @@ export function parseTwitchAuthorizationResponse(body: unknown): TwitchAuthoriza
       stateParams.length !== 1 ||
       stateParams[0] !== state ||
       redirectUriParams.length !== 1 ||
-      !isSameOriginRedirectUri(redirectUriParams[0])
+      !isSameOriginRedirectUri(redirectUriParams[0]) ||
+      clientIdParams.length !== 1 ||
+      clientIdParams[0] !== EXPECTED_CLIENT_ID
     ) {
       return null
     }

--- a/src/lib/twitch/authorization-response.ts
+++ b/src/lib/twitch/authorization-response.ts
@@ -4,7 +4,11 @@ const TWITCH_AUTHORIZATION_PATH = '/oauth2/authorize'
 // バンドルへリテラルとして埋め込まれ、preview/本番で値が異なっても各環境のビルドが
 // 正しい期待値を持つ（Issue #869）。サーバー側のgetTwitchAuthUrl()と同じ変数から
 // URLを生成するため、正当な応答は常にこの値と一致する。
-const EXPECTED_CLIENT_ID = process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID
+// サーバー側は getEnvVar()（src/lib/env-validation.ts）経由で前後の空白・改行を
+// trimしてから使う（Cloudflareダッシュボードでのペースト時などに混入するため）。
+// ここでtrimしないと、混入があった場合にサーバーの生成値とここでの期待値がズレ、
+// 正当なログイン/再認証/BOT接続まで誤ってfail-closedでブロックしてしまう。
+const EXPECTED_CLIENT_ID = process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID?.trim()
 // サーバー側の生成方式はcrypto.randomUUID()（36文字、16進数+ハイフン）または
 // randomBytesHex(32)（64文字、16進数のみ）のいずれかで、他の文字は使わない。
 // ここで許可文字を絞ることで、stateが後段でdocument.cookieへ直接埋め込まれる

--- a/src/lib/twitch/authorization-response.ts
+++ b/src/lib/twitch/authorization-response.ts
@@ -58,6 +58,12 @@ function isSameOriginRedirectUri(redirectUri: string): boolean {
  * 場合は fail-closed でnullを返す（ビルド時にインライン化されるため実質常に設定済み）。
  */
 export function parseTwitchAuthorizationResponse(body: unknown): TwitchAuthorizationResponse | null {
+  // EXPECTED_CLIENT_IDが未設定（undefinedまたは空文字）ならfail-closed。このガードが
+  // ないと、env値が空文字のときに `client_id=`（空値）を持つURLが
+  // `clientIdParams[0] !== EXPECTED_CLIENT_ID`（'' !== ''）をすり抜けて検証を通過して
+  // しまう（Issue #869 review follow-up）。
+  if (!EXPECTED_CLIENT_ID) return null
+
   if (typeof body !== 'object' || body === null) return null
 
   const { loginUrl, state } = body as Record<string, unknown>

--- a/tests/unit/components/channel-points-access-section.test.tsx
+++ b/tests/unit/components/channel-points-access-section.test.tsx
@@ -232,7 +232,7 @@ describe("ChannelPointsAccessSection", () => {
       });
       const redirectUri = encodeURIComponent(`${window.location.origin}/api/auth/twitch/callback`);
       return jsonResponse({
-        loginUrl: `https://id.twitch.tv/oauth2/authorize?mock=1&redirect_uri=${redirectUri}&state=abc12345`,
+        loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=${process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID}&redirect_uri=${redirectUri}&state=abc12345`,
         state: "abc12345",
       });
     });
@@ -254,7 +254,7 @@ describe("ChannelPointsAccessSection", () => {
     const redirectUri = encodeURIComponent(`${window.location.origin}/api/auth/twitch/callback`);
     await waitFor(() =>
       expect(window.location.href).toBe(
-        `https://id.twitch.tv/oauth2/authorize?mock=1&redirect_uri=${redirectUri}&state=abc12345`
+        `https://id.twitch.tv/oauth2/authorize?client_id=${process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID}&redirect_uri=${redirectUri}&state=abc12345`
       )
     );
   });

--- a/tests/unit/components/chat-delivery-warning.test.tsx
+++ b/tests/unit/components/chat-delivery-warning.test.tsx
@@ -180,7 +180,7 @@ describe('ChatDeliveryWarning', () => {
   it('成功時はOAuth state cookieを保存してTwitchへredirectする', async () => {
     stubLocationHref()
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
-      loginUrl: `https://id.twitch.tv/oauth2/authorize?mock=1&redirect_uri=${encodeURIComponent(window.location.origin + '/api/auth/twitch/callback')}&state=state-123`,
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=${process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID}&redirect_uri=${encodeURIComponent(window.location.origin + '/api/auth/twitch/callback')}&state=state-123`,
       state: 'state-123',
     }), {
       status: 200,
@@ -191,7 +191,7 @@ describe('ChatDeliveryWarning', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Twitchと再認証' }))
 
     await waitFor(() => expect(window.location.href).toBe(
-      `https://id.twitch.tv/oauth2/authorize?mock=1&redirect_uri=${encodeURIComponent(window.location.origin + '/api/auth/twitch/callback')}&state=state-123`,
+      `https://id.twitch.tv/oauth2/authorize?client_id=${process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID}&redirect_uri=${encodeURIComponent(window.location.origin + '/api/auth/twitch/callback')}&state=state-123`,
     ))
     expect(document.cookie).toContain('twitch_auth_state=state-123')
   })

--- a/tests/unit/twitch-authorization-response.test.ts
+++ b/tests/unit/twitch-authorization-response.test.ts
@@ -6,8 +6,11 @@ import { parseTwitchAuthorizationResponse } from '@/lib/twitch/authorization-res
 describe('parseTwitchAuthorizationResponse', () => {
   const VALID_STATE = 'state-abc123'
   const SAME_ORIGIN_REDIRECT_URI = `${window.location.origin}/api/auth/twitch/callback`
+  // tests/setup.ts が NEXT_PUBLIC_TWITCH_CLIENT_ID='test-client-id' を設定する。
+  // 有効なclient_idは実装の EXPECTED_CLIENT_ID（＝このenv var）と一致させる。
+  const VALID_CLIENT_ID = process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!
   const VALID_LOGIN_URL =
-    `https://id.twitch.tv/oauth2/authorize?client_id=abc&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${VALID_STATE}`
+    `https://id.twitch.tv/oauth2/authorize?client_id=${VALID_CLIENT_ID}&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${VALID_STATE}`
 
   it('Twitch公式の認可URLかつstateが一致すれば正規化して返す', () => {
     const result = parseTwitchAuthorizationResponse({ loginUrl: VALID_LOGIN_URL, state: VALID_STATE })
@@ -93,7 +96,7 @@ describe('parseTwitchAuthorizationResponse', () => {
     // 実質テストできなくなる（vacuous test）ため、他はすべて有効な形にする。
     const shortState = 'short1'
     const result = parseTwitchAuthorizationResponse({
-      loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=abc&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${shortState}`,
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=${VALID_CLIENT_ID}&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${shortState}`,
       state: shortState,
     })
 
@@ -102,7 +105,7 @@ describe('parseTwitchAuthorizationResponse', () => {
 
   it('stateがちょうど8文字なら正規化して返す（下限の境界値）', () => {
     const boundaryState = 'a'.repeat(8)
-    const loginUrl = `https://id.twitch.tv/oauth2/authorize?client_id=abc&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${boundaryState}`
+    const loginUrl = `https://id.twitch.tv/oauth2/authorize?client_id=${VALID_CLIENT_ID}&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${boundaryState}`
     const result = parseTwitchAuthorizationResponse({ loginUrl, state: boundaryState })
 
     expect(result).toEqual({ loginUrl, state: boundaryState })
@@ -113,7 +116,7 @@ describe('parseTwitchAuthorizationResponse', () => {
     // 実質テストできなくなる（vacuous test）ため、他はすべて有効な形にする。
     const longState = 'a'.repeat(257)
     const result = parseTwitchAuthorizationResponse({
-      loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=abc&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${longState}`,
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=${VALID_CLIENT_ID}&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${longState}`,
       state: longState,
     })
 
@@ -122,7 +125,7 @@ describe('parseTwitchAuthorizationResponse', () => {
 
   it('stateがちょうど256文字なら正規化して返す（上限の境界値）', () => {
     const boundaryState = 'a'.repeat(256)
-    const loginUrl = `https://id.twitch.tv/oauth2/authorize?client_id=abc&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${boundaryState}`
+    const loginUrl = `https://id.twitch.tv/oauth2/authorize?client_id=${VALID_CLIENT_ID}&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${boundaryState}`
     const result = parseTwitchAuthorizationResponse({ loginUrl, state: boundaryState })
 
     expect(result).toEqual({ loginUrl, state: boundaryState })
@@ -131,6 +134,42 @@ describe('parseTwitchAuthorizationResponse', () => {
   it('URLに重複したstateクエリパラメータがあればnullを返す', () => {
     const result = parseTwitchAuthorizationResponse({
       loginUrl: `https://id.twitch.tv/oauth2/authorize?state=${VALID_STATE}&state=other-value`,
+      state: VALID_STATE,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('client_idが自アプリのものと異なればnullを返す（Issue #869: consent phishing対策）', () => {
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=attacker-client-id&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${VALID_STATE}`,
+      state: VALID_STATE,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('client_idが欠落していればnullを返す', () => {
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${VALID_STATE}`,
+      state: VALID_STATE,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('URLに重複したclient_idクエリパラメータがあればnullを返す', () => {
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=${VALID_CLIENT_ID}&client_id=${VALID_CLIENT_ID}&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${VALID_STATE}`,
+      state: VALID_STATE,
+    })
+
+    expect(result).toBeNull()
+  })
+
+  it('client_idとredirect_uriの両方が攻撃者のものならnullを返す（consent phishingの完全なケース）', () => {
+    const result = parseTwitchAuthorizationResponse({
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=attacker-client-id&redirect_uri=${encodeURIComponent('https://evil.example.com/callback')}&state=${VALID_STATE}`,
       state: VALID_STATE,
     })
 

--- a/tests/unit/twitch-authorization-response.test.ts
+++ b/tests/unit/twitch-authorization-response.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { parseTwitchAuthorizationResponse } from '@/lib/twitch/authorization-response'
 
 // Issue #865: reauth API・BOT接続APIの両方が共有するOAuth応答検証。
@@ -174,6 +174,41 @@ describe('parseTwitchAuthorizationResponse', () => {
     })
 
     expect(result).toBeNull()
+  })
+
+  // EXPECTED_CLIENT_ID はモジュール読み込み時に評価される定数のため、env値を
+  // 変えて再評価させるには resetModules + 動的importが必要（storage-usage.test.ts等と同型）。
+  describe('EXPECTED_CLIENT_ID の環境変数評価', () => {
+    afterEach(() => {
+      vi.unstubAllEnvs()
+      vi.resetModules()
+    })
+
+    it('env値に前後の空白・改行が混入していてもtrimして一致判定する（サーバー側getEnvVar()のtrimと整合、Issue #869フォローアップ）', async () => {
+      // サーバー側の getTwitchAuthUrl() は getEnvVar() 経由でtrim済みの値からURLを
+      // 生成する（src/lib/env-validation.ts）。Cloudflareダッシュボードでのペースト時
+      // などにenv値へ前後の空白・改行が混入した場合でも、クライアント側がtrimしなければ
+      // 正当な応答まで誤ってfail-closedでブロックしてしまう回帰を防ぐ。
+      vi.stubEnv('NEXT_PUBLIC_TWITCH_CLIENT_ID', `${VALID_CLIENT_ID}\n`)
+      vi.resetModules()
+      const { parseTwitchAuthorizationResponse: parseWithWhitespaceEnv } =
+        await import('@/lib/twitch/authorization-response')
+
+      const result = parseWithWhitespaceEnv({ loginUrl: VALID_LOGIN_URL, state: VALID_STATE })
+
+      expect(result).toEqual({ loginUrl: VALID_LOGIN_URL, state: VALID_STATE })
+    })
+
+    it('期待client_idが未設定ならfail-closedで常にnullを返す', async () => {
+      vi.stubEnv('NEXT_PUBLIC_TWITCH_CLIENT_ID', '')
+      vi.resetModules()
+      const { parseTwitchAuthorizationResponse: parseWithoutExpectedClientId } =
+        await import('@/lib/twitch/authorization-response')
+
+      const result = parseWithoutExpectedClientId({ loginUrl: VALID_LOGIN_URL, state: VALID_STATE })
+
+      expect(result).toBeNull()
+    })
   })
 
   it('URLにusername/passwordが埋め込まれていればnullを返す', () => {

--- a/tests/unit/twitch-authorization-response.test.ts
+++ b/tests/unit/twitch-authorization-response.test.ts
@@ -19,8 +19,12 @@ describe('parseTwitchAuthorizationResponse', () => {
   })
 
   it('redirect_uriが自アプリと異なるoriginならnullを返す（Issue #869: consent phishing対策）', () => {
+    // client_idを検証対象外の箇所へ含める理由: 含めないとclient_id欠落だけでも
+    // nullになり、redirect_uriのorigin検証自体を実質テストできなくなる
+    // （vacuous test）。他の否定テストも同様の理由でclient_id/redirect_uriを
+    // 有効な形にしている。
     const result = parseTwitchAuthorizationResponse({
-      loginUrl: `https://id.twitch.tv/oauth2/authorize?redirect_uri=${encodeURIComponent('https://evil.example.com/callback')}&state=${VALID_STATE}`,
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=${VALID_CLIENT_ID}&redirect_uri=${encodeURIComponent('https://evil.example.com/callback')}&state=${VALID_STATE}`,
       state: VALID_STATE,
     })
 
@@ -29,7 +33,7 @@ describe('parseTwitchAuthorizationResponse', () => {
 
   it('redirect_uriが欠落していればnullを返す', () => {
     const result = parseTwitchAuthorizationResponse({
-      loginUrl: `https://id.twitch.tv/oauth2/authorize?state=${VALID_STATE}`,
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=${VALID_CLIENT_ID}&state=${VALID_STATE}`,
       state: VALID_STATE,
     })
 
@@ -38,7 +42,7 @@ describe('parseTwitchAuthorizationResponse', () => {
 
   it('URLに重複したredirect_uriクエリパラメータがあればnullを返す', () => {
     const result = parseTwitchAuthorizationResponse({
-      loginUrl: `https://id.twitch.tv/oauth2/authorize?redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&redirect_uri=${encodeURIComponent('https://evil.example.com/callback')}&state=${VALID_STATE}`,
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=${VALID_CLIENT_ID}&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&redirect_uri=${encodeURIComponent('https://evil.example.com/callback')}&state=${VALID_STATE}`,
       state: VALID_STATE,
     })
 
@@ -47,7 +51,7 @@ describe('parseTwitchAuthorizationResponse', () => {
 
   it('redirect_uriが不正なURL文字列ならnullを返す', () => {
     const result = parseTwitchAuthorizationResponse({
-      loginUrl: `https://id.twitch.tv/oauth2/authorize?redirect_uri=not-a-url&state=${VALID_STATE}`,
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=${VALID_CLIENT_ID}&redirect_uri=not-a-url&state=${VALID_STATE}`,
       state: VALID_STATE,
     })
 
@@ -56,7 +60,7 @@ describe('parseTwitchAuthorizationResponse', () => {
 
   it('originがTwitch公式と異なればnullを返す', () => {
     const result = parseTwitchAuthorizationResponse({
-      loginUrl: `https://evil.example.com/oauth2/authorize?state=${VALID_STATE}`,
+      loginUrl: `https://evil.example.com/oauth2/authorize?client_id=${VALID_CLIENT_ID}&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${VALID_STATE}`,
       state: VALID_STATE,
     })
 
@@ -65,7 +69,7 @@ describe('parseTwitchAuthorizationResponse', () => {
 
   it('pathがoauth2/authorize以外ならnullを返す', () => {
     const result = parseTwitchAuthorizationResponse({
-      loginUrl: `https://id.twitch.tv/oauth2/token?state=${VALID_STATE}`,
+      loginUrl: `https://id.twitch.tv/oauth2/token?client_id=${VALID_CLIENT_ID}&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${VALID_STATE}`,
       state: VALID_STATE,
     })
 
@@ -74,7 +78,7 @@ describe('parseTwitchAuthorizationResponse', () => {
 
   it('URL内のstateとbodyのstateが不一致ならnullを返す', () => {
     const result = parseTwitchAuthorizationResponse({
-      loginUrl: `https://id.twitch.tv/oauth2/authorize?state=different-state`,
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=${VALID_CLIENT_ID}&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=different-state`,
       state: VALID_STATE,
     })
 
@@ -133,7 +137,7 @@ describe('parseTwitchAuthorizationResponse', () => {
 
   it('URLに重複したstateクエリパラメータがあればnullを返す', () => {
     const result = parseTwitchAuthorizationResponse({
-      loginUrl: `https://id.twitch.tv/oauth2/authorize?state=${VALID_STATE}&state=other-value`,
+      loginUrl: `https://id.twitch.tv/oauth2/authorize?client_id=${VALID_CLIENT_ID}&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${VALID_STATE}&state=other-value`,
       state: VALID_STATE,
     })
 
@@ -209,11 +213,26 @@ describe('parseTwitchAuthorizationResponse', () => {
 
       expect(result).toBeNull()
     })
+
+    it('期待client_idが空文字でclient_id=（空値）が来てもnullを返す（fail-closedガードの回帰防止）', async () => {
+      // ガードの明示的なチェック（`if (!EXPECTED_CLIENT_ID) return null`）がないと、
+      // EXPECTED_CLIENT_IDが''のとき `client_id=`（空値）を持つURLが
+      // `'' !== ''` をすり抜けて検証を通過してしまう（review follow-up）。
+      vi.stubEnv('NEXT_PUBLIC_TWITCH_CLIENT_ID', '')
+      vi.resetModules()
+      const { parseTwitchAuthorizationResponse: parseWithEmptyExpectedClientId } =
+        await import('@/lib/twitch/authorization-response')
+
+      const loginUrl = `https://id.twitch.tv/oauth2/authorize?client_id=&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${VALID_STATE}`
+      const result = parseWithEmptyExpectedClientId({ loginUrl, state: VALID_STATE })
+
+      expect(result).toBeNull()
+    })
   })
 
   it('URLにusername/passwordが埋め込まれていればnullを返す', () => {
     const result = parseTwitchAuthorizationResponse({
-      loginUrl: `https://attacker:pw@id.twitch.tv/oauth2/authorize?state=${VALID_STATE}`,
+      loginUrl: `https://attacker:pw@id.twitch.tv/oauth2/authorize?client_id=${VALID_CLIENT_ID}&redirect_uri=${encodeURIComponent(SAME_ORIGIN_REDIRECT_URI)}&state=${VALID_STATE}`,
       state: VALID_STATE,
     })
 


### PR DESCRIPTION
## 概要

Issue #869: `parseTwitchAuthorizationResponse` がOAuth認可URLの `client_id` を検証しておらず、consent phishingの残存リスクがあったため、期待値との照合を追加した。

## 変更内容

- `src/lib/twitch/authorization-response.ts`
  - `EXPECTED_CLIENT_ID = process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID` を定義（NEXT_PUBLIC_のためビルド時にクライアントバンドルへリテラル埋め込みされ、preview/本番の環境差異は各ビルドが担う）
  - 認可URLの `client_id` がちょうど1件・期待値と完全一致することを検証。不一致・欠落・重複は全て null（fail-closed）を返す
  - 既存の redirect_uri origin検証（#868）と併せ、同一originの応答がclient_id/redirect_uri両方を攻撃者のものへ差し替えた完全なconsent phishingケースを遮断
- `tests/unit/twitch-authorization-response.test.ts`
  - client_idの欠落・不一致・重複、client_id+redirect_uri両方攻撃者の完全ケースを追加
  - 既存テストの有効URLを期待client_id（setup.tsのtest値）へ更新

## 検証

- `npx vitest run tests/unit/twitch-authorization-response.test.ts`: 25 passed
- `npm run typecheck`: 成功
- `npx eslint` (対象2ファイル): クリーン
- fable相当の厳格レビュー実施済み（セキュリティ・バグ・テスト・呼び出し元7箇所の整合性すべて問題なし）

## 関連

- Issue #869, #865
- PR #868（redirect_uri検証を追加した前段）