### PR TITLE
security: 入力検証・EventSubリプレイ防止・tos/accept CSRF・SECURITY.md整合（#836）

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,7 +31,7 @@ An unbounded decompression chain in HTTP responses on Node.js Fetch API via Cont
 ### Security Best Practices
 
 #### Session Management
-- Sessions use `SameSite='strict'` for CSRF protection
+- Sessions use `SameSite='lax'`（OAuth コールバックで Cookie を到達させるため。constants.ts 参照）
 - CSRF tokens provide additional protection layer
 - Sessions expire after 7 days
 - Version field prevents concurrent modifications
@@ -39,12 +39,13 @@ An unbounded decompression chain in HTTP responses on Node.js Fetch API via Cont
 #### Cookie Security
 - All cookies use `httpOnly: true`
 - All cookies use `secure: true` in production
-- State cookie uses `SameSite='lax' to allow OAuth callback
+- State cookie uses `SameSite='lax'` to allow OAuth callback
 
 #### Input Validation
 - All API inputs are validated
 - Rate limiting prevents abuse
 - CSRF protection on all state-changing requests
+  （例外: `/api/twitch/eventsub/debug` の DELETE は #831 で追跡中）
 
 #### Rate Limiting
 - In-memory rate limiting for development

--- a/src/app/api/cards/batch/route.ts
+++ b/src/app/api/cards/batch/route.ts
@@ -3,6 +3,7 @@ import { getSession, canUseStreamerFeatures } from "@/lib/session";
 
 import {
   validateCardName,
+  validateCardDescription,
   validateImageUrl,
   validateRarity,
 } from "@/lib/validations";
@@ -239,6 +240,15 @@ export async function POST(request: NextRequest) {
 
       if (typeof card.dropRate !== "number" || card.dropRate < 0 || card.dropRate > 1) {
         validationErrors.push(`カード${i + 1}: ${ERROR_MESSAGES.DROP_RATE_INVALID}`);
+      }
+
+      // Issue #836: 単体作成（POST /api/cards）は validateCardDescription を適用しているが、
+      // バッチ経由は description の長さ検証がなく単体側の制限を迂回できていた。
+      // 同じ検証を適用して迂回を閉じる（null/undefined は許可されるため従来挙動は不変）。
+      const descriptionValidation = validateCardDescription(card.description);
+      if (!descriptionValidation.valid) {
+        validationErrors.push(`カード${i + 1}: ${descriptionValidation.error}`);
+        continue;
       }
     }
 

--- a/src/app/api/cards/route.ts
+++ b/src/app/api/cards/route.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/validations";
 import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
 import { checkRateLimit, rateLimits, getRateLimitIdentifier, retryAfterSeconds } from "@/lib/rate-limit";
+import { safeParseInt } from "@/lib/parse";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
@@ -715,8 +716,10 @@ export async function GET(request: NextRequest) {
   // ページネーションパラメータ
   // CardManager requests limit=1000 to load all cards for management view
   // カード管理画面では全カード取得のためlimit=1000でリクエストされる
-  const limit = Math.min(parseInt(searchParams.get("limit") || "12", 10), 1000);
-  const offset = parseInt(searchParams.get("offset") || "0", 10);
+  // Issue #836: parseInt 直接使用（"abc"→NaN、負値そのまま）をやめ、
+  // safeParseInt + clamp で PostgreSQL へ不正値を渡さない。
+  const limit = Math.min(safeParseInt(searchParams.get("limit"), 12), 1000);
+  const offset = Math.max(0, safeParseInt(searchParams.get("offset"), 0));
 
   // Sorting parameters (default: created_at desc)
   // 並び替えパラメータ（デフォルト: created_at 降順）

--- a/src/app/api/gacha-history/route.ts
+++ b/src/app/api/gacha-history/route.ts
@@ -18,6 +18,8 @@ import {
 // ---------------------------------------------------------------------------
 import { eq } from "drizzle-orm";
 import { getDb } from "@/lib/db/client";
+import { safeParseInt } from "@/lib/parse";
+import { UUID_REGEX } from "@/lib/validations";
 
 import { withDbRetry } from "@/lib/db/retry";
 import { streamers as streamersTable } from "@/lib/db/schema";
@@ -51,17 +53,6 @@ async function fetchStreamerIdPg(twitchUserId: string): Promise<{ id: string } |
 
 const VALID_RARITIES = ["common", "rare", "epic", "legendary"];
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-/**
- * Parse integer with NaN fallback
- * NaN時にデフォルト値を返すintパーサー
- */
-function safeParseInt(value: string | null, defaultValue: number): number {
-  if (!value) return defaultValue;
-  const parsed = parseInt(value, 10);
-  return Number.isNaN(parsed) ? defaultValue : parsed;
-}
 
 /**
  * GET /api/gacha-history

--- a/src/app/api/streamer/additional-rewards/route.ts
+++ b/src/app/api/streamer/additional-rewards/route.ts
@@ -8,6 +8,7 @@ import { validateCSRFToken } from "@/lib/csrf";
 import { validateContentType } from "@/lib/request-validation";
 import { logger } from "@/lib/logger.server";
 import { resolveCollectionNameField, isRegisteredOrUnchanged, DEFAULT_PACK_SENTINEL } from "@/lib/validation/collection-name";
+import { validateRewardId, validateRewardName } from "@/lib/validations";
 import {
   checkCollectionHasActiveCards,
   isMissingCollectionNameColumn,
@@ -456,6 +457,16 @@ export async function POST(request: NextRequest) {
 
     if (!rewardId) {
       return NextResponse.json({ error: ERROR_MESSAGES.MISSING_REWARD_ID }, { status: 400 });
+    }
+
+    // Issue #836: rewardId は Twitch の報酬 ID（UUID）形式を要求する。
+    // 非 UUID が保存されると EventSub 購読条件（condition.reward_id）と不整合を起こす。
+    if (!validateRewardId(rewardId).valid) {
+      return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
+    }
+    // rewardName は文字列 + 長さ上限 + 制御文字禁止（null は許可）。
+    if (!validateRewardName(rewardName).valid) {
+      return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
     }
 
     const normalizedDrawCount = drawCount === undefined ? 1 : Number(drawCount);

--- a/src/app/api/streamer/settings/route.ts
+++ b/src/app/api/streamer/settings/route.ts
@@ -23,6 +23,7 @@ import {
   isRegisteredOrUnchanged,
   DEFAULT_PACK_SENTINEL,
 } from "@/lib/validation/collection-name";
+import { validateRewardId, validateRewardName, validateChatAnnouncementTemplate } from "@/lib/validations";
 import {
   checkCollectionHasActiveCards,
   isMissingCollectionNameColumn,
@@ -807,6 +808,46 @@ export async function POST(request: NextRequest) {
     }
 
     if (gachaSoundRules !== undefined && !Array.isArray(gachaSoundRules)) {
+      return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
+    }
+
+    // Issue #836: チャネルポイント報酬・チャット通知設定の入力検証。
+    // 同じルート内の boolean 検証（showUnownedCards 等）と対称にする。
+    // channelPointRewardId は Twitch の報酬 ID（UUID）。null はクリアを意味する。
+    if (
+      channelPointRewardId !== undefined
+      && !validateRewardId(channelPointRewardId).valid
+    ) {
+      return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
+    }
+    if (
+      channelPointRewardName !== undefined
+      && !validateRewardName(channelPointRewardName).valid
+    ) {
+      return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
+    }
+    if (
+      gachaSoundEnabled !== undefined
+      && typeof gachaSoundEnabled !== "boolean"
+    ) {
+      return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
+    }
+    if (
+      chatAnnouncementEnabled !== undefined
+      && typeof chatAnnouncementEnabled !== "boolean"
+    ) {
+      return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
+    }
+    if (
+      chatAnnouncementTemplate !== undefined
+      && !validateChatAnnouncementTemplate(chatAnnouncementTemplate).valid
+    ) {
+      return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
+    }
+    if (
+      chatAnnouncementMultiTemplate !== undefined
+      && !validateChatAnnouncementTemplate(chatAnnouncementMultiTemplate).valid
+    ) {
       return NextResponse.json({ error: ERROR_MESSAGES.INVALID_REQUEST }, { status: 400 });
     }
 

--- a/src/app/api/tos/accept/route.ts
+++ b/src/app/api/tos/accept/route.ts
@@ -1,6 +1,8 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { eq } from 'drizzle-orm'
 import { getSession } from '@/lib/session'
+import { validateCSRFToken } from '@/lib/csrf'
+import { checkRateLimit, rateLimits, getRateLimitIdentifier } from '@/lib/rate-limit'
 
 import { logger } from '@/lib/logger.server'
 import { ERROR_MESSAGES } from '@/lib/constants'
@@ -19,13 +21,39 @@ import { users as usersTable } from '@/lib/db/schema'
  * Records user's acceptance of Terms of Service
  */
 export async function POST(request: NextRequest) {
-  // Next.js の Route Handler と直接呼び出すテストの双方で統一したシグネチャを
-  // 維持する。POST 本体はセッションだけを使うため、リクエスト本文は意図的に読まない。
-  void request;
+  // Issue #836: セッションCookie認証で状態変更するルートのため、他のルートと
+  // 同じ順序（CSRF → セッション取得 → レート制限 → セッション確認）で検証する。
+  // POST 本体はセッションだけを使うため、本文は意図的に読まない（void request は廃止し、
+  // validateCSRFToken がリクエストヘッダーを検証する）。
   try {
-    // セッションからユーザー情報を取得
+    const csrfValidation = await validateCSRFToken(request)
+    if (!csrfValidation.valid) {
+      return NextResponse.json(
+        { error: ERROR_MESSAGES.FORBIDDEN },
+        { status: 403 }
+      )
+    }
+
+    // セッションからユーザー情報を取得（レート制限の識別子に使う）
     // Get user info from session
     const session = await getSession()
+
+    const identifier = await getRateLimitIdentifier(request, session?.twitchUserId);
+    const rateLimitResult = await checkRateLimit(rateLimits.tosAccept, identifier);
+
+    if (!rateLimitResult.success) {
+      return NextResponse.json(
+        { error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
+        {
+          status: 429,
+          headers: {
+            'X-RateLimit-Limit': String(rateLimitResult.limit),
+            'X-RateLimit-Remaining': String(rateLimitResult.remaining),
+            'X-RateLimit-Reset': String(rateLimitResult.reset),
+          },
+        }
+      );
+    }
 
     if (!session) {
       // 未認証の場合は401エラーを返す

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -178,14 +178,20 @@ export async function POST(request: NextRequest) {
     //   allowlist default-denyと同じfail-safeの考え方）。
     const maintenanceState = getMaintenanceState();
     if (maintenanceState.mode !== 'off') {
-      await parkEventSubNotification({
+      const parked = await parkEventSubNotification({
         messageId,
         payload: data,
         subscriptionType,
         maintenanceState,
       });
-      // 退避（= 処理の永続化）が完了したので、この message-id を重複排除に記録する
-      await markEventSubMessageSeen(messageId);
+      // 退避（= 処理の永続化）が完了した場合のみ、この message-id を重複排除に記録する。
+      // 退避に失敗した場合（KV書き込み不可等）は記録しない: ここで記録すると、
+      // Twitch が同一 message-id を独自に再送してきた際に重複と誤判定され、
+      // 再退避のチャンスを失って通知が永久に失われる。KV退避が失敗しても2xxを返す方針
+      // （下記コメント・parkEventSubNotification内のコメント参照）自体は維持する。
+      if (parked) {
+        await markEventSubMessageSeen(messageId);
+      }
       return NextResponse.json({ received: true });
     }
 

--- a/src/app/api/twitch/eventsub/route.ts
+++ b/src/app/api/twitch/eventsub/route.ts
@@ -6,6 +6,7 @@ import { logger } from "@/lib/logger.server";
 import { reportError } from "@/lib/sentry/error-handler";
 import { getMaintenanceState } from "@/lib/maintenance/state";
 import { parkEventSubNotification } from "@/lib/maintenance/eventsub-park";
+import { isDuplicateEventSubMessage, markEventSubMessageSeen } from "@/lib/eventsub-dedup";
 // Issue #787 Stage 1: ガチャ交換・レイド処理ロジック本体は
 // src/lib/services/eventsub-redemption.ts へ純粋移動した（ロジック変更なし）。
 // Issue #787 Stage 3 の /api/admin/eventsub-replay route が同じ handleRedemption /
@@ -97,6 +98,17 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: ERROR_MESSAGES.INVALID_SIGNATURE }, { status: 403 });
   }
 
+  // Issue #836: Twitch 公式仕様の再送防御（10分窓のタイムスタンプ検証）。
+  // 古い（または不正な）タイムスタンプの再送を拒否する。Date.parse が NaN を
+  // 返すケースは Math.abs(NaN) > 10min が false になるため明示的に弾くこと。
+  // 注意: 10分を超えた遅延再送（停電復旧後等）は 403 になるが、これは Twitch 公式
+  // ガイドの推奨どおりであり、受信側の障害を原因とする再送は KV 退避 + 2xx の
+  // 既存経路で処理される（本ルートは revoke 判定材料になる 5xx を返さない設計）。
+  const timestampMs = Date.parse(timestamp);
+  if (Number.isNaN(timestampMs) || Math.abs(Date.now() - timestampMs) > 10 * 60 * 1000) {
+    return NextResponse.json({ error: ERROR_MESSAGES.INVALID_SIGNATURE }, { status: 403 });
+  }
+
   if (messageType !== MESSAGE_TYPE_NOTIFICATION) {
     const ip = getClientIp(request);
     const identifier = `ip:${ip}`;
@@ -118,6 +130,16 @@ export async function POST(request: NextRequest) {
   }
 
   if (messageType === MESSAGE_TYPE_NOTIFICATION) {
+    // Issue #836: message-id の重複排除（KV、TTL 10分）。同一 id の再送は
+    // 以降の処理をスキップし、Twitch には常に 2xx を返す（非2xx は
+    // subscription の revoke 判定材料になるため）。verification は再送時に
+    // challenge を返し直すのが正しいため対象外（revocation もここでは対象外。
+    // 重複 revoke は冪等に処理される）。
+    if (await isDuplicateEventSubMessage(messageId)) {
+      logger.info('[EventSub] Duplicate message-id ignored', { messageId });
+      return NextResponse.json({ received: true });
+    }
+
     const subscriptionType = data.subscription.type;
     const event = data.event;
 
@@ -162,6 +184,8 @@ export async function POST(request: NextRequest) {
         subscriptionType,
         maintenanceState,
       });
+      // 退避（= 処理の永続化）が完了したので、この message-id を重複排除に記録する
+      await markEventSubMessageSeen(messageId);
       return NextResponse.json({ received: true });
     }
 
@@ -198,6 +222,9 @@ export async function POST(request: NextRequest) {
         // retry recordを永続化できないまま2xxを返すとTwitchは配送完了とみなし、
         // 部分付与・outbox欠落が永久化する。maintenance中の可用性優先方針とは違い、
         // 既に業務処理が失敗した通常時は503で再送を要求し、データ欠落を防ぐ。
+        // 注意（issue #836）: この経路では dedup 記録を行わない。記録済みだと
+        // Twitch が同一 message-id で再送してきた際に重複と誤判定され、ガチャ未実行の
+        // まま通知が永久喪失するため。
         logger.error('[EventSub] Retryable notification could not be persisted', {
           messageId,
           subscriptionType,
@@ -206,6 +233,9 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // 処理（または退避）が完了したので、この message-id を重複排除に記録する。
+    // 以降は同一 message-id の再送を 2xx で受領してスキップする。
+    await markEventSubMessageSeen(messageId);
     return NextResponse.json({ received: true });
   }
 

--- a/src/lib/eventsub-dedup.ts
+++ b/src/lib/eventsub-dedup.ts
@@ -17,30 +17,12 @@
  * - 適用対象は notification / revocation のみ。verification は同一 message-id の
  *   再送時に challenge を返し直すのが正しく、重複排除すると購読確立を壊しうる。
  */
-import type { KVNamespaceLike } from '@/lib/maintenance/eventsub-park'
+// eventsub-park.ts が RATE_LIMIT_KV バインディングの取得ロジックとバインディング名を
+// 一元管理している（同ファイル冒頭のコメント参照）。同じバインディングを参照する
+// 本モジュールはそれを再実装せず再利用する（issue #836 レビューで指摘された重複を解消）。
+import { getMaintenanceKvBinding } from '@/lib/maintenance/eventsub-park'
 
-const DEDUP_KV_BINDING_NAME = 'RATE_LIMIT_KV'
 const DEDUP_TTL_SECONDS = 10 * 60 // Twitch の再送窓（10分）
-
-/**
- * Cloudflare Workers 環境から KV バインディングを取得する。
- * Workers 外の環境（next dev / Node / テスト）では null（= フェイルオープン）。
- * eventsub-park.ts の getMaintenanceKvBinding と同じフォールバックパターン。
- */
-async function getDedupKvBinding(): Promise<KVNamespaceLike | null> {
-  try {
-    // ローカル開発時に @opennextjs/cloudflare をバンドルしないよう動的 import
-    // （db/client.ts, r2-client.ts と同じ理由）
-    const { getCloudflareContext } = await import('@opennextjs/cloudflare')
-    const { env } = await getCloudflareContext({ async: true })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const binding = (env as any)[DEDUP_KV_BINDING_NAME] as KVNamespaceLike | undefined
-    return binding ?? null
-  } catch {
-    // Cloudflare Workers 環境ではない（next dev / Node / テスト）
-    return null
-  }
-}
 
 /**
  * message-id が既知（10分以内に受信・処理完了済み）かどうかを判定する。
@@ -51,7 +33,7 @@ async function getDedupKvBinding(): Promise<KVNamespaceLike | null> {
  */
 export async function isDuplicateEventSubMessage(messageId: string): Promise<boolean> {
   if (!messageId) return false // ヘッダー欠落時は重複判定しない（署名検証で弾かれる）
-  const binding = await getDedupKvBinding()
+  const binding = await getMaintenanceKvBinding()
   if (!binding) return false // Workers 外 or KV 未設定: フェイルオープン
   try {
     const existing = await binding.get(`eventsub:dedup:${messageId}`)
@@ -70,7 +52,7 @@ export async function isDuplicateEventSubMessage(messageId: string): Promise<boo
  */
 export async function markEventSubMessageSeen(messageId: string): Promise<void> {
   if (!messageId) return
-  const binding = await getDedupKvBinding()
+  const binding = await getMaintenanceKvBinding()
   if (!binding) return
   try {
     await binding.put(`eventsub:dedup:${messageId}`, '1', { expirationTtl: DEDUP_TTL_SECONDS })

--- a/src/lib/eventsub-dedup.ts
+++ b/src/lib/eventsub-dedup.ts
@@ -1,0 +1,80 @@
+/**
+ * EventSub 通知のリプレイ（重複配信）防止 / issue #836
+ *
+ * Twitch は EventSub 通知を再送する場合があり、受信側に 10 分窓のタイムスタンプ検証と
+ * message-id の重複排除を要求する（Twitch 公式仕様）。本モジュールは KV ベースの
+ * message-id 重複排除を提供する。
+ *
+ * 設計の考え方:
+ * - キー: `eventsub:dedup:${messageId}`、TTL 10 分（Twitch の再送窓と同じ）
+ * - 重複判定（isDuplicateEventSubMessage）と記録（markEventSubMessageSeen）は分離し、
+ *   記録は「処理が完了した（2xx を返す）」時点で呼び出す。処理失敗（503 を返す）時に
+ *   記録済みだと、Twitch が同一 message-id で再送してきた際に重複と誤判定され、
+ *   ガチャ未実行のまま通知が永久喪失するため（route 側のコメント参照）。
+ * - KV 取得に失敗した場合はフェイルオープン（重複と誤判定して通知を落とさない）。
+ *   二重付与は DB 層（gacha_history.event_id UNIQUE + ON CONFLICT DO NOTHING）で
+ *   完全に閉じているため、KV 障害時に既知と誤判定するリスクの方が大きい。
+ * - 適用対象は notification / revocation のみ。verification は同一 message-id の
+ *   再送時に challenge を返し直すのが正しく、重複排除すると購読確立を壊しうる。
+ */
+import type { KVNamespaceLike } from '@/lib/maintenance/eventsub-park'
+
+const DEDUP_KV_BINDING_NAME = 'RATE_LIMIT_KV'
+const DEDUP_TTL_SECONDS = 10 * 60 // Twitch の再送窓（10分）
+
+/**
+ * Cloudflare Workers 環境から KV バインディングを取得する。
+ * Workers 外の環境（next dev / Node / テスト）では null（= フェイルオープン）。
+ * eventsub-park.ts の getMaintenanceKvBinding と同じフォールバックパターン。
+ */
+async function getDedupKvBinding(): Promise<KVNamespaceLike | null> {
+  try {
+    // ローカル開発時に @opennextjs/cloudflare をバンドルしないよう動的 import
+    // （db/client.ts, r2-client.ts と同じ理由）
+    const { getCloudflareContext } = await import('@opennextjs/cloudflare')
+    const { env } = await getCloudflareContext({ async: true })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const binding = (env as any)[DEDUP_KV_BINDING_NAME] as KVNamespaceLike | undefined
+    return binding ?? null
+  } catch {
+    // Cloudflare Workers 環境ではない（next dev / Node / テスト）
+    return null
+  }
+}
+
+/**
+ * message-id が既知（10分以内に受信・処理完了済み）かどうかを判定する。
+ * 記録（markEventSubMessageSeen）とは分離されており、この関数は読み取りのみ。
+ *
+ * @param messageId twitch-eventsub-message-id ヘッダー値
+ * @returns true なら重複（以降の処理をスキップすべき）
+ */
+export async function isDuplicateEventSubMessage(messageId: string): Promise<boolean> {
+  if (!messageId) return false // ヘッダー欠落時は重複判定しない（署名検証で弾かれる）
+  const binding = await getDedupKvBinding()
+  if (!binding) return false // Workers 外 or KV 未設定: フェイルオープン
+  try {
+    const existing = await binding.get(`eventsub:dedup:${messageId}`)
+    return existing !== null
+  } catch {
+    return false
+  }
+}
+
+/**
+ * message-id を KV へ記録する（処理完了後に呼び出すこと）。
+ * 書き込み失敗時はフェイルオープン（次回も未知扱いになり、DB 層の UNIQUE 制約が
+ * 二重付与の最終防御となる）。
+ *
+ * @param messageId twitch-eventsub-message-id ヘッダー値
+ */
+export async function markEventSubMessageSeen(messageId: string): Promise<void> {
+  if (!messageId) return
+  const binding = await getDedupKvBinding()
+  if (!binding) return
+  try {
+    await binding.put(`eventsub:dedup:${messageId}`, '1', { expirationTtl: DEDUP_TTL_SECONDS })
+  } catch {
+    // 記録失敗は致命的ではない（二重付与は DB 層が防ぐ）
+  }
+}

--- a/src/lib/maintenance/eventsub-park.ts
+++ b/src/lib/maintenance/eventsub-park.ts
@@ -144,8 +144,13 @@ export interface ParkEventSubNotificationInput {
  * Cloudflare Workers 環境から RATE_LIMIT_KV バインディングを取得する。
  * next dev 等 Workers 外の環境、または binding 未設定時は null を返す
  * （r2-client.ts の getR2Binding と同じフォールバックパターン）。
+ *
+ * このモジュール外（src/lib/eventsub-dedup.ts、issue #836）からも同じ
+ * RATE_LIMIT_KV バインディングを参照するため export する。バインディング名を
+ * この1箇所に集約するという上部コメントの設計意図（KV_BINDING_NAME参照）を
+ * 保つため、呼び出し側で同名の定数・同じ取得ロジックを再実装しないこと。
  */
-async function getMaintenanceKvBinding(): Promise<KVNamespaceLike | null> {
+export async function getMaintenanceKvBinding(): Promise<KVNamespaceLike | null> {
   try {
     // ローカル開発時に @opennextjs/cloudflare をバンドルしないよう動的 import
     // （db/client.ts, r2-client.ts と同じ理由）

--- a/src/lib/maintenance/eventsub-park.ts
+++ b/src/lib/maintenance/eventsub-park.ts
@@ -93,7 +93,7 @@ const PARK_TTL_SECONDS = 7 * 24 * 60 * 60
  * 一覧取得・個別取得・削除の3メソッドを追加。型は実際の Cloudflare Workers KV
  * API（list/get/delete）に合わせている。
  */
-interface KVNamespaceLike {
+export interface KVNamespaceLike {
   put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>
   /**
    * キー一覧を取得する。`list_complete: false` の場合は返却された `cursor` を

--- a/src/lib/parse.ts
+++ b/src/lib/parse.ts
@@ -1,0 +1,16 @@
+/**
+ * クエリパラメータ等の文字列を安全に整数へパースする共通ヘルパ。
+ * issue #836: GET /api/cards 等で parseInt 直接使用により
+ * "abc" → NaN、負値が PostgreSQL に渡り 500 ノイズを生む問題を防ぐ。
+ * 呼び出し側で Math.min/Math.max による clamp と組み合わせる。
+ *
+ * @param value パース対象の文字列（クエリパラメータ等）。null ならデフォルト値
+ * @param defaultValue パース不能・1 未満の値のフォールバック
+ * @returns パース結果。パース不能または 1 未満の場合は defaultValue
+ */
+export function safeParseInt(value: string | null, defaultValue: number): number {
+  if (value === null) return defaultValue
+  const parsed = Number.parseInt(value, 10)
+  if (Number.isNaN(parsed) || parsed < 1) return defaultValue
+  return parsed
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -310,6 +310,8 @@ export const rateLimits = {
   authLogin: createRatelimit("authLogin", 5, 60 * 1000),
   authCallback: createRatelimit("authCallback", 10, 60 * 1000),
   authLogout: createRatelimit("authLogout", 10, 60 * 1000),
+  // Issue #836: 利用規約同意（一度きりの操作）。誤発火・連打対策に authLogout と同水準。
+  tosAccept: createRatelimit("tosAccept", 10, 60 * 1000),
   authReauth: createRatelimit("authReauth", 3, 60 * 1000),
   // スコープ確認は読み取り専用の低リスク操作なので、authReauthより緩い制限を設定
   // check-scope is a read-only low-risk operation, so use a more generous limit than authReauth

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -1,5 +1,5 @@
 
-import { CARD_DESCRIPTION_MAX_CHARACTERS, ERROR_MESSAGES } from './constants'
+import { CARD_DESCRIPTION_MAX_CHARACTERS, TWITCH_CHAT_MESSAGE_MAX_CHARACTERS, ERROR_MESSAGES } from './constants'
 import { countCharacters } from './text-utils'
 // validateDropRateSumのDB読取はPlanetScale/Drizzleの単一経路。
 import { and, eq } from 'drizzle-orm'
@@ -181,6 +181,98 @@ export function validateRarity(rarity: unknown): { valid: boolean; error?: strin
 
   if (/[\u0000-\u001f\u007f]/.test(trimmedRarity)) {
     return { valid: false, error: ERROR_MESSAGES.INVALID_RARITY }
+  }
+
+  return { valid: true }
+}
+
+/**
+ * Twitch チャネルポイント報酬 ID の形式検証（UUID）。issue #836。
+ *
+ * Twitch の報酬 ID は UUID 形式。チャネルポイント報酬の紐付け（streamer/settings）と
+ * 追加報酬（additional-rewards）の reward_id として保存されるため、非 UUID の値が
+ * EventSub 購読条件（condition.reward_id）と不整合を起こさないようルート層で検証する。
+ * null / undefined は「設定なし・クリア」を意味するため許可する。
+ */
+export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function validateRewardId(rewardId: unknown): { valid: boolean; error?: string } {
+  if (rewardId === null || rewardId === undefined) {
+    return { valid: true }
+  }
+
+  if (typeof rewardId !== 'string') {
+    return { valid: false, error: ERROR_MESSAGES.INVALID_REQUEST }
+  }
+
+  // 空文字列は「報酬なし」を意味する（クライアントは未選択時に "" を送る）
+  const trimmedId = rewardId.trim()
+  if (trimmedId === '') {
+    return { valid: true }
+  }
+
+  if (!UUID_REGEX.test(trimmedId)) {
+    return { valid: false, error: ERROR_MESSAGES.INVALID_REQUEST }
+  }
+
+  return { valid: true }
+}
+
+/**
+ * 報酬名の検証（文字列 + 100 字上限 + 制御文字禁止）。issue #836。
+ * null / undefined は許可（設定なし・クリアを意味する）。
+ */
+export function validateRewardName(rewardName: unknown): { valid: boolean; error?: string } {
+  if (rewardName === null || rewardName === undefined) {
+    return { valid: true }
+  }
+
+  if (typeof rewardName !== 'string') {
+    return { valid: false, error: ERROR_MESSAGES.INVALID_REQUEST }
+  }
+
+  const trimmedName = rewardName.trim()
+
+  if (trimmedName.length === 0 || trimmedName.length > 100) {
+    return { valid: false, error: ERROR_MESSAGES.INVALID_REQUEST }
+  }
+
+  if (/[\u0000-\u001f\u007f]/.test(trimmedName)) {
+    return { valid: false, error: ERROR_MESSAGES.INVALID_REQUEST }
+  }
+
+  return { valid: true }
+}
+
+/**
+ * チャット通知テンプレートの検証（文字列 + 500 字上限）。issue #836。
+ * null は許可（デフォルトテンプレートを使用）。送信時にも 500 字へ truncate される
+ * （chat-service）ため、上限は保存時・送信時の双方で一貫している。
+ * 複数行テンプレートは正当なユースケース（UI は textarea rows=3）のため、
+ * 改行（LF/CR）とタブは許可する。制御文字チェックは改行・タブを除外する。
+ */
+const TEMPLATE_CONTROL_CHAR_REGEX = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/
+
+export function validateChatAnnouncementTemplate(template: unknown): { valid: boolean; error?: string } {
+  if (template === null || template === undefined) {
+    return { valid: true }
+  }
+
+  if (typeof template !== 'string') {
+    return { valid: false, error: ERROR_MESSAGES.INVALID_REQUEST }
+  }
+
+  if (countCharacters(template) > TWITCH_CHAT_MESSAGE_MAX_CHARACTERS) {
+    return { valid: false, error: ERROR_MESSAGES.INVALID_REQUEST }
+  }
+
+  if (TEMPLATE_CONTROL_CHAR_REGEX.test(template)) {
+    return { valid: false, error: ERROR_MESSAGES.INVALID_REQUEST }
+  }
+
+  // 空白のみのテンプレートは「通知文が無い」状態になるため拒否する
+  if (template.trim() === '') {
+    return { valid: false, error: ERROR_MESSAGES.INVALID_REQUEST }
   }
 
   return { valid: true }

--- a/src/lib/validations.ts
+++ b/src/lib/validations.ts
@@ -221,6 +221,11 @@ export function validateRewardId(rewardId: unknown): { valid: boolean; error?: s
 /**
  * 報酬名の検証（文字列 + 100 字上限 + 制御文字禁止）。issue #836。
  * null / undefined は許可（設定なし・クリアを意味する）。
+ * 空文字列（trim後）も validateRewardId と対称に「名前なし」として許可する。
+ * ChannelPointSettings.tsx の handleSave は保存のたびに channelPointRewardId/Name を
+ * 両方送信するため（useState(currentRewardName || "") で初期化）、reward_name が
+ * 未設定な既存データを持つ行では "" が送られうる。ここを拒否すると、そのようなデータを
+ * 持つ配信者は無関係な設定変更（パック紐付け等）まで保存できなくなるレグレッションになる。
  */
 export function validateRewardName(rewardName: unknown): { valid: boolean; error?: string } {
   if (rewardName === null || rewardName === undefined) {
@@ -233,7 +238,11 @@ export function validateRewardName(rewardName: unknown): { valid: boolean; error
 
   const trimmedName = rewardName.trim()
 
-  if (trimmedName.length === 0 || trimmedName.length > 100) {
+  if (trimmedName === '') {
+    return { valid: true }
+  }
+
+  if (trimmedName.length > 100) {
     return { valid: false, error: ERROR_MESSAGES.INVALID_REQUEST }
   }
 

--- a/tests/unit/additional-rewards-api.test.ts
+++ b/tests/unit/additional-rewards-api.test.ts
@@ -121,10 +121,10 @@ describe("/api/streamer/additional-rewards raid options", () => {
   it("persists drawCount and raid-limited options", async () => {
     const db = primeDb({
       selects: [{ rows: [streamer()] }],
-      inserts: [{ rows: [{ id: "additional-1", reward_id: "raid-reward" }] }],
+      inserts: [{ rows: [{ id: "additional-1", reward_id: "44444444-4444-4444-4444-444444444444" }] }],
     });
     const response = await POST(request({
-      rewardId: "raid-reward",
+      rewardId: "44444444-4444-4444-4444-444444444444",
       rewardName: "Raid 10",
       drawCount: 10,
       isRaidLimited: true,
@@ -141,7 +141,7 @@ describe("/api/streamer/additional-rewards raid options", () => {
       inserts: [{ rows: [{ id: "additional-1", collection_name: "weapons" }] }],
     });
     const response = await POST(request({
-      rewardId: "extra-reward",
+      rewardId: "44444444-4444-4444-4444-444444444444",
       rewardName: "Weapons",
       collectionName: "weapons",
     }));
@@ -154,7 +154,7 @@ describe("/api/streamer/additional-rewards raid options", () => {
       selects: [{ rows: [streamer(["empty-pack"])] }, { rows: [{ count: 0 }] }],
     });
     const response = await POST(request({
-      rewardId: "extra-reward",
+      rewardId: "44444444-4444-4444-4444-444444444444",
       rewardName: "Empty",
       collectionName: "empty-pack",
     }));
@@ -163,14 +163,14 @@ describe("/api/streamer/additional-rewards raid options", () => {
   });
 
   it("rejects a present but invalid collectionName type", async () => {
-    const response = await POST(request({ rewardId: "extra-reward", collectionName: 123 }));
+    const response = await POST(request({ rewardId: "44444444-4444-4444-4444-444444444444", collectionName: 123 }));
     expect(response.status).toBe(400);
   });
 
   it("rejects an unregistered pack name", async () => {
     const db = primeDb({ selects: [{ rows: [streamer(["characters"])] }] });
     const response = await POST(request({
-      rewardId: "extra-reward",
+      rewardId: "44444444-4444-4444-4444-444444444444",
       rewardName: "Weapons",
       collectionName: "weapons",
     }));
@@ -181,9 +181,9 @@ describe("/api/streamer/additional-rewards raid options", () => {
   it("still creates a reward with no pack", async () => {
     const db = primeDb({
       selects: [{ rows: [streamer()] }],
-      inserts: [{ rows: [{ id: "additional-1", reward_id: "extra-reward" }] }],
+      inserts: [{ rows: [{ id: "additional-1", reward_id: "44444444-4444-4444-4444-444444444444" }] }],
     });
-    const response = await POST(request({ rewardId: "extra-reward", rewardName: "No Pack" }));
+    const response = await POST(request({ rewardId: "44444444-4444-4444-4444-444444444444", rewardName: "No Pack" }));
     expect(response.status).toBe(200);
     expect((await response.json()).success).toBe(true);
     expect(db.insertCalls[0]).not.toHaveProperty("collection_name");
@@ -195,7 +195,7 @@ describe("/api/streamer/additional-rewards raid options", () => {
       inserts: [{ rows: [{ id: "additional-1", collection_name: DEFAULT_PACK_SENTINEL }] }],
     });
     const response = await POST(request({
-      rewardId: "extra-reward",
+      rewardId: "44444444-4444-4444-4444-444444444444",
       rewardName: "Default",
       collectionName: DEFAULT_PACK_SENTINEL,
     }));
@@ -210,7 +210,7 @@ describe("/api/streamer/additional-rewards raid options", () => {
       selects: [{ rows: [streamer()] }, { rows: [{ count: 0 }] }],
     });
     const response = await POST(request({
-      rewardId: "extra-reward",
+      rewardId: "44444444-4444-4444-4444-444444444444",
       rewardName: "Default",
       collectionName: DEFAULT_PACK_SENTINEL,
     }));
@@ -224,10 +224,10 @@ describe("/api/streamer/additional-rewards raid options", () => {
         { error: { code: "42703", message: "column streamers.card_pack_names does not exist" } },
         { rows: [{ id: "streamer-1", channel_point_reward_id: "main-reward" }] },
       ],
-      inserts: [{ rows: [{ id: "additional-1", reward_id: "extra-reward" }] }],
+      inserts: [{ rows: [{ id: "additional-1", reward_id: "44444444-4444-4444-4444-444444444444" }] }],
     });
     const response = await POST(request({
-      rewardId: "extra-reward",
+      rewardId: "44444444-4444-4444-4444-444444444444",
       rewardName: "Weapons",
       collectionName: "weapons",
     }));
@@ -238,7 +238,7 @@ describe("/api/streamer/additional-rewards raid options", () => {
 
   it("rejects drawCount outside the supported range", async () => {
     const response = await POST(request({
-      rewardId: "raid-reward",
+      rewardId: "44444444-4444-4444-4444-444444444444",
       rewardName: "Raid 20",
       drawCount: 20,
       isRaidLimited: true,

--- a/tests/unit/additional-rewards-driver-parity.test.ts
+++ b/tests/unit/additional-rewards-driver-parity.test.ts
@@ -354,7 +354,7 @@ describe("streamer/additional-rewards: PlanetScale契約 (#663)", () => {
   describe("POST", () => {
     it("所有権確認後に正しいテーブルと値でINSERTする", async () => {
       const OWNED_STREAMER = { id: "streamer-1", channel_point_reward_id: "main-reward", card_pack_names: [] as string[] };
-      const NEW_REWARD = { id: "additional-1", reward_id: "extra-reward", reward_name: "Extra", draw_count: 5, is_raid_limited: false };
+      const NEW_REWARD = { id: "additional-1", reward_id: "22222222-2222-2222-2222-222222222222", reward_name: "Extra", draw_count: 5, is_raid_limited: false };
 
       const pg = createDrizzleDbMock({
         selects: [{ rows: [OWNED_STREAMER] }],
@@ -364,7 +364,7 @@ describe("streamer/additional-rewards: PlanetScale契約 (#663)", () => {
       const { POST: pgPOST } = await loadRoute();
       const pgResponse = await pgPOST(
         jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", {
-          rewardId: "extra-reward",
+          rewardId: "22222222-2222-2222-2222-222222222222",
           rewardName: "Extra",
           drawCount: 5,
         })
@@ -376,7 +376,7 @@ describe("streamer/additional-rewards: PlanetScale契約 (#663)", () => {
       expect(getDb).toHaveBeenCalled();
       expect(pg.insertCalls[0].table).toBe(streamerAdditionalGachaRewardsTable);
       expect(pg.insertCalls[0].values).toEqual(
-        expect.objectContaining({ streamer_id: "streamer-1", reward_id: "extra-reward", draw_count: 5, is_raid_limited: false })
+        expect.objectContaining({ streamer_id: "streamer-1", reward_id: "22222222-2222-2222-2222-222222222222", draw_count: 5, is_raid_limited: false })
       );
     });
 
@@ -392,7 +392,7 @@ describe("streamer/additional-rewards: PlanetScale契約 (#663)", () => {
       const { POST } = await loadRoute();
       const response = await POST(
         jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", {
-          rewardId: "extra-reward",
+          rewardId: "22222222-2222-2222-2222-222222222222",
           drawCount: 10,
           isRaidLimited: true,
         })
@@ -425,7 +425,7 @@ describe("streamer/additional-rewards: PlanetScale契約 (#663)", () => {
       const { POST } = await loadRoute();
       const response = await POST(
         jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", {
-          rewardId: "extra-reward",
+          rewardId: "22222222-2222-2222-2222-222222222222",
           drawCount: 10,
           isRaidLimited: true,
         })
@@ -458,7 +458,7 @@ describe("streamer/additional-rewards: PlanetScale契約 (#663)", () => {
       const { POST } = await loadRoute();
       const response = await POST(
         jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", {
-          rewardId: "extra-reward",
+          rewardId: "22222222-2222-2222-2222-222222222222",
           drawCount: 10,
           isRaidLimited: true,
         })
@@ -478,7 +478,7 @@ describe("streamer/additional-rewards: PlanetScale契約 (#663)", () => {
 
       const { POST } = await loadRoute();
       const response = await POST(
-        jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", { rewardId: "extra-reward" })
+        jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", { rewardId: "22222222-2222-2222-2222-222222222222" })
       );
 
       expect(response.status).toBe(409);
@@ -501,7 +501,7 @@ describe("streamer/additional-rewards: PlanetScale契約 (#663)", () => {
 
       const { POST } = await loadRoute();
       const response = await POST(
-        jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", { rewardId: "extra-reward" })
+        jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", { rewardId: "22222222-2222-2222-2222-222222222222" })
       );
 
       expect(response.status).toBe(409);
@@ -538,7 +538,7 @@ describe("streamer/additional-rewards: PlanetScale契約 (#663)", () => {
             values: vi.fn(() => builder),
             returning: vi.fn(() => builder),
             then: (onFulfilled: any, onRejected: any) =>
-              Promise.resolve([{ id: "additional-1", reward_id: "extra-reward", collection_name: null }]).then(onFulfilled, onRejected),
+              Promise.resolve([{ id: "additional-1", reward_id: "22222222-2222-2222-2222-222222222222", collection_name: null }]).then(onFulfilled, onRejected),
           };
           return builder;
         }),
@@ -548,7 +548,7 @@ describe("streamer/additional-rewards: PlanetScale契約 (#663)", () => {
       const { POST } = await loadRoute();
       const response = await POST(
         jsonRequest("http://localhost/api/streamer/additional-rewards", "POST", {
-          rewardId: "extra-reward",
+          rewardId: "22222222-2222-2222-2222-222222222222",
           rewardName: "Weapons",
           collectionName: "weapons",
         })

--- a/tests/unit/api/cards-batch-route-driver-parity.test.ts
+++ b/tests/unit/api/cards-batch-route-driver-parity.test.ts
@@ -365,4 +365,27 @@ describe("POST /api/cards/batch: PlanetScale契約 (#663)", () => {
     expect(pg.insertCalls).toHaveLength(1);
   });
 
-});
+
+  it("500字を超える description は400で拒否しINSERTしない (#836)", async () => {
+    const pg = createDrizzleDbMock({ selects: [{ rows: [STREAMER_ROW] }] });
+    primePgDb(pg);
+
+    const pgRes = await POST(
+      createBatchRequest({
+        streamerId: "streamer-1",
+        cards: [
+          {
+            name: "Card A",
+            imageUrl: "https://example.com/a.png",
+            rarity: "common",
+            dropRate: 0.5,
+            description: "あ".repeat(501),
+          },
+        ],
+      })
+    );
+
+    expect(pgRes.status).toBe(400);
+    expect(pg.insertCalls).toHaveLength(0);
+  });
+})

--- a/tests/unit/cards-get-api.test.ts
+++ b/tests/unit/cards-get-api.test.ts
@@ -282,3 +282,31 @@ describe("GET /api/cards issued_count", () => {
     expect((await response.json()).cards[0]).not.toHaveProperty("issued_count");
   });
 });
+
+describe("pagination parameter clamping (issue #836)", () => {
+  it("clamps invalid limit values (abc, negative, huge) to the safe range", async () => {
+    for (const [limitParam, expected] of [
+      ["abc", 12],       // parseInt NaN → デフォルト12
+      ["-1", 12],        // 負値 → safeParseInt がデフォルト値（1未満は不正扱い）
+      ["1001", 1000],    // 上限1000
+      ["1000", 1000],    // 正常な最大値
+    ] as const) {
+      const mock = primeCards([BASE_CARD], []);
+      await GET(request({ limit: limitParam }));
+      expect(rowQueryCall(mock.calls).limit).toBe(expected);
+    }
+  });
+
+  it("clamps invalid offset values (abc, negative) to 0", async () => {
+    for (const [offsetParam, expected] of [
+      ["abc", 0],
+      ["-5", 0],
+      ["0", 0],
+      ["25", 25],
+    ] as const) {
+      const mock = primeCards([BASE_CARD], []);
+      await GET(request({ offset: offsetParam }));
+      expect(rowQueryCall(mock.calls).offset).toBe(expected);
+    }
+  });
+});

--- a/tests/unit/eventsub-maintenance-park.test.ts
+++ b/tests/unit/eventsub-maintenance-park.test.ts
@@ -65,6 +65,15 @@ vi.mock('@opennextjs/cloudflare', () => ({
   getCloudflareContext: mocks.getCloudflareContext,
 }))
 
+// Issue #836: EventSub リプレイ防止（message-id 重複排除）は KV を参照する。
+// このテストは maintenance park の挙動検証が目的のため、dedup は「重複なし」で
+// モックし、KV の put/get 回数に影響を与えないようにする（dedup 自体の動作は
+// 専用テストで検証する）。
+vi.mock('@/lib/eventsub-dedup', () => ({
+  isDuplicateEventSubMessage: vi.fn().mockResolvedValue(false),
+  markEventSubMessageSeen: vi.fn().mockResolvedValue(undefined),
+}))
+
 const ALL_MAINTENANCE_ENV_KEYS = [
   'MAINTENANCE_MODE',
   'MAINTENANCE_STARTED_AT',
@@ -111,7 +120,7 @@ async function createEventSubRequest(
 ): Promise<NextRequest> {
   const secret = 'eventsub-test-secret'
   process.env.TWITCH_EVENTSUB_SECRET = secret
-  const timestamp = '2026-07-18T10:00:00Z'
+  const timestamp = new Date().toISOString()
   const body = JSON.stringify(payload)
   const validSignature = await signEventSubBody(secret, messageId, timestamp, body)
   // 正しい署名の末尾1文字だけを変えることで「署名検証は必ず失敗するが、それ以外

--- a/tests/unit/eventsub-redemption.test.ts
+++ b/tests/unit/eventsub-redemption.test.ts
@@ -77,7 +77,9 @@ async function createNotificationRequest(payload: unknown): Promise<NextRequest>
   const secret = 'eventsub-test-secret'
   process.env.TWITCH_EVENTSUB_SECRET = secret
   const messageId = 'eventsub-message-1'
-  const timestamp = '2026-05-11T10:00:00Z'
+  // Issue #836: タイムスタンプ窓（10分）検証の導入により、固定日時は 403 になる。
+  // 現在時刻を使う（再送防止の窓検証に引っかからないようにするため）。
+  const timestamp = new Date().toISOString()
   const body = JSON.stringify(payload)
   const signature = await signEventSubBody(secret, messageId, timestamp, body)
 
@@ -97,6 +99,9 @@ async function createNotificationRequest(payload: unknown): Promise<NextRequest>
 describe('EventSub redemption handling', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // 前テストの dedup 用モック（重複/未受信テスト）が次テストへ漏れないよう
+    // 初期化する（getCloudflareContext の戻り値はこの fixture が上書きする）。
+    mocks.getCloudflareContext.mockReset()
     // unexpected/retryable の失敗は元のWebhookをKVに永続退避できた場合だけ200。
     // このfixtureはreportErrorの回帰テストを、実運用と同じdurable park成功経路で行う。
     mocks.getCloudflareContext.mockResolvedValue({
@@ -157,5 +162,115 @@ describe('EventSub redemption handling', () => {
         gachaError: 'Database error fetching streamer: permission denied',
       }),
     )
+  })
+})
+
+describe('EventSub replay protection (issue #836)', () => {
+  it('NaN タイムスタンプは 403 を返す', async () => {
+    const secret = 'eventsub-test-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = secret
+    const messageId = 'eventsub-nan-1'
+    const body = JSON.stringify({ subscription: { type: 'channel.channel_points_custom_reward_redemption.add' }, event: { broadcaster_user_id: '1' } })
+    const signature = await signEventSubBody(secret, messageId, 'not-a-date', body)
+
+    const request = new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'twitch-eventsub-message-id': messageId,
+        'twitch-eventsub-message-timestamp': 'not-a-date',
+        'twitch-eventsub-message-type': 'notification',
+        'twitch-eventsub-message-signature': signature,
+      },
+      body,
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(403)
+    expect(mocks.executeGachaForEventSub).not.toHaveBeenCalled()
+  })
+
+  beforeEach(() => {
+    mocks.executeGachaForEventSub.mockReset()
+    mocks.executeGachaForEventSub.mockResolvedValue({ success: false, error: 'Streamer not found' })
+  })
+
+  it('11分以上前のタイムスタンプは 403 を返す', async () => {
+    const oldTimestamp = new Date(Date.now() - 11 * 60 * 1000).toISOString()
+    const secret = 'eventsub-test-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = secret
+    const messageId = 'eventsub-stale-1'
+    const body = JSON.stringify({ subscription: { type: 'channel.channel_points_custom_reward_redemption.add' }, event: { broadcaster_user_id: '1' } })
+    const signature = await signEventSubBody(secret, messageId, oldTimestamp, body)
+
+    const request = new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'twitch-eventsub-message-id': messageId,
+        'twitch-eventsub-message-timestamp': oldTimestamp,
+        'twitch-eventsub-message-type': 'notification',
+        'twitch-eventsub-message-signature': signature,
+      },
+      body,
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(403)
+    expect(mocks.executeGachaForEventSub).not.toHaveBeenCalled()
+  })
+
+  it('重複 message-id は 2xx を返し、処理をスキップする', async () => {
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: { RATE_LIMIT_KV: { get: vi.fn().mockResolvedValue('1'), put: vi.fn().mockResolvedValue(undefined) } },
+    })
+    const secret = 'eventsub-test-secret'
+    process.env.TWITCH_EVENTSUB_SECRET = secret
+    const messageId = 'eventsub-dup-1'
+    const timestamp = new Date().toISOString()
+    const body = JSON.stringify({ subscription: { type: 'channel.channel_points_custom_reward_redemption.add' }, event: { broadcaster_user_id: '1' } })
+    const signature = await signEventSubBody(secret, messageId, timestamp, body)
+
+    const request = new NextRequest('http://localhost:3000/api/twitch/eventsub', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'twitch-eventsub-message-id': messageId,
+        'twitch-eventsub-message-timestamp': timestamp,
+        'twitch-eventsub-message-type': 'notification',
+        'twitch-eventsub-message-signature': signature,
+      },
+      body,
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ received: true })
+    expect(mocks.executeGachaForEventSub).not.toHaveBeenCalled()
+  })
+
+  it('未受信 message-id は KV に記録して処理を続行する', async () => {
+    const put = vi.fn().mockResolvedValue(undefined)
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: { RATE_LIMIT_KV: { get: vi.fn().mockResolvedValue(null), put } },
+    })
+    const request = await createNotificationRequest({
+      subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
+      event: {
+        broadcaster_user_id: '1',
+        user_id: 'viewer-1',
+        user_login: 'viewer',
+        user_name: 'Viewer',
+        reward: { id: 'reward-1', title: 'Gacha', cost: 100 },
+      },
+    })
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+    expect(put).toHaveBeenCalledWith(
+      expect.stringContaining('eventsub:dedup:'),
+      '1',
+      expect.objectContaining({ expirationTtl: 600 })
+    )
+    expect(mocks.executeGachaForEventSub).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/unit/eventsub-reward-mismatch.test.ts
+++ b/tests/unit/eventsub-reward-mismatch.test.ts
@@ -118,7 +118,7 @@ async function createNotificationRequest(gachaError: string): Promise<NextReques
   const secret = 'eventsub-test-secret'
   process.env.TWITCH_EVENTSUB_SECRET = secret
   const messageId = `eventsub-${gachaError.replaceAll(' ', '-').toLowerCase()}`
-  const timestamp = '2026-05-11T10:00:00Z'
+  const timestamp = new Date().toISOString()
   const body = JSON.stringify({
     subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
     event: {
@@ -226,7 +226,7 @@ describe('EventSub reward mismatch handling', () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret
     const messageId = 'eventsub-channel-raid'
-    const timestamp = '2026-05-12T00:00:00Z'
+    const timestamp = new Date().toISOString()
     const body = JSON.stringify({
       subscription: { type: 'channel.raid' },
       event: {
@@ -313,7 +313,7 @@ describe('EventSub reward mismatch handling', () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret
     const messageId = 'eventsub-multi-draw'
-    const timestamp = '2026-05-12T00:00:00Z'
+    const timestamp = new Date().toISOString()
     const body = JSON.stringify({
       subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
       event: {
@@ -374,7 +374,7 @@ describe('EventSub reward mismatch handling', () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret
     const messageId = 'eventsub-multi-draw-chat'
-    const timestamp = '2026-05-11T10:00:00Z'
+    const timestamp = new Date().toISOString()
     const body = JSON.stringify({
       subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
       event: {
@@ -449,7 +449,7 @@ describe('EventSub reward mismatch handling', () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret
     const messageId = 'eventsub-multi-draw-single-template'
-    const timestamp = '2026-05-11T10:00:00Z'
+    const timestamp = new Date().toISOString()
     const body = JSON.stringify({
       subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
       event: {
@@ -507,7 +507,7 @@ describe('EventSub reward mismatch handling', () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret
     const messageId = 'eventsub-multi-draw-new-cards'
-    const timestamp = '2026-05-11T10:00:00Z'
+    const timestamp = new Date().toISOString()
     const body = JSON.stringify({
       subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
       event: {
@@ -572,7 +572,7 @@ describe('EventSub reward mismatch handling', () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret
     const messageId = 'eventsub-multi-draw-new-placeholders'
-    const timestamp = '2026-05-11T10:00:00Z'
+    const timestamp = new Date().toISOString()
     const body = JSON.stringify({
       subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
       event: {
@@ -642,7 +642,7 @@ describe('EventSub reward mismatch handling', () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret
     const messageId = 'eventsub-long-multi-draw-chat'
-    const timestamp = '2026-05-11T10:00:00Z'
+    const timestamp = new Date().toISOString()
     const body = JSON.stringify({
       subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
       event: {
@@ -705,7 +705,7 @@ describe('EventSub reward mismatch handling', () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret
     const messageId = 'eventsub-multi-draw-rarity-summary'
-    const timestamp = '2026-05-11T10:00:00Z'
+    const timestamp = new Date().toISOString()
     const body = JSON.stringify({
       subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
       event: {
@@ -779,7 +779,7 @@ describe('EventSub reward mismatch handling', () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret
     const messageId = 'eventsub-new-cards-suffix-preserved'
-    const timestamp = '2026-05-11T10:00:00Z'
+    const timestamp = new Date().toISOString()
     const body = JSON.stringify({
       subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
       event: {
@@ -853,7 +853,7 @@ describe('EventSub reward mismatch handling', () => {
     const secret = 'eventsub-test-secret'
     process.env.TWITCH_EVENTSUB_SECRET = secret
     const messageId = 'eventsub-new-cards-legacy-fallback-zero'
-    const timestamp = '2026-05-11T10:00:00Z'
+    const timestamp = new Date().toISOString()
     const body = JSON.stringify({
       subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
       event: {

--- a/tests/unit/eventsub-user-card-counts-driver-parity.test.ts
+++ b/tests/unit/eventsub-user-card-counts-driver-parity.test.ts
@@ -102,7 +102,7 @@ async function signEventSubBody(secret: string, messageId: string, timestamp: st
 async function createRedemptionRequest(messageId: string): Promise<NextRequest> {
   const secret = 'eventsub-test-secret'
   process.env.TWITCH_EVENTSUB_SECRET = secret
-  const timestamp = '2026-07-01T10:00:00Z'
+  const timestamp = new Date().toISOString()
   const body = JSON.stringify({
     subscription: { type: 'channel.channel_points_custom_reward_redemption.add' },
     event: {

--- a/tests/unit/streamer-settings-api.test.ts
+++ b/tests/unit/streamer-settings-api.test.ts
@@ -244,7 +244,7 @@ describe('POST /api/streamer/settings', () => {
       },
       body: JSON.stringify({
         streamerId: 'streamer123',
-        channelPointRewardId: 'reward-123',
+        channelPointRewardId: '11111111-1111-1111-1111-111111111111',
         channelPointRewardName: 'Test Reward',
       }),
     })
@@ -315,6 +315,45 @@ describe('POST /api/streamer/settings', () => {
     expect(response.status).toBe(400)
     const data = await response.json()
     expect(data.error).toBe('Rarity weights total must be 100%')
+  })
+
+  it('rejects non-UUID channelPointRewardId (issue #836)', async () => {
+    const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        streamerId: 'streamer123',
+        channelPointRewardId: 'reward-123',
+      }),
+    })
+    const response = await POST(request)
+    expect(response.status).toBe(400)
+  })
+
+  it('rejects non-boolean gachaSoundEnabled (issue #836)', async () => {
+    const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        streamerId: 'streamer123',
+        gachaSoundEnabled: 'yes',
+      }),
+    })
+    const response = await POST(request)
+    expect(response.status).toBe(400)
+  })
+
+  it('rejects oversized chatAnnouncementTemplate (issue #836)', async () => {
+    const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        streamerId: 'streamer123',
+        chatAnnouncementTemplate: 'a'.repeat(501),
+      }),
+    })
+    const response = await POST(request)
+    expect(response.status).toBe(400)
   })
 
   it('should allow empty rarity weights object for manual mode switch', async () => {
@@ -1001,7 +1040,7 @@ describe('POST /api/streamer/settings', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         streamerId: 'streamer123',
-        channelPointRewardId: 'reward-123',
+        channelPointRewardId: '11111111-1111-1111-1111-111111111111',
         channelPointCollectionName: 'weapons',
       }),
     })
@@ -1035,7 +1074,7 @@ describe('POST /api/streamer/settings', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
         streamerId: 'streamer123',
-        channelPointRewardId: 'reward-123',
+        channelPointRewardId: '11111111-1111-1111-1111-111111111111',
         channelPointCollectionName: 'empty-pack',
       }),
     })
@@ -1257,7 +1296,7 @@ describe('POST /api/streamer/settings', () => {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
           streamerId: 'streamer123',
-          channelPointRewardId: 'reward-123',
+          channelPointRewardId: '11111111-1111-1111-1111-111111111111',
           channelPointRewardName: 'Test Reward',
         }),
       })
@@ -1265,7 +1304,7 @@ describe('POST /api/streamer/settings', () => {
       const response = await POST(request)
       expect(response.status).toBe(200)
       expect(updateQuery.update).toHaveBeenCalledWith(
-        expect.objectContaining({ channel_point_reward_id: 'reward-123' })
+        expect.objectContaining({ channel_point_reward_id: '11111111-1111-1111-1111-111111111111' })
       )
     })
 
@@ -1296,7 +1335,7 @@ describe('POST /api/streamer/settings', () => {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
           streamerId: 'streamer123',
-          channelPointRewardId: 'reward-123',
+          channelPointRewardId: '11111111-1111-1111-1111-111111111111',
           channelPointRewardName: 'Test Reward',
         }),
       })
@@ -1304,7 +1343,7 @@ describe('POST /api/streamer/settings', () => {
       const response = await POST(request)
       expect(response.status).toBe(200)
       expect(updateQuery.update).toHaveBeenCalledWith(
-        expect.objectContaining({ channel_point_reward_id: 'reward-123' })
+        expect.objectContaining({ channel_point_reward_id: '11111111-1111-1111-1111-111111111111' })
       )
     })
   })

--- a/tests/unit/streamer-settings-api.test.ts
+++ b/tests/unit/streamer-settings-api.test.ts
@@ -330,6 +330,32 @@ describe('POST /api/streamer/settings', () => {
     expect(response.status).toBe(400)
   })
 
+  it('accepts an empty channelPointRewardName alongside a valid reward id (issue #836 regression)', async () => {
+    // ChannelPointSettings.tsx の handleSave は保存のたびに channelPointRewardName を
+    // 送信する（useState(currentRewardName || "") で初期化）。reward_name が未設定な
+    // 既存データを持つ配信者がこの保存操作で 400 にならないことを固定する。
+    const mockDbFixture = createDbFixture()
+      .withMaybeSingleResponse({
+        id: 'streamer123',
+        twitch_user_id: 'streamer123',
+      })
+      .build()
+
+    installDbFixture(mockDbFixture)
+
+    const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        streamerId: 'streamer123',
+        channelPointRewardId: '11111111-1111-1111-1111-111111111111',
+        channelPointRewardName: '',
+      }),
+    })
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+  })
+
   it('rejects non-boolean gachaSoundEnabled (issue #836)', async () => {
     const request = new NextRequest('http://localhost:3000/api/streamer/settings', {
       method: 'POST',

--- a/tests/unit/streamer-settings-driver-parity.test.ts
+++ b/tests/unit/streamer-settings-driver-parity.test.ts
@@ -200,7 +200,7 @@ describe("streamer/settings POST: PlanetScale契約 (#663)", () => {
     const pgResponse = await pgPOST(
       postRequest({
         streamerId: "streamer123",
-        channelPointRewardId: "reward-123",
+        channelPointRewardId: "33333333-3333-3333-3333-333333333333",
         channelPointRewardName: "Test Reward",
       })
     );
@@ -214,7 +214,7 @@ describe("streamer/settings POST: PlanetScale契約 (#663)", () => {
     );
     expect(pg.updateCalls[0].table).toBe(streamersTable);
     expect(pg.updateCalls[0].set).toEqual(
-      expect.objectContaining({ channel_point_reward_id: "reward-123", channel_point_reward_name: "Test Reward" })
+      expect.objectContaining({ channel_point_reward_id: "33333333-3333-3333-3333-333333333333", channel_point_reward_name: "Test Reward" })
     );
     expect(pg.updateCalls[0].where).toEqual(eq(streamersTable.id, "streamer123"));
   });
@@ -224,7 +224,7 @@ describe("streamer/settings POST: PlanetScale契約 (#663)", () => {
     primePgDb(pg);
 
     const { POST } = await loadRoute();
-    const response = await POST(postRequest({ streamerId: "streamer123", channelPointRewardId: "reward-1" }));
+    const response = await POST(postRequest({ streamerId: "streamer123", channelPointRewardId: "33333333-3333-3333-3333-333333333333" }));
     expect(response.status).toBe(403);
   });
 
@@ -368,7 +368,7 @@ describe("streamer/settings POST: PlanetScale契約 (#663)", () => {
     vi.mocked(getDb).mockResolvedValue({ db, sql: {} } as any);
 
     const { POST } = await loadRoute();
-    const response = await POST(postRequest({ streamerId: "streamer123", channelPointRewardId: "reward-1" }));
+    const response = await POST(postRequest({ streamerId: "streamer123", channelPointRewardId: "33333333-3333-3333-3333-333333333333" }));
     const body = await response.json();
 
     expect(response.status).toBe(200);

--- a/tests/unit/tos-accept-route-driver-parity.test.ts
+++ b/tests/unit/tos-accept-route-driver-parity.test.ts
@@ -24,6 +24,18 @@ vi.mock('@/lib/session', () => ({
 vi.mock('@/lib/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }))
+// Issue #836: tos/accept に CSRF 検証・レート制限を追加したため、テストでは
+// 両者を成功扱いにモックする（CSRF 失敗・429 の個別検証は別テストで行う）。
+vi.mock('@/lib/csrf', () => ({
+  validateCSRFToken: vi.fn().mockResolvedValue({ valid: true }),
+}))
+vi.mock('@/lib/rate-limit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/rate-limit')>()
+  return {
+    ...actual,
+    checkRateLimit: vi.fn().mockResolvedValue({ success: true, limit: 10, remaining: 9, reset: Date.now() + 60000 }),
+  }
+})
 
 const SESSION = { twitchUserId: 'user-1' } as any
 
@@ -163,6 +175,26 @@ describe('GET/POST /api/tos/accept: PlanetScale契約 (#711)', () => {
   })
 
   describe('POST', () => {
+    it('CSRF検証失敗: 403 を返し DB に触れない (issue #836)', async () => {
+      vi.mocked(getSession).mockResolvedValue({ twitchUserId: 'user-1' } as any)
+      const csrfMock = (await import('@/lib/csrf')).validateCSRFToken as ReturnType<typeof vi.fn>
+      csrfMock.mockResolvedValueOnce({ valid: false })
+
+      const res = await tosAcceptRoute.POST(createPostRequest() as any)
+      expect(res.status).toBe(403)
+      expect(getDb).not.toHaveBeenCalled()
+    })
+
+    it('レート制限超過: 429 を返す (issue #836)', async () => {
+      vi.mocked(getSession).mockResolvedValue({ twitchUserId: 'user-1' } as any)
+      const rateLimitMock = (await import('@/lib/rate-limit')).checkRateLimit as ReturnType<typeof vi.fn>
+      rateLimitMock.mockResolvedValueOnce({ success: false, limit: 10, remaining: 0, reset: Date.now() + 60000 })
+
+      const res = await tosAcceptRoute.POST(createPostRequest() as any)
+      expect(res.status).toBe(429)
+      expect(getDb).not.toHaveBeenCalled()
+    })
+
     it('未認証: 401 を返し DB に触れない', async () => {
       vi.mocked(getSession).mockResolvedValue(null)
 

--- a/tests/unit/validations.test.ts
+++ b/tests/unit/validations.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { CARD_DESCRIPTION_MAX_CHARACTERS, ERROR_MESSAGES } from '@/lib/constants'
 import { countCharacters, truncateCharacters } from '@/lib/text-utils'
-import { validateCardDescription, validateRarity } from '@/lib/validations'
+import {
+  validateCardDescription,
+  validateRarity,
+  validateRewardId,
+  validateRewardName,
+  validateChatAnnouncementTemplate,
+} from '@/lib/validations'
 
 describe('countCharacters', () => {
   it('日本語文字列を文字単位で数える', () => {
@@ -53,6 +59,105 @@ describe('validateRarity', () => {
     expect(validateRarity('rare\nhidden')).toEqual({
       valid: false,
       error: ERROR_MESSAGES.INVALID_RARITY,
+    })
+  })
+})
+
+describe('validateRewardId (issue #836)', () => {
+  const validUuid = '11111111-1111-1111-1111-111111111111'
+
+  it('UUID 形式を許可する（大文字小文字を問わない）', () => {
+    expect(validateRewardId(validUuid)).toEqual({ valid: true })
+    expect(validateRewardId(validUuid.toUpperCase())).toEqual({ valid: true })
+  })
+
+  it('null / undefined は許可する（設定なし・クリアを意味する）', () => {
+    expect(validateRewardId(null)).toEqual({ valid: true })
+    expect(validateRewardId(undefined)).toEqual({ valid: true })
+  })
+
+  it('空文字列は許可する（クライアントは報酬未選択時に "" を送る）', () => {
+    expect(validateRewardId('')).toEqual({ valid: true })
+    expect(validateRewardId('  ')).toEqual({ valid: true })
+  })
+
+  it('非 UUID 文字列・非文字列を拒否する', () => {
+    expect(validateRewardId('reward-123')).toEqual({
+      valid: false,
+      error: ERROR_MESSAGES.INVALID_REQUEST,
+    })
+    expect(validateRewardId(12345)).toEqual({
+      valid: false,
+      error: ERROR_MESSAGES.INVALID_REQUEST,
+    })
+    expect(validateRewardId('11111111-1111-1111-1111-11111111111g')).toEqual({
+      valid: false,
+      error: ERROR_MESSAGES.INVALID_REQUEST,
+    })
+  })
+})
+
+describe('validateRewardName (issue #836)', () => {
+  it('null / undefined と 1〜100 字の文字列を許可する', () => {
+    expect(validateRewardName(null)).toEqual({ valid: true })
+    expect(validateRewardName(undefined)).toEqual({ valid: true })
+    expect(validateRewardName('Test Reward')).toEqual({ valid: true })
+    expect(validateRewardName('a'.repeat(100))).toEqual({ valid: true })
+  })
+
+  it('101字以上・空文字・制御文字を含む名前を拒否する', () => {
+    expect(validateRewardName('a'.repeat(101))).toEqual({
+      valid: false,
+      error: ERROR_MESSAGES.INVALID_REQUEST,
+    })
+    expect(validateRewardName('   ')).toEqual({
+      valid: false,
+      error: ERROR_MESSAGES.INVALID_REQUEST,
+    })
+    expect(validateRewardName('bad\nname')).toEqual({
+      valid: false,
+      error: ERROR_MESSAGES.INVALID_REQUEST,
+    })
+  })
+
+  it('非文字列を拒否する', () => {
+    expect(validateRewardName(123)).toEqual({
+      valid: false,
+      error: ERROR_MESSAGES.INVALID_REQUEST,
+    })
+  })
+})
+
+describe('validateChatAnnouncementTemplate (issue #836)', () => {
+  it('null / undefined と上限内の文字列を許可する', () => {
+    expect(validateChatAnnouncementTemplate(null)).toEqual({ valid: true })
+    expect(validateChatAnnouncementTemplate(undefined)).toEqual({ valid: true })
+    expect(validateChatAnnouncementTemplate('@{user} がカードを獲得しました！')).toEqual({ valid: true })
+    expect(validateChatAnnouncementTemplate('a'.repeat(500))).toEqual({ valid: true })
+  })
+
+  it('複数行テンプレート（改行・タブ）を許可する', () => {
+    expect(validateChatAnnouncementTemplate('1行目\n2行目')).toEqual({ valid: true })
+    expect(validateChatAnnouncementTemplate('@{user} が獲得！\r\n詳細は {card}')).toEqual({ valid: true })
+    expect(validateChatAnnouncementTemplate('タブ\t区切り')).toEqual({ valid: true })
+  })
+
+  it('上限超過・制御文字（改行以外）・空白のみ・非文字列を拒否する', () => {
+    expect(validateChatAnnouncementTemplate('a'.repeat(501))).toEqual({
+      valid: false,
+      error: ERROR_MESSAGES.INVALID_REQUEST,
+    })
+    expect(validateChatAnnouncementTemplate('bad\u0007bell')).toEqual({
+      valid: false,
+      error: ERROR_MESSAGES.INVALID_REQUEST,
+    })
+    expect(validateChatAnnouncementTemplate('   ')).toEqual({
+      valid: false,
+      error: ERROR_MESSAGES.INVALID_REQUEST,
+    })
+    expect(validateChatAnnouncementTemplate(123)).toEqual({
+      valid: false,
+      error: ERROR_MESSAGES.INVALID_REQUEST,
     })
   })
 })

--- a/tests/unit/validations.test.ts
+++ b/tests/unit/validations.test.ts
@@ -105,12 +105,16 @@ describe('validateRewardName (issue #836)', () => {
     expect(validateRewardName('a'.repeat(100))).toEqual({ valid: true })
   })
 
-  it('101字以上・空文字・制御文字を含む名前を拒否する', () => {
+  it('空文字列・空白のみは「名前未設定」として許可する（validateRewardId と対称）', () => {
+    // ChannelPointSettings.tsx の handleSave は保存のたびに channelPointRewardName を
+    // 送信する（useState(currentRewardName || "") で初期化）。reward_name が未設定な
+    // 既存データを持つ配信者が無関係な設定を保存できなくなるレグレッションを防ぐ。
+    expect(validateRewardName('')).toEqual({ valid: true })
+    expect(validateRewardName('   ')).toEqual({ valid: true })
+  })
+
+  it('101字以上・制御文字を含む名前を拒否する', () => {
     expect(validateRewardName('a'.repeat(101))).toEqual({
-      valid: false,
-      error: ERROR_MESSAGES.INVALID_REQUEST,
-    })
-    expect(validateRewardName('   ')).toEqual({
       valid: false,
       error: ERROR_MESSAGES.INVALID_REQUEST,
     })


### PR DESCRIPTION
## 対応issue
Closes #836（security(low): 残余のセキュリティ指摘まとめ）のうち、項目1〜4を実装

## 変更内容

### 1. 入力バリデーション（4ルート）
- **`src/lib/validations.ts`**: `validateRewardId`(UUID形式、null/undefined/空文字は許可)、`validateRewardName`(100字+制御文字)、`validateChatAnnouncementTemplate`(500字、改行・タブは許可)を追加。`UUID_REGEX` を export
- **`POST /api/streamer/settings`**: channelPointRewardId/Name、chatAnnouncementTemplate/MultiTemplate、gachaSoundEnabled/chatAnnouncementEnabled の検証追加(既存 boolean 検証と対称化)
- **`POST /api/cards/batch`**: description に `validateCardDescription` 適用(単体作成の制限迂回を閉鎖)
- **`GET /api/cards`**: limit/offset を `safeParseInt` + clamp に変更(不正値による DB 500 ノイズ解消)
- **`POST /api/streamer/additional-rewards`**: rewardId(UUID必須)/rewardName の検証追加

### 2. EventSub リプレイ防止（Twitch 公式仕様適合）
- タイムスタンプ10分窓検証(`Date.parse` NaN を明示的に弾く)。403 応答
- `src/lib/eventsub-dedup.ts`(新規): message-id の KV 重複排除(TTL 10分、フェイルオープン)。**記録は処理完了(2xx)後に分離**し、503(再送要求)経路では記録しないことで、再送時の通知喪失を防ぐ

### 3. `POST /api/tos/accept`
- CSRF 検証 + レート制限(`rateLimits.tosAccept` 10回/分)を追加(他ルートと同じ検証順序)

### 4. SECURITY.md
- `SameSite='strict'` → `'lax'`(実装と整合)、CSRF 例外(#831)明記、タイポ修正

## スコープ外(issue に残す)
- 項目5(本番 CSP nonce 化)・項目6(getBaseUrl の Host 検証)は大規模/要検証のため対象外

## 検証
- 全体テスト 3655 passed / typecheck / eslint クリーン
- 新規テスト: validations ヘルパ3種、eventsub リプレイ(11分前 403・NaN 403・重複 2xx・未受信記録)、tos CSRF 403/429、cards GET clamp、cards/batch description 501字拒否、streamer/settings の 400 系3件
- 既存テスト修正: 非UUID fixture→UUID 化、eventsub 固定タイムスタンプ→現在時刻化(窓検証導入のため)、maintenance-park に dedup モック追加
- 自己レビュー: サブエージェントによる厳格レビューで最重要指摘(処理前に dedup 記録すると 503 再送で通知喪失)とテンプレート改行禁止を含む指摘10件を対応

## 補足
- ルートレベルの検証は全て DB アクセス前に完了するため PlanetScale/pg 両経路で同一挙動(driver-parity に影響なし)
- スコープ外の未コミット変更(gacha-sound-settings の flake 修正)はこのPRに含めていない