### PR TITLE
fix(i18n): ハードコード日本語をmessagesキーへ移設し、回帰防止のlint基盤を導入（#835）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,28 @@ jobs:
       - name: Lint
         run: npm run lint
 
+  lint-i18n:
+    name: Lint i18n (Japanese literals)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ハードコード日本語リテラルの回帰防止（#835）。負債リスト
+      # （scripts/i18n-debt-files.js）に無いファイルで日本語リテラルを追加すると失敗する。
+      - name: Lint i18n
+        run: npm run lint:i18n
+
   migration-order-check:
     name: Migration order check
     if: github.event_name == 'pull_request'

--- a/eslint.i18n.config.mjs
+++ b/eslint.i18n.config.mjs
@@ -1,0 +1,97 @@
+import { defineConfig } from "eslint/config";
+import tsParser from "@typescript-eslint/parser";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+import reactHooks from "eslint-plugin-react-hooks";
+import nextPlugin from "@next/eslint-plugin-next";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+// 既存のハードコード日本語を含む負債ファイル（管理規約は scripts/i18n-debt-files.js 参照）。
+// 移設完了ファイルはここから削除すること。
+const i18nDebtFiles = require("./scripts/i18n-debt-files.js");
+
+// ファイルパスを glob パターン化する際、ディレクトリ名に含まれる `[` `]` は
+// glob の文字クラスとして解釈されるため、そのセグメントを `*` に置き換える
+// （例: overlay/[streamerId]/ → overlay/*/。micromatch では [ のエスケープが機能しない）。
+const globSafePath = (f) =>
+  f
+    .split("/")
+    .map((seg) => (/[\[\]]/.test(seg) ? "*" : seg))
+    .join("/");
+
+/**
+ * i18n ハードコード日本語の検出専用 ESLint 設定（#835）。
+ *
+ * 本体の eslint.config.mjs には含めず、`npm run lint:i18n`（ci.yml の専用ジョブ）でのみ
+ * 実行する。理由: 既存コードには大量のハードコード日本語が残っており（負債リスト
+ * scripts/i18n-debt-files.js 参照）、本体設定に入れると既存の 16k 件の lint エラーに埋もれる。
+ * この設定は「移設完了ファイル = 負債リストに無いファイル」に対してのみ
+ * 日本語リテラルがゼロであることを強制する。
+ *
+ * 検出対象:
+ * - 文字列リテラル・テンプレートリテラル・JSX テキストノード内の
+ *   ひらがな/カタカナ/CJK漢字（基本+拡張A）
+ * - コメント内の日本語は対象外（実行時に表示されないため）
+ *
+ * 負債リストの管理: ファイルの移設が完了したら scripts/i18n-debt-files.js から
+ * そのファイルを削除すること。リストに無いファイルで日本語リテラルを追加すると CI が赤くなる。
+ */
+// ひらがな/カタカナ/CJK漢字（基本+拡張A）に加え、日本語文に必ず付随する
+// 和文句読点・全角記号（、。「」〜※等）も検出対象に含める
+// （「※」のみ・全角記号のみの文字列もハードコード日本語の一種として捕捉する）。
+const JA_CHARS = "[\\u3000-\\u303F\\u3040-\\u309F\\u30A0-\\u30FF\\u3400-\\u4DBF\\u4E00-\\u9FFF\\uFF01-\\uFF0F\\uFF1A-\\uFF20\\uFF3B-\\uFF40\\uFF5B-\\uFF65]";
+
+// eslint-disable コメントで no-restricted-syntax を無効化すると検出をすり抜けられるが、
+// これは意図的なソフトガード（完全な強制はプラグイン拡張が必要で YAGNI）。
+// 回帰防止の主目的は「うっかり追加」の検出であり、意図的な無効化はコードレビューで担保する。
+
+export default defineConfig([
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    linterOptions: {
+      // 専用設定では react-hooks 等のルールを有効化しないため、コード内の
+      // eslint-disable コメントが「未使用」扱いで警告になる。日本語リテラル検出が
+      // この設定の唯一の責務なので、disable コメントの未使用警告は抑止する。
+      reportUnusedDisableDirectives: "off",
+    },
+    plugins: {
+      // コード内の eslint-disable コメント（react-hooks/exhaustive-deps や
+      // @typescript-eslint/xxx 等）がルール定義無しでエラーにならないよう、
+      // 参照されうるプラグインのみ登録する（ルール自体は有効化しない。
+      // 日本語リテラル検出がこの設定の唯一の責務）。
+      "react-hooks": reactHooks,
+      "@next/next": nextPlugin,
+      "@typescript-eslint": tsPlugin,
+    },
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: { ecmaFeatures: { jsx: true } },
+      sourceType: "module",
+    },
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: `Literal[value=/${JA_CHARS}/]`,
+          message: "日本語リテラルは messages/*.json のキーへ移設してください",
+        },
+        {
+          selector: `TemplateElement[value.cooked=/${JA_CHARS}/]`,
+          message: "日本語テンプレートは messages/*.json のキーへ移設してください",
+        },
+        {
+          selector: `JSXText[value=/${JA_CHARS}/]`,
+          message: "JSX テキストノードの日本語は messages/*.json のキーへ移設してください",
+        },
+      ],
+    },
+  },
+  {
+    // 負債ファイルは検査対象から除外（後勝ちで no-restricted-syntax を無効化する。
+    // 移設完了時に i18n-debt-files.js から削除すると、このブロックの適用範囲から外れて検査が復活する）
+    files: i18nDebtFiles.map((f) => `**/${globSafePath(f)}`),
+    rules: {
+      "no-restricted-syntax": "off",
+    },
+  },
+]);

--- a/messages/en.json
+++ b/messages/en.json
@@ -14,7 +14,11 @@
     "refresh": "Refresh",
     "copy": "Copy",
     "copied": "Copied",
