### PR TITLE
fix(i18n): enforce guard on release pushes (#888 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,9 @@ jobs:
 
   lint-i18n:
     name: Lint i18n (Japanese literals)
-    if: github.event_name == 'pull_request'
+    # PRだけでなく、preview/mainへマージされたpushでも同じガードを実行する。
+    # PR側のイベントが欠落した場合でも、デプロイ対象のコミットで回帰を検出できるようにする。
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:

--- a/eslint.i18n.config.mjs
+++ b/eslint.i18n.config.mjs
@@ -10,13 +10,15 @@ const require = createRequire(import.meta.url);
 // 移設完了ファイルはここから削除すること。
 const i18nDebtFiles = require("./scripts/i18n-debt-files.js");
 
-// ファイルパスを glob パターン化する際、ディレクトリ名に含まれる `[` `]` は
-// glob の文字クラスとして解釈されるため、そのセグメントを `*` に置き換える
-// （例: overlay/[streamerId]/ → overlay/*/。micromatch では [ のエスケープが機能しない）。
+// ESLint の `files` は glob として評価されるため、負債リストのファイル名に含まれる
+// globメタ文字をリテラルとしてエスケープする。動的ルートの `[streamerId]` を `*` に
+// 置き換えると、同階層の未登録ファイルまで負債扱いになるため、登録された1ファイル
+// だけに除外範囲を限定する。
+const GLOB_META_CHARACTERS = /[\\*?\[\]{}()!+@]/g;
 const globSafePath = (f) =>
   f
     .split("/")
-    .map((seg) => (/[\[\]]/.test(seg) ? "*" : seg))
+    .map((seg) => seg.replace(GLOB_META_CHARACTERS, "\\$&"))
     .join("/");
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@aws-sdk/client-s3": "^3.972.0",
         "@cloudflare/workers-types": "4.20260702.1",
+        "@formatjs/icu-messageformat-parser": "^2.11.4",
         "@opennextjs/cloudflare": "^1.16.1",
         "@swc/helpers": "^0.5.23",
         "@tailwindcss/postcss": "^4",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.972.0",
     "@cloudflare/workers-types": "4.20260702.1",
+    "@formatjs/icu-messageformat-parser": "^2.11.4",
     "@opennextjs/cloudflare": "^1.16.1",
     "@swc/helpers": "^0.5.23",
     "@tailwindcss/postcss": "^4",

--- a/tests/unit/components/card-manager-i18n.test.tsx
+++ b/tests/unit/components/card-manager-i18n.test.tsx
@@ -35,6 +35,22 @@ describe('CardManager i18n safety messages', () => {
     expect(confirmMock).toHaveBeenCalledWith(
       'Permanently delete this card?\n\n⚠️ This will also remove the card from all users who own it.'
     )
-    expect(fetchMock).not.toHaveBeenCalledWith('/api/cards/card-1', expect.anything())
+
+    // `fetch(url, init)` と `fetch(new Request(url, init))` のどちらでも、対象カードへの
+    // DELETEが発生していないことを判定する。呼び出し形式に依存した検証にすると、
+    // キャンセル後の削除回帰を見逃すため、URLとmethodを正規化して確認する。
+    const fetchCalls = fetchMock.mock.calls as unknown as Array<[
+      RequestInfo | URL,
+      RequestInit | undefined,
+    ]>
+    const targetDeleteCalls = fetchCalls.filter(([input, init]) => {
+      const requestLike = typeof input === 'object' && input !== null && 'url' in input
+        ? (input as Request)
+        : null
+      const url = requestLike?.url ?? String(input)
+      const method = requestLike?.method ?? init?.method ?? 'GET'
+      return url.endsWith('/api/cards/card-1') && method.toUpperCase() === 'DELETE'
+    })
+    expect(targetDeleteCalls).toHaveLength(0)
   })
 })

