### PR TITLE
fix(upload): stalled HEIC変換をタイムアウトしてフォームを復帰させる

### DIFF
--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -505,6 +505,23 @@ export default function CardManager({
   // 画像サイズ読み取りの非同期コールバック無効化用カウンター
   // Counter to invalidate stale async image dimension callbacks
   const imageDimensionRequestId = useRef(0);
+  // HEIC変換専用の世代。画像寸法読み取り処理とは別に持ち、変換成功時に
+  // processSelectedFile() が画像寸法用IDを進めても、現行変換の finally が
+  // 自分自身を古いリクエストと誤判定しないようにする。
+  const heicConversionRequestId = useRef(0);
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    // React Strict Mode は開発時に setup -> cleanup -> setup を再実行するため、
+    // 再マウントされた setup では必ず有効状態へ戻す。これを行わないと、
+    // 初回の検証用 cleanup が残り、実際にはマウント中でも変換結果を破棄してしまう。
+    isMountedRef.current = true;
+    return () => {
+      // 画面遷移などでアンマウントされた後に、保留中の変換Promiseから
+      // state更新やクロップ開始を行わない。Worker自体は停止できないため、
+      // 完了後の各経路でこのフラグを確認して結果だけを無効化する。
+      isMountedRef.current = false;
+    };
+  }, []);
   // Cropped image file ready for upload
   // アップロード準備完了のトリミング済み画像ファイル
   const [croppedFile, setCroppedFile] = useState<File | null>(null);
