### PR TITLE
fix(db-migrate): 非加法的migrationを明示フラグ無しではブロックするガード（#800）

### DIFF
--- a/.github/workflows/planetscale-migrate.yml
+++ b/.github/workflows/planetscale-migrate.yml
@@ -63,12 +63,12 @@
 # 新アプリコードが未適用スキーマを読む、または旧アプリコードが削除済みカラムを
 # 読むといった本番障害に直結しうる（industry-standardなexpand/contractパターンで
 # いう「contract」フェーズを無条件に自動化してしまうことに相当）。
-# `scripts/db-migrate.js`にはmigrationの加法性を判定する仕組みが無いため、
-# 非加法的な変更を含むmigrationについては、このworkflowでの自動適用に任せず、
+# `scripts/db-migrate.js`はmigrationの加法性を判定し、未適用migrationに非加法的な文
+# （DROP COLUMN / RENAME / ALTER COLUMN TYPE / DROP TABLE等 / TRUNCATE）が含まれる場合、
+# `--allow-non-additive` 無しでは apply/plan をブロックする（issue #800 で実装済み）。
+# 非加法的な変更を含むmigrationは、このworkflowでの自動適用に任せず、
 # デプロイ順序を人間が管理した上で手動適用すること（例: 新コードのデプロイ完了を
-# 確認してから該当migrationを個別に`apply`する）。この制約を機械的に強制する
-# （非加法的DDLを検知したら明示フラグ無しではブロックする）フォローアップは
-# issue #800 で追跡している。
+# 確認してから該当migrationを個別に`apply`する）。
 #
 # Prerequisites / 前提条件:
 # - GitHub Environment "production" / "preview" の双方に

--- a/scripts/db-migrate.js
+++ b/scripts/db-migrate.js
@@ -23,6 +23,10 @@
  *   - history table が存在しない（＝一度もapply/bootstrapされていない）DBに対して
  *     `--bootstrap` 無しで大量のmigrationをapplyしようとした場合、誤操作防止のため
  *     `--confirm-fresh-apply` を要求する（Fableレビュー Medium-1）
+ *   - 未適用migrationに非加法的な文（DROP COLUMN / RENAME / ALTER COLUMN TYPE /
+ *     DROP TABLE等 / TRUNCATE）が含まれる場合、apply/plan をブロックする。
+ *     自動適用は additive な変更のみ許可する運用（planetscale-migrate.yml）のためで、
+ *     `--allow-non-additive` で明示的に解除する（Issue #800）
  *
  * 使い方:
  *   DATABASE_URL="postgres://..." node scripts/db-migrate.js status
@@ -116,6 +120,14 @@ const HELP_TEXT = `
             実行されていない）DBに対し、--bootstrap を付けずに一定件数以上のmigrationを
             通常applyしようとした場合の確認フラグ。本番DBのような「実際には適用済みのはず」の
             DBへ --bootstrap を付け忘れて誤って全SQLを実行してしまう事故を防ぐためのガード。
+  --allow-non-additive
+            apply/plan コマンド専用（Issue #800）。未適用migrationに非加法的な文
+            （DROP COLUMN / RENAME COLUMN / ALTER COLUMN ... TYPE / DROP TABLE等 / TRUNCATE）が
+            含まれる場合、自動適用は additive な変更のみ許可する運用のため通常はブロックされるが、
+            このフラグでブロックを明示的に解除して続行する。contract フェーズ（列削除・型変更等）は
+            デプロイ順序を人間が管理して手動適用すること。DROP INDEX / DROP CONSTRAINT /
+            DROP POLICY / DROP TRIGGER は対象外（意図的に許可）。bootstrap はSQLを実行せず
+            履歴登録のみのためガード対象外（--allow-non-additive は不要・no-op）。
   --help, -h
             このヘルプを表示する
 
@@ -133,12 +145,12 @@ const HELP_TEXT = `
 // parseArgs が認識する真偽値フラグ（値を取らないもの）。
 // これに含まれず `--` で始まる引数は「未知のフラグ」として unknownArgs に積まれる
 // （Issue #692 Fableレビュー High-2: 未知フラグ・typoを黙って無視しない）。
-const KNOWN_BOOLEAN_FLAGS = ['--help', '-h', '--bootstrap', '--confirm-fresh-apply']
+const KNOWN_BOOLEAN_FLAGS = ['--help', '-h', '--bootstrap', '--confirm-fresh-apply', '--allow-non-additive']
 
 // 未知フラグに対する簡易な「もしかして」候補（--help との組み合わせは対象外）。
 // 厳密な曖昧一致ライブラリは導入せず、Levenshtein距離が近いものだけを提案する簡易実装
 // （YAGNI: このCLIのフラグ数は少なく、厳密なfuzzy matchingを導入する価値が薄いため）。