-    "noImage": "No Image"
+    "noImage": "No Image",
+    "networkError": "A network error occurred",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "supportPlanInfo": "Support plan details"
   },
   "auth": {
     "twitchLogin": "Login with Twitch",
@@ -86,7 +90,8 @@
       "resolutionStandard": "Standard (800px)",
       "resolutionFullHd": "Full HD (1920px)",
       "resolution4k": "4K (3840px)",
-      "previewPoolLabel": "Probability within the \"{pack}\" pack"
+      "previewPoolLabel": "Probability within the \"{pack}\" pack",
+      "intraPercentLabel": "Within {rarity}: "
     },
     "fileUpload": {
       "formats": "Supported: JPEG, PNG, GIF, WebP | ",
@@ -113,6 +118,9 @@
       "errorOccurred": "An error occurred ({status})",
       "uploadLimited": "Upload feature is limited",
       "imageUsage": "Image usage: {usage} / {limit}",
+      "userLimitReached": "The image upload limit is currently 10MB per account. If you exceed the limit, please delete existing images and try again.",
+      "globalLimitReached": "The image upload limit has been reached.",
+      "planOverLimit": "Storage capacity exceeded. Please upgrade your support plan or delete images.",
       "storageLimitReason": "Image Upload Storage Notice\n\nThe current image storage limit is 10MB per account. If you exceed the limit, please delete unnecessary images or consider using URLs to reference images stored on external services (URL references do not count toward the storage limit).\n\nWe are grateful that more users than expected are enjoying the service. This storage limit is a necessary measure to keep the service free. We appreciate your understanding. If we receive many requests for increased storage, we will consider introducing paid plans in the future.",
       "refreshing": "Refreshing",
       "descriptionTooLong": "Description must be {max} characters or fewer.",
@@ -317,7 +325,8 @@
       "defaultWeight": "Default Weight: {weight}%",
       "createCards": "Create {count} cards",
       "fetchFailed": "Failed to fetch emotes",
-      "createFailed": "Failed to create cards"
+      "createFailed": "Failed to create cards",
+      "cardDescriptionFromEmote": "Twitch emote: {name}"
     }
   },
   "rarityProbability": {
@@ -596,7 +605,8 @@
       "scopeRequired": "To enable the Channel Points integration, please grant Twitch permission to read and manage your channel point redemptions.",
       "reauthorizeFailed": "Re-authentication failed. Please try again later.",
       "channelPointsUnavailable": "Channel Points are not currently available on Twitch for this channel. Please check your monetization onboarding and Channel Points settings in the Twitch Creator Dashboard.",
-      "temporarilyUnavailable": "Temporarily unable to check with Twitch. Please try again shortly."
+      "temporarilyUnavailable": "Temporarily unable to check with Twitch. Please try again shortly.",
+      "checkStatus": "Please check the status"
     },
     "form": {
       "selectReward": "Select the channel point redemption that triggers card draws",
@@ -672,6 +682,37 @@
       "missing": "{name} (removed from Pack Management; the current binding is kept)",
       "premiumLocked": "Card Pack (supporter plan feature)",
       "packHint": "Register pack names from \"Pack Management\" in card management"
+    },
+    "eventSubStatus": {
+      "enabled": "Enabled",
+      "pending": "Verifying connection",
+      "failed": "Failed: please reconfigure later",
+      "pendingTitle": "Webhook verification pending",
+      "pendingDescription": "Twitch is attempting to verify the webhook endpoint. This usually completes within seconds to minutes.",
+      "pendingItem1": "Check that the server is running properly",
+      "pendingItem2": "Wait a moment and press the \"Refresh\" button",
+      "pendingItem3": "If it does not resolve, try reconfiguring the reward",
+      "verificationFailedTitle": "Webhook verification failed",
+      "verificationFailedDescription": "Twitch could not verify the webhook.",
+      "verificationFailedItem1": "Check that the server is accessible from the outside",
+      "verificationFailedItem2": "Re-register with the \"Save & Register EventSub\" button",
+      "notificationFailuresTitle": "Too many notification failures",
+      "notificationFailuresDescription": "The subscription was disabled because Twitch notifications failed repeatedly.",
+      "notificationFailuresItem1": "Check the server status",
+      "notificationFailuresItem2": "Re-register with the \"Save & Register EventSub\" button",
+      "authorizationRevokedTitle": "Authorization revoked",
+      "authorizationRevokedDescription": "The subscription was disabled because Twitch authorization was revoked.",
+      "authorizationRevokedItem1": "Please log in again",
+      "authorizationRevokedItem2": "Re-register with the \"Save & Register EventSub\" button",
+      "callbackMismatchTitle": "Callback URL mismatch",
+      "callbackMismatchDescription": "The registered callback URL does not match the current app URL. Please re-register EventSub.",
+      "callbackMismatchCurrent": "Current: {callback}",
+      "callbackMismatchExpected": "Expected: {url}",
+      "unknown": "Unknown",
+      "registrationFailedTitle": "Connection failed",
+      "registrationFailedDescription": "EventSub registration failed. The webhook endpoint could not be reached.",
+      "registrationFailedItem1": "Check that the server is accessible from the outside",
+      "registrationFailedItem2": "Re-register later with the \"Save & Register EventSub\" button"
     }
   },
   "gachaHistory": {
@@ -753,7 +794,13 @@
     "demoNote": "* DEMO button shows your configured cards. Demo cards are shown if you have no cards.",
     "urlUpdated": "Overlay URL has been updated",
     "collectionUrl": "Collection Page URL",
-    "collectionUrlDescription": "A page where viewers can view their collection from this streamer. Share it on chat or social media."
+    "collectionUrlDescription": "A page where viewers can view their collection from this streamer. Share it on chat or social media.",
+    "random": "Random",
+    "gachaError": "Gacha execution error: {msg}",
+    "gachaFailed": "Failed to execute gacha",
+    "executing": "Executing...",
+    "actuallyDraw": "Draw for real",
+    "previewDrawNote": "* \"Draw for real\" is only available in the preview environment. It will be recorded in the DB and appear in history."
   },
   "settingsPage": {
     "title": "Stream Settings",
@@ -1383,5 +1430,17 @@
       "enableFailed": "Failed to enable. Please try again later.",
       "genericError": "An error occurred. Please try again later."
     }
+  },
+  "voteCampaign": {
+    "errorOccurred": "An error occurred",
+    "hiddenNotice": "The campaign panel has been hidden. To show it again, you can enable it from the gear icon (user settings page) in the top right.",
+    "bonusApplied": "+{bonusMb}MB storage bonus applied!",
+    "title": "\"I Voted / Thinking of Voting\" Campaign",
+    "description": "Pressing the button adds +{bonusMb}MB to your image upload capacity (once only)\n* Even if Channel Points are not currently available to you, capacity will be added if you become an Affiliate or Partner in the future.",
+    "processing": "Processing...",
+    "buttonLabel": "I voted / Thinking of voting",
+    "noteVoting": "* We do not ask for proof of voting or anything similar, and this is not for verifying whether you voted. Anyone is welcome, even if you do not currently have voting rights but may gain them in the future.",
+    "notePurpose": "* This campaign is run with the hope of increasing voter turnout. It is not intended to support any particular political party or candidate.",
+    "dismiss": "Don't show again"
   }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -14,7 +14,11 @@
     "refresh": "更新",
     "copy": "コピー",
     "copied": "コピーしました",
