### PR TITLE
fix(upload): use CSP-safe HEIC conversion build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
-        "heic2any": "^0.0.4",
+        "heic-to": "1.5.2",
         "next": "16.1.6",
         "next-intl": "^4.7.0",
         "postgres": "^3.4.9",
@@ -14551,11 +14551,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/heic2any": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
-      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
-      "license": "MIT"
+    "node_modules/heic-to": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/heic-to/-/heic-to-1.5.2.tgz",
+      "integrity": "sha512-8Fns+lZHAWmz5U5IUxDeXKwIf3foBoKNPLxxFY4B0MkLjNuomEIHCoDbDE+x/llFK3NCEO1cu4+n3iUKY+Svmw==",
+      "license": "LGPL-3.0"
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",
-    "heic2any": "^0.0.4",
+    "heic-to": "1.5.2",
     "next": "16.1.6",
     "next-intl": "^4.7.0",
     "postgres": "^3.4.9",

--- a/src/lib/heic-converter.ts
+++ b/src/lib/heic-converter.ts
@@ -9,7 +9,7 @@
  * この方式の利点:
  * - 保存形式は従来どおり JPEG となり、カード表示側・`/api/upload` の変更が不要
  * - サーバー（Cloudflare Workers）でネイティブ画像ライブラリを動かす必要がない
- * - 変換ライブラリ（heic2any、MIT ライセンス）は HEIC 選択時のみ動的 import され、
+ * - 変換ライブラリ（heic-to）はCSP対応ビルドをHEIC選択時だけ動的 import し、
  *   通常アップロードの初期バンドルを増やさない
  *
  * 注意:
@@ -19,7 +19,7 @@
  */
 export const HEIC_INPUT_MAX_BYTES = 25 * 1024 * 1024; // 25MB（変換前の入力上限。デコード後のメモリ使用量は圧縮時サイズより大幅に増えるため、緩めの安全弁）
 
-// heic2any 0.0.4 は変換用 Worker を停止する Abort API を公開していないため、
+// heic-to の変換用 Worker を停止する Abort API は公開されていないため、
 // 呼び出し側が無期限に待ち続けないよう、import とデコードを合わせた総時間に上限を設ける。
 export const HEIC_CONVERSION_TIMEOUT_MS = 30_000;
 
