### PR TITLE
fix(upload): withTimeout敗者Promiseのunhandled rejectionを防止

### DIFF
--- a/src/lib/heic-converter.ts
+++ b/src/lib/heic-converter.ts
@@ -41,6 +41,11 @@ const HEIC_EXTENSIONS = [".heic", ".heif"];
 async function withTimeout<T>(operation: () => Promise<T>, timeoutMs: number): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const operationPromise = Promise.resolve().then(operation);
+  // タイムアウトが先に成立した場合、operationPromise は Worker 側の処理が
+  // 終わるまで裏で生き続ける。ハンドラを一切繋がないと、後から reject された際に
+  // ブラウザ側で unhandled promise rejection が発生するため、結果を使わない
+  // ダミーの catch を必ず繋いでおく（Promise.race に渡す元の Promise の挙動は変えない）。
+  operationPromise.catch(() => {});
   const timeoutPromise = new Promise<never>((_, reject) => {
     timer = setTimeout(() => reject(new Error(HEIC_ERROR_TIMEOUT)), timeoutMs);
   });

--- a/tests/unit/heic-converter.test.ts
+++ b/tests/unit/heic-converter.test.ts
@@ -113,4 +113,36 @@ describe('convertHeicToJpeg (issue #770)', () => {
       vi.useRealTimers()
     }
   })
+
+  it('タイムアウト成立後にheic2anyが遅延rejectしてもunhandled rejectionにならない', async () => {
+    vi.useFakeTimers()
+    const unhandledRejections: unknown[] = []
+    const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason)
+    process.on('unhandledRejection', onUnhandledRejection)
+    try {
+      let rejectHeic2any: (error: Error) => void = () => undefined
+      heic2anyMock.mockImplementation(
+        () => new Promise<Blob>((_, reject) => { rejectHeic2any = reject })
+      )
+
+      const conversion = convertHeicToJpeg(makeFile('photo.heic', 'image/heic'))
+      const rejection = expect(conversion).rejects.toThrow(HEIC_ERROR_TIMEOUT)
+      await Promise.resolve()
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(HEIC_CONVERSION_TIMEOUT_MS)
+      await rejection
+
+      // タイムアウトで呼び出し側には結果を返した後も、heic2any側のPromiseは
+      // 生きたままなので、ここで実際に遅延rejectさせて検証する
+      rejectHeic2any(new Error('late decode failure'))
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(unhandledRejections).toHaveLength(0)
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection)
+      vi.useRealTimers()
+    }
+  })
 })


### PR DESCRIPTION
## 概要

PR #901（`fix(upload): stalled HEIC変換をタイムアウトしてフォームを復帰させる`）のレビュー（fableモデルによる指摘）で見つかった、ブロッキング指摘の修正です。#901 は本コミットが用意できる前に既にマージ済みだったため、フォローアップPRとして切り出しています。

## 問題

`src/lib/heic-converter.ts` の `withTimeout()` は `Promise.race` でタイムアウト側を勝たせた後も、実際の変換処理（動的import + heic2any 呼び出し）の Promise（`operationPromise`）にはハンドラを何も繋いでいませんでした。タイムアウト成立後に元の処理が裏で遅れて reject すると、ブラウザ側で unhandled promise rejection が発生し得ます。本PRの前提自体が「実HEICで変換が異常に滞留する」事象への対応なので、この経路は現実的です。

## 変更内容

- `operationPromise` に結果を使わないダミーの `catch` を常時接続し、unhandled rejection を防止（`Promise.race` に渡す元の Promise の挙動・戻り値は変更なし）
- タイムアウト成立後に heic2any が遅延 reject しても unhandled rejection にならないことを検証する回帰テストを追加（`process.on('unhandledRejection', ...)` で捕捉）

## 検証

- `npx vitest run tests/unit/heic-converter.test.ts tests/unit/components/card-manager-heic.test.tsx` : 19 tests passed（新規1件含む）
- `npx tsc --noEmit` : passed
- `npx eslint src/lib/heic-converter.ts tests/unit/heic-converter.test.ts` : passed
- `git diff --check` : passed

Related: #901, #900, #770

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVGeSPtnCpVsWWuwBLuk9V)_