-const SUGGESTABLE_FLAGS = ['--help', '--bootstrap', '--confirm-fresh-apply']
+const SUGGESTABLE_FLAGS = ['--help', '--bootstrap', '--confirm-fresh-apply', '--allow-non-additive']
 
 /** 2文字列間の編集距離（Levenshtein距離）を計算する純粋関数 */
 function levenshteinDistance(a, b) {
@@ -191,6 +203,7 @@ function parseArgs(argv) {
   const help = args.includes('--help') || args.includes('-h')
   const bootstrap = args.includes('--bootstrap')
   const confirmFreshApply = args.includes('--confirm-fresh-apply')
+  const allowNonAdditive = args.includes('--allow-non-additive')
 
   let command
   let providerFlag
@@ -214,7 +227,7 @@ function parseArgs(argv) {
   }
 
   const provider = providerFlag ? providerFlag.slice('--provider='.length) : undefined
-  return { help, command, bootstrap, confirmFreshApply, provider, unknownArgs }
+  return { help, command, bootstrap, confirmFreshApply, allowNonAdditive, provider, unknownArgs }
 }
 
 const VALID_COMMANDS = ['status', 'plan', 'apply', 'verify']
@@ -225,7 +238,7 @@ const VALID_COMMANDS = ['status', 'plan', 'apply', 'verify']
  * （help / error / 正常系の3値を返す）。
  */
 function resolveConfig(argv, env) {
-  const { help, command, bootstrap, confirmFreshApply, provider, unknownArgs } = parseArgs(argv)
+  const { help, command, bootstrap, confirmFreshApply, allowNonAdditive, provider, unknownArgs } = parseArgs(argv)
   if (help) return { help: true }
 
   if (unknownArgs.length > 0) {
@@ -248,6 +261,10 @@ function resolveConfig(argv, env) {
 
   if (confirmFreshApply && command !== 'apply') {
     return { error: '--confirm-fresh-apply は apply コマンドでのみ使用できます。' }
+  }
+
+  if (allowNonAdditive && command !== 'apply' && command !== 'plan') {
+    return { error: '--allow-non-additive は apply/plan コマンドでのみ使用できます。' }
   }
 
   // 「--provider=」（フラグは指定されているが値が空文字列）を、フラグ自体の省略と同じ
@@ -276,7 +293,7 @@ function resolveConfig(argv, env) {
     }
   }
 
-  return { command, bootstrap, confirmFreshApply, provider: resolvedProvider, databaseUrl }
+  return { command, bootstrap, confirmFreshApply, allowNonAdditive, provider: resolvedProvider, databaseUrl }
 }
 
 /**
@@ -414,6 +431,72 @@ function printBlockingErrors(state) {
   }
 }
 
+/**
+ * 未適用migrationに非加法的(non-additive)な文が含まれるかを検査する / Issue #800。
+ *
+ * CI（planetscale-migrate.yml）は main push 毎に apply を自動実行するため、
+ * DROP COLUMN 等の非加法的変更が含まれるmigrationが誤って混入すると本番障害に直結する。
+ * apply/plan の実行前に pending 全ファイルをスキャンし、検出時はブロックする
+ * （--allow-non-additive 指定時のみ続行。contractフェーズの手動適用は人間が順序管理する）。
+ * 適用済み(non-pending)ファイルは既に本番反映済みのためスキャン対象外。
+ * 部分適用を防ぐため、1件でも検出したら全体をブロックする（先行のadditive分だけ適用して
+ * 途中で止まる、を許さない）。
+ *
+ * @param {{ pending: { sourceDir: string, filename: string, version: string, name: string }[] }} state
+ * @returns {{ version: string, name: string, findings: { kind: string, line: number }[] }[]}
+ *   非加法的な文を含む pending migration の一覧（無ければ空配列）
+ */
+function findNonAdditivePending(state) {
+  const violations = []
+  for (const d of state.pending) {
+    const content = core.readMigrationFile(d.sourceDir, d.filename)
+    const findings = core.detectNonAdditiveStatements(content)
+    if (findings.length > 0) {
+      violations.push({ version: d.version, name: d.name, findings })
+    }
+  }
+  return violations
+}
+
+function printNonAdditiveBlock(violations) {
+  console.error('[db-migrate] 非加法的(non-additive)なmigrationが検出されました:')
+  for (const v of violations) {
+    for (const f of v.findings) {
+      console.error(`  - ${v.version} ${v.name}: ${f.kind} (行 ${f.line})`)
+    }
+  }
+  console.error('[db-migrate] このパイプラインでの自動適用は additive な変更のみ許可されています。')
+  console.error('[db-migrate] --allow-non-additive を付けない限り apply/plan は実行しません。')
+  console.error('[db-migrate] 列削除・型変更等の contract フェーズは、デプロイ順序を人間が管理して手動適用してください。')
+}
+
+function printNonAdditiveWarning(violations) {
+  console.error('[db-migrate] 警告: --allow-non-additive が指定されているため、非加法的migrationを続行します:')
+  for (const v of violations) {
+    for (const f of v.findings) {
+      console.error(`  - ${v.version} ${v.name}: ${f.kind} (行 ${f.line})`)
+    }
+  }
+}
+
+/**
+ * 非加法的migrationガード。1件でも検出されたらブロックする（exit 1）。
+ * --allow-non-additive 指定時は警告ログのみで続行する。
+ * @param {{ pending: object[] }} state
+ * @param {boolean} allowNonAdditive
+ * @returns {boolean} true ならブロック（呼び出し側は処理を中止して exit 1 を返すこと）
+ */
+function shouldBlockNonAdditive(state, allowNonAdditive) {
+  const violations = findNonAdditivePending(state)
+  if (violations.length === 0) return false
+  if (allowNonAdditive) {
+    printNonAdditiveWarning(violations)
+    return false
+  }
+  printNonAdditiveBlock(violations)
+  return true
+}
+
 async function cmdStatus(sql, migrationsDirs, provider) {
   const state = await computeState(sql, migrationsDirs, provider)
   if (hasBlockingErrors(state)) {
@@ -442,10 +525,16 @@ async function cmdStatus(sql, migrationsDirs, provider) {
   return 0
 }
 
-async function cmdPlan(sql, migrationsDirs, provider) {
+async function cmdPlan(sql, migrationsDirs, provider, { allowNonAdditive }) {
   const state = await computeState(sql, migrationsDirs, provider)
   if (hasBlockingErrors(state)) {
     printBlockingErrors(state)
+    return 1
+  }
+
+  // Issue #800: 非加法的migrationの機械的ブロック（dry-runとはいえ、applyが拒否する内容を
+  // 「適用します」と表示するのは誤誘導になるため、planでも同一ガードを掛ける）。
+  if (shouldBlockNonAdditive(state, allowNonAdditive)) {
     return 1
   }
 
@@ -487,7 +576,7 @@ function printApplySummary(results, warnings) {
  * apply コマンド本体。advisory lock を取得したセッション内で、
  * history テーブルの存在確認・整合性チェック・実際の適用（またはbootstrap登録）を行う。
  */
-async function cmdApply(sql, migrationsDirs, provider, { bootstrap, confirmFreshApply, appliedBy, warningSink }) {
+async function cmdApply(sql, migrationsDirs, provider, { bootstrap, confirmFreshApply, allowNonAdditive, appliedBy, warningSink }) {
   // 同時実行防止: 固定キーの advisory lock を取得する。既に別プロセスが保持している場合は
   // ここでブロックし、解放され次第このプロセスが取得する（Issue #692: 「待機またはエラー」の
   // うち「待機」を採用。取得後は他方が適用済みの内容を読むだけなので自然にno-opになる）。
@@ -512,6 +601,13 @@ async function cmdApply(sql, migrationsDirs, provider, { bootstrap, confirmFresh
     const state = await computeState(sql, migrationsDirs, provider)
     if (hasBlockingErrors(state)) {
       printBlockingErrors(state)
+      return 1
+    }
+
+    // Issue #800: 非加法的migrationの機械的ブロック。ここは schema/table 作成の「前」なので、
+    // ブロック時に副作用は一切残らない（shouldBlockFreshApply と同じ「1回しか効かない」問題が
+    // 構造的に起きない）。bootstrap はSQLを実行せず履歴登録のみのためガード対象外。
+    if (!bootstrap && shouldBlockNonAdditive(state, allowNonAdditive)) {
       return 1
     }
 
@@ -726,7 +822,7 @@ async function main() {
     return
   }
 
-  const { command, bootstrap, confirmFreshApply, provider, databaseUrl } = resolved
+  const { command, bootstrap, confirmFreshApply, allowNonAdditive, provider, databaseUrl } = resolved
   const warningSink = { current: null, list: [] }
   const sql = createSqlClient(databaseUrl, warningSink)
   const migrationsDirs = resolveMigrationsDirs(provider)
@@ -741,13 +837,14 @@ async function main() {
     if (command === 'status') {
       exitCode = await cmdStatus(sql, migrationsDirs, provider)
     } else if (command === 'plan') {
-      exitCode = await cmdPlan(sql, migrationsDirs, provider)
+      exitCode = await cmdPlan(sql, migrationsDirs, provider, { allowNonAdditive })
     } else if (command === 'verify') {
       exitCode = await cmdVerify(sql, migrationsDirs, provider)
     } else if (command === 'apply') {
       exitCode = await cmdApply(sql, migrationsDirs, provider, {
         bootstrap,
         confirmFreshApply,
+        allowNonAdditive,
         appliedBy: resolveAppliedBy(process.env),
         warningSink,
       })
@@ -778,6 +875,7 @@ module.exports = {
   resolveAppliedBy,
   hasBlockingErrors,
   shouldBlockFreshApply,
+  shouldBlockNonAdditive,
   FRESH_APPLY_PENDING_THRESHOLD,
   resolveMigrationsDirs,
   SUPABASE_MIGRATIONS_DIR,

--- a/scripts/lib/db-migrate-core.js
+++ b/scripts/lib/db-migrate-core.js
@@ -227,6 +227,91 @@ function containsSetLocal(content) {
 }
 
 /**
+ * 非加法的(non-additive)なmigration文を検知する純粋関数 / Issue #800。
+ *
+ * 背景:
+ * `.github/workflows/planetscale-migrate.yml` が main push 毎に `apply --provider=planetscale`
+ * を自動実行し本番DBへmigrationを適用する。アプリ側の deploy-window fallback は
+ * 加法的（additive）な変更（列追加等）にしか成り立たないため、DROP COLUMN や RENAME 等の
+ * 非加法的変更が混入したmigrationが誤って本番へ自動適用されると、
+ * 新旧アプリコードとスキーマの不一致による本番障害に直結する。
+ * 本関数はその事故を「apply 実行前に」機械的にブロックするための検知を行う
+ * （shouldBlockFreshApply と同じ「事故は起きる前提でコードが守る」設計思想）。
+ *
+ * 検知の考え方:
+ * - 単語だけ（`\bdrop\b` 等）で検知すると、実ファイルに多数存在する列名 `drop_rate`・
+ *   関数名 `rename_card_pack` 等を誤検知するため、「文の形」（`DROP COLUMN` 等）で検知する。
+ * - `DROP INDEX` / `DROP CONSTRAINT` / `DROP POLICY` / `DROP TRIGGER` は
+ *   アプリが読む列・表・関数の契約（クエリ結果面）を変えず、実ファイルにも既に存在する
+ *   ため、意図的にブロック対象外とする。
+ * - 完全なSQLパーサは過剰実装（YAGNI）。正規表現ベースの簡易検知で、未知構文バリアントの
+ *   見逃しは許容し、最終防御はレビュー運用に委ねる。代表的な見逃し例:
+ *   PostgreSQL の `COLUMN` キーワード省略形（`ALTER TABLE t DROP c;` /
+ *   `ALTER TABLE t RENAME a TO b;` / `ALTER id TYPE ...`）は検知しない（誤検知を
+ *   増やさず、安全側に倒さない判断。省略形が混入する場合はレビューで気づく前提）。
+ * - 行コメント・ブロックコメントは事前に除去する（ヘッダー記述やコメント内言及による
+ *   誤検知を防ぐ。extractCreatedIndexNames と同じ前処理。文字列リテラル内や
+ *   DO ブロック内のキーワードは除去されず検知されるが、安全側に倒れるため許容する）。
+ *
+ * @param {string} content - migration ファイルの内容全体
+ * @returns {{ kind: string, line: number }[]} 検出された文の種別と行番号（1始まり）の配列。無ければ空配列
+ */
+const NON_ADDITIVE_PATTERNS = [
+  // 列削除。IF EXISTS が付いていても旧コードが列を読む契約を破壊するためブロックする
+  { kind: 'DROP COLUMN', re: /\bdrop\s+column\b/gi },
+  // 列・表のリネーム。クエリが書く列名・表名の契約を破壊する
+  { kind: 'RENAME COLUMN/TABLE', re: /\brename\s+(column|table|to)\b/gi },
+  // 型変更（ALTER COLUMN ... TYPE / SET DATA TYPE）。読み書きの型契約を変更する。
+  // 識別子は「スペースを含むクォート付き（"my col"）」または「空白・カンマ・セミコロンを
+  // 含まない通常トークン」のどちらでも受ける
+  {
+    kind: 'ALTER COLUMN TYPE',
+    re: /\balter\s+column\s+(?:"[^"]*"|[^\s,;]+)\s+(type|set\s+data\s+type)\b/gi,
+  },
+  // オブジェクト削除。実行時参照が死ぬ。DROP INDEX/CONSTRAINT/POLICY/TRIGGER は対象外
+  // （アプリが読む契約面を変えないため、意図的に許可する）
+  {
+    kind: 'DROP TABLE/VIEW/FUNCTION',
+    re: /\bdrop\s+(table|view|materialized\s+view|function|procedure|schema|sequence|type|domain|extension)\b/gi,
+  },
+  // データ破壊（TRUNCATE ... RESTART IDENTITY CASCADE を含む）。
+  // TRUNCATE は PostgreSQL の unreserved keyword のため識別子（`CREATE TABLE truncate` 等）
+  // にもマッチしうる。対象名の形まで含めることで、識別子としての使用は誤検知しない
+  { kind: 'TRUNCATE', re: /\btruncate\s+(?:table\s+)?(?:[a-z_][a-z0-9_$]*|"[^"]*")/gi },
+]
+
+function detectNonAdditiveStatements(content) {
+  // ブロックコメント除去 → 行コメント除去。ブロックコメント内の改行は行番号を維持する
+  // ため残す（extractCreatedIndexNames の前処理は改行を消すため、行番号を報告する
+  // 本関数ではブロックコメントの文字だけを除去する実装にしている）。
+  const code = content
+    .replace(/\/\*[\s\S]*?\*\//g, (match) => match.replace(/[^\n]/g, ''))
+    .split('\n')
+    .map((line) => line.replace(/--.*$/g, ''))
+    .join('\n')
+  const findings = []
+  for (const p of NON_ADDITIVE_PATTERNS) {
+    for (const match of code.matchAll(p.re)) {
+      // マッチ位置から行番号を算出（1始まり）。ファイルは小さいため先頭から数えてもコストは無視できる
+      const line = code.slice(0, match.index).split('\n').length
+      findings.push({ kind: p.kind, line })
+    }
+  }
+  // ファイル内の出現順（行番号順）で並べ替え、同一行での重複報告は先頭の1件にまとめる
+  // （同一行に DROP COLUMN と TRUNCATE が並ぶことは実運用でほぼ無く、行番号と種別が
+  // 分かれば人間が現物を見て判断できるため、全件列挙はしない）。
+  findings.sort((a, b) => a.line - b.line)
+  const deduped = []
+  let previousLine = -1
+  for (const f of findings) {
+    if (f.line === previousLine) continue
+    deduped.push(f)
+    previousLine = f.line
+  }
+  return deduped
+}
+
+/**
  * forbidden migration に含まれる CREATE INDEX の名前を取り出す純粋関数。
  *
  * CREATE INDEX CONCURRENTLY は失敗時に「無効なindexが残る」ことがある。
@@ -1107,6 +1192,7 @@ module.exports = {
   computeChecksum,
   countEffectiveStatements,
   containsSetLocal,
+  detectNonAdditiveStatements,
   extractCreatedIndexNames,
   extractCreatedIndexDefinitions,
   normalizeIndexDefinition,

--- a/tests/unit/db-migrate-cli.test.ts
+++ b/tests/unit/db-migrate-cli.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import {
   parseArgs,
   resolveConfig,
   resolveAppliedBy,
   hasBlockingErrors,
   shouldBlockFreshApply,
+  shouldBlockNonAdditive,
   FRESH_APPLY_PENDING_THRESHOLD,
   resolveMigrationsDirs,
   SUPABASE_MIGRATIONS_DIR,
@@ -24,6 +28,7 @@ describe('parseArgs', () => {
       command: undefined,
       bootstrap: false,
       confirmFreshApply: false,
+      allowNonAdditive: false,
       provider: undefined,
       unknownArgs: [],
     })
@@ -34,9 +39,12 @@ describe('parseArgs', () => {
     expect(parseArgs(['node', 'db-migrate.js', 'apply']).command).toBe('apply')
   })
 
-  it('--bootstrap / --confirm-fresh-apply / --help / -h を検出する', () => {
+  it('--bootstrap / --confirm-fresh-apply / --allow-non-additive / --help / -h を検出する', () => {
     expect(parseArgs(['node', 'db-migrate.js', 'apply', '--bootstrap']).bootstrap).toBe(true)
     expect(parseArgs(['node', 'db-migrate.js', 'apply', '--confirm-fresh-apply']).confirmFreshApply).toBe(
+      true
+    )
+    expect(parseArgs(['node', 'db-migrate.js', 'apply', '--allow-non-additive']).allowNonAdditive).toBe(
       true
     )
     expect(parseArgs(['node', 'db-migrate.js', '--help']).help).toBe(true)
@@ -174,14 +182,43 @@ describe('resolveConfig', () => {
       databaseUrl: string
       bootstrap: boolean
       confirmFreshApply: boolean
+      allowNonAdditive: boolean
     }
     expect(result).toEqual({
       command: 'plan',
       bootstrap: false,
       confirmFreshApply: false,
+      allowNonAdditive: false,
       provider: 'postgres',
       databaseUrl: env.DATABASE_URL,
     })
+  })
+
+  it('--allow-non-additive は apply/plan でのみ許可され、status/verify ではエラー', () => {
+    const plan = resolveConfig(['node', 'db-migrate.js', 'plan', '--allow-non-additive'], env) as {
+      allowNonAdditive: boolean
+    }
+    expect(plan.allowNonAdditive).toBe(true)
+    const apply = resolveConfig(['node', 'db-migrate.js', 'apply', '--allow-non-additive'], env) as {
+      allowNonAdditive: boolean
+    }
+    expect(apply.allowNonAdditive).toBe(true)
+    const status = resolveConfig(['node', 'db-migrate.js', 'status', '--allow-non-additive'], env) as {
+      error: string
+    }
+    expect(status.error).toContain('--allow-non-additive')
+    const verify = resolveConfig(['node', 'db-migrate.js', 'verify', '--allow-non-additive'], env) as {
+      error: string
+    }
+    expect(verify.error).toContain('--allow-non-additive')
+  })
+
+  it('--allow-non-additive の typo は unknownArgs でエラーになる', () => {
+    const result = resolveConfig(
+      ['node', 'db-migrate.js', 'apply', '--allow-nonadditive'],
+      env
+    ) as { error: string }
+    expect(result.error).toContain('不明な引数')
   })
 })
 
@@ -299,5 +336,58 @@ describe('resolveMigrationsDirs', () => {
 
   it('provider=postgres でも supabase/migrations/ のみを返す', () => {
     expect(resolveMigrationsDirs('postgres')).toEqual([SUPABASE_MIGRATIONS_DIR])
+  })
+})
+
+/**
+ * Issue #800: 非加法的migrationの機械的ブロックガード。
+ * shouldBlockNonAdditive は pending の migration ファイルを実読するため、
+ * 一時ディレクトリにファイルを作って検証する（db-migrate-core.test.ts と同じ流儀）。
+ */
+describe('shouldBlockNonAdditive (Issue #800)', () => {
+  let tmpDir: string
+
+  afterEach(() => {
+    if (tmpDir) rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function makePending(files: Record<string, string>) {
+    tmpDir = mkdtempSync(join(tmpdir(), 'db-migrate-nonadd-'))
+    const pending = []
+    for (const [filename, content] of Object.entries(files)) {
+      writeFileSync(join(tmpDir, filename), content)
+      pending.push({ version: filename.split('_')[0], name: filename, sourceDir: tmpDir, filename })
+    }
+    return { pending }
+  }
+
+  it('非加法的な文を含む pending migration がある場合はブロックする (true)', () => {
+    const state = makePending({
+      '20260901000000_add_column.sql': 'ALTER TABLE users ADD COLUMN IF NOT EXISTS new_col text;',
+      '20260901000001_drop_column.sql': 'ALTER TABLE users DROP COLUMN old_col;',
+    })
+    expect(shouldBlockNonAdditive(state, false)).toBe(true)
+  })
+
+  it('--allow-non-additive 指定時はブロックせず続行する (false)', () => {
+    const state = makePending({
+      '20260901000000_drop_column.sql': 'ALTER TABLE users DROP COLUMN old_col;',
+    })
+    expect(shouldBlockNonAdditive(state, true)).toBe(false)
+  })
+
+  it('非加法的な文が無い pending のみの場合はブロックしない (false)', () => {
+    const state = makePending({
+      '20260901000000_add_column.sql': 'ALTER TABLE users ADD COLUMN IF NOT EXISTS new_col text;',
+    })
+    expect(shouldBlockNonAdditive(state, false)).toBe(false)
+  })
+
+  it('DROP INDEX / DROP CONSTRAINT はブロック対象外（ブロックしない）', () => {
+    const state = makePending({
+      '20260901000000_drop_index.sql': 'DROP INDEX IF EXISTS users_created_idx;',
+      '20260901000001_drop_constraint.sql': 'ALTER TABLE users DROP CONSTRAINT IF EXISTS users_pkey;',
+    })
+    expect(shouldBlockNonAdditive(state, false)).toBe(false)
   })
 })

--- a/tests/unit/db-migrate-core.test.ts
+++ b/tests/unit/db-migrate-core.test.ts
@@ -8,6 +8,7 @@ import {
   computeChecksum,
   countEffectiveStatements,
   containsSetLocal,
+  detectNonAdditiveStatements,
   extractCreatedIndexNames,
   extractCreatedIndexDefinitions,
   validateIndexDefinitions,
@@ -172,6 +173,148 @@ describe('containsSetLocal', () => {
 
   it('SET LOCAL を含まないコードは false', () => {
     expect(containsSetLocal('SET statement_timeout = 0;\nSELECT 1;')).toBe(false)
+  })
+})
+
+describe('detectNonAdditiveStatements (Issue #800)', () => {
+  it('DROP COLUMN を検出する（IF EXISTS・大文字小文字・ダブルクォート識別子を含む）', () => {
+    expect(detectNonAdditiveStatements('ALTER TABLE users DROP COLUMN IF EXISTS old_col;')).toEqual([
+      { kind: 'DROP COLUMN', line: 1 },
+    ])
+    expect(detectNonAdditiveStatements('alter table users drop column "old_col";')).toEqual([
+      { kind: 'DROP COLUMN', line: 1 },
+    ])
+  })
+
+  it('RENAME COLUMN / RENAME TO を検出する', () => {
+    expect(detectNonAdditiveStatements('ALTER TABLE users RENAME COLUMN a TO b;')).toEqual([
+      { kind: 'RENAME COLUMN/TABLE', line: 1 },
+    ])
+    expect(detectNonAdditiveStatements('ALTER TABLE users RENAME TO users_archive;')).toEqual([
+      { kind: 'RENAME COLUMN/TABLE', line: 1 },
+    ])
+  })
+
+  it('ALTER COLUMN ... TYPE / SET DATA TYPE を検出する', () => {
+    expect(detectNonAdditiveStatements('ALTER TABLE users ALTER COLUMN id TYPE bigint;')).toEqual([
+      { kind: 'ALTER COLUMN TYPE', line: 1 },
+    ])
+    expect(detectNonAdditiveStatements('ALTER TABLE users ALTER COLUMN id SET DATA TYPE text;')).toEqual([
+      { kind: 'ALTER COLUMN TYPE', line: 1 },
+    ])
+  })
+
+  it('改行を跨ぐ ALTER TABLE の複数行形式でも検出する', () => {
+    const content = ['ALTER TABLE users', '  ALTER COLUMN id TYPE bigint;'].join('\n')
+    expect(detectNonAdditiveStatements(content)).toEqual([{ kind: 'ALTER COLUMN TYPE', line: 2 }])
+  })
+
+  it('スペースを含むクォート付き識別子の ALTER COLUMN TYPE も検出する', () => {
+    expect(detectNonAdditiveStatements('ALTER TABLE users ALTER COLUMN "my col" TYPE text;')).toEqual([
+      { kind: 'ALTER COLUMN TYPE', line: 1 },
+    ])
+  })
+
+  it('DROP TABLE / VIEW / FUNCTION 等のオブジェクト削除を検出する', () => {
+    expect(detectNonAdditiveStatements('DROP TABLE IF EXISTS cards;')).toEqual([
+      { kind: 'DROP TABLE/VIEW/FUNCTION', line: 1 },
+    ])
+    expect(detectNonAdditiveStatements('DROP FUNCTION IF EXISTS public.redeem();')).toEqual([
+      { kind: 'DROP TABLE/VIEW/FUNCTION', line: 1 },
+    ])
+  })
+
+  it('DROP SCHEMA / PROCEDURE / TYPE / EXTENSION / SEQUENCE / DOMAIN も検出する', () => {
+    for (const sql of [
+      'DROP SCHEMA IF EXISTS legacy CASCADE;',
+      'DROP PROCEDURE IF EXISTS public.cleanup();',
+      'DROP TYPE IF EXISTS public.my_enum;',
+      'DROP EXTENSION IF EXISTS pg_trgm;',
+      'DROP SEQUENCE IF EXISTS public.cards_id_seq;',
+      'DROP DOMAIN IF EXISTS public.my_domain;',
+    ]) {
+      expect(detectNonAdditiveStatements(sql)).toEqual([
+        { kind: 'DROP TABLE/VIEW/FUNCTION', line: 1 },
+      ])
+    }
+  })
+
+  it('COLUMN キーワード省略形（ALTER TABLE t DROP c 等）は検知対象外（挙動の固定化）', () => {
+    // PostgreSQL の省略形構文は誤検知を増やすため意図的に検知しない。
+    // 見逃しはレビュー運用でカバーする前提（コメント参照）。挙動をテストで固定する。
+    expect(detectNonAdditiveStatements('ALTER TABLE users DROP old_col;')).toEqual([])
+    expect(detectNonAdditiveStatements('ALTER TABLE users ALTER id TYPE bigint;')).toEqual([])
+  })
+
+  it('TRUNCATE を検出する（RESTART IDENTITY CASCADE を含む）', () => {
+    expect(detectNonAdditiveStatements('TRUNCATE TABLE cards RESTART IDENTITY CASCADE;')).toEqual([
+      { kind: 'TRUNCATE', line: 1 },
+    ])
+    expect(detectNonAdditiveStatements('TRUNCATE cards;')).toEqual([{ kind: 'TRUNCATE', line: 1 }])
+  })
+
+  it('TRUNCATE を識別子として使う SQL（CREATE TABLE truncate 等）は誤検知しない', () => {
+    expect(detectNonAdditiveStatements('CREATE TABLE IF NOT EXISTS truncate (id bigint);')).toEqual([])
+  })
+
+  it('行コメント・ブロックコメント内の言及は検出しない', () => {
+    const content = [
+      '-- DROP COLUMN や RENAME COLUMN は使わない方針（コメント内の言及は誤検知しないこと）',
+      '/* ALTER TABLE users DROP COLUMN old_col; */',
+      'CREATE TABLE IF NOT EXISTS users (id bigint primary key);',
+    ].join('\n')
+    expect(detectNonAdditiveStatements(content)).toEqual([])
+  })
+
+  it('複数行ブロックコメントの後でも行番号が実際の行と一致する', () => {
+    const content = [
+      '/* ブロックコメント1行目',
+      '   ブロックコメント2行目 */',
+      'ALTER TABLE users DROP COLUMN old_col;',
+    ].join('\n')
+    expect(detectNonAdditiveStatements(content)).toEqual([{ kind: 'DROP COLUMN', line: 3 }])
+  })
+
+  it('DO ブロック / 文字列リテラル内の非加法的文は検知する（安全側・挙動の固定化）', () => {
+    // 完全なSQLパーサは持たないため、動的SQL内の文は除去されず検知される。
+    // 安全側（ブロック側）に倒れる挙動をテストで固定する（仕様変更時は要検討）。
+    const content = [
+      "DO $$ BEGIN",
+      "  EXECUTE 'ALTER TABLE users DROP COLUMN old_col';",
+      "END $$;",
+    ].join('\n')
+    expect(detectNonAdditiveStatements(content)).toEqual([{ kind: 'DROP COLUMN', line: 2 }])
+  })
+
+  it('単語の一部が一致するだけの識別子（drop_rate / rename_card_pack 等）は検出しない', () => {
+    const content = [
+      'ALTER TABLE cards ADD COLUMN IF NOT EXISTS drop_rate numeric NOT NULL DEFAULT 0;',
+      'CREATE FUNCTION rename_card_pack(...) RETURNS void AS $$ ... $$ LANGUAGE plpgsql;',
+      'CREATE TABLE card_drop_rates (id bigint);',
+    ].join('\n')
+    expect(detectNonAdditiveStatements(content)).toEqual([])
+  })
+
+  it('DROP INDEX / CONSTRAINT / POLICY / TRIGGER は意図的に許可する（検出しない）', () => {
+    const content = [
+      'DROP INDEX IF EXISTS users_created_idx;',
+      'ALTER TABLE users DROP CONSTRAINT IF EXISTS users_pkey;',
+      'DROP POLICY IF EXISTS public_read ON cards;',
+      'DROP TRIGGER IF EXISTS trg_updated_at ON users;',
+    ].join('\n')
+    expect(detectNonAdditiveStatements(content)).toEqual([])
+  })
+
+  it('同一行に複数パターンがあっても1件として報告し、行番号順で並べる', () => {
+    const content = ['SELECT 1;', 'ALTER TABLE users DROP COLUMN old_col;', 'DROP TABLE IF EXISTS t;'].join('\n')
+    expect(detectNonAdditiveStatements(content)).toEqual([
+      { kind: 'DROP COLUMN', line: 2 },
+      { kind: 'DROP TABLE/VIEW/FUNCTION', line: 3 },
+    ])
+  })
+
+  it('非加法的な文が無い場合は空配列を返す', () => {
+    expect(detectNonAdditiveStatements('CREATE TABLE IF NOT EXISTS users (id bigint primary key);')).toEqual([])
   })
 })
 

--- a/tests/unit/db-migrate-non-additive-scan.test.ts
+++ b/tests/unit/db-migrate-non-additive-scan.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { readdirSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { detectNonAdditiveStatements } from '../../scripts/lib/db-migrate-core.js'
+
+/**
+ * Issue #800: リポジトリ実ファイル全体への非加法的migrationスキャン（回帰テスト）。
+ *
+ * 目的:
+ * 新規に追加されたmigrationが非加法的な文（DROP COLUMN / RENAME / ALTER COLUMN TYPE /
+ * DROP TABLE等 / TRUNCATE）を含んでいないかを、PR時点で機械的に検知する。
+ * `planetscale-migrate.yml` の自動適用は additive な変更のみ許可する運用のため、
+ * ここで検知されれば CI（apply）でも同じガードにブロックされる。
+ *
+ * 既知の適用済み例外:
+ * 下記6ファイルは本ガード導入前に本番へ適用済みの「関数シグネチャ変更」
+ * （`DROP FUNCTION IF EXISTS <旧シグネチャ>` → `CREATE OR REPLACE FUNCTION`）を含む。
+ * ガードは未適用(pending)migrationのみを対象とするため、これらはブロック対象外であり、
+ * このテストでは例外リストとして明示する。将来、意図的に非加法的なmigrationを追加する
+ * 場合は、contractフェーズとして手動適用すること（このリストに理由を添えて追加する
+ * と、レビューで意図が伝わる）。
+ */
+const KNOWN_APPLIED_NON_ADDITIVE = new Set([
+  '00033_add_reward_cost_to_gacha_history.sql',
+  '00052_add_drawers_to_gacha_drop_stats.sql',
+  '00060_card_stone_exchange_idempotency.sql',
+  '00067_add_card_issuance_limits.sql',
+  '00069_add_issued_card_counts_rpc.sql',
+  '00070_add_gacha_history_reward_id.sql',
+])
+
+const MIGRATION_DIRS = [
+  join(__dirname, '..', '..', 'supabase', 'migrations'),
+  join(__dirname, '..', '..', 'db', 'planetscale', 'migrations'),
+]
+
+describe('全migrationファイルの非加法的文スキャン (Issue #800)', () => {
+  it('既知の適用済み例外以外に非加法的な文を含むmigrationが存在しない', () => {
+    const unexpected: string[] = []
+    for (const dir of MIGRATION_DIRS) {
+      for (const filename of readdirSync(dir).filter((f) => f.endsWith('.sql'))) {
+        const content = readFileSync(join(dir, filename), 'utf8')
+        const findings = detectNonAdditiveStatements(content)
+        if (findings.length > 0 && !KNOWN_APPLIED_NON_ADDITIVE.has(filename)) {
+          unexpected.push(
+            `${filename}: ${findings.map((f) => `${f.kind}(行${f.line})`).join(', ')}`
+          )
+        }
+      }
+    }
+    expect(unexpected, unexpected.join('\n')).toEqual([])
+  })
+
+  it('既知の適用済み例外ファイルは検知対象に実際にマッチしている（リストの陳腐化防止）', () => {
+    let matched = 0
+    for (const dir of MIGRATION_DIRS) {
+      for (const filename of readdirSync(dir).filter((f) => f.endsWith('.sql'))) {
+        if (!KNOWN_APPLIED_NON_ADDITIVE.has(filename)) continue
+        const content = readFileSync(join(dir, filename), 'utf8')
+        if (detectNonAdditiveStatements(content).length > 0) matched++
+      }
+    }
+    // ファイルが削除・改名されたり、内容からDROP系が消えたりしたら例外リストが
+    // 陳腐化して「例外扱い」が無意味になるため、実マッチ件数とリスト件数を突き合わせる
+    expect(matched).toBe(KNOWN_APPLIED_NON_ADDITIVE.size)
+  })
+})


### PR DESCRIPTION
## 対応issue
Closes #800（db-migrate.js: 非加法的(non-additive) migrationを機械的にブロックするガードを追加する）

## 背景
`planetscale-migrate.yml` は main/preview への push 毎に `apply --provider=planetscale` を自動実行し本番DBへmigrationを適用する。deploy-window fallback は加法的(additive)な変更にしか成り立たないため、`DROP COLUMN`・`RENAME COLUMN`・`ALTER COLUMN ... TYPE` 等を含むmigrationが誤って混入すると本番障害に直結する。現状はworkflow冒頭コメントの運用制約のみで機械的な強制が無い。

## 変更内容
- **`scripts/lib/db-migrate-core.js`**: `detectNonAdditiveStatements(content)` を追加。行/ブロックコメント除去後に「文の形」で検知（単語だけの検知は `drop_rate`・`rename_card_pack` 等を大量誤検知するため不可と実測で確認済み）
  - ブロック対象: `DROP COLUMN` / `RENAME COLUMN|TABLE|TO` / `ALTER COLUMN ... TYPE|SET DATA TYPE`(クォート付きスペース入り識別子対応) / `DROP TABLE|VIEW|FUNCTION|PROCEDURE|SCHEMA|SEQUENCE|TYPE|DOMAIN|EXTENSION` / `TRUNCATE`(識別子としての使用は誤検知しない)
  - 意図的に許可: `DROP INDEX` / `DROP CONSTRAINT` / `DROP POLICY` / `DROP TRIGGER`(アプリが読む契約面を変えず、実ファイルに既存)
  - ブロックコメント除去時も行番号を維持する実装（報告行番号の正確性）
- **`scripts/db-migrate.js`**: `--allow-non-additive` フラグ追加。`cmdApply`(schema作成前・副作用なし)と`cmdPlan`で pending 全ファイルをスキャンし、検出時は exit 1 でブロック（フラグ指定時は警告のみ）。bootstrap はSQLを実行しないため対象外。HELP_TEXT・ファイル先頭コメント更新
- **`.github/workflows/planetscale-migrate.yml`**: 「仕組みが無い…issue #800 で追跡」のコメントを実装完了の記述に更新
- **`tests/unit/db-migrate-non-additive-scan.test.ts`**(新規): リポジトリ実ファイル全スキャンの回帰テスト。適用済み6ファイルの `DROP FUNCTION IF EXISTS`(関数シグネチャ変更の前処理、ガード導入前に本番適用済み)は `KNOWN_APPLIED_NON_ADDITIVE` 例外リストで許容し、リスト陳腐化防止検証も含む

## 検証
- 実ファイル86件スキャン: 検出は既知の適用済み例外6件のみ（誤検知ゼロを実測確認）
- 全体テスト 3615 passed / typecheck / eslint クリーン
- 自己レビュー: サブエージェントによる厳格レビューで指摘9件を対応（行番号ズレ修正・クォート識別子対応・TRUNCATE誤検知修正・DOブロック挙動のテスト固定化・重複コード共通化・workflowコメント陳腐化修正ほか）

## 備考
- 検知漏れ（`COLUMN` キーワード省略形等）は意図的な設計判断としてコメント・テストで明文化
- 本ガードは内容ベースで状態に依存しないため、#692 で起きた「2回目実行でガードが無効化」型の事故は構造的に起きない