@@ -34,9 +34,9 @@ const HEIC_EXTENSIONS = [".heic", ".heif"];
 /**
  * Abort API を持たない非同期処理に、利用者向けの有限な待機時間を与える。
  *
- * Promise.race は呼び出し側の Promise を終了させるだけで、heic2any 内部の
- * Worker は停止できない。そのため、タイムアウト後に元の処理が遅れて完了しても
- * 呼び出し側で結果を採用しないこと（CardManager の世代チェック）が必要になる。
+ * Promise.race は呼び出し側の Promise を終了させるだけで、変換 Worker は停止できない。
+ * そのため、タイムアウト後に元の処理が遅れて完了しても呼び出し側で結果を採用しない
+ * こと（CardManager の世代チェック）が必要になる。
  */
 async function withTimeout<T>(operation: () => Promise<T>, timeoutMs: number): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -70,7 +70,11 @@ export function isHeicUpload(file: File): boolean {
 
 /**
  * HEIC / HEIF ファイルを JPEG の File へ変換する。
- * 変換ライブラリ（heic2any）は HEIC 選択時のみ動的 import する。
+ * 変換ライブラリ（heic-to）のCSP対応ビルドをHEIC選択時のみ動的 import する。
+ *
+ * `heic-to/csp` は libheif を unsafe-eval なしでビルドした Worker を含むため、
+ * 本番の厳格なCSPを緩めずにブラウザ内変換を行える。通常のJPEG/PNGではimport
+ * 自体が発生しないので、初期ロードへデコーダを追加しない。
  *
  * @param file HEIC / HEIF ファイル
  * @returns JPEG に変換された File（ファイル名の拡張子は .jpg）
@@ -84,9 +88,10 @@ export async function convertHeicToJpeg(file: File): Promise<File> {
   let output: Blob | Blob[];
   try {
     output = await withTimeout(async () => {
-      const { default: heic2any } = await import("heic2any");
+      // `heic-to/csp` はCSP制約を満たすビルドを選ぶための明示的なサブパス。
+      const { heicTo } = await import("heic-to/csp");
       // quality は既存のクロップ再圧縮（ImageCropper の 0.85）と同等水準にする
-      return heic2any({ blob: file, toType: "image/jpeg", quality: 0.85 });
+      return heicTo({ blob: file, type: "image/jpeg", quality: 0.85 });
     }, HEIC_CONVERSION_TIMEOUT_MS);
   } catch (error) {
     // タイムアウトは呼び出し側で変換失敗と区別できるよう、そのまま伝える。
@@ -97,9 +102,8 @@ export async function convertHeicToJpeg(file: File): Promise<File> {
     throw new Error(HEIC_ERROR_CONVERT_FAILED);
   }
 
-  // heic2any は multiple 未指定時、コンテナ内の全画像をデコードした上で
-  // 先頭（primary image）の Blob を単一で返す。配列は返らないが、型上は
-  // Blob | Blob[] のため防御的に先頭を取る。
+  // heic-to は初期対応としてprimary imageを単一のBlobへ変換する。
+  // 型が将来 Blob[] へ拡張されても先頭画像だけを採用して既存契約を守る。
   const jpegBlob = Array.isArray(output) ? output[0] : output;
   if (!jpegBlob || jpegBlob.size === 0) {
     throw new Error(HEIC_ERROR_CONVERT_FAILED);

--- a/tests/stubs/heic-to-csp.ts
+++ b/tests/stubs/heic-to-csp.ts
@@ -1,0 +1,9 @@
+/**
+ * Vite must resolve a concrete file before Vitest can apply the factory mock
+ * in `heic-converter.test.ts`. The implementation must never run in that
+ * unit test; throwing here makes an accidentally unmocked import fail loudly
+ * instead of performing a real HEIC conversion in the test process.
+ */
+export function heicTo(): never {
+  throw new Error('The heic-to/csp test stub must be mocked by the unit test.')
+}

--- a/tests/unit/heic-converter.test.ts
+++ b/tests/unit/heic-converter.test.ts
@@ -13,9 +13,9 @@ function makeFile(name: string, type: string, size = 1024): File {
   return new File([new Uint8Array(size)], name, { type })
 }
 
-// heic2any の動的 import をモック（変換ユニット自体のテストに実ブラウザ変換は不要）
-vi.mock('heic2any', () => ({
-  default: vi.fn(),
+// heic-to の動的 import をモック（変換ユニット自体のテストに実ブラウザ変換は不要）
+vi.mock('heic-to/csp', () => ({
+  heicTo: vi.fn(),
 }))
 
 describe('isHeicUpload (issue #770)', () => {
@@ -39,15 +39,15 @@ describe('isHeicUpload (issue #770)', () => {
 })
 
 describe('convertHeicToJpeg (issue #770)', () => {
-  let heic2anyMock: ReturnType<typeof vi.fn>
+  let heicToMock: ReturnType<typeof vi.fn>
 
   beforeEach(async () => {
-    heic2anyMock = vi.mocked((await import('heic2any')).default)
-    heic2anyMock.mockReset()
+    heicToMock = vi.mocked((await import('heic-to/csp')).heicTo)
+    heicToMock.mockReset()
   })
 
   it('変換成功時に image/jpeg の File を返し、拡張子は .jpg になる', async () => {
-    heic2anyMock.mockResolvedValue(new Blob(['jpeg-data'], { type: 'image/jpeg' }))
+    heicToMock.mockResolvedValue(new Blob(['jpeg-data'], { type: 'image/jpeg' }))
     const input = makeFile('photo.heic', 'image/heic')
 
     const result = await convertHeicToJpeg(input)
@@ -55,13 +55,13 @@ describe('convertHeicToJpeg (issue #770)', () => {
     expect(result.type).toBe('image/jpeg')
     expect(result.name).toBe('photo.jpg')
     expect(result.lastModified).toBe(input.lastModified)
-    expect(heic2anyMock).toHaveBeenCalledWith(
-      expect.objectContaining({ blob: input, toType: 'image/jpeg', quality: 0.85 })
+    expect(heicToMock).toHaveBeenCalledWith(
+      expect.objectContaining({ blob: input, type: 'image/jpeg', quality: 0.85 })
     )
   })
 
   it('複数画像を含む HEIC コンテナでは primary image（先頭）のみを使う', async () => {
-    heic2anyMock.mockResolvedValue([
+    heicToMock.mockResolvedValue([
       new Blob(['primary'], { type: 'image/jpeg' }),
       new Blob(['secondary'], { type: 'image/jpeg' }),
     ])
@@ -72,7 +72,7 @@ describe('convertHeicToJpeg (issue #770)', () => {
   })
 
   it('変換失敗時は HEIC_CONVERT_FAILED エラーを投げる', async () => {
-    heic2anyMock.mockRejectedValue(new Error('decode failed'))
+    heicToMock.mockRejectedValue(new Error('decode failed'))
 
     await expect(convertHeicToJpeg(makeFile('photo.heic', 'image/heic'))).rejects.toThrow(
       HEIC_ERROR_CONVERT_FAILED
@@ -80,7 +80,7 @@ describe('convertHeicToJpeg (issue #770)', () => {
   })
 
   it('空の出力（サイズ0）は HEIC_CONVERT_FAILED として扱う', async () => {
-    heic2anyMock.mockResolvedValue(new Blob([]))
+    heicToMock.mockResolvedValue(new Blob([]))
 
     await expect(convertHeicToJpeg(makeFile('photo.heic', 'image/heic'))).rejects.toThrow(
       HEIC_ERROR_CONVERT_FAILED
@@ -91,13 +91,13 @@ describe('convertHeicToJpeg (issue #770)', () => {
     const oversized = makeFile('big.heic', 'image/heic', HEIC_INPUT_MAX_BYTES + 1)
 
     await expect(convertHeicToJpeg(oversized)).rejects.toThrow(HEIC_ERROR_TOO_LARGE)
-    expect(heic2anyMock).not.toHaveBeenCalled()
+    expect(heicToMock).not.toHaveBeenCalled()
   })
 
   it('変換が応答しない場合はタイムアウトして HEIC_CONVERSION_TIMEOUT を投げる', async () => {
     vi.useFakeTimers()
     try {
-      heic2anyMock.mockImplementation(() => new Promise<Blob>(() => undefined))
+      heicToMock.mockImplementation(() => new Promise<Blob>(() => undefined))
 
       const conversion = convertHeicToJpeg(makeFile('photo.heic', 'image/heic'))
       // rejection handlerを先に接続し、タイマー発火とアサーションの間に

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,13 @@ export default defineConfig({
     // サブエージェント実行時のさらなる安全対策
     isolate: true, // 各テストファイルを完全に分離
     fileParallelism: false, // ファイル並列実行を無効化（より安全）
+    // A `vi.mock` factory is applied after Vite parses imports. The isolated
+    // dependency install therefore still needs a concrete file for
+    // `heic-to/csp` during import analysis; this alias is test-only and does
+    // not alter the production module resolution.
+    alias: {
+      'heic-to/csp': path.resolve(__dirname, './tests/stubs/heic-to-csp.ts'),
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## 概要
PR #900 のHEICアップロード対応をプレビューで実経路確認したところ、`heic2any` が本番CSPの `unsafe-eval` 制約により変換処理を完了できず、PR #901 のタイムアウト後も実変換が成功しない問題が残りました。

`heic-to@1.5.2` のCSP対応サブパス `heic-to/csp` へ切り替え、厳格なCSPを緩めずにWorker/WASM変換を実行します。PR #901で追加した30秒timeoutとフォーム状態の世代ガードは維持します。

## 検証
- `npm run test:unit`: 269 passed / 1 skipped、3,683 passed / 34 skipped
- 実パッケージを解決した `npm run typecheck`: 成功
- 実パッケージを解決した `npm run build`: 成功
- アプリ内ブラウザのローカルNext本番ビルド（CSP: `unsafe-eval` なし）で実ファイルを変換:
  - `Tree.heic` → `image/jpeg` 6,411 bytes
  - `The Beach.heic` → `image/jpeg` 10,059 bytes
  - ブラウザ console error/warn なし
- VitestのHEIC変換・CardManagerテスト: 18/18成功

## 注意
- `heic-to@1.5.2` はLGPL-3.0です。`package-lock.json`にも記録されています。
- マージ後はpreviewへデプロイし、認証済みアプリ内ブラウザで実HEIC変換が成功することを確認してからmainへ進めます。