### PR TITLE
release: promote preview after PR #894/#895

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -375,7 +375,8 @@
       "rarity": "Rarity"
     },
     "viewCollection": "View Collection",
-    "unownedCard": "???"
+    "unownedCard": "???",
+    "unownedStatus": "Unowned card"
   },
   "collectionProgress": {
     "progress": "{owned}/{total} types",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -375,7 +375,8 @@
       "rarity": "レアリティ順"
     },
     "viewCollection": "コレクションを見る",
-    "unownedCard": "???"
+    "unownedCard": "???",
+    "unownedStatus": "未所持カード"
   },
   "collectionProgress": {
     "progress": "{owned}/{total}種類",

--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -109,7 +109,11 @@ export default function CollectionCard({
       </div>
 
       {!isOwned && (
-        <div className="absolute right-2 top-2 rounded-full bg-black/60 p-1">
+        <div
+          role="img"
+          aria-label="Unowned card"
+          className="absolute right-2 top-2 rounded-full bg-black/60 p-1"
+        >
           <svg
             className="h-3.5 w-3.5 text-white"
             viewBox="0 0 24 24"
@@ -196,7 +200,7 @@ export default function CollectionCard({
       {cardFooter}
     </div>
   ) : (
-    <div className={cardClassName} aria-disabled="true">
+    <div className={cardClassName}>
       {cardContent}
       {cardFooter}
     </div>

--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -158,7 +158,11 @@ export default function CollectionCard({
 
   // 説明の開閉buttonをカード詳細Linkの外へ置くため、フッターはLinkの兄弟として描画する。
   // Keep the footer outside the card Link so its disclosure button is never nested in an anchor.
-  const cardFooter = (
+  const hasCardFooter =
+    (descriptionComponent !== undefined && descriptionComponent !== null) ||
+    (count ?? 0) > 1;
+
+  const cardFooter = hasCardFooter ? (
     <div className="p-3 pt-2">
       {descriptionComponent}
       {(count ?? 0) > 1 && (
@@ -171,7 +175,7 @@ export default function CollectionCard({
         </Link>
       )}
     </div>
-  );
+  ) : null;
 
   // prefetch={false}: Disable automatic prefetching to prevent N+1 API calls
   // Each card link would trigger a server-side fetch of getUserCardDetail() on hover/viewport

--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -158,14 +158,15 @@ export default function CollectionCard({
 
   // 説明の開閉buttonをカード詳細Linkの外へ置くため、フッターはLinkの兄弟として描画する。
   // Keep the footer outside the card Link so its disclosure button is never nested in an anchor.
+  const hasCount = isOwned && (count ?? 0) > 1;
   const hasCardFooter =
     (descriptionComponent !== undefined && descriptionComponent !== null) ||
-    (count ?? 0) > 1;
+    hasCount;
 
   const cardFooter = hasCardFooter ? (
     <div className="p-3 pt-2">
       {descriptionComponent}
-      {(count ?? 0) > 1 && (
+      {hasCount && (
         <Link
           href={cardDetailHref}
           className="text-gray-400 text-sm"

--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -79,7 +79,7 @@ export default function CollectionCard({
     isOwned ? "cursor-pointer hover:scale-105" : "cursor-default"
   } ${isInactive ? "ring-1 ring-amber-400/30" : ""}`;
 
-  const cardBody = (
+  const cardContent = (
     <>
       {/* Card name and rarity badge at the top */}
       {/* 名前とレアリティを一番上に配置 */}
@@ -151,17 +151,26 @@ export default function CollectionCard({
         )}
       </div>
 
-      {/* Description and count at the bottom */}
-      {/* 説明とカウント */}
-      <div className="p-3 pt-2">
-        {descriptionComponent}
-        {(count ?? 0) > 1 && (
-          <div className="text-gray-400 text-sm">
-            {countLabel}
-          </div>
-        )}
-      </div>
     </>
+  );
+
+  const cardDetailHref = `/collection/${streamerId}/card/${id}`;
+
+  // 説明の開閉buttonをカード詳細Linkの外へ置くため、フッターはLinkの兄弟として描画する。
+  // Keep the footer outside the card Link so its disclosure button is never nested in an anchor.
+  const cardFooter = (
+    <div className="p-3 pt-2">
+      {descriptionComponent}
+      {(count ?? 0) > 1 && (
+        <Link
+          href={cardDetailHref}
+          className="text-gray-400 text-sm"
+          prefetch={false}
+        >
+          {countLabel}
+        </Link>
+      )}
+    </div>
   );
 
   // prefetch={false}: Disable automatic prefetching to prevent N+1 API calls
@@ -171,16 +180,20 @@ export default function CollectionCard({
   // 各カードリンクはホバー/ビューポート時にgetUserCardDetail()のサーバー側フェッチを発生させる
   // 50枚のカードがある場合、プリフェッチだけで150以上のDBクエリが発生する
   return isOwned ? (
-    <Link
-      href={`/collection/${streamerId}/card/${id}`}
-      className={cardClassName}
-      prefetch={false}
-    >
-      {cardBody}
-    </Link>
+    <div className={cardClassName}>
+      <Link
+        href={cardDetailHref}
+        className="block"
+        prefetch={false}
+      >
+        {cardContent}
+      </Link>
+      {cardFooter}
+    </div>
   ) : (
     <div className={cardClassName} aria-disabled="true">
-      {cardBody}
+      {cardContent}
+      {cardFooter}
     </div>
   );
 }

--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -43,6 +43,9 @@ interface CollectionCardProps {
   // Whether this card is owned by the current user (default: true for backward compatibility)
   // このカードを現在ユーザーが所持しているか（後方互換のためデフォルトtrue）
   isOwned?: boolean;
+  // Accessible label for the unowned-state marker.
+  // 未所持状態を支援技術へ伝えるラベル。
+  unownedLabel?: string;
   // Whether the card is no longer distributed
   // このカードが現在配布停止中かどうか
   isInactive?: boolean;
@@ -71,6 +74,7 @@ export default function CollectionCard({
   priority = false,
   noImageText,
   isOwned = true,
+  unownedLabel = "Unowned card",
   isInactive = false,
   inactiveLabel,
   descriptionComponent,
@@ -109,10 +113,8 @@ export default function CollectionCard({
       </div>
 
       {!isOwned && (
-        <div
-          aria-hidden="true"
-          className="absolute right-2 top-2 rounded-full bg-black/60 p-1"
-        >
+        <div className="absolute right-2 top-2 rounded-full bg-black/60 p-1">
+          <span className="sr-only">{unownedLabel}</span>
           <svg
             className="h-3.5 w-3.5 text-white"
             viewBox="0 0 24 24"
@@ -173,6 +175,7 @@ export default function CollectionCard({
         <Link
           href={cardDetailHref}
           className="text-gray-400 text-sm"
+          aria-label={`${name}: ${countLabel}`}
           prefetch={false}
         >
           {countLabel}

--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -110,8 +110,7 @@ export default function CollectionCard({
 
       {!isOwned && (
         <div
-          role="img"
-          aria-label="Unowned card"
+          aria-hidden="true"
           className="absolute right-2 top-2 rounded-full bg-black/60 p-1"
         >
           <svg

--- a/src/components/ExpandableDescription.tsx
+++ b/src/components/ExpandableDescription.tsx
@@ -133,7 +133,11 @@ export default function ExpandableDescription({
   const descriptionContent = (
     <p
       ref={textRef}
-      onClick={handleClick}
+      // detailHrefを指定した説明は入力手段によらず詳細リンクとして動作させ、
+      // 展開・折りたたみは専用buttonだけに限定する。
+      // Keep linked descriptions navigable by mouse and keyboard alike; the
+      // disclosure button is the only control that changes expansion state.
+      onClick={detailHref ? undefined : handleClick}
       style={expandedStyle}
       className={[textSizeClass, lineClampClass, isClickable ? "cursor-pointer hover:text-gray-200" : ""].join(" ")}
     >
@@ -144,7 +148,7 @@ export default function ExpandableDescription({
   return (
     <div className="mb-1">
       {detailHref ? (
-        <Link href={detailHref} className="block">
+        <Link href={detailHref} className="block" prefetch={false}>
           {descriptionContent}
         </Link>
       ) : (

--- a/src/components/ExpandableDescription.tsx
+++ b/src/components/ExpandableDescription.tsx
@@ -118,7 +118,7 @@ export default function ExpandableDescription({
 
   // line-clampのクラス名を動的に生成
   // Dynamically generate line-clamp class
-  const lineClampClass = isExpanded ? "" : \`line-clamp-\${maxLines}\`;
+  const lineClampClass = isExpanded ? "" : `line-clamp-${maxLines}`;
 
   // クリック可能かどうか（省略されているか展開済み）
   // Whether clickable (truncated or already expanded)
@@ -127,7 +127,7 @@ export default function ExpandableDescription({
   // 展開時に最大高さが指定されている場合のスタイル
   // Style for expanded state with max height limit
   const expandedStyle = isExpanded && maxExpandedHeight
-    ? { maxHeight: \`\${maxExpandedHeight}px\`, overflowY: "auto" as const }
+    ? { maxHeight: `${maxExpandedHeight}px`, overflowY: "auto" as const }
     : undefined;
 
   const descriptionContent = (

--- a/src/components/ExpandableDescription.tsx
+++ b/src/components/ExpandableDescription.tsx
@@ -47,7 +47,12 @@ export default function ExpandableDescription({
     }
   }, [description]);
 
-  const handleClick = () => {
+  const handleClick = (e: React.MouseEvent) => {
+    // カード全体が詳細画面への Link でラップされている場合（コレクションページ等）、
+    // このクリックが親へバブリングすると「開く/閉じる」と同時にカード詳細へ
+    // 遷移してしまうため、伝播を止める。
+    // Stop propagation so the enclosing card Link (detail navigation) is not triggered.
+    e.stopPropagation();
     // 省略されている場合のみ展開/折りたたみを切り替え
     // Only toggle if text is actually truncated
     if (isTruncated || isExpanded) {

--- a/src/components/ExpandableDescription.tsx
+++ b/src/components/ExpandableDescription.tsx
@@ -39,6 +39,7 @@ export default function ExpandableDescription({
   const tCommon = useTranslations("common");
   const [previousDescription, setPreviousDescription] = useState(description);
   const [isExpanded, setIsExpanded] = useState(false);
+
   // Reactのrender中に直前のpropとの差し替えを同期する。A→B→Aのように
   // 文字列が再利用されても、直前の説明から変わるたびに展開状態を破棄する。
   // Synchronize against the immediately previous prop during render so an A→B→A
@@ -47,6 +48,7 @@ export default function ExpandableDescription({
     setPreviousDescription(description);
     setIsExpanded(false);
   }
+
   const [isTruncated, setIsTruncated] = useState(false);
   const textRef = useRef<HTMLParagraphElement>(null);
 
@@ -79,7 +81,56 @@ export default function ExpandableDescription({
       setIsTruncated(element.scrollHeight > element.clientHeight);
     });
     observer.observe(element);
-    const descriptionContent = (
+    return () => observer.disconnect();
+  }, [description, isExpanded]);
+
+  const handleClick = (e: React.MouseEvent) => {
+    // ResizeObserverに加えて操作時点でも実寸を再確認する。通知前に古い状態が残っても、
+    // 全文が収まる場合は通常遷移を維持し、新たに省略された場合はその場で展開できる。
+    // Re-check the current layout at interaction time as a fallback before a
+    // ResizeObserver notification so stale state cannot block or miss navigation.
+    const element = textRef.current;
+    const currentlyTruncated = element
+      ? element.scrollHeight > element.clientHeight
+      : isTruncated;
+    const isExpansionControl = e.currentTarget.tagName === "BUTTON";
+
+    // 省略された説明の開閉だけをカード内の操作として扱う。preventDefaultは
+    // 親Linkの既定遷移を止め、stopPropagationは親のonClickを止める。
+    // Only an actually truncated description is interactive. preventDefault stops
+    // enclosing-link navigation and stopPropagation prevents its parent onClick.
+    if (!currentlyTruncated && !isExpanded) {
+      // 通知前に残った古いbuttonは、ラベルに反して詳細へ遷移させず次描画で除去する。
+      // A stale button is canceled rather than navigating against its label.
+      setIsTruncated(false);
+      if (isExpansionControl) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      return;
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+    setIsTruncated(true);
+    setIsExpanded(!isExpanded);
+  };
+
+  // line-clampのクラス名を動的に生成
+  // Dynamically generate line-clamp class
+  const lineClampClass = isExpanded ? "" : \`line-clamp-\${maxLines}\`;
+
+  // クリック可能かどうか（省略されているか展開済み）
+  // Whether clickable (truncated or already expanded)
+  const isClickable = isTruncated || isExpanded;
+
+  // 展開時に最大高さが指定されている場合のスタイル
+  // Style for expanded state with max height limit
+  const expandedStyle = isExpanded && maxExpandedHeight
+    ? { maxHeight: \`\${maxExpandedHeight}px\`, overflowY: "auto" as const }
+    : undefined;
+
+  const descriptionContent = (
     <p
       ref={textRef}
       onClick={handleClick}

--- a/src/components/ExpandableDescription.tsx
+++ b/src/components/ExpandableDescription.tsx
@@ -48,14 +48,25 @@ export default function ExpandableDescription({
   }, [description]);
 
   const handleClick = (e: React.MouseEvent) => {
-    // カード全体が詳細画面への Link でラップされている場合（コレクションページ等）、
-    // このクリックが親へバブリングすると「開く/閉じる」と同時にカード詳細へ
-    // 遷移してしまうため、伝播を止める。
-    // Stop propagation so the enclosing card Link (detail navigation) is not triggered.
-    e.stopPropagation();
-    // 省略されている場合のみ展開/折りたたみを切り替え
-    // Only toggle if text is actually truncated
+    // 省略されている場合のみ展開/折りたたみを切り替える。
+    // Only toggle if text is actually truncated (or already expanded, to allow collapsing).
+    //
+    // stopPropagation はこの分岐の内側でのみ呼ぶ。もし条件外（省略されていない
+    // 短い説明文）でも無条件に呼んでしまうと、カード全体が詳細画面への Link で
+    // ラップされている場合（コレクションページ等）に、本来は親へ伝播してカード
+    // 詳細へ遷移するはずのクリックまで飲み込んでしまい、説明文の領域だけ
+    // 何も起きないクリック不能な死角ができてしまう。
+    //
+    // Only call stopPropagation inside this branch. Calling it unconditionally
+    // (even when the text isn't truncated) would swallow clicks that should
+    // otherwise bubble up to the enclosing card Link (detail navigation),
+    // creating a dead click zone over the non-truncated description text.
     if (isTruncated || isExpanded) {
+      // カード全体が詳細画面への Link でラップされている場合（コレクションページ等）、
+      // このクリックが親へバブリングすると「開く/閉じる」と同時にカード詳細へ
+      // 遷移してしまうため、伝播を止める。
+      // Stop propagation so the enclosing card Link (detail navigation) is not triggered.
+      e.stopPropagation();
       setIsExpanded(!isExpanded);
     }
   };

--- a/src/components/ExpandableDescription.tsx
+++ b/src/components/ExpandableDescription.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState, useRef, useEffect } from "react";
 import { useTranslations } from "next-intl";
 
@@ -12,6 +13,9 @@ interface ExpandableDescriptionProps {
   /** 展開時の最大高さをピクセルで指定（デフォルト: 無制限） */
   /** Max height in pixels when expanded (default: unlimited) */
   maxExpandedHeight?: number;
+  /** 詳細ページへのリンク（説明本文だけをリンクにする場合に指定） */
+  /** Optional detail URL for the description text only. */
+  detailHref?: string;
 }
 
 /**
@@ -27,12 +31,22 @@ export default function ExpandableDescription({
   maxLines = 2,
   size = "sm",
   maxExpandedHeight,
+  detailHref,
 }: ExpandableDescriptionProps) {
   // テキストサイズに基づくクラス
   // Classes based on text size
   const textSizeClass = size === "xs" ? "text-xs text-gray-400" : "text-sm text-gray-300";
   const tCommon = useTranslations("common");
+  const [previousDescription, setPreviousDescription] = useState(description);
   const [isExpanded, setIsExpanded] = useState(false);
+  // Reactのrender中に直前のpropとの差し替えを同期する。A→B→Aのように
+  // 文字列が再利用されても、直前の説明から変わるたびに展開状態を破棄する。
+  // Synchronize against the immediately previous prop during render so an A→B→A
+  // sequence cannot resurrect A's old expansion state.
+  if (previousDescription !== description) {
+    setPreviousDescription(description);
+    setIsExpanded(false);
+  }
   const [isTruncated, setIsTruncated] = useState(false);
   const textRef = useRef<HTMLParagraphElement>(null);
 
@@ -47,76 +61,55 @@ export default function ExpandableDescription({
     }
   }, [description]);
 
-  const handleClick = (e: React.MouseEvent) => {
-    // 省略されている場合のみ展開/折りたたみを切り替える。
-    // Only toggle if text is actually truncated (or already expanded, to allow collapsing).
-    //
-    // stopPropagation はこの分岐の内側でのみ呼ぶ。もし条件外（省略されていない
-    // 短い説明文）でも無条件に呼んでしまうと、カード全体が詳細画面への Link で
-    // ラップされている場合（コレクションページ等）に、本来は親へ伝播してカード
-    // 詳細へ遷移するはずのクリックまで飲み込んでしまい、説明文の領域だけ
-    // 何も起きないクリック不能な死角ができてしまう。
-    //
-    // Only call stopPropagation inside this branch. Calling it unconditionally
-    // (even when the text isn't truncated) would swallow clicks that should
-    // otherwise bubble up to the enclosing card Link (detail navigation),
-    // creating a dead click zone over the non-truncated description text.
-    if (isTruncated || isExpanded) {
-      // カード全体が詳細画面への Link でラップされている場合（コレクションページ等）、
-      // このクリックが親へバブリングすると「開く/閉じる」と同時にカード詳細へ
-      // 遷移してしまうため、伝播を止める。
-      // Stop propagation so the enclosing card Link (detail navigation) is not triggered.
-      e.stopPropagation();
-      setIsExpanded(!isExpanded);
+  useEffect(() => {
+    const element = textRef.current;
+    if (!element || typeof ResizeObserver === "undefined") {
+      return;
     }
-  };
 
-  // line-clampのクラス名を動的に生成
-  // Dynamically generate line-clamp class
-  const lineClampClass = isExpanded ? "" : `line-clamp-${maxLines}`;
-
-  // クリック可能かどうか（省略されているか展開済み）
-  // Whether clickable (truncated or already expanded)
-  const isClickable = isTruncated || isExpanded;
-
-  // 展開時に最大高さが指定されている場合のスタイル
-  // Style for expanded state with max height limit
-  const expandedStyle = isExpanded && maxExpandedHeight
-    ? { maxHeight: `${maxExpandedHeight}px`, overflowY: "auto" as const }
-    : undefined;
+    // レイアウト変更を購読し、表示中の「開く」ボタンを実際の省略状態と同期する。
+    // 展開中はline-clampを外しているため、observerからの実寸が非省略でもtrueを維持する。
+    // Observe layout changes so the expand control matches actual truncation; while
+    // expanded, preserve the flag because the clamp is intentionally removed.
+    const observer = new ResizeObserver(() => {
+      if (isExpanded) {
+        setIsTruncated(true);
+        return;
+      }
+      setIsTruncated(element.scrollHeight > element.clientHeight);
+    });
+    observer.observe(element);
+    const descriptionContent = (
+    <p
+      ref={textRef}
+      onClick={handleClick}
+      style={expandedStyle}
+      className={[textSizeClass, lineClampClass, isClickable ? "cursor-pointer hover:text-gray-200" : ""].join(" ")}
+    >
+      {description}
+    </p>
+  );
 
   return (
     <div className="mb-1">
-      <p
-        ref={textRef}
-        onClick={handleClick}
-        style={expandedStyle}
-        className={`${textSizeClass} ${lineClampClass} ${
-          isClickable ? "cursor-pointer hover:text-gray-200" : ""
-        }`}
-      >
-        {description}
-      </p>
-      {/* 展開インジケーター（省略時のみ表示、展開後は非表示だがクリックで折りたたみ可能） */}
-      {/* Expand indicator (shown only when truncated, hidden after expand but click to collapse still works) */}
-      {isTruncated && !isExpanded && (
-        <button
-          onClick={handleClick}
-          className="text-xs text-purple-400 hover:text-purple-300 mt-1 flex items-center gap-1"
-        >
-          <span>▼</span>
-          <span>{tCommon("expand")}</span>
-        </button>
+      {detailHref ? (
+        <Link href={detailHref} className="block">
+          {descriptionContent}
+        </Link>
+      ) : (
+        descriptionContent
       )}
-      {/* 折りたたみインジケーター（展開時のみ表示） */}
-      {/* Collapse indicator (shown only when expanded) */}
-      {isExpanded && (
+      {/* 開閉操作子は単一要素にして、展開状態を支援技術へ通知しフォーカスを維持する。 */}
+      {/* Keep one persistent control so focus survives toggles and assistive tech sees state. */}
+      {isTruncated && (
         <button
+          type="button"
+          aria-expanded={isExpanded}
           onClick={handleClick}
           className="text-xs text-purple-400 hover:text-purple-300 mt-1 flex items-center gap-1"
         >
-          <span>▲</span>
-          <span>{tCommon("collapse")}</span>
+          <span aria-hidden="true">{isExpanded ? "▲" : "▼"}</span>
+          <span>{tCommon(isExpanded ? "collapse" : "expand")}</span>
         </button>
       )}
     </div>

--- a/src/components/SortedCardGrid.tsx
+++ b/src/components/SortedCardGrid.tsx
@@ -143,7 +143,7 @@ export default function SortedCardGrid({
                 showDescription ? (
                   <ExpandableDescription
                     description={card.description as string}
-                    detailHref={`/collection/${streamerId}/card/${card.id}`}
+                    detailHref={isOwned ? `/collection/${streamerId}/card/${card.id}` : undefined}
                   />
                 ) : undefined
               }

--- a/src/components/SortedCardGrid.tsx
+++ b/src/components/SortedCardGrid.tsx
@@ -37,6 +37,9 @@ interface SortedCardGridProps {
     cardCountTemplate: string;
     noImage: string;
     unownedCard: string;
+    // Accessible status text for unowned cards.
+    // 未所持カードの支援技術向け状態ラベル。
+    unownedStatus?: string;
     inactiveStatus: string;
     cardNumberTemplate: string;
     sortLabel: string;
@@ -137,6 +140,7 @@ export default function SortedCardGrid({
                 maskUnownedDetails ? translations.unownedCard : translations.noImage
               }
               isOwned={isOwned}
+              unownedLabel={translations.unownedStatus}
               isInactive={isOwned && !card.is_active}
               inactiveLabel={translations.inactiveStatus}
               descriptionComponent={

--- a/src/components/SortedCardGrid.tsx
+++ b/src/components/SortedCardGrid.tsx
@@ -141,7 +141,10 @@ export default function SortedCardGrid({
               inactiveLabel={translations.inactiveStatus}
               descriptionComponent={
                 showDescription ? (
-                  <ExpandableDescription description={card.description as string} />
+                  <ExpandableDescription
+                    description={card.description as string}
+                    detailHref={`/collection/${streamerId}/card/${card.id}`}
+                  />
                 ) : undefined
               }
             />

--- a/src/components/StreamerCollection.tsx
+++ b/src/components/StreamerCollection.tsx
@@ -77,6 +77,7 @@ export default async function StreamerCollection({
     unownedCard: t("unownedCard"),
     inactiveStatus: tCardManager("status.paused"),
     cardNumberTemplate: t("cardNumber"),
+    unownedStatus: t("unownedStatus"),
     sortLabel: t("sort.label"),
     sortByNumber: t("sort.number"),
     sortByRarity: t("sort.rarity"),

--- a/tests/unit/components/expandable-description.test.tsx
+++ b/tests/unit/components/expandable-description.test.tsx
@@ -125,9 +125,9 @@ describe('ExpandableDescription', () => {
     const parentClick = vi.fn()
 
     render(
-      <Link href="/collection/streamer-1/card/card-1" onClick={parentClick}>
+      <div onClick={parentClick}>
         <ExpandableDescription description="長い説明テキスト" />
-      </Link>
+      </div>
     )
 
     const description = screen.getByText('長い説明テキスト')

--- a/tests/unit/components/expandable-description.test.tsx
+++ b/tests/unit/components/expandable-description.test.tsx
@@ -136,7 +136,14 @@ describe('ExpandableDescription', () => {
     expect(textClick.defaultPrevented).toBe(true)
     expect(parentClick).not.toHaveBeenCalled()
 
-    const button = screen.getByRole('button', { name: /expand/ })
+    // 直前のテキストクリックで既に展開済みのため、ボタンのラベルは
+    // 「開く」ではなく「閉じる」になっている。同一ボタン要素での伝播阻止を
+    // 検証する意図なので、どちらのラベルでも取得できるようにする。
+    // The preceding text click already expanded the description, so the
+    // button's accessible name is "collapse", not "expand". The intent here
+    // is only to verify the same disclosure button also blocks propagation,
+    // so match either label.
+    const button = screen.getByRole('button', { name: /expand|collapse/ })
     fireEvent.click(button)
     expect(parentClick).not.toHaveBeenCalled()
   })

--- a/tests/unit/components/expandable-description.test.tsx
+++ b/tests/unit/components/expandable-description.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import ExpandableDescription from '@/components/ExpandableDescription'
 
@@ -11,18 +11,49 @@ vi.mock('next-intl', () => ({
 // 「開く/閉じる」のクリックが親へバブリングして詳細画面へ同時遷移してしまう問題の回帰テスト。
 // ExpandableDescription は scrollHeight > clientHeight で省略判定するため、
 // テスト環境（レイアウト計算なし）ではプロパティをモックして「省略状態」を作る。
+//
+// 注意: jsdom は scrollHeight/clientHeight を HTMLElement.prototype ではなく
+// Element.prototype 上に定義しているため、HTMLElement.prototype を対象にした
+// getOwnPropertyDescriptor は常に undefined を返す。そのため必ず
+// Object.defineProperty で「値」を直接上書きすることになり、これは vi.spyOn の
+// モックではないので vi.restoreAllMocks() では元に戻らない。復元し忘れると
+// HTMLElement.prototype が恒久的に汚染され、後続のテスト（省略なしの状態を
+// 期待するテスト等）が誤った値を読むことになる。そのため元のディスクリプタを
+// 保存しておき、afterEach で必ず明示的に復元する。
+//
+// Note: jsdom defines scrollHeight/clientHeight on Element.prototype, not
+// HTMLElement.prototype, so a lookup against HTMLElement.prototype always
+// finds no descriptor. We therefore always overwrite it with a plain value via
+// Object.defineProperty, which vi.restoreAllMocks() cannot undo (it only knows
+// about vi.spyOn mocks). Without explicit restoration this permanently
+// pollutes HTMLElement.prototype for every later test in this file — so we
+// save the original descriptors and restore them in afterEach.
+let savedScrollHeightDescriptor: PropertyDescriptor | undefined
+let savedClientHeightDescriptor: PropertyDescriptor | undefined
+
 function stubTruncation() {
-  const proto = HTMLElement.prototype as any
-  const desc = Object.getOwnPropertyDescriptor(proto, 'scrollHeight')
-  // 既存ゲッターが定義されている場合は spyOn で上書き、無ければ defineProperty
-  if (desc && 'get' in desc) {
-    vi.spyOn(proto, 'scrollHeight', 'get').mockReturnValue(100)
-    vi.spyOn(proto, 'clientHeight', 'get').mockReturnValue(50)
-  } else {
-    Object.defineProperty(proto, 'scrollHeight', { configurable: true, value: 100 })
-    Object.defineProperty(proto, 'clientHeight', { configurable: true, value: 50 })
-  }
+  const proto = HTMLElement.prototype
+  savedScrollHeightDescriptor = Object.getOwnPropertyDescriptor(proto, 'scrollHeight')
+  savedClientHeightDescriptor = Object.getOwnPropertyDescriptor(proto, 'clientHeight')
+  Object.defineProperty(proto, 'scrollHeight', { configurable: true, value: 100 })
+  Object.defineProperty(proto, 'clientHeight', { configurable: true, value: 50 })
 }
+
+afterEach(() => {
+  const proto = HTMLElement.prototype
+  if (savedScrollHeightDescriptor) {
+    Object.defineProperty(proto, 'scrollHeight', savedScrollHeightDescriptor)
+  } else {
+    delete (proto as unknown as Record<string, unknown>).scrollHeight
+  }
+  if (savedClientHeightDescriptor) {
+    Object.defineProperty(proto, 'clientHeight', savedClientHeightDescriptor)
+  } else {
+    delete (proto as unknown as Record<string, unknown>).clientHeight
+  }
+  savedScrollHeightDescriptor = undefined
+  savedClientHeightDescriptor = undefined
+})
 
 describe('ExpandableDescription (issue: カード詳細への同時遷移防止)', () => {
   it('「開く」ボタンのクリックは親の onClick（Link 遷移）に伝播しない', () => {
@@ -70,5 +101,24 @@ describe('ExpandableDescription (issue: カード詳細への同時遷移防止)
     fireEvent.click(screen.getByRole('button', { name: /collapse/ }))
 
     expect(parentClick).not.toHaveBeenCalled()
+  })
+
+  // 回帰テスト: 省略されていない（isTruncated=false）短い説明文をクリックした場合は
+  // 内部的にトグルが発生しないため、これまで通りクリックが親（カード詳細への Link）へ
+  // 伝播し、カード全体がクリック可能な領域として機能し続けることを確認する。
+  // stopPropagation を条件外で無条件に呼んでしまうと、この伝播が止まり、
+  // 説明文の領域だけクリックしても何も起きない死角が生まれてしまう。
+  it('省略されていない説明テキストのクリックは親の onClick に伝播する（カード全体のクリック可能性を維持）', () => {
+    // stubTruncation() を呼ばないことで scrollHeight === clientHeight（省略なし）の状態を維持する
+    const parentClick = vi.fn()
+
+    render(
+      <div onClick={parentClick}>
+        <ExpandableDescription description="短い説明" maxLines={2} />
+      </div>
+    )
+
+    fireEvent.click(screen.getByText('短い説明'))
+    expect(parentClick).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/unit/components/expandable-description.test.tsx
+++ b/tests/unit/components/expandable-description.test.tsx
@@ -1,5 +1,5 @@
-import { act, afterEach, createEvent, describe, expect, it, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, createEvent, fireEvent, render, screen } from '@testing-library/react'
 import Link from 'next/link'
 import ExpandableDescription from '@/components/ExpandableDescription'
 

--- a/tests/unit/components/expandable-description.test.tsx
+++ b/tests/unit/components/expandable-description.test.tsx
@@ -1,7 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { act, createEvent, fireEvent, render, screen } from '@testing-library/react'
+import type { AnchorHTMLAttributes } from 'react'
 import Link from 'next/link'
 import ExpandableDescription from '@/components/ExpandableDescription'
+
+type MockLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  prefetch?: boolean
+}
+
+vi.mock('next/link', () => ({
+  default: ({ prefetch, ...props }: MockLinkProps) => (
+    <a {...props} data-prefetch={String(prefetch)} />
+  ),
+}))
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key,
@@ -88,8 +99,15 @@ describe('ExpandableDescription', () => {
     const detailLink = screen.getByRole('link')
     const button = screen.getByRole('button', { name: /expand/ })
     expect(detailLink.contains(button)).toBe(false)
+    expect(detailLink).toHaveAttribute('data-prefetch', 'false')
     expect(button).toHaveAttribute('type', 'button')
     expect(button).toHaveAttribute('aria-expanded', 'false')
+
+    const description = screen.getByText('長い説明テキスト')
+    const descriptionClick = createEvent.click(description)
+    fireEvent(description, descriptionClick)
+    expect(descriptionClick.defaultPrevented).toBe(false)
+    parentClick.mockClear()
 
     button.focus()
     fireEvent.click(button)

--- a/tests/unit/components/expandable-description.test.tsx
+++ b/tests/unit/components/expandable-description.test.tsx
@@ -1,42 +1,56 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { act, afterEach, createEvent, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import Link from 'next/link'
 import ExpandableDescription from '@/components/ExpandableDescription'
 
-// next-intl のモック: キーをそのまま返す（「開く/閉じる」の文言検証は不要）
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key,
 }))
 
-// コレクションページ等でカード全体が <Link>(詳細遷移) でラップされているため、
-// 「開く/閉じる」のクリックが親へバブリングして詳細画面へ同時遷移してしまう問題の回帰テスト。
-// ExpandableDescription は scrollHeight > clientHeight で省略判定するため、
-// テスト環境（レイアウト計算なし）ではプロパティをモックして「省略状態」を作る。
-//
-// 注意: jsdom は scrollHeight/clientHeight を HTMLElement.prototype ではなく
-// Element.prototype 上に定義しているため、HTMLElement.prototype を対象にした
-// getOwnPropertyDescriptor は常に undefined を返す。そのため必ず
-// Object.defineProperty で「値」を直接上書きすることになり、これは vi.spyOn の
-// モックではないので vi.restoreAllMocks() では元に戻らない。復元し忘れると
-// HTMLElement.prototype が恒久的に汚染され、後続のテスト（省略なしの状態を
-// 期待するテスト等）が誤った値を読むことになる。そのため元のディスクリプタを
-// 保存しておき、afterEach で必ず明示的に復元する。
-//
-// Note: jsdom defines scrollHeight/clientHeight on Element.prototype, not
-// HTMLElement.prototype, so a lookup against HTMLElement.prototype always
-// finds no descriptor. We therefore always overwrite it with a plain value via
-// Object.defineProperty, which vi.restoreAllMocks() cannot undo (it only knows
-// about vi.spyOn mocks). Without explicit restoration this permanently
-// pollutes HTMLElement.prototype for every later test in this file — so we
-// save the original descriptors and restore them in afterEach.
+type LayoutValue = number | (() => number)
+
 let savedScrollHeightDescriptor: PropertyDescriptor | undefined
 let savedClientHeightDescriptor: PropertyDescriptor | undefined
 
-function stubTruncation() {
+function stubLayout(scrollHeight: LayoutValue, clientHeight: LayoutValue) {
   const proto = HTMLElement.prototype
+  const readLayoutValue = (value: LayoutValue) => typeof value === 'function' ? value() : value
   savedScrollHeightDescriptor = Object.getOwnPropertyDescriptor(proto, 'scrollHeight')
   savedClientHeightDescriptor = Object.getOwnPropertyDescriptor(proto, 'clientHeight')
-  Object.defineProperty(proto, 'scrollHeight', { configurable: true, value: 100 })
-  Object.defineProperty(proto, 'clientHeight', { configurable: true, value: 50 })
+  Object.defineProperty(proto, 'scrollHeight', {
+    configurable: true,
+    get: () => readLayoutValue(scrollHeight),
+  })
+  Object.defineProperty(proto, 'clientHeight', {
+    configurable: true,
+    get: () => readLayoutValue(clientHeight),
+  })
+}
+
+function installResizeObserver() {
+  let callback: ResizeObserverCallback | undefined
+  const disconnect = vi.fn()
+  class TestResizeObserver {
+    constructor(nextCallback: ResizeObserverCallback) {
+      callback = nextCallback
+    }
+
+    observe() {}
+
+    disconnect() {
+      disconnect()
+    }
+  }
+
+  vi.stubGlobal('ResizeObserver', TestResizeObserver)
+  return {
+    notify() {
+      act(() => {
+        callback?.([], {} as ResizeObserver)
+      })
+    },
+    disconnect,
+  }
 }
 
 afterEach(() => {
@@ -53,72 +67,152 @@ afterEach(() => {
   }
   savedScrollHeightDescriptor = undefined
   savedClientHeightDescriptor = undefined
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
-describe('ExpandableDescription (issue: カード詳細への同時遷移防止)', () => {
-  it('「開く」ボタンのクリックは親の onClick（Link 遷移）に伝播しない', () => {
-    stubTruncation()
+describe('ExpandableDescription', () => {
+  it('keeps the detail link and disclosure button as separate interactive siblings', () => {
+    stubLayout(100, 50)
     const parentClick = vi.fn()
 
     render(
       <div onClick={parentClick}>
-        <ExpandableDescription description="長い説明テキスト" maxLines={2} />
+        <ExpandableDescription
+          description="長い説明テキスト"
+          detailHref="/collection/streamer-1/card/card-1"
+        />
       </div>
     )
 
-    // 省略状態なので「開く」ボタンが表示される（▼ 記号がアクセシブルネームに含まれるため正規表現で探す）
-    const expandButton = screen.getByRole('button', { name: /expand/ })
-    fireEvent.click(expandButton)
+    const detailLink = screen.getByRole('link')
+    const button = screen.getByRole('button', { name: /expand/ })
+    expect(detailLink.contains(button)).toBe(false)
+    expect(button).toHaveAttribute('type', 'button')
+    expect(button).toHaveAttribute('aria-expanded', 'false')
 
+    button.focus()
+    fireEvent.click(button)
+    expect(parentClick).not.toHaveBeenCalled()
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+    expect(document.activeElement).toBe(button)
+
+    fireEvent.click(button)
+    expect(button).toHaveAttribute('aria-expanded', 'false')
+    expect(document.activeElement).toBe(button)
+  })
+
+  it('prevents detail navigation from truncated text and disclosure controls', () => {
+    stubLayout(100, 50)
+    const parentClick = vi.fn()
+
+    render(
+      <Link href="/collection/streamer-1/card/card-1" onClick={parentClick}>
+        <ExpandableDescription description="長い説明テキスト" />
+      </Link>
+    )
+
+    const description = screen.getByText('長い説明テキスト')
+    const textClick = createEvent.click(description)
+    fireEvent(description, textClick)
+    expect(textClick.defaultPrevented).toBe(true)
+    expect(parentClick).not.toHaveBeenCalled()
+
+    const button = screen.getByRole('button', { name: /expand/ })
+    fireEvent.click(button)
     expect(parentClick).not.toHaveBeenCalled()
   })
 
-  it('説明テキスト自体のクリックも親の onClick に伝播しない', () => {
-    stubTruncation()
+  it('preserves normal detail navigation for short description text', () => {
+    stubLayout(50, 50)
+    const parentClick = vi.fn()
+
+    render(
+      <Link href="/collection/streamer-1/card/card-1" onClick={parentClick}>
+        <ExpandableDescription description="短い説明テキスト" />
+      </Link>
+    )
+
+    const description = screen.getByText('短い説明テキスト')
+    const click = createEvent.click(description)
+    fireEvent(description, click)
+    expect(click.defaultPrevented).toBe(false)
+    expect(parentClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses detailHref to navigate short text without nesting a button in the anchor', () => {
+    stubLayout(50, 50)
     const parentClick = vi.fn()
 
     render(
       <div onClick={parentClick}>
-        <ExpandableDescription description="長い説明テキスト" maxLines={2} />
+        <ExpandableDescription
+          description="短い説明テキスト"
+          detailHref="/collection/streamer-1/card/card-1"
+        />
       </div>
     )
 
-    fireEvent.click(screen.getByText('長い説明テキスト'))
-    expect(parentClick).not.toHaveBeenCalled()
+    const detailLink = screen.getByRole('link')
+    const description = screen.getByText('短い説明テキスト')
+    const click = createEvent.click(description)
+    fireEvent(description, click)
+    expect(detailLink.contains(screen.queryByRole('button'))).toBe(false)
+    expect(click.defaultPrevented).toBe(false)
+    expect(parentClick).toHaveBeenCalledTimes(1)
   })
 
-  it('展開後の「閉じる」ボタンのクリックも親の onClick に伝播しない', () => {
-    stubTruncation()
-    const parentClick = vi.fn()
+  it('synchronizes ResizeObserver changes and disconnects on unmount', () => {
+    const layout = { scrollHeight: 100, clientHeight: 50 }
+    stubLayout(() => layout.scrollHeight, () => layout.clientHeight)
+    const observer = installResizeObserver()
 
-    render(
-      <div onClick={parentClick}>
-        <ExpandableDescription description="長い説明テキスト" maxLines={2} />
-      </div>
+    const { unmount } = render(
+      <ExpandableDescription
+        description="長い説明テキスト"
+        detailHref="/collection/streamer-1/card/card-1"
+      />
+    )
+
+    layout.scrollHeight = 50
+    layout.clientHeight = 50
+    observer.notify()
+    expect(screen.queryByRole('button', { name: /expand/ })).not.toBeInTheDocument()
+
+    layout.scrollHeight = 100
+    layout.clientHeight = 50
+    observer.notify()
+    const button = screen.getByRole('button', { name: /expand/ })
+    expect(button).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(button)
+    expect(button).toHaveAttribute('aria-expanded', 'true')
+    observer.notify()
+    expect(screen.getByRole('button', { name: /collapse/ })).toHaveAttribute('aria-expanded', 'true')
+
+    unmount()
+    expect(observer.disconnect).toHaveBeenCalled()
+  })
+
+  it('resets expansion after A to B to A description replacement', () => {
+    const layout = { scrollHeight: 100, clientHeight: 50 }
+    stubLayout(() => layout.scrollHeight, () => layout.clientHeight)
+    const { rerender } = render(
+      <ExpandableDescription description="説明A" />
     )
 
     fireEvent.click(screen.getByRole('button', { name: /expand/ }))
-    fireEvent.click(screen.getByRole('button', { name: /collapse/ }))
+    expect(screen.getByRole('button', { name: /collapse/ })).toHaveAttribute('aria-expanded', 'true')
 
-    expect(parentClick).not.toHaveBeenCalled()
-  })
+    layout.scrollHeight = 50
+    layout.clientHeight = 50
+    rerender(<ExpandableDescription description="説明B" />)
 
-  // 回帰テスト: 省略されていない（isTruncated=false）短い説明文をクリックした場合は
-  // 内部的にトグルが発生しないため、これまで通りクリックが親（カード詳細への Link）へ
-  // 伝播し、カード全体がクリック可能な領域として機能し続けることを確認する。
-  // stopPropagation を条件外で無条件に呼んでしまうと、この伝播が止まり、
-  // 説明文の領域だけクリックしても何も起きない死角が生まれてしまう。
-  it('省略されていない説明テキストのクリックは親の onClick に伝播する（カード全体のクリック可能性を維持）', () => {
-    // stubTruncation() を呼ばないことで scrollHeight === clientHeight（省略なし）の状態を維持する
-    const parentClick = vi.fn()
+    layout.scrollHeight = 100
+    layout.clientHeight = 50
+    rerender(<ExpandableDescription description="説明A" />)
 
-    render(
-      <div onClick={parentClick}>
-        <ExpandableDescription description="短い説明" maxLines={2} />
-      </div>
-    )
-
-    fireEvent.click(screen.getByText('短い説明'))
-    expect(parentClick).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole('button', { name: /expand/ })).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByRole('button', { name: /collapse/ })).not.toBeInTheDocument()
   })
 })

--- a/tests/unit/components/expandable-description.test.tsx
+++ b/tests/unit/components/expandable-description.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ExpandableDescription from '@/components/ExpandableDescription'
+
+// next-intl のモック: キーをそのまま返す（「開く/閉じる」の文言検証は不要）
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+// コレクションページ等でカード全体が <Link>(詳細遷移) でラップされているため、
+// 「開く/閉じる」のクリックが親へバブリングして詳細画面へ同時遷移してしまう問題の回帰テスト。
+// ExpandableDescription は scrollHeight > clientHeight で省略判定するため、
+// テスト環境（レイアウト計算なし）ではプロパティをモックして「省略状態」を作る。
+function stubTruncation() {
+  const proto = HTMLElement.prototype as any
+  const desc = Object.getOwnPropertyDescriptor(proto, 'scrollHeight')
+  // 既存ゲッターが定義されている場合は spyOn で上書き、無ければ defineProperty
+  if (desc && 'get' in desc) {
+    vi.spyOn(proto, 'scrollHeight', 'get').mockReturnValue(100)
+    vi.spyOn(proto, 'clientHeight', 'get').mockReturnValue(50)
+  } else {
+    Object.defineProperty(proto, 'scrollHeight', { configurable: true, value: 100 })
+    Object.defineProperty(proto, 'clientHeight', { configurable: true, value: 50 })
+  }
+}
+
+describe('ExpandableDescription (issue: カード詳細への同時遷移防止)', () => {
+  it('「開く」ボタンのクリックは親の onClick（Link 遷移）に伝播しない', () => {
+    stubTruncation()
+    const parentClick = vi.fn()
+
+    render(
+      <div onClick={parentClick}>
+        <ExpandableDescription description="長い説明テキスト" maxLines={2} />
+      </div>
+    )
+
+    // 省略状態なので「開く」ボタンが表示される（▼ 記号がアクセシブルネームに含まれるため正規表現で探す）
+    const expandButton = screen.getByRole('button', { name: /expand/ })
+    fireEvent.click(expandButton)
+
+    expect(parentClick).not.toHaveBeenCalled()
+  })
+
+  it('説明テキスト自体のクリックも親の onClick に伝播しない', () => {
+    stubTruncation()
+    const parentClick = vi.fn()
+
+    render(
+      <div onClick={parentClick}>
+        <ExpandableDescription description="長い説明テキスト" maxLines={2} />
+      </div>
+    )
+
+    fireEvent.click(screen.getByText('長い説明テキスト'))
+    expect(parentClick).not.toHaveBeenCalled()
+  })
+
+  it('展開後の「閉じる」ボタンのクリックも親の onClick に伝播しない', () => {
+    stubTruncation()
+    const parentClick = vi.fn()
+
+    render(
+      <div onClick={parentClick}>
+        <ExpandableDescription description="長い説明テキスト" maxLines={2} />
+      </div>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /expand/ }))
+    fireEvent.click(screen.getByRole('button', { name: /collapse/ }))
+
+    expect(parentClick).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/components/sorted-card-grid.test.tsx
+++ b/tests/unit/components/sorted-card-grid.test.tsx
@@ -126,6 +126,9 @@ describe('SortedCardGrid - unowned card visibility (Issue #395)', () => {
     expect(screen.getByAltText('SecretCard')).toBeInTheDocument()
     // 説明テキストも見える
     expect(screen.getByText(/カード説明テキスト/)).toBeInTheDocument()
+    // 公開モードでも未所持カードは詳細遷移を提供しない
+    // Unowned public cards reveal content but remain non-navigable.
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
   })
 
   it('hides unowned card image / name / description when hideUnownedDetails=true (placeholder only)', () => {

--- a/tests/unit/components/sorted-card-grid.test.tsx
+++ b/tests/unit/components/sorted-card-grid.test.tsx
@@ -53,6 +53,7 @@ const baseTranslations = {
   cardCountTemplate: 'x{count}',
   noImage: 'NoImage',
   unownedCard: '???',
+  unownedStatus: '未所持カード',
   inactiveStatus: 'PAUSED',
   cardNumberTemplate: '#{number}',
   sortLabel: '並び替え',
@@ -93,6 +94,7 @@ describe('SortedCardGrid - unowned card visibility (Issue #395)', () => {
     )
     expect(screen.getByText('OwnedCard')).toBeInTheDocument()
     expect(screen.getByAltText('OwnedCard')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'OwnedCard: x2' })).toBeInTheDocument()
   })
 
   it('reveals name/image/description for unowned cards when hideUnownedDetails=false (公開モード)', () => {
@@ -126,6 +128,7 @@ describe('SortedCardGrid - unowned card visibility (Issue #395)', () => {
     expect(screen.getByAltText('SecretCard')).toBeInTheDocument()
     // 説明テキストも見える
     expect(screen.getByText(/カード説明テキスト/)).toBeInTheDocument()
+    expect(screen.getByText('未所持カード')).toBeInTheDocument()
     // 公開モードでも未所持カードは詳細遷移を提供しない
     // Unowned public cards reveal content but remain non-navigable.
     expect(screen.queryByRole('link')).not.toBeInTheDocument()

--- a/tests/unit/components/sorted-card-grid.test.tsx
+++ b/tests/unit/components/sorted-card-grid.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import SortedCardGrid from '@/components/SortedCardGrid'
 import type { Card } from '@/types/database'
 
@@ -129,6 +129,58 @@ describe('SortedCardGrid - unowned card visibility (Issue #395)', () => {
     // 公開モードでも未所持カードは詳細遷移を提供しない
     // Unowned public cards reveal content but remain non-navigable.
     expect(screen.queryByRole('link')).not.toBeInTheDocument()
+  })
+
+  it('keeps disclosure controls outside detail links and operable for owned and unowned cards', () => {
+    const proto = HTMLElement.prototype
+    const savedScrollHeight = Object.getOwnPropertyDescriptor(proto, 'scrollHeight')
+    const savedClientHeight = Object.getOwnPropertyDescriptor(proto, 'clientHeight')
+    Object.defineProperty(proto, 'scrollHeight', { configurable: true, value: 100 })
+    Object.defineProperty(proto, 'clientHeight', { configurable: true, value: 50 })
+
+    try {
+      const cards = [
+        {
+          ...baseCard({ id: 'owned-long', name: 'OwnedLong', description: '長い説明1' }),
+          count: 1,
+          isOwned: true,
+        },
+        {
+          ...baseCard({ id: 'unowned-long', name: 'UnownedLong', description: '長い説明2' }),
+          count: 0,
+          isOwned: false,
+        },
+      ]
+      render(
+        <SortedCardGrid
+          cards={cards}
+          streamerId="streamer-1"
+          hideUnownedDetails={false}
+          translations={baseTranslations}
+        />
+      )
+
+      const buttons = screen.getAllByRole('button', { name: '開く' })
+      expect(buttons).toHaveLength(2)
+      for (const button of buttons) {
+        expect(button.closest('a')).toBeNull()
+        expect(button.closest('[aria-disabled="true"]')).toBeNull()
+        button.focus()
+        fireEvent.click(button)
+        expect(button).toHaveAttribute('aria-expanded', 'true')
+      }
+    } finally {
+      if (savedScrollHeight) {
+        Object.defineProperty(proto, 'scrollHeight', savedScrollHeight)
+      } else {
+        delete (proto as unknown as Record<string, unknown>).scrollHeight
+      }
+      if (savedClientHeight) {
+        Object.defineProperty(proto, 'clientHeight', savedClientHeight)
+      } else {
+        delete (proto as unknown as Record<string, unknown>).clientHeight
+      }
+    }
   })
 
   it('hides unowned card image / name / description when hideUnownedDetails=true (placeholder only)', () => {


### PR DESCRIPTION
## 対象
- PR #894: `ExpandableDescription` のクリック伝播停止
- PR #895: preview実経路で判明した、詳細リンクと開閉操作の競合を構造的に分離するfollow-up

## preview検証
- 現在のpreview先頭: `a8c1cc227d162378d94afcfa127c348f637aeb70`
- URL: https://twica-preview.tsubasa-azumagakito.workers.dev
- overlay: https://twica-preview.tsubasa-azumagakito.workers.dev/overlay/9d0f9d09-3972-4aa2-b32e-c6d222a6cfd9
- `/`、realtime-config、DB gap-recovery を確認（HTTP 200）
- realtime-config は `do-primary`、overlay realtime version は `do-primary-v1`
- 認証済み `あずまぐ` でコレクションを開き、長文説明の「開く」→「閉じる」を実操作
- 開閉時にカード詳細へ遷移せず、URLがコレクション一覧のまま維持されることを確認
- previewブラウザのerror/warnログは0件
- PR #895 headのCI run #31207962943: test、typecheck/build、migration、i18n lint、Supabase-independent build がsuccess

このPRをマージ後、main本番デプロイ完了を確認し、本番でも同じコレクション開閉・詳細遷移・ブラウザログの確認を行います。