### PR TITLE
fix: 不正なstreamer UUIDをDBアクセス前に拒否する

### DIFF
--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -7,6 +7,7 @@ import { reportError } from "@/lib/sentry/error-handler";
 import { RARITY_ORDER } from "@/lib/constants";
 
 import { logPerf, perfStart } from "@/lib/perf";
+import { isCanonicalUuid } from "@/lib/uuid-validation";
 // ---------------------------------------------------------------------------
 // PlanetScale の読み取り実装で使う import。
 // count は既存コードの `const { count } = await ...` 分割代入と名前が衝突する
@@ -2255,10 +2256,16 @@ export const getUserCardsForStreamer = cache(async (
  * getStreamerById の Drizzle（pg 直結）実装 (#571)
  *
  * .maybeSingle() 相当: id は主キーのため最大1行。0行なら null。
- * streamerId は URL パラメータ由来で不正な UUID 文字列が渡りうるが、その場合は
- * null を返すため、pg 版も catch して null に落とす（外部挙動のパリティ）。
+ * streamerId は URL パラメータ由来で不正な UUID 文字列が渡りうる。不正値は
+ * DBアクセス前に null へ落とし、有効だが未登録のIDと同じ404契約を維持する。
+ * 実際のDB障害だけは catch して記録し、null に落とす（外部挙動のパリティ）。
  */
 async function getStreamerByIdPg(streamerId: string): Promise<Streamer | null> {
+  // Issue #908: PostgreSQLのuuid列へ不正文字列を渡すとSQLSTATE 22P02になり、
+  // 期待される404アクセスまでlogger.error経由で本番Issue化されていた。
+  // 外部入力を最初の型境界でallowlistし、DB/retry/error-reporterへ一切流さない。
+  if (!isCanonicalUuid(streamerId)) return null;
+
   try {
     const rows = await withDbRetry(
       async () => {

--- a/src/lib/overlay-route-validation.ts
+++ b/src/lib/overlay-route-validation.ts
@@ -1,4 +1,5 @@
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+import { isCanonicalUuid } from "@/lib/uuid-validation"
+
 const OVERLAY_EVENTS_PATH_PATTERN = /^\/api\/overlay\/([^/]+)\/events\/?$/
 
 /**
@@ -18,5 +19,5 @@ export function hasInvalidOverlayEventsStreamerId(pathname: string): boolean {
     return true
   }
 
-  return !UUID_PATTERN.test(streamerId)
+  return !isCanonicalUuid(streamerId)
 }

--- a/src/lib/uuid-validation.ts
+++ b/src/lib/uuid-validation.ts
@@ -1,0 +1,17 @@
+// TwiCa がURLやDB主キーとして発行するUUIDは、PostgreSQLの出力と同じ
+// 8-4-4-4-12の標準構造へ統一されている。PostgreSQL自体は波括弧付きや
+// ハイフン省略形も受理するが、アプリが生成しない表記まで外部入力で許可する
+// 必要はないため、境界ではこの構造だけをallowlistする。既存overlay検証との
+// 互換性を保つため英字の大文字・小文字は区別せず、表記の小文字化は行わない。
+const CANONICAL_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * 値がTwiCaで使用する標準UUID構造かを判定する。
+ *
+ * UUIDのversion/variantまでは制限しない。既存データの生成元が変わっても、
+ * 128bit UUIDとして正しい標準表記なら同じDB主キー境界を安全に通せるため。
+ */
+export function isCanonicalUuid(value: string): boolean {
+  return CANONICAL_UUID_PATTERN.test(value)
+}

--- a/tests/unit/dashboard-data-driver-parity.test.ts
+++ b/tests/unit/dashboard-data-driver-parity.test.ts
@@ -22,6 +22,8 @@ import {
   getUserCardDetail,
 } from '@/lib/dashboard-data'
 import { getDb } from '@/lib/db/client'
+import { logger } from '@/lib/logger'
+import { logErrorFromLogger } from '@/lib/sentry/error-handler'
 import {
   cards as cardsTable,
   collectionCompletions as collectionCompletionsTable,
@@ -495,18 +497,59 @@ describe('dashboard-data: Drizzle 読み取り', () => {
       })
     })
 
-    it('IDで配信者を取得し、0行なら null を返す', async () => {
+    it('標準UUIDで配信者を取得し、0行なら null を返す', async () => {
+      const streamerId = '94cb6927-8733-4f1c-8e7e-0afb89773daa'
+      const missingStreamerId = 'd3f5a9c1-78e4-4f2a-b6d9-10c8e7a54321'
+      const streamer = makeStreamerRow({ id: streamerId })
       const found = await runWithDb(
-        { tables: tableRows([[streamersTable, [STREAMER]]]) },
-        () => getStreamerById('streamer-1')
+        { tables: tableRows([[streamersTable, [streamer]]]) },
+        () => getStreamerById(streamerId)
       )
-      expect(found.result).toEqual(STREAMER)
+      expect(found.result).toEqual(streamer)
 
       const missing = await runWithDb(
         { tables: tableRows([[streamersTable, []]]) },
-        () => getStreamerById('missing')
+        () => getStreamerById(missingStreamerId)
       )
       expect(missing.result).toBeNull()
+    })
+
+    it('不正なUUIDはDBアクセスもエラー記録もせず null を返す (Issue #908)', async () => {
+      // 本番で報告された35文字のstreamerIdをそのまま回帰入力に使う。
+      // 例外をcatchするだけではlogger.serverがerror-reporterへ永続化するため、
+      // getDb()より前に拒否できていることと副作用が無いことを両方確認する。
+      const malformedStreamerId = 'e92022fd-3d30-b840-c78bbea56920'
+      const { result, db } = await runWithDb(
+        { tables: tableRows([[streamersTable, [STREAMER]]]) },
+        () => getStreamerById(malformedStreamerId)
+      )
+
+      expect(result).toBeNull()
+      expect(getDb).not.toHaveBeenCalled()
+      expect(db.select).not.toHaveBeenCalled()
+      expect(logger.error).not.toHaveBeenCalled()
+      expect(logErrorFromLogger).not.toHaveBeenCalled()
+    })
+
+    it('標準UUIDで発生したDB障害は従来どおりエラー記録して null を返す', async () => {
+      const streamerId = '94cb6927-8733-4f1c-8e7e-0afb89773daa'
+      const { result } = await runWithDb(
+        {
+          tables: tableRows([[streamersTable, [STREAMER]]]),
+          errors: new Map([
+            [streamersTable, [Object.assign(new Error('permission denied'), { code: '42501' })]],
+          ]),
+        },
+        () => getStreamerById(streamerId)
+      )
+
+      expect(result).toBeNull()
+      expect(getDb).toHaveBeenCalledTimes(1)
+      expect(logger.error).toHaveBeenCalledWith(
+        'Error in getStreamerById (pg)',
+        expect.objectContaining({ error: expect.any(Error) })
+      )
+      expect(logErrorFromLogger).toHaveBeenCalledTimes(1)
     })
 
     it('所有カードへ配信者と所持数を付与する', async () => {

--- a/tests/unit/overlay-route-validation.test.ts
+++ b/tests/unit/overlay-route-validation.test.ts
@@ -34,6 +34,12 @@ describe("hasInvalidOverlayEventsStreamerId", () => {
     ).toBe(true);
   });
 
+  it("rejects a URL segment that cannot be decoded", () => {
+    expect(
+      hasInvalidOverlayEventsStreamerId("/api/overlay/%E0%A4%A/events")
+    ).toBe(true);
+  });
+
   it("does not validate unrelated paths", () => {
     expect(
       hasInvalidOverlayEventsStreamerId(

--- a/tests/unit/uuid-validation.test.ts
+++ b/tests/unit/uuid-validation.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { isCanonicalUuid } from '@/lib/uuid-validation'
+
+describe('isCanonicalUuid', () => {
+  it.each([
+    '94cb6927-8733-4f1c-8e7e-0afb89773daa',
+    // 既存overlay検証が許可していた大文字表記は後方互換として維持する。
+    '94CB6927-8733-4F1C-8E7E-0AFB89773DAA',
+  ])('標準の8-4-4-4-12構造を受理する: %s', (value) => {
+    expect(isCanonicalUuid(value)).toBe(true)
+  })
+
+  it.each([
+    // Issue #908で本番へ到達した35文字の値。
+    'e92022fd-3d30-b840-c78bbea56920',
+    '94cb6927-8733-4f1c-8e7e-0afb89773daasuffix',
+    '{94cb6927-8733-4f1c-8e7e-0afb89773daa}',
+    '94cb692787334f1c8e7e0afb89773daa',
+    ' 94cb6927-8733-4f1c-8e7e-0afb89773daa',
+  ])('アプリが生成しないUUID表記を拒否する: %s', (value) => {
+    expect(isCanonicalUuid(value)).toBe(false)
+  })
+})


### PR DESCRIPTION
## 概要
- コレクションURLなどから渡る streamer ID をDBアクセス前にUUID検証
- 不正値はログ・リトライ・DBクエリを行わず not found として扱う
- overlay route と同じ共有バリデータを利用し、回帰テストを追加

## 検証
- ローカル unit: 3,263件成功
- integration: 13件成功
- typecheck / build / workers build / i18n / migration-order: 成功
- 独立 Sol 厳格レビュー: 指摘なし
- preview PR #910: 必須CI・マージ後CIすべて成功
- twica-preview b5320520-e8d9-4b55-9025-9892c1f54045 を100%配信
- 認証済みCodexアプリ内ブラウザで正常コレクション表示を確認
- Issue #908 の不正UUIDで404表示、ブラウザエラー0件、Cloudflare error tail無出力、Issue発生回数増加なし

## 関連
- Preview PR: #910

Fixes #908