-    "noImage": "No Image"
+    "noImage": "No Image",
+    "networkError": "ネットワークエラーが発生しました",
+    "expand": "開く",
+    "collapse": "閉じる",
+    "supportPlanInfo": "支援特典について"
   },
   "auth": {
     "twitchLogin": "Twitchでログイン",
@@ -86,7 +90,8 @@
       "resolutionStandard": "標準 (800px)",
       "resolutionFullHd": "Full HD (1920px)",
       "resolution4k": "4K (3840px)",
-      "previewPoolLabel": "「{pack}」パック内での確率"
+      "previewPoolLabel": "「{pack}」パック内での確率",
+      "intraPercentLabel": "{rarity}内: "
     },
     "fileUpload": {
       "formats": "対応形式: JPEG, PNG, GIF, WebP | ",
@@ -113,6 +118,9 @@
       "errorOccurred": "エラーが発生しました ({status})",
       "uploadLimited": "アップロード機能が制限されています",
       "imageUsage": "画像使用量: {usage} / {limit}",
+      "userLimitReached": "画像のアップロード上限は現在一アカウントにつき10MBです。上限を超える場合は、既存の画像を削除してから再度お試しください。",
+      "globalLimitReached": "画像のアップロード上限に達しました。",
+      "planOverLimit": "ストレージ容量を超過しています。支援特典をアップグレードするか、画像を削除してください。",
       "storageLimitReason": "画像アップロード容量に関するご案内\n\n現在、1アカウントあたりの画像容量上限は10MBとなっております。上限を超える場合は、不要な画像を削除していただくか、外部ストレージに保存した画像のURL引用をご検討ください（URL参照の場合は容量制限に含まれません）。\n\n予想を上回る多くの方にご利用いただいており、無料サービスを継続するための苦渋の措置となります。何卒ご理解いただけますと幸いです。なお、支援特典により容量を拡張できます。詳しくは「支援特典について」をご確認ください。",
       "refreshing": "更新中",
       "descriptionTooLong": "説明は{max}文字以内で入力してください。",
@@ -317,7 +325,8 @@
       "defaultWeight": "デフォルト重み: {weight}%",
       "createCards": "{count}件のカードを作成",
       "fetchFailed": "エモートの取得に失敗しました",
-      "createFailed": "カードの作成に失敗しました"
+      "createFailed": "カードの作成に失敗しました",
+      "cardDescriptionFromEmote": "Twitchエモート: {name}"
     }
   },
   "rarityProbability": {
@@ -596,7 +605,8 @@
       "scopeRequired": "チャネルポイント連携を有効化するには、Twitchでチャネルポイント引き換えの読み取り・管理権限の許可が必要です。",
       "reauthorizeFailed": "再認証に失敗しました。時間をおいて再度お試しください。",
       "channelPointsUnavailable": "現在Twitch上でチャネルポイントを利用できません。Twitch Creator Dashboardで収益化オンボーディングとチャネルポイント設定をご確認ください。",
-      "temporarilyUnavailable": "Twitchへの確認に一時的に失敗しました。時間をおいて再試行してください。"
+      "temporarilyUnavailable": "Twitchへの確認に一時的に失敗しました。時間をおいて再試行してください。",
+      "checkStatus": "状態を確認してください"
     },
     "form": {
       "selectReward": "カード引き換えのきっかけにするチャネルポイント引き換えを選択",
@@ -672,6 +682,37 @@
       "missing": "{name}(パック管理で登録解除済み。現在の紐付けは維持されています)",
       "premiumLocked": "カードパック（支援プラン限定機能）",
       "packHint": "パック名はカード管理の「パック管理」から登録できます"
+    },
+    "eventSubStatus": {
+      "enabled": "有効",
+      "pending": "接続確認中",
+      "failed": "失敗：時間をおいて再設定してください",
+      "pendingTitle": "Webhook検証待ち",
+      "pendingDescription": "TwitchがWebhookエンドポイントの検証を試みています。通常は数秒〜数分で完了します。",
+      "pendingItem1": "サーバーが正常に動作しているか確認してください",
+      "pendingItem2": "しばらく待ってから「更新」ボタンを押してください",
+      "pendingItem3": "解決しない場合は、報酬を再設定してみてください",
+      "verificationFailedTitle": "Webhook検証失敗",
+      "verificationFailedDescription": "TwitchからのWebhook検証に失敗しました。",
+      "verificationFailedItem1": "サーバーが外部からアクセス可能か確認してください",
+      "verificationFailedItem2": "「保存 & EventSub登録」ボタンで再登録してください",
+      "notificationFailuresTitle": "通知失敗が多発",
+      "notificationFailuresDescription": "Twitchからの通知が何度も失敗したため、サブスクリプションが無効化されました。",
+      "notificationFailuresItem1": "サーバーの状態を確認してください",
+      "notificationFailuresItem2": "「保存 & EventSub登録」ボタンで再登録してください",
+      "authorizationRevokedTitle": "認証が取り消されました",
+      "authorizationRevokedDescription": "Twitchの認証が取り消されたため、サブスクリプションが無効化されました。",
+      "authorizationRevokedItem1": "再度ログインしてください",
+      "authorizationRevokedItem2": "「保存 & EventSub登録」ボタンで再登録してください",
+      "callbackMismatchTitle": "Callback URL不一致",
+      "callbackMismatchDescription": "登録されているCallback URLと現在のアプリURLが一致しません。EventSubを再登録してください。",
+      "callbackMismatchCurrent": "現在: {callback}",
+      "callbackMismatchExpected": "期待: {url}",
+      "unknown": "不明",
+      "registrationFailedTitle": "接続失敗",
+      "registrationFailedDescription": "EventSubの登録に失敗しました。Webhookエンドポイントに到達できませんでした。",
+      "registrationFailedItem1": "サーバーが外部からアクセス可能か確認してください",
+      "registrationFailedItem2": "時間をおいて「保存 & EventSub登録」ボタンで再登録してください"
     }
   },
   "gachaHistory": {
@@ -753,7 +794,13 @@
     "demoNote": "※ DEMOボタンで設定されたカードが表示されます。カードがない場合はデモカードが表示されます。",
     "urlUpdated": "オーバーレイURLが更新されました",
     "collectionUrl": "コレクションページURL",
-    "collectionUrlDescription": "視聴者がこの配信者のコレクションを確認できるページです。チャットやSNSで共有できます。"
+    "collectionUrlDescription": "視聴者がこの配信者のコレクションを確認できるページです。チャットやSNSで共有できます。",
+    "random": "ランダム",
+    "gachaError": "ガチャ実行エラー: {msg}",
+    "gachaFailed": "ガチャ実行に失敗しました",
+    "executing": "実行中...",
+    "actuallyDraw": "実際に引く",
+    "previewDrawNote": "※「実際に引く」はプレビュー環境専用です。DBに記録され、履歴に残ります。"
   },
   "settingsPage": {
     "title": "配信設定",
@@ -801,7 +848,10 @@
     "description": "獲得したカードを確認できます。",
     "streamerOwnedCards": "全体所持枚数: {total}枚",
     "streamerCompletionProgress": "コンプリート進捗: {owned}/（全{total}種類）",
-    "progressAria": "コンプリート進捗 {percent}%"
+    "progressAria": "コンプリート進捗 {percent}%",
+    "overallOwnedCards": "全体所持枚数: {total}枚",
+    "overallCompletionProgress": "コンプリート進捗: {owned}/（全{total}種類）",
+    "completionBasisNote": "* コンプリート進捗は現在配布中のカードを基準に計算されています。"
   },
   "languageSwitcher": {
     "label": "言語",
@@ -1380,5 +1430,17 @@
       "enableFailed": "有効化に失敗しました。時間をおいて再試行してください。",
       "genericError": "エラーが発生しました。時間をおいて再試行してください。"
     }
+  },
+  "voteCampaign": {
+    "errorOccurred": "エラーが発生しました",
+    "hiddenNotice": "キャンペーンパネルを非表示にしました。再表示したい場合は、右上の歯車アイコン（ユーザ設定ページ）から設定できます。",
+    "bonusApplied": "+{bonusMb}MB のストレージボーナスが適用されました！",
+    "title": "選挙行ったよ/行こうかな キャンペーン",
+    "description": "ボタンを押すと画像アップロード容量が +{bonusMb}MB されます（1回限り）\n※ 現在チャネルポイントが使えないユーザ様でも、将来アフィリエイト・パートナーになった際に容量追加されます。",
+    "processing": "処理中...",
+    "buttonLabel": "選挙行ったよ/行こうかな",
+    "noteVoting": "＊ 投票済証の提示など証拠を求めることはありません。投票したか否かを確認するためのものではありません。また、現在選挙権のない方でも、将来得ることがあれば投票行こうかな、と思って頂ければ、どなたでもOKです。",
+    "notePurpose": "＊ 本応援は、投票率が上がって欲しいな、という思いで開催しております。特定の政党や候補者を応援するものではありません。",
+    "dismiss": "今後表示しない"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint",
+    "lint:i18n": "eslint --config eslint.i18n.config.mjs src",
     "typecheck": "tsc --noEmit",
     "test:unit": "vitest run tests/unit",
     "test:integration": "vitest run tests/integration",

--- a/scripts/i18n-debt-files.js
+++ b/scripts/i18n-debt-files.js
@@ -1,0 +1,47 @@
+'use strict'
+
+/**
+ * i18n ハードコード日本語の負債リスト（#835）。
+ *
+ * eslint.i18n.config.mjs がこのリストに含まれるファイルを日本語リテラル検査から
+ * 除外する（既存の膨大なハードコード日本語を一度に修正するとレビュー不能な規模になるため、
+ * 負債として明示的に管理しながら、移設完了ファイルから順次除外していく運用）。
+ *
+ * 管理規約:
+ * - ファイルの i18n 移設が完了したら、このリストからそのファイルを削除すること。
+ *   削除されると `npm run lint:i18n` がそのファイルの日本語リテラルを検出して CI が赤くなる。
+ * - 新規ファイルをこのリストに追加しないこと（新規コードは最初から i18n を守る）。
+ */
+module.exports = [
+  'src/app/api/cards/batch-update/route.ts',
+  'src/app/api/cards/batch/route.ts',
+  'src/app/api/gacha/demo/route.ts',
+  'src/app/api/storage-bonus/vote-campaign/route.ts',
+  'src/app/api/streamer/additional-rewards/route.ts',
+  'src/app/api/twitch/eventsub/subscribe/route.ts',
+  'src/app/api/twitch/rewards/route.ts',
+  'src/app/auth/callback-complete/page.tsx',
+  'src/app/dashboard/page.tsx',
+  'src/app/layout.tsx',
+  'src/app/not-found.tsx',
+  'src/app/overlay/[streamerId]/page.tsx',
+  'src/app/plans/page.tsx',
+  'src/app/releases/page.tsx',
+  'src/components/CardPackModal.tsx',
+  'src/components/ChatAnnouncementSettings.tsx',
+  'src/components/ImageCropper.tsx',
+  'src/components/LanguageSwitcher.tsx',
+  'src/components/SupportPlanSection.tsx',
+  'src/components/VoteCampaignReshowSetting.tsx',
+  'src/lib/auth-error-handler.ts',
+  'src/lib/card-issuance.ts',
+  'src/lib/card-number-errors.ts',
+  'src/lib/constants.ts',
+  'src/lib/csrf.ts',
+  'src/lib/db/schema.ts',
+  'src/lib/maintenance/eventsub-park.ts',
+  'src/lib/maintenance/guard.ts',
+  'src/lib/r2-client.ts',
+  'src/lib/services/eventsub-redemption.ts',
+  'src/lib/twitch/chat-service.ts',
+]

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -654,17 +654,17 @@ export default function CardManager({
       });
       if (!response.ok) {
         const error = await response.json();
-        throw new Error(error.error || "エモートの取得に失敗しました");
+        throw new Error(error.error || t("emoteImport.fetchFailed"));
       }
       const data: TwitchEmote[] = await response.json();
       setEmotes(data);
     } catch (error) {
       logger.error("Failed to fetch emotes:", error);
-      setEmoteError(error instanceof Error ? error.message : "エモートの取得に失敗しました");
+      setEmoteError(error instanceof Error ? error.message : t("emoteImport.fetchFailed"));
     } finally {
       setLoadingEmotes(false);
     }