@@ -1096,6 +1113,9 @@ export default function CardManager({
     // Reset cropping state
     // トリミング状態をリセット
     imageDimensionRequestId.current++;
+    // キャンセル中のHEIC変換を無効化し、古いPromiseが後から状態を戻さないようにする
+    heicConversionRequestId.current++;
+    setIsConvertingHeic(false);
     setCropModalOpen(false);
     setCropModeModalOpen(false);
     setSelectedCropMode("square");
@@ -1118,25 +1138,28 @@ export default function CardManager({
     const file = e.target.files?.[0];
     setUploadError(null);
     if (file) {
+      // 新しいファイル選択は、前のHEIC変換結果を常に無効化する。
+      const conversionRequestId = ++heicConversionRequestId.current;
       // Issue #770: HEIC / HEIF はブラウザで表示できないため、選択直後に
       // クライアント側で JPEG へ変換してから既存フローへ渡す。変換中は入力が
-      // 無効化されるため、request id はフォームのキャンセル（resetForm 等）による
-      // 古い変換結果の無視に使う。
+      // 無効化されるため、世代IDはフォームのキャンセル（resetForm 等）や
+      // 再選択による古い変換結果の無視に使う。
       if (isHeicUpload(file)) {
         setIsConvertingHeic(true);
-        const requestId = ++imageDimensionRequestId.current;
         try {
           const converted = await convertHeicToJpeg(file);
-          if (requestId !== imageDimensionRequestId.current) return;
+          if (!isMountedRef.current || conversionRequestId !== heicConversionRequestId.current) return;
           processSelectedFile(converted);
         } catch (error) {
-          if (requestId !== imageDimensionRequestId.current) return;
+          if (!isMountedRef.current || conversionRequestId !== heicConversionRequestId.current) return;
           if (error instanceof Error && error.message === HEIC_ERROR_TOO_LARGE) {
             setUploadError(t("messages.heicTooLarge", { mb: HEIC_INPUT_MAX_BYTES / (1024 * 1024) }));
           } else {
             setUploadError(t("messages.heicConvertFailed"));
           }
         } finally {
+          // キャンセル・再選択後に完了した古い変換は、現在の入力状態を変更してはならない。
+          if (!isMountedRef.current || conversionRequestId !== heicConversionRequestId.current) return;
           // 変換完了（成功・失敗とも）で入力を再度有効化し、生の HEIC が
           // フォーム送信に残らないようファイル入力をクリアする
           setIsConvertingHeic(false);
@@ -1146,6 +1169,8 @@ export default function CardManager({
         }
         return;
       }
+      // HEIC変換が発生しない選択でも、念のため変換中表示を解除する。
+      setIsConvertingHeic(false);
       // Only validate file type before cropping (skip size check)
       // Cropped image will be compressed to JPEG, so original size doesn't matter
       // トリミング前はファイルタイプのみ検証（サイズチェックはスキップ）

--- a/src/lib/heic-converter.ts
+++ b/src/lib/heic-converter.ts
@@ -19,12 +19,40 @@
  */
 export const HEIC_INPUT_MAX_BYTES = 25 * 1024 * 1024; // 25MB（変換前の入力上限。デコード後のメモリ使用量は圧縮時サイズより大幅に増えるため、緩めの安全弁）
 
+// heic2any 0.0.4 は変換用 Worker を停止する Abort API を公開していないため、
+// 呼び出し側が無期限に待ち続けないよう、import とデコードを合わせた総時間に上限を設ける。
+export const HEIC_CONVERSION_TIMEOUT_MS = 30_000;
+
 // 変換処理の失敗種別（呼び出し側で Error.message を比較するための定数）
 export const HEIC_ERROR_TOO_LARGE = "HEIC_TOO_LARGE";
 export const HEIC_ERROR_CONVERT_FAILED = "HEIC_CONVERT_FAILED";
+export const HEIC_ERROR_TIMEOUT = "HEIC_CONVERSION_TIMEOUT";
 
 const HEIC_MIME_TYPES = ["image/heic", "image/heif"];
 const HEIC_EXTENSIONS = [".heic", ".heif"];
+
+/**
+ * Abort API を持たない非同期処理に、利用者向けの有限な待機時間を与える。
+ *
+ * Promise.race は呼び出し側の Promise を終了させるだけで、heic2any 内部の
+ * Worker は停止できない。そのため、タイムアウト後に元の処理が遅れて完了しても
+ * 呼び出し側で結果を採用しないこと（CardManager の世代チェック）が必要になる。
+ */
+async function withTimeout<T>(operation: () => Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const operationPromise = Promise.resolve().then(operation);
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(HEIC_ERROR_TIMEOUT)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([operationPromise, timeoutPromise]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}
 
 /**
  * アップロード対象ファイルが HEIC / HEIF かどうかを判定する。
@@ -53,23 +81,19 @@ export async function convertHeicToJpeg(file: File): Promise<File> {
     throw new Error(HEIC_ERROR_TOO_LARGE);
   }
 
-  let heic2any: (input: {
-    blob: Blob;
-    toType: string;
-    quality?: number;
-  }) => Promise<Blob | Blob[]>;
-  try {
-    const mod = await import("heic2any");
-    heic2any = mod.default;
-  } catch {
-    throw new Error(HEIC_ERROR_CONVERT_FAILED);
-  }
-
   let output: Blob | Blob[];
   try {
-    // quality は既存のクロップ再圧縮（ImageCropper の 0.85）と同等水準にする
-    output = await heic2any({ blob: file, toType: "image/jpeg", quality: 0.85 });
-  } catch {
+    output = await withTimeout(async () => {
+      const { default: heic2any } = await import("heic2any");
+      // quality は既存のクロップ再圧縮（ImageCropper の 0.85）と同等水準にする
+      return heic2any({ blob: file, toType: "image/jpeg", quality: 0.85 });
+    }, HEIC_CONVERSION_TIMEOUT_MS);
+  } catch (error) {
+    // タイムアウトは呼び出し側で変換失敗と区別できるよう、そのまま伝える。
+    // それ以外のライブラリ内部エラーは既存の利用者向けエラーへ正規化する。
+    if (error instanceof Error && error.message === HEIC_ERROR_TIMEOUT) {
+      throw error;
+    }
     throw new Error(HEIC_ERROR_CONVERT_FAILED);
   }
 

--- a/tests/unit/components/card-manager-heic.test.tsx
+++ b/tests/unit/components/card-manager-heic.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { StrictMode } from 'react'
 import { NextIntlClientProvider } from 'next-intl'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import CardManager from '@/components/CardManager'
@@ -32,8 +33,8 @@ function stubImageLoad() {
   })
 }
 
-function renderCardManager() {
-  return render(
+function renderCardManager({ strictMode = false }: { strictMode?: boolean } = {}) {
+  const content = (
     <NextIntlClientProvider locale="ja" messages={jaMessages}>
       <CardManager
         streamerId="streamer-1"
@@ -42,6 +43,7 @@ function renderCardManager() {
       />
     </NextIntlClientProvider>
   )
+  return render(strictMode ? <StrictMode>{content}</StrictMode> : content)
 }
 
 function openFormAndSelectFile(container: HTMLElement, file: File) {
@@ -100,6 +102,23 @@ describe('CardManager HEIC conversion (issue #770)', () => {
     expect(screen.queryByText('トリミングサイズを選択')).not.toBeInTheDocument()
   })
 
+  it('タイムアウトエラー時も変換中表示を解除し、再選択できる状態に戻る', async () => {
+    mocks.isHeicUpload.mockReturnValue(true)
+    mocks.convertHeicToJpeg.mockRejectedValue(new Error('HEIC_CONVERSION_TIMEOUT'))
+    const { container } = renderCardManager()
+
+    openFormAndSelectFile(container, heicFile())
+
+    // 実タイマーを30秒進めるテストはconverter単体で行い、ここではタイムアウトが
+    // コンポーネントへ届いた後の利用者向け終了状態を固定する。
+    expect(
+      await screen.findByText('HEIC画像を読み込めませんでした。別の画像を選択するか、JPEGへ変換してから再度お試しください。')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('HEIC画像を変換中…')).not.toBeInTheDocument()
+    expect((container.querySelector('input[type="file"]') as HTMLInputElement).disabled).toBe(false)
+    expect(screen.queryByText('トリミングサイズを選択')).not.toBeInTheDocument()
+  })
+
   it('サイズ上限超過時は専用エラーを表示する', async () => {
     mocks.isHeicUpload.mockReturnValue(true)
     mocks.convertHeicToJpeg.mockRejectedValue(new Error('HEIC_TOO_LARGE'))
@@ -147,5 +166,76 @@ describe('CardManager HEIC conversion (issue #770)', () => {
     })
     expect(screen.queryByText('トリミングサイズを選択')).not.toBeInTheDocument()
     expect(screen.queryByText('HEIC画像を読み込めませんでした。別の画像を選択するか、JPEGへ変換してから再度お試しください。')).not.toBeInTheDocument()
+  })
+
+  it('キャンセル後に開き直したフォームの変換状態を、古い変換が解除しない', async () => {
+    stubImageLoad()
+    mocks.isHeicUpload.mockReturnValue(true)
+    let resolveFirst: (file: File) => void
+    let resolveSecond: (file: File) => void
+    let conversionCount = 0
+    mocks.convertHeicToJpeg.mockImplementation(
+      () => new Promise<File>((resolve) => {
+        if (conversionCount++ === 0) {
+          resolveFirst = resolve
+        } else {
+          resolveSecond = resolve
+        }
+      })
+    )
+    const { container } = renderCardManager()
+
+    openFormAndSelectFile(container, heicFile())
+    expect(await screen.findByRole('status')).toHaveTextContent('HEIC画像を変換中…')
+    fireEvent.click(screen.getByText('キャンセル'))
+
+    // 古い変換が未完了でも、キャンセル後は状態を持ち越さず新規フォームを開ける
+    openFormAndSelectFile(container, heicFile())
+    expect(await screen.findByRole('status')).toHaveTextContent('HEIC画像を変換中…')
+
+    // 古い変換の finally が実行されても、現在の変換中表示は維持する
+    resolveFirst!(jpegFile())
+    await waitFor(() => expect(mocks.convertHeicToJpeg).toHaveBeenCalledTimes(2))
+    expect(screen.getByRole('status')).toHaveTextContent('HEIC画像を変換中…')
+
+    resolveSecond!(jpegFile())
+    expect(await screen.findByText('トリミングサイズを選択')).toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('Strict Modeでも変換完了後に既存フローへ進める', async () => {
+    stubImageLoad()
+    mocks.isHeicUpload.mockReturnValue(true)
+    mocks.convertHeicToJpeg.mockResolvedValue(jpegFile())
+    const { container } = renderCardManager({ strictMode: true })
+
+    openFormAndSelectFile(container, heicFile())
+
+    // Strict Modeの検証用cleanup後も、現行setupがマウント中として扱われることを確認する。
+    expect(await screen.findByText('トリミングサイズを選択')).toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('アンマウント後に遅延した変換結果を反映しない', async () => {
+    mocks.isHeicUpload.mockReturnValue(true)
+    let resolveConvert: (file: File) => void
+    mocks.convertHeicToJpeg.mockImplementation(
+      () => new Promise<File>((resolve) => { resolveConvert = resolve })
+    )
+    const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    const { container, unmount } = renderCardManager()
+
+    openFormAndSelectFile(container, heicFile())
+    expect(await screen.findByRole('status')).toHaveTextContent('HEIC画像を変換中…')
+
+    unmount()
+    resolveConvert!(jpegFile())
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // アンマウント済みのコンポーネントに対する遅延結果は、クロップ開始に必要な
+    // object URL作成まで到達しない。DOMが消えたことだけではこのガードの回帰を
+    // 検出できないため、結果を処理した場合に必ず発生する副作用を直接検証する。
+    expect(createObjectURLSpy).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/heic-converter.test.ts
+++ b/tests/unit/heic-converter.test.ts
@@ -3,8 +3,10 @@ import {
   isHeicUpload,
   convertHeicToJpeg,
   HEIC_INPUT_MAX_BYTES,
+  HEIC_CONVERSION_TIMEOUT_MS,
   HEIC_ERROR_TOO_LARGE,
   HEIC_ERROR_CONVERT_FAILED,
+  HEIC_ERROR_TIMEOUT,
 } from '@/lib/heic-converter'
 
 function makeFile(name: string, type: string, size = 1024): File {
@@ -90,5 +92,25 @@ describe('convertHeicToJpeg (issue #770)', () => {
 
     await expect(convertHeicToJpeg(oversized)).rejects.toThrow(HEIC_ERROR_TOO_LARGE)
     expect(heic2anyMock).not.toHaveBeenCalled()
+  })
+
+  it('変換が応答しない場合はタイムアウトして HEIC_CONVERSION_TIMEOUT を投げる', async () => {
+    vi.useFakeTimers()
+    try {
+      heic2anyMock.mockImplementation(() => new Promise<Blob>(() => undefined))
+
+      const conversion = convertHeicToJpeg(makeFile('photo.heic', 'image/heic'))
+      // rejection handlerを先に接続し、タイマー発火とアサーションの間に
+      // Vitestが一時的な未処理rejectionとして扱わないようにする。
+      const rejection = expect(conversion).rejects.toThrow(HEIC_ERROR_TIMEOUT)
+      // 動的 import のmicrotaskを先に進め、変換Promiseがタイマーを登録してから時間を進める
+      await Promise.resolve()
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(HEIC_CONVERSION_TIMEOUT_MS)
+
+      await rejection
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })


### PR DESCRIPTION
## 概要

PR #900 のpreview実経路テストで、実在するHEICファイル2件が「HEIC画像を変換中…」のまま100秒以上継続し、入力と追加操作が復帰しない事象を確認しました。本追補では、クライアント側HEIC変換に30秒の上限を設け、変換失敗・タイムアウト後にフォームを再選択可能な状態へ戻します。

## 変更内容

- `heic2any` の動的importと変換処理を30秒でタイムアウト
- キャンセル、再選択、アンマウント後の古いPromise結果を世代ID・マウント状態で破棄
- React Strict Modeのsetup/cleanup再実行後も現行コンポーネントを有効扱い
- タイムアウト、Strict Mode、キャンセル後の再オープン、アンマウント競合をテスト

## 検証

- focused Vitest: 18 tests passed
- TypeScript: passed
- ESLint対象4ファイル: passed
- git diff --check: passed
- previewで実HEIC 2件を選択し、無期限の変換中状態になることを確認済み（本PRデプロイ後に30秒以内のエラー復帰を再確認予定）

Related: #900, #770