### PR TITLE
fix(api): レート制限のretryAfterをepochミリ秒誤用から秒単位へ統一修正（#786）

### DIFF
--- a/src/app/api/cards/[id]/route.ts
+++ b/src/app/api/cards/[id]/route.ts
@@ -8,7 +8,7 @@ import {
   validateRarity,
 } from "@/lib/validations";
 import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
-import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, rateLimits, getRateLimitIdentifier, retryAfterSeconds } from "@/lib/rate-limit";
 import { extractTwitchUserId } from "@/types/database";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
@@ -348,7 +348,7 @@ export async function PUT(
     return NextResponse.json<ApiRateLimitResponse>(
       {
         error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-        retryAfter: (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000)
+        retryAfter: retryAfterSeconds(rateLimitResult.reset)
       },
       {
         status: 429,
@@ -666,7 +666,7 @@ export async function DELETE(
     return NextResponse.json<ApiRateLimitResponse>(
       {
         error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-        retryAfter: (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000)
+        retryAfter: retryAfterSeconds(rateLimitResult.reset)
       },
       {
         status: 429,

--- a/src/app/api/cards/batch-update/route.ts
+++ b/src/app/api/cards/batch-update/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { getSession, canUseStreamerFeatures } from "@/lib/session";
 
 import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
-import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, rateLimits, getRateLimitIdentifier, retryAfterSeconds } from "@/lib/rate-limit";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
@@ -161,7 +161,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json<ApiRateLimitResponse>(
       {
         error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-        retryAfter: (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000)
+        retryAfter: retryAfterSeconds(rateLimitResult.reset)
       },
       {
         status: 429,

--- a/src/app/api/cards/batch/route.ts
+++ b/src/app/api/cards/batch/route.ts
@@ -8,7 +8,7 @@ import {
 } from "@/lib/validations";
 import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
 import { logger } from "@/lib/logger.server";
-import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, rateLimits, getRateLimitIdentifier, retryAfterSeconds } from "@/lib/rate-limit";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
@@ -150,7 +150,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json<ApiRateLimitResponse>(
       {
         error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-        retryAfter: (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000)
+        retryAfter: retryAfterSeconds(rateLimitResult.reset)
       },
       {
         status: 429,

--- a/src/app/api/cards/collections/route.ts
+++ b/src/app/api/cards/collections/route.ts
@@ -1,7 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
-import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, rateLimits, getRateLimitIdentifier, retryAfterSeconds } from "@/lib/rate-limit";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
@@ -209,7 +209,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json<ApiRateLimitResponse>(
       {
         error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-        retryAfter: (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000),
+        retryAfter: retryAfterSeconds(rateLimitResult.reset),
       },
       {
         status: 429,
@@ -297,7 +297,7 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json<ApiRateLimitResponse>(
       {
         error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-        retryAfter: (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000),
+        retryAfter: retryAfterSeconds(rateLimitResult.reset),
       },
       {
         status: 429,

--- a/src/app/api/cards/route.ts
+++ b/src/app/api/cards/route.ts
@@ -9,7 +9,7 @@ import {
   validateRarity,
 } from "@/lib/validations";
 import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
-import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, rateLimits, getRateLimitIdentifier, retryAfterSeconds } from "@/lib/rate-limit";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
@@ -196,7 +196,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json<ApiRateLimitResponse>(
       {
         error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-        retryAfter: (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000)
+        retryAfter: retryAfterSeconds(rateLimitResult.reset)
       },
       {
         status: 429,
@@ -743,7 +743,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json<ApiRateLimitResponse>(
       {
         error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-        retryAfter: (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000)
+        retryAfter: retryAfterSeconds(rateLimitResult.reset)
       },
       {
         status: 429,

--- a/src/app/api/gacha/demo/route.ts
+++ b/src/app/api/gacha/demo/route.ts
@@ -4,7 +4,7 @@ import { logger } from "@/lib/logger.server";
 import { getSession } from "@/lib/session";
 import { getStreamerIdByTwitchUserId } from "@/lib/user-data";
 import { ERROR_MESSAGES } from "@/lib/constants";
-import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, rateLimits, getRateLimitIdentifier, retryAfterSeconds } from "@/lib/rate-limit";
 import type { ApiRateLimitResponse } from "@/types/api";
 import { eq, and } from "drizzle-orm";
 import { getDb } from "@/lib/db/client";
@@ -203,7 +203,7 @@ export async function POST(request: NextRequest) {
         return NextResponse.json<ApiRateLimitResponse>(
           {
             error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-            retryAfter: (generalRateLimitResult.reset || 0) - Math.floor(Date.now() / 1000),
+            retryAfter: retryAfterSeconds(generalRateLimitResult.reset),
           },
           {
             status: 429,
@@ -233,7 +233,7 @@ export async function POST(request: NextRequest) {
         return NextResponse.json<ApiRateLimitResponse>(
           {
             error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-            retryAfter: (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000),
+            retryAfter: retryAfterSeconds(rateLimitResult.reset),
           },
           {
             status: 429,

--- a/src/app/api/gacha/route.ts
+++ b/src/app/api/gacha/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { GachaService } from "@/lib/services/gacha";
 import { getSession } from "@/lib/session";
-import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { checkRateLimit, rateLimits, getRateLimitIdentifier, retryAfterSeconds } from "@/lib/rate-limit";
 import { reportGachaError } from "@/lib/sentry/error-handler";
 import { setUserContext, setRequestContext } from "@/lib/sentry/user-context";
 import { GACHA_COST, ERROR_MESSAGES } from "@/lib/constants";
@@ -53,7 +53,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json<ApiRateLimitResponse>(
       { 
         error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-        retryAfter: (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000)
+        retryAfter: retryAfterSeconds(rateLimitResult.reset)
       },
       {
         status: 429,

--- a/src/app/api/overlay/[streamerId]/demo-events/route.ts
+++ b/src/app/api/overlay/[streamerId]/demo-events/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getOverlayDemoEvent } from '@/lib/overlay/demo-event-store'
 import { ERROR_MESSAGES } from '@/lib/constants'
-import { checkRateLimit, getRateLimitIdentifier, rateLimits } from '@/lib/rate-limit'
+import { checkRateLimit, getRateLimitIdentifier, rateLimits, retryAfterSeconds } from '@/lib/rate-limit'
 import type { ApiRateLimitResponse } from '@/types/api'
 
 interface RouteParams {
@@ -36,7 +36,7 @@ export async function GET(
     return NextResponse.json<ApiRateLimitResponse>(
       {
         error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-        retryAfter: (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000),
+        retryAfter: retryAfterSeconds(rateLimitResult.reset),
       },
       {
         status: 429,

--- a/src/app/api/overlay/[streamerId]/events/route.ts
+++ b/src/app/api/overlay/[streamerId]/events/route.ts
@@ -5,6 +5,7 @@ import {
   checkRateLimit,
   getRateLimitIdentifier,
   rateLimits,
+  retryAfterSeconds,
 } from "@/lib/rate-limit";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import type { Rarity } from "@/types/database";
@@ -276,8 +277,7 @@ export async function GET(
       return NextResponse.json<ApiRateLimitResponse>(
         {
           error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-          retryAfter:
-            (rateLimitResult.reset || 0) - Math.floor(Date.now() / 1000),
+          retryAfter: retryAfterSeconds(rateLimitResult.reset),
         },
         {
           status: 429,

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getSession, canUseStreamerFeatures } from '@/lib/session';
 import { handleApiError, handleBlobError } from '@/lib/error-handler';
 import { validateUpload, getUploadErrorMessage } from '@/lib/upload-validation';
-import { checkRateLimit, rateLimits, getRateLimitIdentifier } from '@/lib/rate-limit';
+import { checkRateLimit, rateLimits, getRateLimitIdentifier, retryAfterSeconds } from '@/lib/rate-limit';
 import { ERROR_MESSAGES, UPLOAD_CONFIG, STORAGE_LIMIT_MESSAGES } from '@/lib/constants';
 import { getFileTypeFromBuffer, getFileExtension, isValidExtension } from '@/lib/file-utils';
 import { logger } from '@/lib/logger.server';
@@ -31,7 +31,7 @@ async function validateRequest(request: NextRequest): Promise<ValidateRequestRes
       error: NextResponse.json(
         {
           error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-          retryAfter: rateLimitResult.reset,
+          retryAfter: retryAfterSeconds(rateLimitResult.reset),
         },
         {
           status: 429,

--- a/src/app/api/upload/sound/route.ts
+++ b/src/app/api/upload/sound/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSession, canUseStreamerFeatures } from '@/lib/session';
 import { handleApiError, handleBlobError } from '@/lib/error-handler';
-import { checkRateLimit, rateLimits, getRateLimitIdentifier } from '@/lib/rate-limit';
+import { checkRateLimit, rateLimits, getRateLimitIdentifier, retryAfterSeconds } from '@/lib/rate-limit';
 import { ERROR_MESSAGES, SOUND_UPLOAD_CONFIG } from '@/lib/constants';
 import { getSoundFileTypeFromBuffer, getFileExtension, isValidSoundExtension } from '@/lib/file-utils';
 import { logger } from '@/lib/logger.server';
@@ -31,7 +31,7 @@ async function validateRequest(request: NextRequest): Promise<ValidateRequestRes
       error: NextResponse.json(
         {
           error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED,
-          retryAfter: rateLimitResult.reset,
+          retryAfter: retryAfterSeconds(rateLimitResult.reset),
         },
         {
           status: 429,

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -432,3 +432,23 @@ export async function getRateLimitIdentifier(
   const ip = getClientIp(request);
   return `ip:${ip}`;
 }
+
+/**
+ * Convert a rate-limit reset time (epoch ms) into a client-facing retry-after value in seconds.
+ * レート制限のリセット時刻（epochミリ秒）を、クライアント向けの「待機すべき秒数」へ変換する。
+ *
+ * RateLimitResult.reset は `Date.now() + windowMs` の epoch ミリ秒であるため、
+ * 秒単位に変換するには現在時刻（ミリ秒）との差を取ってから 1000 で割る必要がある。
+ * 過去に `Math.floor(Date.now() / 1000)` を直接引く誤った実装があり、
+ * 約 1.7e12 秒（≒5万年）という無意味な値を返していた（issue #786）。
+ *
+ * @param reset - リセット予定時刻（epoch ミリ秒）。省略時のみ fallbackMs 後の時刻とみなす
+ *               （`??` のため明示的な 0 はフォールバックせず 0 秒＝即時再試行許可を意味する）
+ * @param fallbackMs - reset 未指定時のフォールバック待機時間（ミリ秒）
+ * @returns 待機すべき秒数（0 以上にクランプした整数）
+ */
+export function retryAfterSeconds(reset?: number, fallbackMs = 60000): number {
+  const resetTime = reset ?? Date.now() + fallbackMs;
+  // 429 返却時点で reset が過去になっているケース（KV に残った古いカウンタ等）でも負値を返さないようクランプする
+  return Math.max(0, Math.ceil((resetTime - Date.now()) / 1000));
+}

--- a/tests/unit/api/gacha-demo-route.test.ts
+++ b/tests/unit/api/gacha-demo-route.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/lib/rate-limit', () => ({
   checkRateLimit: vi.fn(),
   getRateLimitIdentifier: vi.fn(),
   rateLimits: { gachaDemoBroadcast: {}, gachaDemoCard: {} },
+  retryAfterSeconds: vi.fn(),
 }))
 
 const mockGetSession = vi.mocked(getSession)

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { retryAfterSeconds } from "@/lib/rate-limit";
+
+describe("retryAfterSeconds", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reset(epochミリ秒)と現在時刻の差分を秒(整数)に変換する", () => {
+    const reset = Date.now() + 60_000;
+    expect(retryAfterSeconds(reset)).toBe(60);
+  });
+
+  it("端数は切り上げる(59.2秒残 → 60秒)", () => {
+    const reset = Date.now() + 59_200;
+    expect(retryAfterSeconds(reset)).toBe(60);
+  });
+
+  it("1秒未満の正の残り時間は1秒に切り上げる", () => {
+    const reset = Date.now() + 500;
+    expect(retryAfterSeconds(reset)).toBe(1);
+  });
+
+  it("resetが現在時刻と同値の場合は0を返す", () => {
+    expect(retryAfterSeconds(Date.now())).toBe(0);
+  });
+
+  it("大きな残り時間も秒単位の整数に正しく変換する", () => {
+    const reset = Date.now() + 3_600_000;
+    expect(retryAfterSeconds(reset)).toBe(3600);
+  });
+
+  it("reset未指定時はフォールバック値(fallbackMs、デフォルト60000)を使う", () => {
+    expect(retryAfterSeconds()).toBe(60);
+    expect(retryAfterSeconds(undefined, 3_600_000)).toBe(3600);
+  });
+
+  it("resetが過去の場合は0にクランプする", () => {
+    expect(retryAfterSeconds(Date.now() - 5_000)).toBe(0);
+  });
+});

--- a/tests/unit/upload.test.ts
+++ b/tests/unit/upload.test.ts
@@ -11,7 +11,13 @@ import { uploadToR2WithRetry } from '@/lib/r2-client'
 // Mock dependencies
 vi.mock('next/headers')
 vi.mock('@/lib/session')
-vi.mock('@/lib/rate-limit')
+vi.mock('@/lib/rate-limit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/rate-limit')>()
+  return {
+    ...actual,
+    checkRateLimit: vi.fn(),
+  }
+})
 vi.mock('@/lib/csrf')
 // Mock R2 client for upload functionality
 // R2クライアントをモックしてアップロード機能をテスト
@@ -84,7 +90,11 @@ describe('POST /api/upload', () => {
       expect(response.status).toBe(429)
       const body = await response.json()
       expect(body.error).toBe('Too many requests. Please try again later.')
+      // retryAfter は秒単位の小さな正の整数であること（epochミリ秒のまま返す過去のバグ #786 の回帰防止）
       expect(body.retryAfter).toBeDefined()
+      expect(Number.isInteger(body.retryAfter)).toBe(true)
+      expect(body.retryAfter).toBeGreaterThan(0)
+      expect(body.retryAfter).toBeLessThanOrEqual(60)
     })
   })
 


### PR DESCRIPTION
## 対応issue
Closes #786（レート制限のretryAfter計算がepoch秒/ミリ秒の取り違えで無意味な値になる）

## 背景
`RateLimitResult.reset` は `Date.now() + windowMs` の **epochミリ秒**だが、各routeの `retryAfter` 計算は以下の誤りがあった:
- パターンA(13箇所): `(reset || 0) - Math.floor(Date.now() / 1000)` … ミリ秒から秒を引き、約1.7e12秒(≒5万年)になる
- パターンB(2箇所): `retryAfter: rateLimitResult.reset` … ミリ秒をそのまま返す

## 変更内容
- `src/lib/rate-limit.ts` に `retryAfterSeconds(reset?, fallbackMs?)` を追加(epochミリ秒→秒変換、`Math.ceil`で切り上げ、`Math.max(0, ...)`でクランプ、`??`でreset未指定時のみフォールバック)
- 壊れた15箇所を `retryAfterSeconds(rateLimitResult.reset)` に統一置換(11ファイル)
- 既存の正しい Retry-After ヘッダー実装(support系9箇所)には触れない(スコープ外)

## テスト
- 新規 `tests/unit/rate-limit.test.ts`: 単位変換・切り上げ・1秒未満・0クランプ・大値・フォールバック(計7件)
- `tests/unit/upload.test.ts`: 429時に `retryAfter` が秒単位の正の整数(0<retryAfter<=60)であることを検証するよう強化(モックをimportOriginalベースに変更)
- `tests/unit/api/gacha-demo-route.test.ts`: ファクトリモックに `retryAfterSeconds: vi.fn()` を追加
- 全体: 3597 passed / typecheck / eslint クリーン

## 備考
- クライアント側(`src/types/api.ts`)の型はそのまま。UIでの `retryAfter` 実利用は現状なし
- 大規模な共通ヘルパ化(429生成40セットの一括置換)はYAGNIの観点から見送り。`X-RateLimit-Reset` ヘッダーのミリ秒そのまま送出は同種の指摘のため issue #786 に追記する
- 自己レビュー: サブエージェントによる厳格レビューを実施し、指摘4件(モック実装複製・エッジケース不足・`reset:0`セマンティクス・テストファイル名)を解消済み