--- a/tests/unit/components/card-manager-i18n.test.tsx
+++ b/tests/unit/components/card-manager-i18n.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import CardManager from '@/components/CardManager'
+import enMessages from '../../../messages/en.json'
+import { baseCard } from '../../utils/card-manager-test-helpers'
+
+vi.mock('@/lib/logger')
+
+describe('CardManager i18n safety messages', () => {
+  afterEach(() => {
+    // このテストは confirm と fetch を差し替えるため、後続テストへブラウザAPIの
+    // モックが漏れないように各テスト終了時に必ず元へ戻す。
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('英語の完全削除確認を表示し、キャンセル時は削除APIを呼ばない', () => {
+    const confirmMock = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const fetchMock = vi.fn(() => new Promise<Response>(() => {}))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <NextIntlClientProvider locale="en" messages={enMessages}>
+        <CardManager
+          streamerId="streamer-1"
+          initialCards={[baseCard({ id: 'card-1' })]}
+          initialRarityWeights={{}}
+        />
+      </NextIntlClientProvider>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete Permanently' }))
+
+    expect(confirmMock).toHaveBeenCalledWith(
+      'Permanently delete this card?\n\n⚠️ This will also remove the card from all users who own it.'
+    )
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/cards/card-1', expect.anything())
+  })
+})

--- a/tests/unit/components/card-manager-i18n.test.tsx
+++ b/tests/unit/components/card-manager-i18n.test.tsx
@@ -30,6 +30,7 @@ describe('CardManager i18n safety messages', () => {
       </NextIntlClientProvider>
     )
 
+    const fetchCallCountBeforeCancel = fetchMock.mock.calls.length
     fireEvent.click(screen.getByRole('button', { name: 'Delete Permanently' }))
 
     expect(confirmMock).toHaveBeenCalledWith(
@@ -48,9 +49,11 @@ describe('CardManager i18n safety messages', () => {
         ? (input as Request)
         : null
       const url = requestLike?.url ?? String(input)
-      const method = requestLike?.method ?? init?.method ?? 'GET'
+      // FetchのRequestInitはRequest本体のmethodを上書きできるため、initを優先する。
+      const method = init?.method ?? requestLike?.method ?? 'GET'
       return url.endsWith('/api/cards/card-1') && method.toUpperCase() === 'DELETE'
     })
     expect(targetDeleteCalls).toHaveLength(0)
+    expect(fetchMock.mock.calls).toHaveLength(fetchCallCountBeforeCancel)
   })
 })

--- a/tests/unit/eslint-i18n-rule.test.ts
+++ b/tests/unit/eslint-i18n-rule.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { Linter } from 'eslint'
+import { ESLint, Linter } from 'eslint'
 import tsParser from '@typescript-eslint/parser'
 import eslintI18nConfig from '../../eslint.i18n.config.mjs'
+import { resolve } from 'node:path'
 
 /**
  * eslint.i18n.config.mjs（#835 の日本語リテラル検出専用設定）の動作テスト。
@@ -10,6 +11,11 @@ import eslintI18nConfig from '../../eslint.i18n.config.mjs'
  * CI（lint-i18n ジョブ）が失敗する仕組みが、意図どおり機能することを固定する。
  */
 const linter = new Linter()
+// Vitest transforms `import.meta.url` into a non-file module URL, so passing it to
+// `fileURLToPath` is not portable. The test command runs from the repository root;
+// resolving the known config filename from `process.cwd()` yields the absolute path
+// ESLint requires without depending on the module URL scheme.
+const i18nConfigPath = resolve(process.cwd(), 'eslint.i18n.config.mjs')
 
 function lint(code: string) {
   // 設定の負債リスト除外はパスベースのため、Linter API では適用されない。
@@ -25,6 +31,12 @@ function lint(code: string) {
       rules: eslintI18nConfig[0].rules,
     },
   ])
+}
+
+async function lintWithConfigFile(code: string, filePath: string) {
+  const eslint = new ESLint({ overrideConfigFile: i18nConfigPath })
+  const [result] = await eslint.lintText(code, { filePath })
+  return result.messages
 }
 
 describe('eslint.i18n.config.mjs（日本語リテラル検出）', () => {
@@ -51,5 +63,19 @@ describe('eslint.i18n.config.mjs（日本語リテラル検出）', () => {
   it('コメント内の日本語は検出しない（実行時に表示されないため）', () => {
     const result = lint('// コメント内の日本語は検出しない\nconst message = "ok";')
     expect(result.filter((r) => r.ruleId === 'no-restricted-syntax')).toEqual([])
+  })
+
+  it('負債リストの動的ルートだけを除外し、同階層の未登録ファイルは検出する', async () => {
+    const registeredRoute = await lintWithConfigFile(
+      'const message = "既存の負債";',
+      'src/app/overlay/[streamerId]/page.tsx'
+    )
+    const unregisteredSibling = await lintWithConfigFile(
+      'const message = "新しい日本語";',
+      'src/app/overlay/settings/page.tsx'
+    )
+
+    expect(registeredRoute.some((r) => r.ruleId === 'no-restricted-syntax')).toBe(false)
+    expect(unregisteredSibling.some((r) => r.ruleId === 'no-restricted-syntax')).toBe(true)
   })
 })

--- a/tests/unit/i18n-message-parity.test.ts
+++ b/tests/unit/i18n-message-parity.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { parse, TYPE, type MessageFormatElement } from '@formatjs/icu-messageformat-parser'
 import jaMessages from '../../messages/ja.json'
 import enMessages from '../../messages/en.json'
 
@@ -29,11 +30,38 @@ function collectMessages(value: unknown, prefix = ''): Array<[string, string]> {
   return []
 }
 
-// next-intl のメッセージ引数は `{name}` の形式で記述されるため、キー集合だけでなく
-// 各キーの引数名集合も比較する。片方の翻訳だけ引数を削除・改名すると、実行時に
-// プレースホルダーがそのまま表示されるため、翻訳追加時点で検出できるようにする。
+// next-intl は単純な `{name}` だけでなく、plural/select/number/date の ICU 構文も
+// 受け付ける。正規表現では formatted argument や分岐内の引数を取りこぼし、文字列
+// リテラルを誤検出するため、実行時と同じFormatJSのASTパーサーで引数名を収集する。
 function collectPlaceholders(message: string): string[] {
-  return [...message.matchAll(/\{([A-Za-z0-9_]+)\}/g)].map((match) => match[1]).sort()
+  const placeholders = new Set<string>()
+
+  const visit = (elements: MessageFormatElement[]) => {
+    for (const element of elements) {
+      switch (element.type) {
+        case TYPE.argument:
+        case TYPE.number:
+        case TYPE.date:
+        case TYPE.time:
+        case TYPE.select:
+        case TYPE.plural:
+          placeholders.add(element.value)
+          if (element.type === TYPE.select || element.type === TYPE.plural) {
+            Object.values(element.options).forEach((option) => visit(option.value))
+          }
+          break
+        case TYPE.tag:
+          visit(element.children)
+          break
+        case TYPE.literal:
+        case TYPE.pound:
+          break
+      }
+    }
+  }
+
+  visit(parse(message))
+  return [...placeholders].sort()
 }
 
 describe('i18n メッセージキー・パリティ (ja/en)', () => {
@@ -68,5 +96,13 @@ describe('i18n メッセージキー・パリティ (ja/en)', () => {
     })
 
     expect(differences).toEqual([])
+  })
+
+  it('ICUのformatted・分岐内引数を検出し、リテラル波括弧を引数扱いしない', () => {
+    expect(
+      collectPlaceholders(
+        "{count, plural, =0 {該当なし} other {{count, number}件、{name}さん}} '{literal}'"
+      )
+    ).toEqual(['count', 'name'])
   })
 })

