### PR TITLE
chore(release): promote validated preview HEIC conversion to main

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -127,7 +127,10 @@
       "imageUrlInvalidAspectRatio": "Image URL must be portrait (vertical) or square (current: {width}x{height})",
       "imageUrlResolutionExceeded": "Image URL resolution exceeds limit. Max width: {maxWidth}px, max height: {maxHeight}px (current: {width}x{height})",
       "imageUrlLoadFailed": "Failed to load image URL. Please check the URL.",
-      "imageUrlValidating": "Validating image..."
+      "imageUrlValidating": "Validating image...",
+      "heicConverting": "Converting HEIC image...",
+      "heicConvertFailed": "Could not read the HEIC image. Please choose another image or convert it to JPEG and try again.",
+      "heicTooLarge": "The HEIC image is too large. Please choose an image under {mb}MB."
     },
     "cardNumberEditor": {
       "title": "Edit Card Numbers",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -127,7 +127,10 @@
       "imageUrlInvalidAspectRatio": "画像URLの画像は縦長または正方形である必要があります（現在: {width}x{height}）",
       "imageUrlResolutionExceeded": "画像URLの解像度が制限を超えています。横幅{maxWidth}px、縦幅{maxHeight}pxまでです（現在: {width}x{height}）",
       "imageUrlLoadFailed": "画像URLの読み込みに失敗しました。URLを確認してください。",
-      "imageUrlValidating": "画像を検証中..."
+      "imageUrlValidating": "画像を検証中...",
+      "heicConverting": "HEIC画像を変換中…",
+      "heicConvertFailed": "HEIC画像を読み込めませんでした。別の画像を選択するか、JPEGへ変換してから再度お試しください。",
+      "heicTooLarge": "HEIC画像のサイズが大きすぎます。{mb}MB以下の画像を選択してください。"
     },
     "cardNumberEditor": {
       "title": "カード番号をまとめて編集",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
+        "heic2any": "^0.0.4",
         "next": "16.1.6",
         "next-intl": "^4.7.0",
         "postgres": "^3.4.9",
@@ -14549,6 +14550,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "drizzle-orm": "^0.45.2",
-        "heic2any": "^0.0.4",
+        "heic-to": "1.5.2",
         "next": "16.1.6",
         "next-intl": "^4.7.0",
         "postgres": "^3.4.9",
@@ -14551,11 +14551,11 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/heic2any": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
-      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
-      "license": "MIT"
+    "node_modules/heic-to": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/heic-to/-/heic-to-1.5.2.tgz",
+      "integrity": "sha512-8Fns+lZHAWmz5U5IUxDeXKwIf3foBoKNPLxxFY4B0MkLjNuomEIHCoDbDE+x/llFK3NCEO1cu4+n3iUKY+Svmw==",
+      "license": "LGPL-3.0"
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",
-    "heic2any": "^0.0.4",
+    "heic-to": "1.5.2",
     "next": "16.1.6",
     "next-intl": "^4.7.0",
     "postgres": "^3.4.9",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",
+    "heic2any": "^0.0.4",
     "next": "16.1.6",
     "next-intl": "^4.7.0",
     "postgres": "^3.4.9",

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -505,6 +505,23 @@ export default function CardManager({
   // 画像サイズ読み取りの非同期コールバック無効化用カウンター
   // Counter to invalidate stale async image dimension callbacks
   const imageDimensionRequestId = useRef(0);
+  // HEIC変換専用の世代。画像寸法読み取り処理とは別に持ち、変換成功時に
+  // processSelectedFile() が画像寸法用IDを進めても、現行変換の finally が
+  // 自分自身を古いリクエストと誤判定しないようにする。
+  const heicConversionRequestId = useRef(0);
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    // React Strict Mode は開発時に setup -> cleanup -> setup を再実行するため、
+    // 再マウントされた setup では必ず有効状態へ戻す。これを行わないと、
+    // 初回の検証用 cleanup が残り、実際にはマウント中でも変換結果を破棄してしまう。
+    isMountedRef.current = true;
+    return () => {
+      // 画面遷移などでアンマウントされた後に、保留中の変換Promiseから
+      // state更新やクロップ開始を行わない。Worker自体は停止できないため、
+      // 完了後の各経路でこのフラグを確認して結果だけを無効化する。
+      isMountedRef.current = false;
+    };
+  }, []);
   // Cropped image file ready for upload
   // アップロード準備完了のトリミング済み画像ファイル
   const [croppedFile, setCroppedFile] = useState<File | null>(null);
@@ -1096,6 +1113,9 @@ export default function CardManager({
     // Reset cropping state
     // トリミング状態をリセット
     imageDimensionRequestId.current++;
+    // キャンセル中のHEIC変換を無効化し、古いPromiseが後から状態を戻さないようにする
+    heicConversionRequestId.current++;
+    setIsConvertingHeic(false);
     setCropModalOpen(false);
     setCropModeModalOpen(false);
     setSelectedCropMode("square");
@@ -1118,25 +1138,28 @@ export default function CardManager({
     const file = e.target.files?.[0];
     setUploadError(null);
     if (file) {
+      // 新しいファイル選択は、前のHEIC変換結果を常に無効化する。
+      const conversionRequestId = ++heicConversionRequestId.current;
       // Issue #770: HEIC / HEIF はブラウザで表示できないため、選択直後に
       // クライアント側で JPEG へ変換してから既存フローへ渡す。変換中は入力が
-      // 無効化されるため、request id はフォームのキャンセル（resetForm 等）による
-      // 古い変換結果の無視に使う。
+      // 無効化されるため、世代IDはフォームのキャンセル（resetForm 等）や
+      // 再選択による古い変換結果の無視に使う。
       if (isHeicUpload(file)) {
         setIsConvertingHeic(true);
-        const requestId = ++imageDimensionRequestId.current;
         try {
           const converted = await convertHeicToJpeg(file);
-          if (requestId !== imageDimensionRequestId.current) return;
+          if (!isMountedRef.current || conversionRequestId !== heicConversionRequestId.current) return;
           processSelectedFile(converted);
         } catch (error) {
-          if (requestId !== imageDimensionRequestId.current) return;
+          if (!isMountedRef.current || conversionRequestId !== heicConversionRequestId.current) return;
           if (error instanceof Error && error.message === HEIC_ERROR_TOO_LARGE) {
             setUploadError(t("messages.heicTooLarge", { mb: HEIC_INPUT_MAX_BYTES / (1024 * 1024) }));
           } else {
             setUploadError(t("messages.heicConvertFailed"));
           }
         } finally {
+          // キャンセル・再選択後に完了した古い変換は、現在の入力状態を変更してはならない。
+          if (!isMountedRef.current || conversionRequestId !== heicConversionRequestId.current) return;
           // 変換完了（成功・失敗とも）で入力を再度有効化し、生の HEIC が
           // フォーム送信に残らないようファイル入力をクリアする
           setIsConvertingHeic(false);
@@ -1146,6 +1169,8 @@ export default function CardManager({
         }
         return;
       }
+      // HEIC変換が発生しない選択でも、念のため変換中表示を解除する。
+      setIsConvertingHeic(false);
       // Only validate file type before cropping (skip size check)
       // Cropped image will be compressed to JPEG, so original size doesn't matter
       // トリミング前はファイルタイプのみ検証（サイズチェックはスキップ）

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -14,6 +14,7 @@ import { DEFAULT_PACK_SENTINEL } from "@/lib/validation/collection-name";
 import { cardMatchesPackKey } from "@/lib/collection-packs";
 import { computeEffectiveWeights, resolveRarityWeightsForPool } from "@/lib/rarity-weight-calculator";
 import { isAllowedCardUploadFile, shouldPreserveOriginalCardUpload } from "@/lib/card-upload-mode";
+import { isHeicUpload, convertHeicToJpeg, HEIC_INPUT_MAX_BYTES, HEIC_ERROR_TOO_LARGE } from "@/lib/heic-converter";
 import { MAX_ISSUANCE_COUNT_CAP, getIssuanceInfo } from "@/lib/card-issuance";
 import { parseMaintenanceError } from "@/lib/maintenance/client";
 import { useMaintenanceStatus } from "./MaintenanceStatusProvider";
@@ -462,6 +463,8 @@ export default function CardManager({
   const isDescriptionTooLong = descriptionCharacterCount > CARD_DESCRIPTION_MAX_CHARACTERS;
   const [saving, setSaving] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  // Issue #770: HEIC 画像を JPEG へ変換中の状態（変換中は入力を無効化する）
+  const [isConvertingHeic, setIsConvertingHeic] = useState(false);
   // Issue #393再設計: デプロイ窓(card_pack_names列未検出)でパック紐付けだけ
   // 保留された稀なケースの通知。resetForm()がuploadErrorを即座にクリアする
   // ため、フォームの表示状態から独立させる。
@@ -1111,73 +1114,109 @@ export default function CardManager({
     }
   };
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     setUploadError(null);
     if (file) {
+      // Issue #770: HEIC / HEIF はブラウザで表示できないため、選択直後に
+      // クライアント側で JPEG へ変換してから既存フローへ渡す。変換中は入力が
+      // 無効化されるため、request id はフォームのキャンセル（resetForm 等）による
+      // 古い変換結果の無視に使う。
+      if (isHeicUpload(file)) {
+        setIsConvertingHeic(true);
+        const requestId = ++imageDimensionRequestId.current;
+        try {
+          const converted = await convertHeicToJpeg(file);
+          if (requestId !== imageDimensionRequestId.current) return;
+          processSelectedFile(converted);
+        } catch (error) {
+          if (requestId !== imageDimensionRequestId.current) return;
+          if (error instanceof Error && error.message === HEIC_ERROR_TOO_LARGE) {
+            setUploadError(t("messages.heicTooLarge", { mb: HEIC_INPUT_MAX_BYTES / (1024 * 1024) }));
+          } else {
+            setUploadError(t("messages.heicConvertFailed"));
+          }
+        } finally {
+          // 変換完了（成功・失敗とも）で入力を再度有効化し、生の HEIC が
+          // フォーム送信に残らないようファイル入力をクリアする
+          setIsConvertingHeic(false);
+          if (fileInputRef.current) {
+            fileInputRef.current.value = "";
+          }
+        }
+        return;
+      }
       // Only validate file type before cropping (skip size check)
       // Cropped image will be compressed to JPEG, so original size doesn't matter
       // トリミング前はファイルタイプのみ検証（サイズチェックはスキップ）
       // トリミング後はJPEGに圧縮されるため、元のサイズは問題にならない
-      if (!isAllowedCardUploadFile(file)) {
-        setUploadError(getUploadErrorMessage("INVALID_FILE_TYPE"));
-        return;
-      }
-      if (shouldPreserveOriginalCardUpload(file)) {
-        // GIFはトリミング/再圧縮されず原本のままアップロードされるため、
-        // クライアント側でもプラン上限を事前にチェックし UX を早期化する
-        // （サーバ側 validateUpload でも最終的に弾かれるが、無駄なネットワークを避ける）
-        const validation = validateUpload(file, maxUploadSize);
-        if (!validation.valid) {
-          setUploadError(getUploadErrorMessage(validation.error!));
-          return;
-        }
-        imageDimensionRequestId.current++;
-        if (croppedPreviewUrl) {
-          URL.revokeObjectURL(croppedPreviewUrl);
-        }
-        setSelectedFileForCrop(null);
-        setSourceImageWidth(null);
-        setCropModeModalOpen(false);
-        setCropModalOpen(false);
-        setSelectedCropMode("square");
-        setCroppedFile(file);
-        setCroppedPreviewUrl(URL.createObjectURL(file));
-        return;
-      }
-      // 画像の実サイズを読み取ってからモーダルを開く
-      // Read actual image dimensions before opening the modal
-      const requestId = ++imageDimensionRequestId.current;
-      const img = document.createElement("img");
-      const objectUrl = URL.createObjectURL(file);
-      img.onload = () => {
-        URL.revokeObjectURL(objectUrl);
-        // キャンセルや再選択で無効化されたコールバックを無視
-        // Ignore stale callback from cancelled/re-selected file
-        if (requestId !== imageDimensionRequestId.current) return;
-        const imgWidth = img.naturalWidth;
-        setSourceImageWidth(imgWidth);
-        // 画像幅以下の解像度のうち最大のものをデフォルトに設定
-        // Default to the largest resolution that doesn't exceed image width
-        const validWidths = availableWidths.filter((w) => w <= imgWidth);
-        const defaultWidth = validWidths.length > 0
-          ? Math.max(...validWidths)
-          : Math.min(...availableWidths);
-        setSelectedWidth(defaultWidth);
-        setSelectedFileForCrop(file);
-        setCropModeModalOpen(true);
-      };
-      img.onerror = () => {
-        URL.revokeObjectURL(objectUrl);
-        if (requestId !== imageDimensionRequestId.current) return;
-        // 読み取り失敗時はフォールバック：従来通り全選択肢を表示
-        setSourceImageWidth(null);
-        setSelectedWidth(maxImageWidth);
-        setSelectedFileForCrop(file);
-        setCropModeModalOpen(true);
-      };
-      img.src = objectUrl;
+      processSelectedFile(file);
     }
+  };
+
+  /**
+   * 検証済みファイルをクロップモード選択へ渡す共通処理（#770 で HEIC 変換後も流用）。
+   * HEIC 変換済み JPEG は通常ファイルと同様に扱う。
+   */
+  const processSelectedFile = (file: File) => {
+    if (!isAllowedCardUploadFile(file)) {
+      setUploadError(getUploadErrorMessage("INVALID_FILE_TYPE"));
+      return;
+    }
+    if (shouldPreserveOriginalCardUpload(file)) {
+      // GIFはトリミング/再圧縮されず原本のままアップロードされるため、
+      // クライアント側でもプラン上限を事前にチェックし UX を早期化する
+      // （サーバ側 validateUpload でも最終的に弾かれるが、無駄なネットワークを避ける）
+      const validation = validateUpload(file, maxUploadSize);
+      if (!validation.valid) {
+        setUploadError(getUploadErrorMessage(validation.error!));
+        return;
+      }
+      imageDimensionRequestId.current++;
+      if (croppedPreviewUrl) {
+        URL.revokeObjectURL(croppedPreviewUrl);
+      }
+      setSelectedFileForCrop(null);
+      setSourceImageWidth(null);
+      setCropModeModalOpen(false);
+      setCropModalOpen(false);
+      setSelectedCropMode("square");
+      setCroppedFile(file);
+      setCroppedPreviewUrl(URL.createObjectURL(file));
+      return;
+    }
+    // 画像の実サイズを読み取ってからモーダルを開く
+    // Read actual image dimensions before opening the modal
+    const requestId = ++imageDimensionRequestId.current;
+    const img = document.createElement("img");
+    const objectUrl = URL.createObjectURL(file);
+    img.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+      // キャンセルや再選択で無効化されたコールバックを無視
+      // Ignore stale callback from cancelled/re-selected file
+      if (requestId !== imageDimensionRequestId.current) return;
+      const imgWidth = img.naturalWidth;
+      setSourceImageWidth(imgWidth);
+      // 画像幅以下の解像度のうち最大のものをデフォルトに設定
+      // Default to the largest resolution that doesn't exceed image width
+      const validWidths = availableWidths.filter((w) => w <= imgWidth);
+      const defaultWidth = validWidths.length > 0
+        ? Math.max(...validWidths)
+        : Math.min(...availableWidths);
+      setSelectedWidth(defaultWidth);
+      setSelectedFileForCrop(file);
+      setCropModeModalOpen(true);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      if (requestId !== imageDimensionRequestId.current) return;
+      // 読み取り失敗時はフォールバック：従来通り全選択肢を表示
+      setSourceImageWidth(null);
+      setSelectedWidth(maxImageWidth);
+      setSelectedFileForCrop(file);
+      setCropModeModalOpen(true);
+    };
+    img.src = objectUrl;
   };
 
   /**
@@ -1976,10 +2015,10 @@ export default function CardManager({
                     <input
                       type="file"
                       name="image"
-                      accept="image/*"
+                      accept="image/jpeg,image/png,image/gif,image/webp,image/heic,image/heif,.jpg,.jpeg,.png,.gif,.webp,.heic,.heif"
                       ref={fileInputRef}
                       onChange={handleFileChange}
-                      disabled={storageStatus?.uploadDisabled}
+                      disabled={storageStatus?.uploadDisabled || isConvertingHeic}
                       className={`w-full min-w-0 text-sm text-gray-400 file:mr-4 file:rounded-lg file:border-0 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white ${
                         storageStatus?.uploadDisabled
                           ? 'opacity-50 cursor-not-allowed file:bg-gray-500'
@@ -1999,6 +2038,12 @@ export default function CardManager({
                         maxMb: Math.floor((maxUploadSize ?? 1 * 1024 * 1024) / (1024 * 1024)),
                       })}
                     </p>
+                    {/* Issue #770: HEIC 画像の JPEG 変換中表示 */}
+                    {isConvertingHeic && (
+                      <p className="text-xs text-purple-400" role="status">
+                        {t("messages.heicConverting")}
+                      </p>
+                    )}
                     <input
                       type="url"
                       name="imageUrl"
@@ -2172,7 +2217,7 @@ export default function CardManager({
               <div className="mt-6 flex gap-4">
                 <button
                   type="submit"
-                  disabled={saving || isDescriptionTooLong || isMaintenanceBlocked}
+                  disabled={saving || isConvertingHeic || isDescriptionTooLong || isMaintenanceBlocked}
                   title={isMaintenanceBlocked ? tMaintenance("writeDisabled") : undefined}
                   className="rounded-lg bg-purple-600 px-6 py-2 text-white hover:bg-purple-700 disabled:opacity-50"
                 >

--- a/src/lib/heic-converter.ts
+++ b/src/lib/heic-converter.ts
@@ -1,0 +1,90 @@
+/**
+ * HEIC / HEIF 画像のクライアント側 JPEG 変換 / issue #770
+ *
+ * iPhone 等で撮影した画像は HEIC 形式になることがあるが、カード画像アップロードは
+ * JPEG / PNG / GIF / WebP のみ許可している。HEIC を R2 に原形式で保存するのではなく、
+ * ファイル選択直後にクライアント側で JPEG へ変換し、既存の画像サイズ取得・トリミング・
+ * 圧縮・`/api/upload` 処理へ渡す方式をとる。
+ *
+ * この方式の利点:
+ * - 保存形式は従来どおり JPEG となり、カード表示側・`/api/upload` の変更が不要
+ * - サーバー（Cloudflare Workers）でネイティブ画像ライブラリを動かす必要がない
+ * - 変換ライブラリ（heic2any、MIT ライセンス）は HEIC 選択時のみ動的 import され、
+ *   通常アップロードの初期バンドルを増やさない
+ *
+ * 注意:
+ * - HEIC は圧縮時のファイルサイズに比べデコード後のメモリ使用量が大きいため、
+ *   変換前に専用の入力サイズ上限（HEIC_INPUT_MAX_BYTES）を設ける。
+ * - HEIC コンテナに複数画像がある場合、初期対応では primary image のみを使用する。
+ */
+export const HEIC_INPUT_MAX_BYTES = 25 * 1024 * 1024; // 25MB（変換前の入力上限。デコード後のメモリ使用量は圧縮時サイズより大幅に増えるため、緩めの安全弁）
+
+// 変換処理の失敗種別（呼び出し側で Error.message を比較するための定数）
+export const HEIC_ERROR_TOO_LARGE = "HEIC_TOO_LARGE";
+export const HEIC_ERROR_CONVERT_FAILED = "HEIC_CONVERT_FAILED";
+
+const HEIC_MIME_TYPES = ["image/heic", "image/heif"];
+const HEIC_EXTENSIONS = [".heic", ".heif"];
+
+/**
+ * アップロード対象ファイルが HEIC / HEIF かどうかを判定する。
+ * File.type が空文字列の環境でも拡張子で判定できるようにする。
+ *
+ * @param file 選択されたファイル
+ * @returns true なら HEIC / HEIF（クライアント側で JPEG 変換が必要）
+ */
+export function isHeicUpload(file: File): boolean {
+  const mime = file.type.toLowerCase();
+  if (HEIC_MIME_TYPES.includes(mime)) return true;
+  const name = file.name.toLowerCase();
+  return HEIC_EXTENSIONS.some((ext) => name.endsWith(ext));
+}
+
+/**
+ * HEIC / HEIF ファイルを JPEG の File へ変換する。
+ * 変換ライブラリ（heic2any）は HEIC 選択時のみ動的 import する。
+ *
+ * @param file HEIC / HEIF ファイル
+ * @returns JPEG に変換された File（ファイル名の拡張子は .jpg）
+ * @throws 変換失敗時・入力サイズ上限超過時は利用者向けのメッセージ付き Error
+ */
+export async function convertHeicToJpeg(file: File): Promise<File> {
+  if (file.size > HEIC_INPUT_MAX_BYTES) {
+    throw new Error(HEIC_ERROR_TOO_LARGE);
+  }
+
+  let heic2any: (input: {
+    blob: Blob;
+    toType: string;
+    quality?: number;
+  }) => Promise<Blob | Blob[]>;
+  try {
+    const mod = await import("heic2any");
+    heic2any = mod.default;
+  } catch {
+    throw new Error(HEIC_ERROR_CONVERT_FAILED);
+  }
+
+  let output: Blob | Blob[];
+  try {
+    // quality は既存のクロップ再圧縮（ImageCropper の 0.85）と同等水準にする
+    output = await heic2any({ blob: file, toType: "image/jpeg", quality: 0.85 });
+  } catch {
+    throw new Error(HEIC_ERROR_CONVERT_FAILED);
+  }
+
+  // heic2any は multiple 未指定時、コンテナ内の全画像をデコードした上で
+  // 先頭（primary image）の Blob を単一で返す。配列は返らないが、型上は
+  // Blob | Blob[] のため防御的に先頭を取る。
+  const jpegBlob = Array.isArray(output) ? output[0] : output;
+  if (!jpegBlob || jpegBlob.size === 0) {
+    throw new Error(HEIC_ERROR_CONVERT_FAILED);
+  }
+
+  // ファイル名の拡張子を .jpg に置換し、元の lastModified を維持する
+  const baseName = file.name.replace(/\.[^.]+$/, "");
+  return new File([jpegBlob], `${baseName}.jpg`, {
+    type: "image/jpeg",
+    lastModified: file.lastModified,
+  });
+}

--- a/src/lib/heic-converter.ts
+++ b/src/lib/heic-converter.ts
@@ -9,7 +9,7 @@
  * この方式の利点:
  * - 保存形式は従来どおり JPEG となり、カード表示側・`/api/upload` の変更が不要
  * - サーバー（Cloudflare Workers）でネイティブ画像ライブラリを動かす必要がない
- * - 変換ライブラリ（heic2any、MIT ライセンス）は HEIC 選択時のみ動的 import され、
+ * - 変換ライブラリ（heic-to）はCSP対応ビルドをHEIC選択時だけ動的 import し、
  *   通常アップロードの初期バンドルを増やさない
  *
  * 注意:
@@ -19,7 +19,7 @@
  */
 export const HEIC_INPUT_MAX_BYTES = 25 * 1024 * 1024; // 25MB（変換前の入力上限。デコード後のメモリ使用量は圧縮時サイズより大幅に増えるため、緩めの安全弁）
 
-// heic2any 0.0.4 は変換用 Worker を停止する Abort API を公開していないため、
+// heic-to の変換用 Worker を停止する Abort API は公開されていないため、
 // 呼び出し側が無期限に待ち続けないよう、import とデコードを合わせた総時間に上限を設ける。
 export const HEIC_CONVERSION_TIMEOUT_MS = 30_000;
 
@@ -34,9 +34,9 @@ const HEIC_EXTENSIONS = [".heic", ".heif"];
 /**
  * Abort API を持たない非同期処理に、利用者向けの有限な待機時間を与える。
  *
- * Promise.race は呼び出し側の Promise を終了させるだけで、heic2any 内部の
- * Worker は停止できない。そのため、タイムアウト後に元の処理が遅れて完了しても
- * 呼び出し側で結果を採用しないこと（CardManager の世代チェック）が必要になる。
+ * Promise.race は呼び出し側の Promise を終了させるだけで、変換 Worker は停止できない。
+ * そのため、タイムアウト後に元の処理が遅れて完了しても呼び出し側で結果を採用しない
+ * こと（CardManager の世代チェック）が必要になる。
  */
 async function withTimeout<T>(operation: () => Promise<T>, timeoutMs: number): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -70,7 +70,11 @@ export function isHeicUpload(file: File): boolean {
 
 /**
  * HEIC / HEIF ファイルを JPEG の File へ変換する。
- * 変換ライブラリ（heic2any）は HEIC 選択時のみ動的 import する。
+ * 変換ライブラリ（heic-to）のCSP対応ビルドをHEIC選択時のみ動的 import する。
+ *
+ * `heic-to/csp` は libheif を unsafe-eval なしでビルドした Worker を含むため、
+ * 本番の厳格なCSPを緩めずにブラウザ内変換を行える。通常のJPEG/PNGではimport
+ * 自体が発生しないので、初期ロードへデコーダを追加しない。
  *
  * @param file HEIC / HEIF ファイル
  * @returns JPEG に変換された File（ファイル名の拡張子は .jpg）
@@ -84,9 +88,10 @@ export async function convertHeicToJpeg(file: File): Promise<File> {
   let output: Blob | Blob[];
   try {
     output = await withTimeout(async () => {
-      const { default: heic2any } = await import("heic2any");
+      // `heic-to/csp` はCSP制約を満たすビルドを選ぶための明示的なサブパス。
+      const { heicTo } = await import("heic-to/csp");
       // quality は既存のクロップ再圧縮（ImageCropper の 0.85）と同等水準にする
-      return heic2any({ blob: file, toType: "image/jpeg", quality: 0.85 });
+      return heicTo({ blob: file, type: "image/jpeg", quality: 0.85 });
     }, HEIC_CONVERSION_TIMEOUT_MS);
   } catch (error) {
     // タイムアウトは呼び出し側で変換失敗と区別できるよう、そのまま伝える。
@@ -97,9 +102,8 @@ export async function convertHeicToJpeg(file: File): Promise<File> {
     throw new Error(HEIC_ERROR_CONVERT_FAILED);
   }
 
-  // heic2any は multiple 未指定時、コンテナ内の全画像をデコードした上で
-  // 先頭（primary image）の Blob を単一で返す。配列は返らないが、型上は
-  // Blob | Blob[] のため防御的に先頭を取る。
+  // heic-to は初期対応としてprimary imageを単一のBlobへ変換する。
+  // 型が将来 Blob[] へ拡張されても先頭画像だけを採用して既存契約を守る。
   const jpegBlob = Array.isArray(output) ? output[0] : output;
   if (!jpegBlob || jpegBlob.size === 0) {
     throw new Error(HEIC_ERROR_CONVERT_FAILED);

--- a/src/lib/heic-converter.ts
+++ b/src/lib/heic-converter.ts
@@ -19,12 +19,40 @@
  */
 export const HEIC_INPUT_MAX_BYTES = 25 * 1024 * 1024; // 25MB（変換前の入力上限。デコード後のメモリ使用量は圧縮時サイズより大幅に増えるため、緩めの安全弁）
 
+// heic2any 0.0.4 は変換用 Worker を停止する Abort API を公開していないため、
+// 呼び出し側が無期限に待ち続けないよう、import とデコードを合わせた総時間に上限を設ける。
+export const HEIC_CONVERSION_TIMEOUT_MS = 30_000;
+
 // 変換処理の失敗種別（呼び出し側で Error.message を比較するための定数）
 export const HEIC_ERROR_TOO_LARGE = "HEIC_TOO_LARGE";
 export const HEIC_ERROR_CONVERT_FAILED = "HEIC_CONVERT_FAILED";
+export const HEIC_ERROR_TIMEOUT = "HEIC_CONVERSION_TIMEOUT";
 
 const HEIC_MIME_TYPES = ["image/heic", "image/heif"];
 const HEIC_EXTENSIONS = [".heic", ".heif"];
+
+/**
+ * Abort API を持たない非同期処理に、利用者向けの有限な待機時間を与える。
+ *
+ * Promise.race は呼び出し側の Promise を終了させるだけで、heic2any 内部の
+ * Worker は停止できない。そのため、タイムアウト後に元の処理が遅れて完了しても
+ * 呼び出し側で結果を採用しないこと（CardManager の世代チェック）が必要になる。
+ */
+async function withTimeout<T>(operation: () => Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const operationPromise = Promise.resolve().then(operation);
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(HEIC_ERROR_TIMEOUT)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([operationPromise, timeoutPromise]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}
 
 /**
  * アップロード対象ファイルが HEIC / HEIF かどうかを判定する。
@@ -53,23 +81,19 @@ export async function convertHeicToJpeg(file: File): Promise<File> {
     throw new Error(HEIC_ERROR_TOO_LARGE);
   }
 
-  let heic2any: (input: {
-    blob: Blob;
-    toType: string;
-    quality?: number;
-  }) => Promise<Blob | Blob[]>;
-  try {
-    const mod = await import("heic2any");
-    heic2any = mod.default;
-  } catch {
-    throw new Error(HEIC_ERROR_CONVERT_FAILED);
-  }
-
   let output: Blob | Blob[];
   try {
-    // quality は既存のクロップ再圧縮（ImageCropper の 0.85）と同等水準にする
-    output = await heic2any({ blob: file, toType: "image/jpeg", quality: 0.85 });
-  } catch {
+    output = await withTimeout(async () => {
+      const { default: heic2any } = await import("heic2any");
+      // quality は既存のクロップ再圧縮（ImageCropper の 0.85）と同等水準にする
+      return heic2any({ blob: file, toType: "image/jpeg", quality: 0.85 });
+    }, HEIC_CONVERSION_TIMEOUT_MS);
+  } catch (error) {
+    // タイムアウトは呼び出し側で変換失敗と区別できるよう、そのまま伝える。
+    // それ以外のライブラリ内部エラーは既存の利用者向けエラーへ正規化する。
+    if (error instanceof Error && error.message === HEIC_ERROR_TIMEOUT) {
+      throw error;
+    }
     throw new Error(HEIC_ERROR_CONVERT_FAILED);
   }
 

--- a/tests/stubs/heic-to-csp.ts
+++ b/tests/stubs/heic-to-csp.ts
@@ -1,0 +1,9 @@
+/**
+ * Vite must resolve a concrete file before Vitest can apply the factory mock
+ * in `heic-converter.test.ts`. The implementation must never run in that
+ * unit test; throwing here makes an accidentally unmocked import fail loudly
+ * instead of performing a real HEIC conversion in the test process.
+ */
+export function heicTo(): never {
+  throw new Error('The heic-to/csp test stub must be mocked by the unit test.')
+}

--- a/tests/unit/components/card-manager-heic.test.tsx
+++ b/tests/unit/components/card-manager-heic.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { StrictMode } from 'react'
 import { NextIntlClientProvider } from 'next-intl'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import CardManager from '@/components/CardManager'
@@ -32,8 +33,8 @@ function stubImageLoad() {
   })
 }
 
-function renderCardManager() {
-  return render(
+function renderCardManager({ strictMode = false }: { strictMode?: boolean } = {}) {
+  const content = (
     <NextIntlClientProvider locale="ja" messages={jaMessages}>
       <CardManager
         streamerId="streamer-1"
@@ -42,6 +43,7 @@ function renderCardManager() {
       />
     </NextIntlClientProvider>
   )
+  return render(strictMode ? <StrictMode>{content}</StrictMode> : content)
 }
 
 function openFormAndSelectFile(container: HTMLElement, file: File) {
@@ -100,6 +102,23 @@ describe('CardManager HEIC conversion (issue #770)', () => {
     expect(screen.queryByText('トリミングサイズを選択')).not.toBeInTheDocument()
   })
 
+  it('タイムアウトエラー時も変換中表示を解除し、再選択できる状態に戻る', async () => {
+    mocks.isHeicUpload.mockReturnValue(true)
+    mocks.convertHeicToJpeg.mockRejectedValue(new Error('HEIC_CONVERSION_TIMEOUT'))
+    const { container } = renderCardManager()
+
+    openFormAndSelectFile(container, heicFile())
+
+    // 実タイマーを30秒進めるテストはconverter単体で行い、ここではタイムアウトが
+    // コンポーネントへ届いた後の利用者向け終了状態を固定する。
+    expect(
+      await screen.findByText('HEIC画像を読み込めませんでした。別の画像を選択するか、JPEGへ変換してから再度お試しください。')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('HEIC画像を変換中…')).not.toBeInTheDocument()
+    expect((container.querySelector('input[type="file"]') as HTMLInputElement).disabled).toBe(false)
+    expect(screen.queryByText('トリミングサイズを選択')).not.toBeInTheDocument()
+  })
+
   it('サイズ上限超過時は専用エラーを表示する', async () => {
     mocks.isHeicUpload.mockReturnValue(true)
     mocks.convertHeicToJpeg.mockRejectedValue(new Error('HEIC_TOO_LARGE'))
@@ -147,5 +166,76 @@ describe('CardManager HEIC conversion (issue #770)', () => {
     })
     expect(screen.queryByText('トリミングサイズを選択')).not.toBeInTheDocument()
     expect(screen.queryByText('HEIC画像を読み込めませんでした。別の画像を選択するか、JPEGへ変換してから再度お試しください。')).not.toBeInTheDocument()
+  })
+
+  it('キャンセル後に開き直したフォームの変換状態を、古い変換が解除しない', async () => {
+    stubImageLoad()
+    mocks.isHeicUpload.mockReturnValue(true)
+    let resolveFirst: (file: File) => void
+    let resolveSecond: (file: File) => void
+    let conversionCount = 0
+    mocks.convertHeicToJpeg.mockImplementation(
+      () => new Promise<File>((resolve) => {
+        if (conversionCount++ === 0) {
+          resolveFirst = resolve
+        } else {
+          resolveSecond = resolve
+        }
+      })
+    )
+    const { container } = renderCardManager()
+
+    openFormAndSelectFile(container, heicFile())
+    expect(await screen.findByRole('status')).toHaveTextContent('HEIC画像を変換中…')
+    fireEvent.click(screen.getByText('キャンセル'))
+
+    // 古い変換が未完了でも、キャンセル後は状態を持ち越さず新規フォームを開ける
+    openFormAndSelectFile(container, heicFile())
+    expect(await screen.findByRole('status')).toHaveTextContent('HEIC画像を変換中…')
+
+    // 古い変換の finally が実行されても、現在の変換中表示は維持する
+    resolveFirst!(jpegFile())
+    await waitFor(() => expect(mocks.convertHeicToJpeg).toHaveBeenCalledTimes(2))
+    expect(screen.getByRole('status')).toHaveTextContent('HEIC画像を変換中…')
+
+    resolveSecond!(jpegFile())
+    expect(await screen.findByText('トリミングサイズを選択')).toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('Strict Modeでも変換完了後に既存フローへ進める', async () => {
+    stubImageLoad()
+    mocks.isHeicUpload.mockReturnValue(true)
+    mocks.convertHeicToJpeg.mockResolvedValue(jpegFile())
+    const { container } = renderCardManager({ strictMode: true })
+
+    openFormAndSelectFile(container, heicFile())
+
+    // Strict Modeの検証用cleanup後も、現行setupがマウント中として扱われることを確認する。
+    expect(await screen.findByText('トリミングサイズを選択')).toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('アンマウント後に遅延した変換結果を反映しない', async () => {
+    mocks.isHeicUpload.mockReturnValue(true)
+    let resolveConvert: (file: File) => void
+    mocks.convertHeicToJpeg.mockImplementation(
+      () => new Promise<File>((resolve) => { resolveConvert = resolve })
+    )
+    const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test')
+    const { container, unmount } = renderCardManager()
+
+    openFormAndSelectFile(container, heicFile())
+    expect(await screen.findByRole('status')).toHaveTextContent('HEIC画像を変換中…')
+
+    unmount()
+    resolveConvert!(jpegFile())
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // アンマウント済みのコンポーネントに対する遅延結果は、クロップ開始に必要な
+    // object URL作成まで到達しない。DOMが消えたことだけではこのガードの回帰を
+    // 検出できないため、結果を処理した場合に必ず発生する副作用を直接検証する。
+    expect(createObjectURLSpy).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/components/card-manager-heic.test.tsx
+++ b/tests/unit/components/card-manager-heic.test.tsx
@@ -1,0 +1,151 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import CardManager from '@/components/CardManager'
+import jaMessages from '../../../messages/ja.json'
+
+// heic-converter をモックし、実ブラウザ変換（wasm）に依存しないテストにする
+const mocks = vi.hoisted(() => ({
+  isHeicUpload: vi.fn(),
+  convertHeicToJpeg: vi.fn(),
+}))
+
+vi.mock('@/lib/heic-converter', () => ({
+  isHeicUpload: mocks.isHeicUpload,
+  convertHeicToJpeg: mocks.convertHeicToJpeg,
+  HEIC_INPUT_MAX_BYTES: 25 * 1024 * 1024,
+  HEIC_ERROR_TOO_LARGE: 'HEIC_TOO_LARGE',
+  HEIC_ERROR_CONVERT_FAILED: 'HEIC_CONVERT_FAILED',
+}))
+
+vi.mock('@/lib/logger')
+
+// happy-dom は blob URL に対する img の読み込みイベント（onload/onerror）を発火しないため、
+// src が設定されたら onload を呼び出すスタブで、クロップモーダルが開くまでの既存フローを
+// テストで再現する。
+function stubImageLoad() {
+  vi.spyOn(HTMLImageElement.prototype, 'src', 'set').mockImplementation(function (
+    this: HTMLImageElement
+  ) {
+    // 読み込みは非同期で完了する想定（React のコールバックにそのまま乗せない）
+    setTimeout(() => this.onload?.(new Event('load')), 0)
+  })
+}
+
+function renderCardManager() {
+  return render(
+    <NextIntlClientProvider locale="ja" messages={jaMessages}>
+      <CardManager
+        streamerId="streamer-1"
+        initialCards={[]}
+        initialRarityWeights={{}}
+      />
+    </NextIntlClientProvider>
+  )
+}
+
+function openFormAndSelectFile(container: HTMLElement, file: File) {
+  // カードが空の初期状態ではフォームが開いていないため、「新規カード追加」で開く
+  fireEvent.click(screen.getByText('新規カード追加'))
+  const input = container.querySelector('input[type="file"]') as HTMLInputElement
+  fireEvent.change(input, { target: { files: [file] } })
+}
+
+const heicFile = () => new File([new Uint8Array(1024)], 'photo.heic', { type: 'image/heic' })
+const jpegFile = () => new File(['jpeg-data'], 'photo.jpg', { type: 'image/jpeg' })
+
+describe('CardManager HEIC conversion (issue #770)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('HEIC選択時に変換中表示を出し、変換完了後はクロップモード選択モーダルが開く', async () => {
+    stubImageLoad()
+    mocks.isHeicUpload.mockReturnValue(true)
+    // 変換完了まで pending にする（変換中表示の確認のため）
+    let resolveConvert: (file: File) => void
+    mocks.convertHeicToJpeg.mockImplementation(
+      () => new Promise<File>((resolve) => { resolveConvert = resolve })
+    )
+    const { container } = renderCardManager()
+
+    openFormAndSelectFile(container, heicFile())
+
+    // 変換中はステータス表示が出て、ファイル入力が無効化される
+    expect(await screen.findByRole('status')).toHaveTextContent('HEIC画像を変換中…')
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    expect(input.disabled).toBe(true)
+
+    // 変換完了 → 変換済み JPEG で既存フロー（クロップモード選択）が進む
+    resolveConvert!(jpegFile())
+    expect(await screen.findByText('トリミングサイズを選択')).toBeInTheDocument()
+    expect(screen.queryByText('HEIC画像を変換中…')).not.toBeInTheDocument()
+    expect(mocks.convertHeicToJpeg).toHaveBeenCalledTimes(1)
+  })
+
+  it('変換失敗時はエラーを表示し、HEIC原本は既存フローへ渡らない', async () => {
+    mocks.isHeicUpload.mockReturnValue(true)
+    mocks.convertHeicToJpeg.mockRejectedValue(new Error('HEIC_CONVERT_FAILED'))
+    const { container } = renderCardManager()
+
+    openFormAndSelectFile(container, heicFile())
+
+    expect(
+      await screen.findByText('HEIC画像を読み込めませんでした。別の画像を選択するか、JPEGへ変換してから再度お試しください。')
+    ).toBeInTheDocument()
+    // 変換後は入力が再度有効になる
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    expect(input.disabled).toBe(false)
+    // クロップモーダルは開かない
+    expect(screen.queryByText('トリミングサイズを選択')).not.toBeInTheDocument()
+  })
+
+  it('サイズ上限超過時は専用エラーを表示する', async () => {
+    mocks.isHeicUpload.mockReturnValue(true)
+    mocks.convertHeicToJpeg.mockRejectedValue(new Error('HEIC_TOO_LARGE'))
+    const { container } = renderCardManager()
+
+    openFormAndSelectFile(container, heicFile())
+
+    expect(
+      await screen.findByText('HEIC画像のサイズが大きすぎます。25MB以下の画像を選択してください。')
+    ).toBeInTheDocument()
+  })
+
+  it('HEIC以外の通常ファイルは変換処理を呼ばず既存フローへ進む', async () => {
+    stubImageLoad()
+    mocks.isHeicUpload.mockReturnValue(false)
+    const { container } = renderCardManager()
+
+    openFormAndSelectFile(container, new File([new Uint8Array(1024)], 'photo.jpg', { type: 'image/jpeg' }))
+
+    expect(mocks.convertHeicToJpeg).not.toHaveBeenCalled()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    // 既存フロー（クロップモード選択）が通常どおり進む
+    expect(await screen.findByText('トリミングサイズを選択')).toBeInTheDocument()
+  })
+
+  it('変換中にフォームをキャンセルした場合は、古い変換結果が反映されない', async () => {
+    stubImageLoad()
+    mocks.isHeicUpload.mockReturnValue(true)
+    let resolveConvert: (file: File) => void
+    mocks.convertHeicToJpeg.mockImplementation(
+      () => new Promise<File>((resolve) => { resolveConvert = resolve })
+    )
+    const { container } = renderCardManager()
+
+    openFormAndSelectFile(container, heicFile())
+    expect(await screen.findByRole('status')).toHaveTextContent('HEIC画像を変換中…')
+
+    // 変換中にフォームをキャンセル（resetForm が request id を進める）
+    fireEvent.click(screen.getByText('キャンセル'))
+
+    // 変換は後から完了するが、request id の不一致により結果は破棄される
+    resolveConvert!(jpegFile())
+    await waitFor(() => {
+      expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    })
+    expect(screen.queryByText('トリミングサイズを選択')).not.toBeInTheDocument()
+    expect(screen.queryByText('HEIC画像を読み込めませんでした。別の画像を選択するか、JPEGへ変換してから再度お試しください。')).not.toBeInTheDocument()
+  })
+})

--- a/tests/unit/heic-converter.test.ts
+++ b/tests/unit/heic-converter.test.ts
@@ -3,8 +3,10 @@ import {
   isHeicUpload,
   convertHeicToJpeg,
   HEIC_INPUT_MAX_BYTES,
+  HEIC_CONVERSION_TIMEOUT_MS,
   HEIC_ERROR_TOO_LARGE,
   HEIC_ERROR_CONVERT_FAILED,
+  HEIC_ERROR_TIMEOUT,
 } from '@/lib/heic-converter'
 
 function makeFile(name: string, type: string, size = 1024): File {
@@ -90,5 +92,25 @@ describe('convertHeicToJpeg (issue #770)', () => {
 
     await expect(convertHeicToJpeg(oversized)).rejects.toThrow(HEIC_ERROR_TOO_LARGE)
     expect(heic2anyMock).not.toHaveBeenCalled()
+  })
+
+  it('変換が応答しない場合はタイムアウトして HEIC_CONVERSION_TIMEOUT を投げる', async () => {
+    vi.useFakeTimers()
+    try {
+      heic2anyMock.mockImplementation(() => new Promise<Blob>(() => undefined))
+
+      const conversion = convertHeicToJpeg(makeFile('photo.heic', 'image/heic'))
+      // rejection handlerを先に接続し、タイマー発火とアサーションの間に
+      // Vitestが一時的な未処理rejectionとして扱わないようにする。
+      const rejection = expect(conversion).rejects.toThrow(HEIC_ERROR_TIMEOUT)
+      // 動的 import のmicrotaskを先に進め、変換Promiseがタイマーを登録してから時間を進める
+      await Promise.resolve()
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(HEIC_CONVERSION_TIMEOUT_MS)
+
+      await rejection
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/tests/unit/heic-converter.test.ts
+++ b/tests/unit/heic-converter.test.ts
@@ -13,9 +13,9 @@ function makeFile(name: string, type: string, size = 1024): File {
   return new File([new Uint8Array(size)], name, { type })
 }
 
-// heic2any の動的 import をモック（変換ユニット自体のテストに実ブラウザ変換は不要）
-vi.mock('heic2any', () => ({
-  default: vi.fn(),
+// heic-to の動的 import をモック（変換ユニット自体のテストに実ブラウザ変換は不要）
+vi.mock('heic-to/csp', () => ({
+  heicTo: vi.fn(),
 }))
 
 describe('isHeicUpload (issue #770)', () => {
@@ -39,15 +39,15 @@ describe('isHeicUpload (issue #770)', () => {
 })
 
 describe('convertHeicToJpeg (issue #770)', () => {
-  let heic2anyMock: ReturnType<typeof vi.fn>
+  let heicToMock: ReturnType<typeof vi.fn>
 
   beforeEach(async () => {
-    heic2anyMock = vi.mocked((await import('heic2any')).default)
-    heic2anyMock.mockReset()
+    heicToMock = vi.mocked((await import('heic-to/csp')).heicTo)
+    heicToMock.mockReset()
   })
 
   it('変換成功時に image/jpeg の File を返し、拡張子は .jpg になる', async () => {
-    heic2anyMock.mockResolvedValue(new Blob(['jpeg-data'], { type: 'image/jpeg' }))
+    heicToMock.mockResolvedValue(new Blob(['jpeg-data'], { type: 'image/jpeg' }))
     const input = makeFile('photo.heic', 'image/heic')
 
     const result = await convertHeicToJpeg(input)
@@ -55,13 +55,13 @@ describe('convertHeicToJpeg (issue #770)', () => {
     expect(result.type).toBe('image/jpeg')
     expect(result.name).toBe('photo.jpg')
     expect(result.lastModified).toBe(input.lastModified)
-    expect(heic2anyMock).toHaveBeenCalledWith(
-      expect.objectContaining({ blob: input, toType: 'image/jpeg', quality: 0.85 })
+    expect(heicToMock).toHaveBeenCalledWith(
+      expect.objectContaining({ blob: input, type: 'image/jpeg', quality: 0.85 })
     )
   })
 
   it('複数画像を含む HEIC コンテナでは primary image（先頭）のみを使う', async () => {
-    heic2anyMock.mockResolvedValue([
+    heicToMock.mockResolvedValue([
       new Blob(['primary'], { type: 'image/jpeg' }),
       new Blob(['secondary'], { type: 'image/jpeg' }),
     ])
@@ -72,7 +72,7 @@ describe('convertHeicToJpeg (issue #770)', () => {
   })
 
   it('変換失敗時は HEIC_CONVERT_FAILED エラーを投げる', async () => {
-    heic2anyMock.mockRejectedValue(new Error('decode failed'))
+    heicToMock.mockRejectedValue(new Error('decode failed'))
 
     await expect(convertHeicToJpeg(makeFile('photo.heic', 'image/heic'))).rejects.toThrow(
       HEIC_ERROR_CONVERT_FAILED
@@ -80,7 +80,7 @@ describe('convertHeicToJpeg (issue #770)', () => {
   })
 
   it('空の出力（サイズ0）は HEIC_CONVERT_FAILED として扱う', async () => {
-    heic2anyMock.mockResolvedValue(new Blob([]))
+    heicToMock.mockResolvedValue(new Blob([]))
 
     await expect(convertHeicToJpeg(makeFile('photo.heic', 'image/heic'))).rejects.toThrow(
       HEIC_ERROR_CONVERT_FAILED
@@ -91,13 +91,13 @@ describe('convertHeicToJpeg (issue #770)', () => {
     const oversized = makeFile('big.heic', 'image/heic', HEIC_INPUT_MAX_BYTES + 1)
 
     await expect(convertHeicToJpeg(oversized)).rejects.toThrow(HEIC_ERROR_TOO_LARGE)
-    expect(heic2anyMock).not.toHaveBeenCalled()
+    expect(heicToMock).not.toHaveBeenCalled()
   })
 
   it('変換が応答しない場合はタイムアウトして HEIC_CONVERSION_TIMEOUT を投げる', async () => {
     vi.useFakeTimers()
     try {
-      heic2anyMock.mockImplementation(() => new Promise<Blob>(() => undefined))
+      heicToMock.mockImplementation(() => new Promise<Blob>(() => undefined))
 
       const conversion = convertHeicToJpeg(makeFile('photo.heic', 'image/heic'))
       // rejection handlerを先に接続し、タイマー発火とアサーションの間に

--- a/tests/unit/heic-converter.test.ts
+++ b/tests/unit/heic-converter.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import {
+  isHeicUpload,
+  convertHeicToJpeg,
+  HEIC_INPUT_MAX_BYTES,
+  HEIC_ERROR_TOO_LARGE,
+  HEIC_ERROR_CONVERT_FAILED,
+} from '@/lib/heic-converter'
+
+function makeFile(name: string, type: string, size = 1024): File {
+  return new File([new Uint8Array(size)], name, { type })
+}
+
+// heic2any の動的 import をモック（変換ユニット自体のテストに実ブラウザ変換は不要）
+vi.mock('heic2any', () => ({
+  default: vi.fn(),
+}))
+
+describe('isHeicUpload (issue #770)', () => {
+  it('MIME が image/heic / image/heif のファイルを判定する', () => {
+    expect(isHeicUpload(makeFile('photo.heic', 'image/heic'))).toBe(true)
+    expect(isHeicUpload(makeFile('photo.heif', 'image/heif'))).toBe(true)
+  })
+
+  it('拡張子 .heic / .HEIC / .heif で判定する（File.type が空でも）', () => {
+    expect(isHeicUpload(makeFile('photo.heic', ''))).toBe(true)
+    expect(isHeicUpload(makeFile('photo.HEIC', 'application/octet-stream'))).toBe(true)
+    expect(isHeicUpload(makeFile('photo.heif', ''))).toBe(true)
+  })
+
+  it('HEIC 以外（JPEG / PNG / GIF / WebP）を HEIC と誤判定しない', () => {
+    expect(isHeicUpload(makeFile('photo.jpg', 'image/jpeg'))).toBe(false)
+    expect(isHeicUpload(makeFile('photo.png', 'image/png'))).toBe(false)
+    expect(isHeicUpload(makeFile('photo.gif', 'image/gif'))).toBe(false)
+    expect(isHeicUpload(makeFile('photo.webp', 'image/webp'))).toBe(false)
+  })
+})
+
+describe('convertHeicToJpeg (issue #770)', () => {
+  let heic2anyMock: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    heic2anyMock = vi.mocked((await import('heic2any')).default)
+    heic2anyMock.mockReset()
+  })
+
+  it('変換成功時に image/jpeg の File を返し、拡張子は .jpg になる', async () => {
+    heic2anyMock.mockResolvedValue(new Blob(['jpeg-data'], { type: 'image/jpeg' }))
+    const input = makeFile('photo.heic', 'image/heic')
+
+    const result = await convertHeicToJpeg(input)
+
+    expect(result.type).toBe('image/jpeg')
+    expect(result.name).toBe('photo.jpg')
+    expect(result.lastModified).toBe(input.lastModified)
+    expect(heic2anyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ blob: input, toType: 'image/jpeg', quality: 0.85 })
+    )
+  })
+
+  it('複数画像を含む HEIC コンテナでは primary image（先頭）のみを使う', async () => {
+    heic2anyMock.mockResolvedValue([
+      new Blob(['primary'], { type: 'image/jpeg' }),
+      new Blob(['secondary'], { type: 'image/jpeg' }),
+    ])
+
+    const result = await convertHeicToJpeg(makeFile('photo.heic', 'image/heic'))
+
+    expect(await result.text()).toBe('primary')
+  })
+
+  it('変換失敗時は HEIC_CONVERT_FAILED エラーを投げる', async () => {
+    heic2anyMock.mockRejectedValue(new Error('decode failed'))
+
+    await expect(convertHeicToJpeg(makeFile('photo.heic', 'image/heic'))).rejects.toThrow(
+      HEIC_ERROR_CONVERT_FAILED
+    )
+  })
+
+  it('空の出力（サイズ0）は HEIC_CONVERT_FAILED として扱う', async () => {
+    heic2anyMock.mockResolvedValue(new Blob([]))
+
+    await expect(convertHeicToJpeg(makeFile('photo.heic', 'image/heic'))).rejects.toThrow(
+      HEIC_ERROR_CONVERT_FAILED
+    )
+  })
+
+  it('入力サイズが上限を超える場合は変換せず HEIC_TOO_LARGE を投げる', async () => {
+    const oversized = makeFile('big.heic', 'image/heic', HEIC_INPUT_MAX_BYTES + 1)
+
+    await expect(convertHeicToJpeg(oversized)).rejects.toThrow(HEIC_ERROR_TOO_LARGE)
+    expect(heic2anyMock).not.toHaveBeenCalled()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,13 @@ export default defineConfig({
     // サブエージェント実行時のさらなる安全対策
     isolate: true, // 各テストファイルを完全に分離
     fileParallelism: false, // ファイル並列実行を無効化（より安全）
+    // A `vi.mock` factory is applied after Vite parses imports. The isolated
+    // dependency install therefore still needs a concrete file for
+    // `heic-to/csp` during import analysis; this alias is test-only and does
+    // not alter the production module resolution.
+    alias: {
+      'heic-to/csp': path.resolve(__dirname, './tests/stubs/heic-to-csp.ts'),
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## 概要
previewでPR #900/#901/#905のHEICアップロード変更を反映し、認証済みアプリ内ブラウザで実HEIC 2件の変換成功を確認しました。本PRは同じpreviewブランチをmainへ昇格します。

## preview確認済み
- Workers version `059589c1-4123-4d4b-8d81-81f9936862a0` を100%へ昇格
- `Tree.heic`、`The Beach.heic` の両方で「トリミングサイズを選択」モーダルまで到達
- 本番CSP相当（`unsafe-eval`なし、`worker-src 'self' blob:`）で動作
- ブラウザ console error/warnなし
- テスト用カードは保存せず、カード件数30件を維持

## main昇格前の確認
- preview向けPR #905の必須CIは全件成功
- `npm run test:unit`: 269 passed / 1 skipped、3,683 passed / 34 skipped
- 実パッケージのtypecheck/build成功

本PRマージ後にproductionへデプロイし、同じ認証済みアプリ内ブラウザで再確認します。