-  }, []);
+  }, [t]);
 
   /**
    * Get emotes that don't already exist as cards (by name comparison)
@@ -725,7 +725,7 @@ export default function CardManager({
         imageUrl: emote.imageUrl,
         rarity: emoteDefaultRarity,
         dropRate: emoteDefaultDropRate,
-        description: `Twitchエモート: ${emote.name}`,
+        description: t("emoteImport.cardDescriptionFromEmote", { name: emote.name }),
       }));
 
       const response = await fetch("/api/cards/batch", {
@@ -747,7 +747,7 @@ export default function CardManager({
         // {code, message, ...}オブジェクトのままError.messageへ文字列化され
         // "[object Object]"表示になっていた）。
         const maintenanceError = parseMaintenanceError(response, error);
-        throw new Error(maintenanceError?.message || error.error || "カードの作成に失敗しました");
+        throw new Error(maintenanceError?.message || error.error || t("emoteImport.createFailed"));
       }
 
       const result = await response.json();
@@ -769,7 +769,7 @@ export default function CardManager({
       setSelectedEmotes(new Set());
     } catch (error) {
       logger.error("Failed to create cards from emotes:", error);
-      setEmoteError(error instanceof Error ? error.message : "カードの作成に失敗しました");
+      setEmoteError(error instanceof Error ? error.message : t("emoteImport.createFailed"));
     } finally {
       setCreatingCards(false);
     }
@@ -1391,7 +1391,16 @@ export default function CardManager({
           // ストレージ制限エラーを処理 (507)
           if (uploadResponse.status === 507) {
             const errorData = await uploadResponse.json();
-            setUploadError(errorData.error);
+            // API はロケール依存の日本語文言を error に、機械判別用の code を返す
+            // （#835: 英語ロケールでも制限理由を表示できるよう、クライアント側で t() 解決する）。
+            // 未知の code は従来どおりサーバー文言へフォールバックする。
+            setUploadError(
+              errorData.code === "GLOBAL_LIMIT_REACHED"
+                ? t("messages.globalLimitReached")
+                : errorData.code === "USER_LIMIT_REACHED"
+                  ? t("messages.userLimitReached")
+                  : errorData.error
+            );
             fetchStorageStatus(); // Refresh storage status
             setSaving(false);
             return;
@@ -1473,7 +1482,7 @@ export default function CardManager({
         // フォールバック表示。#694 Stage 6bの要求「fetch失敗時のエラー表示」）。
         const maintenanceError = parseMaintenanceError(response, errorData);
         setUploadError(
-          maintenanceError?.message || errorData.error || `エラーが発生しました (${response.status})`
+          maintenanceError?.message || errorData.error || t("messages.errorOccurred", { status: response.status })
         );
         logger.error("Failed to save card:", errorData);
       }
@@ -1507,7 +1516,7 @@ export default function CardManager({
         // #694 Stage 6bレビュー指摘対応: maintenance mode による503拒否なら
         // サーバーの案内文言を優先する（他の書き込み経路と同じパターン）。
         const maintenanceError = parseMaintenanceError(response, errorData);
-        alert(`操作に失敗しました: ${maintenanceError?.message || errorData.error}`);
+        alert(t("messages.operationFailed", { msg: maintenanceError?.message || errorData.error }));
         logger.error("Toggle active failed:", errorData);
       } else {
         const responseData = await response.json();
@@ -1528,13 +1537,13 @@ export default function CardManager({
     } catch (error) {
       setCards(originalCards);
       logger.error("Failed to toggle card active:", error);
-      alert("ネットワークエラーが発生しました");
+      alert(tCommon("networkError"));
     }
   };
 
   // 全体削除（手持ちからも削除）
   const handleDelete = async (cardId: string) => {
-    if (!confirm("このカードを完全に削除しますか？\n\n⚠️ 既にこのカードを持っているユーザーの手持ちからも削除されます。")) return;
+    if (!confirm(t("confirmations.fullDeleteCard"))) return;
 
     const originalCards = cards;
     try {
@@ -1581,6 +1590,16 @@ export default function CardManager({
   };
 
   const getRarityInfo = (rarity: Rarity) => getRarityDisplayInfo(rarity);
+
+  // storage-status API の message はロケール依存の日本語文言が直に来るため、
+  // 機械判別用フラグから t() で解決した文言を表示に使う（#835: 英語ロケールでも
+  // 制限理由を表示できるようにする）。フラグが立っていない場合は null（表示なし）。
+  const storageLimitMessage = () => {
+    if (storageStatus?.planOverLimit) return t("messages.planOverLimit");
+    if (storageStatus?.globalLimitReached) return t("messages.globalLimitReached");
+    if (storageStatus?.userLimitReached) return t("messages.userLimitReached");
+    return null;
+  };
 
   return (
     <div className="rounded-xl bg-gray-800 p-6">
@@ -1644,10 +1663,10 @@ export default function CardManager({
         <div className="mb-4 rounded-lg bg-red-500/10 border border-red-500/30 p-4">
           <p className="font-medium text-red-300 mb-1">{t("messages.uploadLimited")}</p>
           <p className="text-sm text-red-400/80">
-            {storageStatus.message}
+            {storageLimitMessage()}
           </p>
           <a href="/plans" className="mt-2 inline-block text-xs text-purple-400 hover:text-purple-300 underline">
-            支援特典について
+            {tCommon("supportPlanInfo")}
           </a>
         </div>
       )}
@@ -1665,12 +1684,12 @@ export default function CardManager({
       {/* ストレージ使用量をパネルレベルで表示 */}
       {storageStatus && (
         <div className="mb-6">
-          {storageStatus.uploadDisabled && storageStatus.message && !storageStatus.planOverLimit ? (
+          {storageStatus.uploadDisabled && !storageStatus.planOverLimit ? (
             <div className="rounded-lg bg-yellow-500/10 border border-yellow-500/30 p-3 text-sm text-yellow-300">
               <p className="font-medium mb-1">{t("messages.uploadLimited")}</p>
-              <p className="text-yellow-400/80 text-xs leading-relaxed">{storageStatus.message}</p>
+              <p className="text-yellow-400/80 text-xs leading-relaxed">{storageLimitMessage()}</p>
               <a href="/plans" className="mt-1 inline-block text-xs text-purple-400 hover:text-purple-300 underline">
-                支援特典について
+                {tCommon("supportPlanInfo")}
               </a>
             </div>
           ) : (
@@ -1699,9 +1718,9 @@ export default function CardManager({
           {/* 容量制限の説明テキスト: ?アイコンクリックで表示/非表示を切り替え */}
           {showStorageHelp && !storageStatus.uploadDisabled && (
             <div className="mt-2">
-              <p className="text-yellow-400/80 text-xs leading-relaxed">{storageStatus.message || t("messages.storageLimitReason")}</p>
+              <p className="text-yellow-400/80 text-xs leading-relaxed">{storageLimitMessage() || t("messages.storageLimitReason")}</p>
               <a href="/plans" className="mt-1 inline-block text-xs text-purple-400 hover:text-purple-300 underline">
-                支援特典について
+                {tCommon("supportPlanInfo")}
               </a>
             </div>
           )}
@@ -2107,7 +2126,7 @@ export default function CardManager({
                     if (!stats) return null;
                     return (
                       <span className="flex items-center gap-2 text-xs text-gray-400 shrink-0">
-                        <span>{getRarityLabel(formData.rarity)}内: <span className="text-white">{stats.intraPercent.toFixed(0)}%</span></span>
+                        <span>{t("form.intraPercentLabel", { rarity: getRarityLabel(formData.rarity) })}<span className="text-white">{stats.intraPercent.toFixed(0)}%</span></span>
                         <span className="text-gray-500">→</span>
                         <span>{t("form.overallDropRate")}: <span className="text-green-400">{stats.overallPercent.toFixed(1)}%</span></span>
                       </span>

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -462,7 +462,7 @@ export default function ChannelPointSettings({
         }
       } else if (eventSubData.warning) {
         // 警告状態：サブスクリプションの確認が必要
-        setMessage(eventSubData.message || "状態を確認してください");
+        setMessage(eventSubData.message || t("messages.checkStatus"));
         setEventSubStatus("pending");
         setRegistrationFailed(false);
         setSavedMainRewardId(selectedRewardId);
@@ -897,7 +897,7 @@ export default function ChannelPointSettings({
     <p className="mt-1 text-xs text-gray-500">
       {t("collections.premiumLocked")}
       <a href="/plans" className="ml-1 text-purple-400 hover:text-purple-300 underline">
-        支援特典について
+        {tCommon("supportPlanInfo")}
       </a>
     </p>
   );
@@ -995,108 +995,108 @@ export default function ChannelPointSettings({
                              ? "text-red-400"
                              : "text-yellow-400"
                        }>
-                         {/* Display user-friendly status text */}
-                         {/* ユーザーフレンドリーなステータステキストを表示 */}
-                         {sub.status === "enabled"
-                           ? "有効"
-                           : sub.status === "webhook_callback_verification_pending"
-                             ? "接続確認中"
-                             : ["webhook_callback_verification_failed", "notification_failures_exceeded", "authorization_revoked"].includes(sub.status)
-                               ? "失敗：時間をおいて再設定してください"
-                               : sub.status}
-                       </span>
-                     </div>
-                     {/* Explanation for pending verification status */}
-                     {/* 検証待ち状態の説明 */}
-                     {sub.status === "webhook_callback_verification_pending" && (
-                       <div className="mt-1 rounded bg-yellow-500/10 p-2 text-xs text-yellow-300">
-                         <p className="font-medium">Webhook検証待ち</p>
-                         <p className="mt-1 text-yellow-400/80">
-                           TwitchがWebhookエンドポイントの検証を試みています。
-                           通常は数秒〜数分で完了します。
-                         </p>
-                         <ul className="mt-1 list-inside list-disc text-yellow-400/70">
-                           <li>サーバーが正常に動作しているか確認してください</li>
-                           <li>しばらく待ってから「更新」ボタンを押してください</li>
-                           <li>解決しない場合は、報酬を再設定してみてください</li>
-                         </ul>
-                       </div>
-                     )}
-                     {/* Explanation for failed verification status */}
-                     {/* 検証失敗状態の説明 */}
-                     {sub.status === "webhook_callback_verification_failed" && (
-                       <div className="mt-1 rounded bg-red-500/10 p-2 text-xs text-red-300">
-                         <p className="font-medium">Webhook検証失敗</p>
-                         <p className="mt-1 text-red-400/80">
-                           TwitchからのWebhook検証に失敗しました。
-                         </p>
-                         <ul className="mt-1 list-inside list-disc text-red-400/70">
-                           <li>サーバーが外部からアクセス可能か確認してください</li>
-                           <li>「保存 & EventSub登録」ボタンで再登録してください</li>
-                         </ul>
-                       </div>
-                     )}
-                     {/* Explanation for notification failures exceeded */}
-                     {/* 通知失敗超過の説明 */}
-                     {sub.status === "notification_failures_exceeded" && (
-                       <div className="mt-1 rounded bg-red-500/10 p-2 text-xs text-red-300">
-                         <p className="font-medium">通知失敗が多発</p>
-                         <p className="mt-1 text-red-400/80">
-                           Twitchからの通知が何度も失敗したため、サブスクリプションが無効化されました。
-                         </p>
-                         <ul className="mt-1 list-inside list-disc text-red-400/70">
-                           <li>サーバーの状態を確認してください</li>
-                           <li>「保存 & EventSub登録」ボタンで再登録してください</li>
-                         </ul>
-                       </div>
-                     )}
-                     {/* Explanation for authorization revoked */}
-                     {/* 認証取り消しの説明 */}
-                     {sub.status === "authorization_revoked" && (
-                       <div className="mt-1 rounded bg-red-500/10 p-2 text-xs text-red-300">
-                         <p className="font-medium">認証が取り消されました</p>
-                         <p className="mt-1 text-red-400/80">
-                           Twitchの認証が取り消されたため、サブスクリプションが無効化されました。
-                         </p>
-                         <ul className="mt-1 list-inside list-disc text-red-400/70">
-                           <li>再度ログインしてください</li>
-                           <li>「保存 & EventSub登録」ボタンで再登録してください</li>
-                         </ul>
-                       </div>
-                     )}
-                     {/* Callback URL mismatch warning */}
-                     {/* Callback URL不一致の警告 */}
-                     {sub.debug && !sub.debug.callbackMatch && (
-                       <div className="mt-1 rounded bg-red-500/10 p-2 text-xs text-red-300">
-                         <p className="font-medium">Callback URL不一致</p>
-                         <p className="mt-1 text-red-400/80">
-                           登録されているCallback URLと現在のアプリURLが一致しません。
-                           EventSubを再登録してください。
-                         </p>
-                         <p className="mt-1 text-red-400/60 break-all">
-                           現在: {sub.transport?.callback || "不明"}
-                         </p>
-                         <p className="text-red-400/60 break-all">
-                           期待: {sub.debug.expectedCallbackUrl}
-                         </p>
-                       </div>
-                     )}
-                   </div>
-                 ))}
-               </div>
-             ) : registrationFailed ? (
-               /* Registration failed - webhook unreachable */
-               /* 登録失敗 - Webhookに到達できなかった */
-               <div className="rounded bg-red-500/10 p-3 text-xs text-red-300">
-                 <p className="font-medium">接続失敗</p>
-                 <p className="mt-1 text-red-400/80">
-                   EventSubの登録に失敗しました。Webhookエンドポイントに到達できませんでした。
-                 </p>
-                 <ul className="mt-1 list-inside list-disc text-red-400/70">
-                   <li>サーバーが外部からアクセス可能か確認してください</li>
-                   <li>時間をおいて「保存 & EventSub登録」ボタンで再登録してください</li>
-                 </ul>
-               </div>
+                          {/* Display user-friendly status text */}
+                          {/* ユーザーフレンドリーなステータステキストを表示 */}
+                          {sub.status === "enabled"
+                            ? t("eventSubStatus.enabled")
+                            : sub.status === "webhook_callback_verification_pending"
+                              ? t("eventSubStatus.pending")
+                              : ["webhook_callback_verification_failed", "notification_failures_exceeded", "authorization_revoked"].includes(sub.status)
+                                ? t("eventSubStatus.failed")
+                                : sub.status}
+                        </span>
+                      </div>
+                      {/* Explanation for pending verification status */}
+                      {/* 検証待ち状態の説明 */}
+                      {sub.status === "webhook_callback_verification_pending" && (
+                        <div className="mt-1 rounded bg-yellow-500/10 p-2 text-xs text-yellow-300">
+                          <p className="font-medium">{t("eventSubStatus.pendingTitle")}</p>
+                          <p className="mt-1 text-yellow-400/80">
+                            {t("eventSubStatus.pendingDescription")}
+                          </p>
+                          <ul className="mt-1 list-inside list-disc text-yellow-400/70">
+                            <li>{t("eventSubStatus.pendingItem1")}</li>
+                            <li>{t("eventSubStatus.pendingItem2")}</li>
+                            <li>{t("eventSubStatus.pendingItem3")}</li>
+                          </ul>
+                        </div>
+                      )}
+                      {/* Explanation for failed verification status */}
+                      {/* 検証失敗状態の説明 */}
+                      {sub.status === "webhook_callback_verification_failed" && (
+                        <div className="mt-1 rounded bg-red-500/10 p-2 text-xs text-red-300">
+                          <p className="font-medium">{t("eventSubStatus.verificationFailedTitle")}</p>
+                          <p className="mt-1 text-red-400/80">
+                            {t("eventSubStatus.verificationFailedDescription")}
+                          </p>
+                          <ul className="mt-1 list-inside list-disc text-red-400/70">
+                            <li>{t("eventSubStatus.verificationFailedItem1")}</li>
+                            <li>{t("eventSubStatus.verificationFailedItem2")}</li>
+                          </ul>
+                        </div>
+                      )}
+                      {/* Explanation for notification failures exceeded */}
+                      {/* 通知失敗超過の説明 */}
+                      {sub.status === "notification_failures_exceeded" && (
+                        <div className="mt-1 rounded bg-red-500/10 p-2 text-xs text-red-300">
+                          <p className="font-medium">{t("eventSubStatus.notificationFailuresTitle")}</p>
+                          <p className="mt-1 text-red-400/80">
+                            {t("eventSubStatus.notificationFailuresDescription")}
+                          </p>
+                          <ul className="mt-1 list-inside list-disc text-red-400/70">
+                            <li>{t("eventSubStatus.notificationFailuresItem1")}</li>
+                            <li>{t("eventSubStatus.notificationFailuresItem2")}</li>
+                          </ul>
+                        </div>
+                      )}
+                      {/* Explanation for authorization revoked */}
+                      {/* 認証取り消しの説明 */}
+                      {sub.status === "authorization_revoked" && (
+                        <div className="mt-1 rounded bg-red-500/10 p-2 text-xs text-red-300">
+                          <p className="font-medium">{t("eventSubStatus.authorizationRevokedTitle")}</p>
+                          <p className="mt-1 text-red-400/80">
+                            {t("eventSubStatus.authorizationRevokedDescription")}
+                          </p>
+                          <ul className="mt-1 list-inside list-disc text-red-400/70">
+                            <li>{t("eventSubStatus.authorizationRevokedItem1")}</li>
+                            <li>{t("eventSubStatus.authorizationRevokedItem2")}</li>
+                          </ul>
+                        </div>
+                      )}
+                      {/* Callback URL mismatch warning */}
+                      {/* Callback URL不一致の警告 */}
+                      {sub.debug && !sub.debug.callbackMatch && (
+                        <div className="mt-1 rounded bg-red-500/10 p-2 text-xs text-red-300">
+                          <p className="font-medium">{t("eventSubStatus.callbackMismatchTitle")}</p>
+                          <p className="mt-1 text-red-400/80">
+                            {t("eventSubStatus.callbackMismatchDescription")}
+                          </p>
+                          <p className="mt-1 text-red-400/60 break-all">
+                            {t("eventSubStatus.callbackMismatchCurrent", {
+                              callback: sub.transport?.callback || t("eventSubStatus.unknown"),
+                            })}
+                          </p>
+                          <p className="text-red-400/60 break-all">
+                            {t("eventSubStatus.callbackMismatchExpected", { url: sub.debug.expectedCallbackUrl })}
+                          </p>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ) : registrationFailed ? (
+                /* Registration failed - webhook unreachable */
+                /* 登録失敗 - Webhookに到達できなかった */
+                <div className="rounded bg-red-500/10 p-3 text-xs text-red-300">
+                  <p className="font-medium">{t("eventSubStatus.registrationFailedTitle")}</p>
+                  <p className="mt-1 text-red-400/80">
+                    {t("eventSubStatus.registrationFailedDescription")}
+                  </p>
+                  <ul className="mt-1 list-inside list-disc text-red-400/70">
+                    <li>{t("eventSubStatus.registrationFailedItem1")}</li>
+                    <li>{t("eventSubStatus.registrationFailedItem2")}</li>
+                  </ul>
+                </div>
              ) : (
                <p className="text-xs text-gray-500">
                  {t("form.noSubscriptions")}

--- a/src/components/ExpandableDescription.tsx
+++ b/src/components/ExpandableDescription.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { useTranslations } from "next-intl";
 
 interface ExpandableDescriptionProps {
   description: string;
@@ -30,6 +31,7 @@ export default function ExpandableDescription({
   // テキストサイズに基づくクラス
   // Classes based on text size
   const textSizeClass = size === "xs" ? "text-xs text-gray-400" : "text-sm text-gray-300";
+  const tCommon = useTranslations("common");
   const [isExpanded, setIsExpanded] = useState(false);
   const [isTruncated, setIsTruncated] = useState(false);
   const textRef = useRef<HTMLParagraphElement>(null);
@@ -87,7 +89,7 @@ export default function ExpandableDescription({
           className="text-xs text-purple-400 hover:text-purple-300 mt-1 flex items-center gap-1"
         >
           <span>▼</span>
-          <span>開く</span>
+          <span>{tCommon("expand")}</span>
         </button>
       )}
       {/* 折りたたみインジケーター（展開時のみ表示） */}
@@ -98,7 +100,7 @@ export default function ExpandableDescription({
           className="text-xs text-purple-400 hover:text-purple-300 mt-1 flex items-center gap-1"
         >
           <span>▲</span>
-          <span>閉じる</span>
+          <span>{tCommon("collapse")}</span>
         </button>
       )}
     </div>

--- a/src/components/OverlayPreview.tsx
+++ b/src/components/OverlayPreview.tsx
@@ -547,15 +547,15 @@ export default function OverlayPreview({
         // maintenance mode による503拒否ならサーバーの案内文言を優先する。
         const maintenanceError = parseMaintenanceError(response, errorData);
         console.error("Gacha API error:", errorData);
-        alert(`ガチャ実行エラー: ${maintenanceError?.message || errorData.error || "Unknown error"}`);
+        alert(t("gachaError", { msg: maintenanceError?.message || errorData.error || "Unknown error" }));
       }
     } catch (error) {
       console.error("Failed to execute gacha:", error);
-      alert("ガチャ実行に失敗しました");
+      alert(t("gachaFailed"));
     } finally {
       setIsExecuting(false);
     }
-  }, [streamerId, isExecuting, isMaintenanceBlocked, tMaintenance]);
+  }, [streamerId, isExecuting, isMaintenanceBlocked, tMaintenance, t]);
 
   // オプションの切り替え
   const toggleOption = (key: keyof OverlayOptions) => {
@@ -893,7 +893,7 @@ export default function OverlayPreview({
               onChange={(e) => setSelectedCardId(e.target.value)}
               className="rounded-lg bg-gray-700 px-3 py-2 text-sm text-white border border-gray-600 focus:border-purple-500 focus:outline-none min-w-[200px]"
             >
-              <option value="random">ランダム</option>
+              <option value="random">{t("random")}</option>
               {activeCards.map((card) => (
                 <option key={card.id} value={card.id}>
                   {card.name} ({card.rarity})
@@ -950,7 +950,7 @@ export default function OverlayPreview({
                   : "bg-green-600 hover:bg-green-700"
               }`}
             >
-              {isExecuting ? "実行中..." : "実際に引く"}
+              {isExecuting ? t("executing") : t("actuallyDraw")}
             </button>
           )}
         </div>
@@ -970,7 +970,7 @@ export default function OverlayPreview({
       {/* Explanation for preview environment */}
       {isPreviewEnvironment && activeCards.length > 0 && (
         <p className="text-xs text-gray-500 mt-1">
-          ※「実際に引く」はプレビュー環境専用です。DBに記録され、履歴に残ります。
+          {t("previewDrawNote")}
         </p>
       )}
 

--- a/src/components/VoteCampaignButton.tsx
+++ b/src/components/VoteCampaignButton.tsx
@@ -22,6 +22,8 @@ interface VoteCampaignButtonProps {
 export default function VoteCampaignButton({ visible, bonusMb }: VoteCampaignButtonProps) {
   const router = useRouter()
   const tMaintenance = useTranslations('maintenance')
+  const tVote = useTranslations('voteCampaign')
+  const tCommon = useTranslations('common')
   // #694 Stage 6c: dashboard/page.tsxで使われるため dashboard/layout.tsx の
   // MaintenanceStatusProvider配下（Context経由でmode取得）。
   const { mode: maintenanceMode } = useMaintenanceStatus()
@@ -53,7 +55,7 @@ export default function VoteCampaignButton({ visible, bonusMb }: VoteCampaignBut
       return (
         <div className="mb-8 rounded-xl bg-gray-800/50 border border-gray-600/50 p-4">
           <p className="text-sm text-gray-300">
-            キャンペーンパネルを非表示にしました。再表示したい場合は、右上の歯車アイコン（ユーザ設定ページ）から設定できます。
+            {tVote('hiddenNotice')}
           </p>
         </div>
       )
@@ -90,13 +92,13 @@ export default function VoteCampaignButton({ visible, bonusMb }: VoteCampaignBut
           const data = await response.json()
           // maintenance mode による503拒否ならサーバーの案内文言を優先する。
           const maintenanceError = parseMaintenanceError(response, data)
-          setError(maintenanceError?.message || data.error || 'エラーが発生しました')
+          setError(maintenanceError?.message || data.error || tVote('errorOccurred'))
         } catch {
-          setError('エラーが発生しました')
+          setError(tVote('errorOccurred'))
         }
       }
     } catch {
-      setError('ネットワークエラーが発生しました')
+      setError(tCommon('networkError'))
     } finally {
       setIsLoading(false)
     }
@@ -113,7 +115,7 @@ export default function VoteCampaignButton({ visible, bonusMb }: VoteCampaignBut
     return (
       <div className="mb-8 rounded-xl bg-gradient-to-r from-green-900/50 to-emerald-900/50 border border-green-600/50 p-6">
         <p className="text-sm font-medium text-green-300">
-          +{bonusMb}MB のストレージボーナスが適用されました！
+          {tVote('bonusApplied', { bonusMb })}
         </p>
       </div>
     )
@@ -122,11 +124,10 @@ export default function VoteCampaignButton({ visible, bonusMb }: VoteCampaignBut
   return (
     <div className="mb-8 rounded-xl bg-gradient-to-r from-pink-900/50 to-purple-900/50 border border-pink-600/50 p-6">
       <h3 className="mb-2 text-lg font-semibold text-white">
-        選挙行ったよ/行こうかな キャンペーン
+        {tVote('title')}
       </h3>
-      <p className="mb-3 text-sm text-gray-300">
-        ボタンを押すと画像アップロード容量が +{bonusMb}MB されます（1回限り）<br />
-        ※ 現在チャネルポイントが使えないユーザ様でも、将来アフィリエイト・パートナーになった際に容量追加されます。
+      <p className="mb-3 text-sm text-gray-300 whitespace-pre-line">
+        {tVote('description', { bonusMb })}
       </p>
 
       {error && (
@@ -163,19 +164,19 @@ export default function VoteCampaignButton({ visible, bonusMb }: VoteCampaignBut
                 d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
               />
             </svg>
-            処理中...
+            {tVote('processing')}
           </>
         ) : (
-          '選挙行ったよ/行こうかな'
+          tVote('buttonLabel')
         )}
       </button>
 
       <div className="mt-4 space-y-2 text-xs text-gray-400 leading-relaxed">
         <p>
-          ＊ 投票済証の提示など証拠を求めることはありません。投票したか否かを確認するためのものではありません。また、現在選挙権のない方でも、将来得ることがあれば投票行こうかな、と思って頂ければ、どなたでもOKです。
+          {tVote('noteVoting')}
         </p>
         <p>
-          ＊ 本応援は、投票率が上がって欲しいな、という思いで開催しております。特定の政党や候補者を応援するものではありません。
+          {tVote('notePurpose')}
         </p>
       </div>
 
@@ -185,7 +186,7 @@ export default function VoteCampaignButton({ visible, bonusMb }: VoteCampaignBut
           onClick={handleDismiss}
           className="text-xs text-gray-500 underline hover:text-gray-400 transition"
         >
-          今後表示しない
+          {tVote('dismiss')}
         </button>
       </div>
     </div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -447,8 +447,9 @@ export const STORAGE_LIMIT_MESSAGES = {
   // User limit message: increased to 10MB
   // ユーザー制限メッセージ: 10MBに増加
   USER_LIMIT_REACHED: '画像のアップロード上限は現在一アカウントにつき10MBです。上限を超える場合は、既存の画像を削除してから再度お試しください。',
-  // Global limit message: kept for backwards compatibility but no longer used
-  // グローバル制限メッセージ: 後方互換性のために残すが使用されない
+  // 後方互換のため維持。クライアントは code フィールドで t() 解決するため、この文言は
+  // サーバーフォールバック（未知のクライアント等）でしか表示されない
+  // （#835: 英語ロケールでも制限理由を表示できるよう、APIの error 文言は最終手段）。
   GLOBAL_LIMIT_REACHED: '画像のアップロード上限に達しました。',
 } as const
 

--- a/tests/unit/components/overlay-preview.test.tsx
+++ b/tests/unit/components/overlay-preview.test.tsx
@@ -31,6 +31,7 @@ const messages = {
     demoHelpTitle: 'デモの種類',
     close: '閉じる',
     demoNote: 'デモノート',
+    random: 'ランダム',
     urlUpdated: 'オーバーレイURLが更新されました',
     collectionUrl: 'コレクションページURL',
     collectionUrlDescription: 'コレクションページです。',

--- a/tests/unit/components/sorted-card-grid.test.tsx
+++ b/tests/unit/components/sorted-card-grid.test.tsx
@@ -1,7 +1,18 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import SortedCardGrid from '@/components/SortedCardGrid'
 import type { Card } from '@/types/database'
+
+// ExpandableDescription が useTranslations（next-intl）を使うようになったため（#835）、
+// Provider なしのテストでもキー解決が動くよう next-intl をモックする。
+// このテストの対象（SortedCardGrid）は translations を props で受けるため、
+// モックは ExpandableDescription の「開く/閉じる」だけ解決できれば十分。
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const map: Record<string, string> = { expand: '開く', collapse: '閉じる' }
+    return map[key] ?? key
+  },
+}))
 
 // Issue #395: 未所持カードを視聴者向けに表示するときの「詳細を隠す」モードを検証する。
 // hideUnownedDetails=true のとき、未所持カードは画像が表示されず、プレースホルダーテキスト ("???")

--- a/tests/unit/eslint-i18n-rule.test.ts
+++ b/tests/unit/eslint-i18n-rule.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { Linter } from 'eslint'
+import tsParser from '@typescript-eslint/parser'
+import eslintI18nConfig from '../../eslint.i18n.config.mjs'
+
+/**
+ * eslint.i18n.config.mjs（#835 の日本語リテラル検出専用設定）の動作テスト。
+ *
+ * 負債リスト（scripts/i18n-debt-files.js）に無いファイルで日本語リテラルを追加すると
+ * CI（lint-i18n ジョブ）が失敗する仕組みが、意図どおり機能することを固定する。
+ */
+const linter = new Linter()
+
+function lint(code: string) {
+  // 設定の負債リスト除外はパスベースのため、Linter API では適用されない。
+  // ここでは「検出ルール本体」の動作のみを検証する（負債除外の動作は npm run lint:i18n が担保）。
+  return linter.verify(code, [
+    {
+      plugins: eslintI18nConfig[0].plugins,
+      languageOptions: {
+        parser: tsParser,
+        parserOptions: { ecmaFeatures: { jsx: true } },
+        sourceType: 'module',
+      },
+      rules: eslintI18nConfig[0].rules,
+    },
+  ])
+}
+
+describe('eslint.i18n.config.mjs（日本語リテラル検出）', () => {
+  it('文字列リテラル内の日本語を検出する', () => {
+    const result = lint('const message = "エラーが発生しました";')
+    expect(result.some((r) => r.ruleId === 'no-restricted-syntax')).toBe(true)
+  })
+
+  it('テンプレートリテラル内の日本語を検出する', () => {
+    const result = lint('const message = `操作に失敗しました: ${reason}`;')
+    expect(result.some((r) => r.ruleId === 'no-restricted-syntax')).toBe(true)
+  })
+
+  it('JSX テキストノード内の日本語を検出する', () => {
+    const result = lint('export const C = () => <span>開く</span>;')
+    expect(result.some((r) => r.ruleId === 'no-restricted-syntax')).toBe(true)
+  })
+
+  it('ASCII のみのコードは検出しない', () => {
+    const result = lint('const message = "An error occurred"; const t = "hello";')
+    expect(result.filter((r) => r.ruleId === 'no-restricted-syntax')).toEqual([])
+  })
+
+  it('コメント内の日本語は検出しない（実行時に表示されないため）', () => {
+    const result = lint('// コメント内の日本語は検出しない\nconst message = "ok";')
+    expect(result.filter((r) => r.ruleId === 'no-restricted-syntax')).toEqual([])
+  })
+})

--- a/tests/unit/i18n-message-parity.test.ts
+++ b/tests/unit/i18n-message-parity.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import jaMessages from '../../messages/ja.json'
+import enMessages from '../../messages/en.json'
+
+/**
+ * messages/ja.json と messages/en.json のキー集合が完全に一致することの回帰テスト（#835）。
+ *
+ * 英語ロケールのユーザーに翻訳なしの文言が表示される（またはキー名がそのまま表示される）
+ * 事故を防ぐため、トップレベル全スコープを深層比較する。キーを追加する場合は必ず
+ * 両ファイルに追加すること。
+ */
+function collectKeys(value: unknown, prefix = ''): string[] {
+  if (typeof value === 'object' && value !== null) {
+    return Object.entries(value as Record<string, unknown>).flatMap(([key, child]) => [
+      prefix + key,
+      ...collectKeys(child, `${prefix}${key}.`),
+    ])
+  }
+  return []
+}
+
+describe('i18n メッセージキー・パリティ (ja/en)', () => {
+  it('トップレベルのスコープ集合が一致する', () => {
+    expect(Object.keys(jaMessages).sort()).toEqual(Object.keys(enMessages).sort())
+  })
+
+  it('全スコープのキー集合が深層で一致する', () => {
+    const jaKeys = collectKeys(jaMessages)
+    const enKeys = collectKeys(enMessages)
+    const jaOnly = jaKeys.filter((k) => !enKeys.includes(k)).sort()
+    const enOnly = enKeys.filter((k) => !jaKeys.includes(k)).sort()
+
+    expect({
+      'jaのみに存在するキー（en.jsonへの追加漏れ）': jaOnly,
+      'enのみに存在するキー（ja.jsonへの追加漏れ）': enOnly,
+    }).toEqual({
+      'jaのみに存在するキー（en.jsonへの追加漏れ）': [],
+      'enのみに存在するキー（ja.jsonへの追加漏れ）': [],
+    })
+  })
+})


### PR DESCRIPTION
## 対応issue
Closes #835（i18n: 破壊的操作の確認ダイアログなど、i18nをすり抜けたハードコード日本語が残っている）

## 変更内容

### 1. 最優先: カード完全削除の確認ダイアログ（安全性）
- `CardManager.tsx` の `confirm()` を既存キー `cardManager.confirmations.fullDeleteCard` に移設（ja 文言は従来と完全一致を確認）
- 同ファイルのハードコード日本語12箇所（エラー文言・alert・テンプレート）を既存・新規キーに移設

### 2. ChannelPointSettings の EventSub ステータス説明（30箇所）
- 検証待ち/検証失敗/通知失敗超過/認証取り消し/Callback URL不一致/接続失敗の各説明を `channelPointSettings.eventSubStatus.*` にキー化

### 3. STORAGE_LIMIT のクライアント解決
- API（upload 507 / storage-status）の日本語 `message`/`error` は後方互換のため維持し、**クライアント側で `code` フラグから `t()` 解決**する方式に変更（契約変更なし）
- `STORAGE_LIMIT_MESSAGES.GLOBAL_LIMIT_REACHED` の誤コメント（「使用されない」→実際は使用中）を是正

### 4. その他の移設
- VoteCampaignButton（12箇所、`<br />` は `\n` + whitespace-pre-line に変更）、OverlayPreview（5箇所）、ExpandableDescription（開く/閉じる）、CardManager の「支援特典について」リンク
- 既存の en のみ 3 キー（collectionPage）の ja 追加漏れも解消

### 5. 回帰防止の基盤
- **`eslint.i18n.config.mjs`（新規）**: 日本語リテラル（文字列/テンプレート/JSXテキスト）を検出する専用設定。既存違反31ファイルは `scripts/i18n-debt-files.js` の負債リストで除外（移設完了ファイルから順次削除する運用）
- **`npm run lint:i18n` + ci.yml の `lint-i18n` ジョブ（新規）**: 負債リスト外のファイルで日本語リテラルが 0 件であることを CI で強制
- **`tests/unit/i18n-message-parity.test.ts`（新規）**: ja/en のキー集合の深層パリティテスト
- **`tests/unit/eslint-i18n-rule.test.ts`（新規）**: 検出ルールの動作テスト

## 検証
- `npm run lint:i18n`: 0件（移設ファイル含め全非負債ファイルでゼロ違反を実測）
- `npm run typecheck` / 全体テスト 3622 passed
- 移設文言は ja 表示が従来と完全一致することを確認（VoteCampaignButton の `<br />`→`\n` は whitespace-pre-line で表示を維持）
- 自己レビュー: サブエージェントによる厳格レビューで指摘8件を対応（`<br />`リテラル表示の実バグ修正・インデント整形・JA_CHARS拡張・コメント是正ほか）

## 備考
- ESLint の `eslint-disable` コメントによる無効化は可能だが、これは意図的なソフトガード（完全強制はYAGNI）。コードレビューで担保する旨を設定コメントに明記
- スコープ外の未コミット変更（tests/unit/components/gacha-sound-settings-reward-select.test.tsx の flake 修正）はこのPRに含めていない（別途判断）