--- a/tests/unit/i18n-message-parity.test.ts
+++ b/tests/unit/i18n-message-parity.test.ts
@@ -19,6 +19,23 @@ function collectKeys(value: unknown, prefix = ''): string[] {
   return []
 }
 
+function collectMessages(value: unknown, prefix = ''): Array<[string, string]> {
+  if (typeof value === 'string') return [[prefix, value]]
+  if (typeof value === 'object' && value !== null) {
+    return Object.entries(value as Record<string, unknown>).flatMap(([key, child]) =>
+      collectMessages(child, `${prefix}${key}.`)
+    )
+  }
+  return []
+}
+
+// next-intl のメッセージ引数は `{name}` の形式で記述されるため、キー集合だけでなく
+// 各キーの引数名集合も比較する。片方の翻訳だけ引数を削除・改名すると、実行時に
+// プレースホルダーがそのまま表示されるため、翻訳追加時点で検出できるようにする。
+function collectPlaceholders(message: string): string[] {
+  return [...message.matchAll(/\{([A-Za-z0-9_]+)\}/g)].map((match) => match[1]).sort()
+}
+
 describe('i18n メッセージキー・パリティ (ja/en)', () => {
   it('トップレベルのスコープ集合が一致する', () => {
     expect(Object.keys(jaMessages).sort()).toEqual(Object.keys(enMessages).sort())
@@ -37,5 +54,19 @@ describe('i18n メッセージキー・パリティ (ja/en)', () => {
       'jaのみに存在するキー（en.jsonへの追加漏れ）': [],
       'enのみに存在するキー（ja.jsonへの追加漏れ）': [],
     })
+  })
+
+  it('各メッセージのプレースホルダー集合が一致する', () => {
+    const jaMessagesByKey = new Map(collectMessages(jaMessages))
+    const enMessagesByKey = new Map(collectMessages(enMessages))
+    const differences = [...jaMessagesByKey.keys()].flatMap((key) => {
+      const jaPlaceholders = collectPlaceholders(jaMessagesByKey.get(key) ?? '')
+      const enPlaceholders = collectPlaceholders(enMessagesByKey.get(key) ?? '')
+      return JSON.stringify(jaPlaceholders) === JSON.stringify(enPlaceholders)
+        ? []
+        : [{ key, jaPlaceholders, enPlaceholders }]
+    })
+
+    expect(differences).toEqual([])
   })
 })


### PR DESCRIPTION
## 概要

PR #888 の独立レビューで確認した、preview/main昇格前に解消すべきi18nガードの追補です。

- `lint-i18n` をPRだけでなく `preview` / `main` へのpushでも実行
- i18n負債リストの動的ルートを過剰除外しないglobリテラルエスケープ
- 登録済み動的ルートと同階層の未登録ファイルを区別するESLint統合テスト
- 英語ロケールの完全削除確認文言と、キャンセル時にDELETEしないことを検証
- ja/enメッセージのICUプレースホルダー引数パリティをFormatJS ASTで検証
- RequestInitがRequest本体のmethodを上書きする削除回帰ケースも検証

PR #888本体はすでにpreviewへマージ済みですが、この追補をpreviewに反映して再検証してからmainへ昇格します。

## 検証

- `npm run test:unit`: 266 files passed, 3,633 passed / 34 skipped
- `npm run test:integration`: 13 passed
- 対象テスト: 11 passed
- `npm run lint:i18n`: passed
- `npm run typecheck`: passed
- changed-file ESLint: passed
- `git diff --check`: passed