### PR TITLE
perf: Cloudflare Workerの定常ポーリングCPUを削減

### DIFF
--- a/src/app/api/gacha/demo/route.ts
+++ b/src/app/api/gacha/demo/route.ts
@@ -11,7 +11,12 @@ import { getDb } from "@/lib/db/client";
 import { withDbRetry } from "@/lib/db/retry";
 import { cards as cardsTable } from "@/lib/db/schema";
 import { CARDS_SAFE_COLUMNS, isMissingCardsBattleColumnError } from "@/lib/db/cards-safe-columns";
-import { publishOverlayDemoEvent } from "@/lib/overlay/demo-event-store";
+import {
+  createOverlayDemoEvent,
+  storeOverlayDemoEvent,
+} from "@/lib/overlay/demo-event-store";
+import { publishOverlayDemoRealtimeEvent } from "@/lib/overlay-realtime/publisher";
+import { runInBackground } from "@/lib/background-task";
 
 /**
  * Fetch one card from the authoritative PlanetScale database.
@@ -175,8 +180,9 @@ const DEMO_CARDS: Array<Omit<Card, 'id' | 'created_at' | 'updated_at' | 'streame
 
 /**
  * Public demo-card endpoint. Card reads are always served from PlanetScale.
- * `broadcast=true` publishes a short-lived KV demo event consumed by the same
- * polling endpoint as OBS, so no Supabase Realtime project is required.
+ * `broadcast=true` stores a short-lived KV fallback and sends the same event
+ * through the signed Durable Object transport used by OBS. This preserves an
+ * immediate demo while avoiding a permanent fast polling loop or Supabase.
  */
 export async function POST(request: NextRequest) {
   try {
@@ -253,14 +259,59 @@ export async function POST(request: NextRequest) {
 
     const respondWithCard = async (card: Card, targetStreamerId: string | null) => {
       if (broadcast && targetStreamerId) {
-        try {
-          await publishOverlayDemoEvent(targetStreamerId, card);
-          logger.info(`Demo polling event published for streamer ${targetStreamerId}`);
-        } catch (publishError) {
-          // Demo transport is non-business data; preserve the historical
-          // best-effort response behaviour if KV is temporarily unavailable.
-          logger.error("Failed to publish demo overlay event:", { publishError });
-        }
+        const demoEvent = createOverlayDemoEvent(card);
+
+        // Start both transports before awaiting either one. The KV fallback
+        // and immediate Durable Object fanout are independent best-effort
+        // paths: a rejected KV write must not suppress socket delivery, and a
+        // rejected/failed publisher must not suppress fallback persistence.
+        // Both receive the exact same frozen event, preserving cross-transport
+        // identity and preventing timing-dependent payload divergence.
+        const fallbackTask = storeOverlayDemoEvent(targetStreamerId, demoEvent);
+        const realtimeTask = publishOverlayDemoRealtimeEvent(targetStreamerId, demoEvent);
+        const deliveryTask = Promise.allSettled([fallbackTask, realtimeTask]).then(
+          ([fallbackResult, realtimeResult]) => {
+            if (fallbackResult.status === "fulfilled") {
+              logger.info("Demo overlay KV fallback stored", { streamerId: targetStreamerId });
+            } else {
+              logger.error("Demo overlay KV fallback failed", {
+                streamerId: targetStreamerId,
+                error: fallbackResult.reason instanceof Error
+                  ? fallbackResult.reason.name
+                  : "unknown",
+              });
+            }
+
+            if (realtimeResult.status === "rejected") {
+              logger.error("Demo overlay realtime publish rejected", {
+                streamerId: targetStreamerId,
+                error: realtimeResult.reason instanceof Error
+                  ? realtimeResult.reason.name
+                  : "unknown",
+              });
+              return;
+            }
+
+            const { outcome, attempts, errorCode } = realtimeResult.value;
+            const context = { streamerId: targetStreamerId, attempts, errorCode };
+            if (outcome === "accepted") {
+              logger.info("Demo overlay realtime publish accepted", context);
+            } else if (outcome === "skipped") {
+              logger.warn("Demo overlay realtime publish skipped", context);
+            } else {
+              // The publisher reports exhausted retries and validation errors
+              // as a fulfilled `failed` outcome, not a rejected Promise. Keep
+              // that operational failure out of the success log classification.
+              logger.error("Demo overlay realtime publish failed", context);
+            }
+          },
+        );
+
+        // In Workers this registers already-started delivery with waitUntil and
+        // lets the API response return immediately. Local/test runtimes await
+        // the same all-settled task, which prevents unhandled rejections while
+        // preserving the production response-lifetime boundary.
+        await runInBackground("overlay demo delivery", deliveryTask);
       }
       return NextResponse.json({ card, userTwitchUsername: "DemoUser" });
     };

--- a/src/app/api/overlay/[streamerId]/events/route.ts
+++ b/src/app/api/overlay/[streamerId]/events/route.ts
@@ -19,16 +19,16 @@ import {
 import { isMissingCardPaddingColorError } from "@/lib/db/cards-safe-columns";
 import {
   buildPollingRealtimeEvents,
+  isValidOverlayHistoryId,
   isValidStreamerId,
 } from "@/lib/overlay-realtime/contract";
 import { resolveOverlayRealtimeConfigVersion } from "@/lib/overlay-realtime/resolve-config";
 import { getOverlayDemoEvent } from "@/lib/overlay/demo-event-store";
+import { normalizeOverlayHistoryTimestamp } from "@/lib/overlay-history-cursor";
 
 // A redemption produces at most 15 rows. The larger bounded page keeps one
 // batch together and gives gap recovery headroom without an unbounded query.
 const OVERLAY_EVENT_ROW_LIMIT = 100;
-const HISTORY_ID_PATTERN =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 interface RouteParams {
   params: Promise<{ streamerId: string }>;
@@ -49,96 +49,6 @@ interface OverlayHistoryRow {
   user_twitch_username: string | null;
   reward_id: string | null;
   card: OverlayHistoryCard | null;
-}
-
-function normalizeDateParam(value: string | null): string | null {
-  if (!value) return null;
-
-  // PlanetScale/PostgreSQL returns timestamptz cursors with a signed offset
-  // and microseconds (for example `...14.511943+00:00`). Parse that stable
-  // wire shape explicitly instead of depending on Date.parse: the
-  // Cloudflare/OpenNext runtime has rejected the signed-offset form even
-  // though browsers commonly accept it. Once the first row advanced the OBS
-  // cursor to that value, every later poll therefore returned HTTP 400 and no
-  // subsequent gacha result could be displayed.
-  const match = value.match(
-    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,6}))?(Z|([+-]| )(\d{2}):(\d{2}))$/
-  );
-  if (!match) return null;
-
-  const [
-    ,
-    yearText,
-    monthText,
-    dayText,
-    hourText,
-    minuteText,
-    secondText,
-    fraction = "",
-    timezone,
-    offsetSign,
-    offsetHourText,
-    offsetMinuteText,
-  ] = match;
-  const year = Number(yearText);
-  const month = Number(monthText);
-  const day = Number(dayText);
-  const hour = Number(hourText);
-  const minute = Number(minuteText);
-  const second = Number(secondText);
-  // PostgreSQL represents years before 1 CE with a separate BC suffix rather
-  // than ISO year zero. This public cursor grammar intentionally excludes BC
-  // and extended years so every accepted value remains a four-digit DB value.
-  if (year < 1) return null;
-
-  // Build at whole-second precision. JavaScript Date stores only
-  // milliseconds, while PostgreSQL cursors use up to six fractional digits.
-  // Keeping the fraction outside Date prevents truncating the authoritative
-  // `(redeemed_at, id)` cursor and re-reading the same database row forever.
-  // setUTCFullYear is used instead of Date.UTC so four-digit years below 100
-  // are not implicitly remapped into 1900-1999.
-  const localDate = new Date(0);
-  localDate.setUTCFullYear(year, month - 1, day);
-  localDate.setUTCHours(hour, minute, second, 0);
-
-  // Date setters normalize invalid calendar values (for example February 30)
-  // instead of rejecting them. Compare every component so a malformed public
-  // cursor cannot silently move the polling window to another day.
-  if (
-    localDate.getUTCFullYear() !== year ||
-    localDate.getUTCMonth() !== month - 1 ||
-    localDate.getUTCDate() !== day ||
-    localDate.getUTCHours() !== hour ||
-    localDate.getUTCMinutes() !== minute ||
-    localDate.getUTCSeconds() !== second
-  ) {
-    return null;
-  }
-
-  let offsetMinutes = 0;
-  if (timezone !== "Z") {
-    const offsetHours = Number(offsetHourText);
-    const offsetMinutePart = Number(offsetMinuteText);
-    if (offsetHours > 23 || offsetMinutePart > 59) return null;
-    // A literal plus in a query string can be normalized to a space by an
-    // application/x-www-form-urlencoded parser before NextRequest exposes
-    // the value. In the timezone-sign position only, treat that space as a
-    // positive offset. The strict surrounding timestamp pattern prevents
-    // accepting arbitrary whitespace or a malformed public cursor.
-    offsetMinutes =
-      (offsetSign === "-" ? -1 : 1) *
-      (offsetHours * 60 + offsetMinutePart);
-  }
-
-  const utcDate = new Date(localDate.getTime() - offsetMinutes * 60_000);
-  // A valid four-digit local year can cross into year 0 or 10000 after offset
-  // conversion. Date#toISOString uses an extended signed-year representation
-  // there, which is outside this endpoint's strict cursor grammar and would
-  // make fixed-width canonicalization unsafe.
-  const utcYear = utcDate.getUTCFullYear();
-  if (utcYear < 1 || utcYear > 9999) return null;
-  const utcWholeSecond = utcDate.toISOString().slice(0, 19);
-  return `${utcWholeSecond}${fraction ? `.${fraction}` : ""}Z`;
 }
 
 /**
@@ -262,7 +172,7 @@ export async function GET(
     }
 
     const { searchParams } = new URL(request.url);
-    const since = normalizeDateParam(searchParams.get("since"));
+    const since = normalizeOverlayHistoryTimestamp(searchParams.get("since"));
     if (!since) {
       return NextResponse.json(
         { error: "Invalid since parameter" },
@@ -271,7 +181,7 @@ export async function GET(
     }
     const demoSinceParam = searchParams.get("demoSince");
     const demoSince = demoSinceParam
-      ? normalizeDateParam(demoSinceParam)
+      ? normalizeOverlayHistoryTimestamp(demoSinceParam)
       : null;
     if (demoSinceParam && !demoSince) {
       return NextResponse.json(
@@ -282,7 +192,7 @@ export async function GET(
 
     const afterIdParam = searchParams.get("afterId");
     const afterId =
-      afterIdParam && HISTORY_ID_PATTERN.test(afterIdParam) ? afterIdParam : null;
+      afterIdParam && isValidOverlayHistoryId(afterIdParam) ? afterIdParam : null;
     if (afterIdParam && !afterId) {
       return NextResponse.json(
         { error: "Invalid afterId parameter" },
@@ -362,7 +272,7 @@ export async function GET(
     // same database timestamp contract used by the query predicate, so a
     // normalization failure indicates a server-side invariant violation.
     const normalizedNextCursor = lastHistoryRow
-      ? normalizeDateParam(lastHistoryRow.redeemed_at)
+      ? normalizeOverlayHistoryTimestamp(lastHistoryRow.redeemed_at)
       : null;
     if (lastHistoryRow && !normalizedNextCursor) {
       throw new Error("Invalid redeemed_at value returned by the database");
@@ -384,13 +294,12 @@ export async function GET(
       overlayVersion: process.env.NEXT_PUBLIC_OVERLAY_VERSION ?? "dev",
       // Rollout/rollback signal carried on a request the overlay already makes.
       //
-      // Every overlay polls this endpoint: every ~3s in polling-only mode and
-      // every ~30s as gap recovery while the socket is healthy. Echoing the
-      // effective config version here lets the client drop its separate
-      // 30-second config poll, which was roughly half of all overlay traffic,
-      // without weakening the kill switch: an operator flipping the allowlist
-      // is now noticed on the next pass the client was making anyway (faster in
-      // polling-only mode, unchanged while DO-connected).
+      // Polling-only/disconnected overlays already call this endpoint, so they
+      // can learn a transport change from the same response without a second
+      // config request. A healthy DO connection performs history recovery only
+      // at startup/reconnect or after a sequence gap; its room notice and the
+      // infrequent reconciliation covers steady-state changes and gapless
+      // post-commit publish failures.
       //
       // Computed through the shared resolver so this value can never disagree
       // with what the config endpoint would return.

--- a/src/app/api/overlay/[streamerId]/realtime-config/route.ts
+++ b/src/app/api/overlay/[streamerId]/realtime-config/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server'
-import { isValidStreamerId } from '@/lib/overlay-realtime/contract'
+import {
+  isValidOverlayVersion,
+  isValidStreamerId,
+} from '@/lib/overlay-realtime/contract'
 import { resolveOverlayRealtimeConfig } from '@/lib/overlay-realtime/resolve-config'
 
 interface RouteParams {
@@ -14,14 +17,14 @@ interface RouteParams {
  * pages, which is the kill switch required to fall back to polling-only during
  * a Durable Objects incident.
  *
- * Connected overlays no longer poll this endpoint on their own timer: the
- * events endpoint echoes `realtimeConfigVersion` on every pass a client already
- * makes, and the client refetches here only when that value changes. This
- * endpoint is therefore a startup + change-triggered read.
+ * Polling-only overlays and a DO-connected overlay's ten-minute reconciliation
+ * learn transport/build changes from `/events`. This lightweight, DB-free
+ * endpoint is therefore used at startup and for change-triggered refetches.
  *
  * The short cache TTL is deliberately kept. A longer TTL would risk serving a
  * pre-change config to the very refetch that a detected change triggered; the
- * traffic saving comes from removing the timer, not from caching.
+ * traffic saving comes from the low reconciliation cadence and eliminating a
+ * separate steady-state config poll, not from another application cache layer.
  */
 export async function GET(
   _request: Request,
@@ -32,7 +35,15 @@ export async function GET(
     return NextResponse.json({ error: 'Invalid streamer ID' }, { status: 400 })
   }
 
-  return NextResponse.json(resolveOverlayRealtimeConfig(streamerId), {
+  const overlayVersion = process.env.NEXT_PUBLIC_OVERLAY_VERSION ?? 'dev'
+
+  return NextResponse.json({
+    ...resolveOverlayRealtimeConfig(streamerId),
+    // The field remains optional for rolling compatibility. Although this
+    // value is build-controlled, apply the same public-contract bound as the
+    // browser so a malformed deployment variable is never reflected verbatim.
+    ...(isValidOverlayVersion(overlayVersion) ? { overlayVersion } : {}),
+  }, {
     headers: {
       'Cache-Control': 'public, max-age=15, stale-while-revalidate=15',
     },

--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -5,7 +5,14 @@ import { useParams } from "next/navigation";
 import Image from "next/image";
 import type { Card, Rarity } from "@/types/database";
 import { logger } from "@/lib/logger";
-import { subscribeToGachaResults } from "@/lib/realtime";
+import {
+  isValidOverlayHistoryId,
+} from "@/lib/overlay-realtime/contract";
+import { normalizeOverlayHistoryTimestamp } from "@/lib/overlay-history-cursor";
+import {
+  subscribeToGachaResults,
+  type OverlayHistoryCursor,
+} from "@/lib/realtime";
 import {
   type OverlayEffectStyle,
   type OverlayEffectParticle,
@@ -137,18 +144,9 @@ interface OverlayOptions {
 // リロード対象外として扱われる(overlay-version.ts 参照)。
 const CURRENT_OVERLAY_VERSION = process.env.NEXT_PUBLIC_OVERLAY_VERSION ?? "dev";
 
-// Issue #569: primary transport稼働中に「バージョン確認だけ」を行う間隔。
-// 接続中は旧フォールバックポーリングでイベント取得を重複させず、
-// この間隔でoverlayVersionだけを軽量に確認する(pollOverlayEvents参照)。
-// レビュー指摘: 以前はリロードジッター上限(RELOAD_JITTER_MAX_MS)と同じ
-// 定数(TEN_MINUTES_MS)を共有していたが、「確認間隔」と「ジッター上限」は
-// 意味の異なる独立したチューニング値であり、結合していると片方だけを
-// 変更したい場合に紛らわしいため分離した。値は据え置き(10分)。
-const VERSION_CHECK_INTERVAL_MS = 10 * 60 * 1000;
 // Issue #569: バージョン不一致検出からリロード実行までのランダムジッター上限。
 // サンダリングハード回避のため、0〜この値の範囲でリロード実行タイミングを
-// 散らす(checkOverlayVersion参照)。VERSION_CHECK_INTERVAL_MSと値はどちらも
-// 10分だが、意味的に独立したチューニング値のため別定数として管理する。
+// 散らす(checkOverlayVersion参照)。
 const RELOAD_JITTER_MAX_MS = 10 * 60 * 1000;
 // 演出中で実行を見送った場合の再試行間隔(演出を壊さないための待ち時間)
 const RELOAD_DEFER_RETRY_MS = 30 * 1000;
@@ -166,6 +164,8 @@ const IMAGE_METADATA_TIMEOUT_MS = 1_500;
 // sessionStorage キー。リロード前後で状態を引き継ぐために使う
 const RELOAD_COOLDOWN_STORAGE_KEY = "twica-overlay-reload";
 const POLLSTATE_STORAGE_KEY = "twica-overlay-pollstate";
+const pollStateStorageKey = (streamerId: string) =>
+  `${POLLSTATE_STORAGE_KEY}:${streamerId}`;
 
 export default function OverlayPage() {
   const params = useParams();
@@ -241,19 +241,18 @@ export default function OverlayPage() {
   //  subscriptionが破棄・再作成される問題を回避）
   const displayResultRef = useRef<(data: GachaResult) => void>(() => {});
   const addDebugLogRef = useRef<(message: string) => void>(() => {});
+  // subscription effectはstreamerIdだけに依存させる。displayResult/addDebugLogと
+  // 同じrefミラーで最新版を参照し、callback再生成による再接続を防ぐ。
+  const checkOverlayVersionRef = useRef<(received: string | undefined) => void>(() => {});
   const connectionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollCursorRef = useRef(new Date().toISOString());
+  const pollHistoryIdRef = useRef("");
   const seenHistoryIdsRef = useRef<Set<string>>(new Set());
   const lastPollingErrorLogRef = useRef(0);
   // Issue #569: バージョン不一致検出＋自動リロード用のref群。
   // showCardは演出中判定にrefで参照する必要がある(setTimeoutコールバック内で
   // stateを直接読むとクロージャ生成時点の古い値のままになるため)。
   const showCardRef = useRef(showCard);
-  // Realtime接続中にバージョン確認だけを行う最終実行時刻(10分に1回に絞るため)。
-  // 0で初期化し、接続後最初のポーリングTickで即座に1回だけ確認を行う(以降は
-  // 10分間隔に絞られる)。Date.now()はレンダー中に呼べない(React Compilerの
-  // purityルールで検出される)ため、ここでは呼ばずrefの初期値は0固定にする。
-  const lastVersionCheckAtRef = useRef(0);
   // ジッター待機中/演出中の再試行待ち(＝リロードが予約済み)かどうか。
   // 二重にsetTimeoutを積んでしまわないようにするフラグ
   const reloadScheduledRef = useRef(false);
@@ -297,21 +296,44 @@ export default function OverlayPage() {
     showCardRef.current = showCard;
   }, [showCard]);
 
-  // Issue #569: マウント時、直前のバージョン起因リロードでpollCursor/
-  // seenHistoryIdsをsessionStorageに退避していた場合はここで復元する。
+  // Issue #569: マウント時、直前のバージョン起因リロードで正確な
+  // (pollCursor, pollHistoryId)/seenHistoryIdsをsessionStorageに退避していた
+  // 場合はここで復元する。
   // TTL(15分)超過や壊れたJSONの場合はparsePollStateがnullを返すため、
   // その場合は何も復元されず通常どおり「今」を起点にポーリングを開始する。
   // このeffectは他のeffect(ポーリングスケジューラ・Realtime購読)より前に
   // 定義しているため、それらが最初に動く前に確実に復元が完了する。
   useEffect(() => {
+    // 同じcomponent instanceでstreamer paramが変わる場合、前streamerのDB位置や
+    // dedupe集合を新しい購読へ持ち込まない。
+    pollCursorRef.current = new Date().toISOString();
+    pollHistoryIdRef.current = "";
+    seenHistoryIdsRef.current = new Set();
     try {
-      const raw = sessionStorage.getItem(POLLSTATE_STORAGE_KEY);
+      const scopedKey = pollStateStorageKey(streamerId);
+      // 新形式はstreamer単位。旧buildがリロード直前に書いた非scoped keyも
+      // 1回だけ読み、rolling deployment中の互換性を保つ。
+      const raw =
+        sessionStorage.getItem(scopedKey)
+        ?? sessionStorage.getItem(POLLSTATE_STORAGE_KEY);
       const restored = parsePollState(raw, Date.now(), POLLSTATE_TTL_MS);
       if (restored) {
-        pollCursorRef.current = restored.pollCursor;
+        if (restored.pollHistoryId) {
+          pollCursorRef.current = restored.pollCursor;
+          pollHistoryIdRef.current = restored.pollHistoryId;
+        } else {
+          // 旧snapshotには同一timestamp行のtie-breakerが無い。1msだけ巻き戻し、
+          // sessionStorageのseen IDで既表示分をdedupeする方が、`gt(since)`で
+          // 同時刻の未表示行を永久に飛ばすより安全。
+          pollCursorRef.current = new Date(
+            Date.parse(restored.pollCursor) - 1,
+          ).toISOString();
+          pollHistoryIdRef.current = "";
+        }
         seenHistoryIdsRef.current = new Set(restored.seenHistoryIds);
       }
       // 復元の成否に関わらず使用後(またはTTL切れ)は必ず削除し、残骸を残さない
+      sessionStorage.removeItem(scopedKey);
       sessionStorage.removeItem(POLLSTATE_STORAGE_KEY);
     } catch {
       // OBSブラウザソース等でsessionStorageが無効/利用不可でも本体動作を壊さない
@@ -323,7 +345,7 @@ export default function OverlayPage() {
         clearTimeout(reloadTimeoutRef.current);
       }
     };
-  }, []);
+  }, [streamerId]);
 
   // 効果音設定を取得し、HTMLAudioElementでプリロード
   // オーバーレイ初期化時にstreamerの効果音設定をAPIから取得
@@ -780,9 +802,10 @@ export default function OverlayPage() {
         JSON.stringify({ version: targetVersion, reloadedAt: Date.now() }),
       );
       sessionStorage.setItem(
-        POLLSTATE_STORAGE_KEY,
+        pollStateStorageKey(streamerId),
         serializePollState({
           pollCursor: pollCursorRef.current,
+          pollHistoryId: pollHistoryIdRef.current,
           seenHistoryIds: Array.from(seenHistoryIdsRef.current),
           savedAt: Date.now(),
         }),
@@ -795,7 +818,7 @@ export default function OverlayPage() {
     // リロード窓での演出取りこぼしを防ぐため、演出中でなくクールダウンもクリアな
     // 「今」のタイミングで遅延せず即座にリロードする
     location.reload();
-  }, []);
+  }, [streamerId]);
 
   // attemptReloadRefを最新のcallbackで更新(processQueueRefと同じパターン)
   useEffect(() => {
@@ -803,8 +826,8 @@ export default function OverlayPage() {
   }, [attemptReload]);
 
   /**
-   * Issue #569: ポーリング応答のoverlayVersionを自身のビルドバージョンと比較し、
-   * 不一致ならリロードをスケジュールする。
+   * Issue #569: transport controllerのconfig/events応答に含まれるoverlayVersionを
+   * 自身のビルドバージョンと比較し、不一致ならリロードをスケジュールする。
    */
   const checkOverlayVersion = useCallback((received: string | undefined) => {
     if (!shouldScheduleReload(CURRENT_OVERLAY_VERSION, received)) {
@@ -826,51 +849,39 @@ export default function OverlayPage() {
     }, jitterMs);
   }, [attemptReload]);
 
+  // transport callbackから常に最新版を呼びつつ、subscription useEffectの
+  // dependencyへcheckOverlayVersionを追加して再購読を誘発しない。
+  useEffect(() => {
+    checkOverlayVersionRef.current = checkOverlayVersion;
+  }, [checkOverlayVersion]);
+
   /**
-   * 旧transportから残すversion-check兼緊急polling loop。
+   * 旧transportから残すdisconnected時限定の緊急polling loop。
    *
    * 現在のtransport controllerはsubscribeToGachaResults内でDOをprimaryとし、
-   * PlanetScale履歴をgap recoveryとして読み、
-   * connectionStatus=connected中はここでeventsを処理しない。これにより二重表示を
-   * 防ぎつつ、旧loopをversion-check専用として安全に残す。
+   * PlanetScale履歴をgap recoveryとして読む。controllerがconnectedを報告して
+   * いる間はnetwork前にreturnし、version通知もcontrollerのconfig/events応答から
+   * 受け取るため、この旧loopはWorker invocationもDB queryも発生させない。
    */
   const pollOverlayEvents = useCallback(async () => {
-    // 3秒おきのポーリングURLは接続中/未接続どちらの経路でも同一なため共通化する
+    if (connectionStatusRef.current === "connected") {
+      return;
+    }
+
     const buildEventsUrl = () => {
       const url = new URL(`/api/overlay/${streamerId}/events`, window.location.origin);
       url.searchParams.set("since", pollCursorRef.current);
+      if (pollHistoryIdRef.current) {
+        url.searchParams.set("afterId", pollHistoryIdRef.current);
+      }
       url.searchParams.set("_", String(Date.now()));
       return url.toString();
     };
 
-    if (connectionStatusRef.current === "connected") {
-      // Issue #569: primary transport接続中もこの関数は3秒おきに呼ばれ続けるが、
-      // 従来は何もせず早期returnしていた。ここに「VERSION_CHECK_INTERVAL_MSに
-      // 1回、バージョン確認だけ行う」経路を追加する。
-      // 理由: primary transportの受信イベントはこの旧loopのseenHistoryIdsRefに
-      // 登録されないため、接続中にevents配列を処理すると同一演出がポーリング
-      // 経路からも再生され二重演出になる。そのため接続中は応答のoverlayVersion
-      // だけを読み、events配列には一切触れない(表示・カーソル前進・seen登録の
-      // いずれも行わない)。
-      const now = Date.now();
-      if (now - lastVersionCheckAtRef.current < VERSION_CHECK_INTERVAL_MS) {
-        return;
-      }
-      lastVersionCheckAtRef.current = now;
-
-      try {
-        const data = await fetchJsonWithXhrFallback<{ overlayVersion?: string }>(buildEventsUrl());
-        checkOverlayVersion(data.overlayVersion);
-      } catch {
-        // バージョン確認専用の背景チェックであり演出表示には無関係なため、
-        // 失敗時はログを出さず静かに次の10分後の機会に委ねる
-      }
-      return;
-    }
-
     try {
       const data = await fetchJsonWithXhrFallback<{
         events?: OverlayPollingEvent[];
+        nextCursor?: OverlayHistoryCursor | null;
         overlayVersion?: string;
       }>(buildEventsUrl());
       checkOverlayVersion(data.overlayVersion);
@@ -880,10 +891,8 @@ export default function OverlayPage() {
           continue;
         }
         seenHistoryIdsRef.current.add(event.id);
-        const redeemedAtMs = Date.parse(event.redeemedAt);
-        pollCursorRef.current = Number.isFinite(redeemedAtMs)
-          ? new Date(redeemedAtMs).toISOString()
-          : event.redeemedAt;
+        pollCursorRef.current = event.redeemedAt;
+        pollHistoryIdRef.current = event.id;
         addDebugLogRef.current(`Polling fallback received: ${event.id}`);
         displayResultRef.current({
           card: event.card as Card,
@@ -892,6 +901,21 @@ export default function OverlayPage() {
           soundGroupId: event.eventId?.replace(/:\d+$/, "") ?? event.id,
           rewardId: event.rewardId ?? null,
         });
+      }
+      // The server cursor also advances across defensive LEFT JOIN misses that
+      // produce no display event. Prefer it over the last rendered row so a
+      // malformed historical card cannot pin recovery on the same DB page.
+      if (
+        data.nextCursor
+        && isValidOverlayHistoryId(data.nextCursor.historyId)
+      ) {
+        const normalizedCursor = normalizeOverlayHistoryTimestamp(
+          data.nextCursor.redeemedAt,
+        );
+        if (normalizedCursor) {
+          pollCursorRef.current = normalizedCursor;
+          pollHistoryIdRef.current = data.nextCursor.historyId;
+        }
       }
     } catch (error) {
       const now = Date.now();
@@ -1010,14 +1034,6 @@ export default function OverlayPage() {
     const cleanup = subscribeToGachaResults(streamerId, (payload) => {
       addDebugLogRef.current(`Received payload: ${payload.type}`);
       if (payload.type === 'gacha' && payload.card) {
-        // Primary polling provides the exact timestamp that its DB query
-        // delivered. Advancing to callback wall-clock time would skip any row
-        // committed between that query and this callback when emergency
-        // fallback takes over. Demo payloads intentionally omit historyCursor
-        // and therefore never advance the business-history cursor.
-        if (payload.historyCursor) {
-          pollCursorRef.current = payload.historyCursor;
-        }
         displayResultRef.current({
           card: payload.card as unknown as Card,
           cards: payload.cards as unknown as Card[] | undefined,
@@ -1030,6 +1046,17 @@ export default function OverlayPage() {
         });
       }
     }, {
+      // Cursor ownership stays inside the transport controller. The page only
+      // mirrors its exact DB pair so a build-version reload can hand the same
+      // position to the next controller instance without a time-only gap.
+      initialHistoryCursor: {
+        redeemedAt: pollCursorRef.current,
+        historyId: pollHistoryIdRef.current,
+      },
+      onHistoryCursor: (cursor) => {
+        pollCursorRef.current = cursor.redeemedAt;
+        pollHistoryIdRef.current = cursor.historyId;
+      },
       onError: (error) => {
         addDebugLogRef.current(`Connection error: ${error.message} (expected: ${error.isExpected})`);
         if (error.isExpected) {
@@ -1050,6 +1077,9 @@ export default function OverlayPage() {
       },
       onStatusChange: (status) => {
         addDebugLogRef.current(`Connection status: ${status}`);
+      },
+      onOverlayVersion: (overlayVersion) => {
+        checkOverlayVersionRef.current(overlayVersion);
       },
     });
 

--- a/src/components/MaintenanceStatusProvider.tsx
+++ b/src/components/MaintenanceStatusProvider.tsx
@@ -21,8 +21,9 @@
  * - 一方で、メンテ解除後にバナーが消えるまで/書き込みボタンが再度有効になるまで
  *   の体感待ち時間は短いほど良い。60秒は「サーバー負荷を抑えつつ、解除後
  *   1分以内にはUIが追従する」という妥当なバランス値として選んだ。
- * - ページロード時に必ず1回即時fetchするため、ページを開いた瞬間の状態は
- *   常に最新（60秒待たされない）。
+ * - 可視状態でページを開いた時と、hiddenからvisibleへ戻った時に即時fetch
+ *   するため、ユーザーが見る状態は60秒待たず最新になる。hidden中は不要な
+ *   Worker invocationを止める。
  */
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
 import { fetchMaintenanceStatus, type MaintenanceStatusResponse } from '@/lib/maintenance/client'
@@ -32,12 +33,20 @@ const POLL_INTERVAL_MS = 60_000
 
 /**
  * fetchMaintenanceStatus() 自体が fail-safe に { mode: 'off' } を返す設計
- * （client.ts参照）なので、Context の初期値も同じ安全側のデフォルトに揃える。
- * これにより、初回fetch完了前の一瞬（またはProviderが無い文脈で誤って
- * useContextした場合）も「通常運用中」として振る舞い、誤ってバナー表示・
- * ボタンdisableが先走ることを防ぐ。
+ * （client.ts参照）なので、Context の初期値も同じデフォルトに揃える。
+ * Provider外と初期visible mountの確認待ちは、既存契約どおり「通常運用中」として
+ * 振る舞う。初回取得失敗時もサーバー側guardWriteが最終的にwriteを拒否するため、
+ * この契約をhidden対応のために広げて変更しない。
  */
 const OFF_STATUS: MaintenanceStatusResponse = { mode: 'off' }
+
+/**
+ * hiddenからvisibleへ戻った直後だけ使う、再確認中のwrite-blocking状態。
+ * MaintenanceStatusResponseへloadingフラグを追加すると全consumerの契約変更になるが、
+ * 既存consumerは例外なく `mode !== 'off'` をwrite不可として扱う。そのため既存型の
+ * read-onlyを一時値に使い、古いoffを最新確認完了まで再提示しない最小変更にする。
+ */
+const VISIBILITY_REFRESH_STATUS: MaintenanceStatusResponse = { mode: 'read-only' }
 
 /**
  * 生の Context をテスト用に export する。アプリケーションコードは
@@ -65,7 +74,7 @@ interface MaintenanceStatusProviderProps {
 
 /**
  * dashboard/layout.tsx に1つだけ配置するプロバイダ。
- * マウント時に即時fetchし、以降 POLL_INTERVAL_MS 間隔でポーリングする。
+ * 可視状態で即時fetchし、以降 POLL_INTERVAL_MS 間隔でポーリングする。
  */
 export function MaintenanceStatusProvider({ children }: MaintenanceStatusProviderProps) {
   const [status, setStatus] = useState<MaintenanceStatusResponse>(OFF_STATUS)
@@ -75,20 +84,71 @@ export function MaintenanceStatusProvider({ children }: MaintenanceStatusProvide
     // のを防ぐためのガード。dashboard内ページ遷移でlayoutごとアンマウントされる
     // ケースを想定。
     let cancelled = false
+    let intervalId: ReturnType<typeof setInterval> | null = null
+    // hidden切替後や新しいvisible refresh後に古いrequestが完了しても、その
+    // responseで最新statusを上書きしないための世代番号。共有fetch helperへ
+    // AbortSignalを追加せず、このProvider内だけで競合を閉じ込める。
+    let requestGeneration = 0
 
-    const load = async () => {
+    const load = async (blockWritesWhileLoading = false) => {
+      const generation = ++requestGeneration
+
+      if (blockWritesWhileLoading) {
+        // visible復帰時はhidden中にサーバーがread-onlyへ変わった可能性があるため、
+        // request完了まで古いoffを公開しない。既に非offならwriteは無効化済みなので、
+        // expectedEndAt等の実status詳細を一時値で消さず、その状態を維持する。
+        setStatus((current) => (
+          current.mode === 'off' ? VISIBILITY_REFRESH_STATUS : current
+        ))
+      }
+
       const next = await fetchMaintenanceStatus()
-      if (!cancelled) {
+      if (!cancelled && generation === requestGeneration) {
         setStatus(next)
       }
     }
 
-    load()
-    const intervalId = setInterval(load, POLL_INTERVAL_MS)
+    const stopPolling = () => {
+      if (intervalId !== null) {
+        clearInterval(intervalId)
+        intervalId = null
+      }
+    }
+
+    const startPolling = (blockWritesWhileLoading = false) => {
+      if (
+        cancelled
+        || document.visibilityState === 'hidden'
+        || intervalId !== null
+      ) {
+        return
+      }
+      void load(blockWritesWhileLoading)
+      intervalId = setInterval(() => void load(), POLL_INTERVAL_MS)
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        stopPolling()
+        // 可視中に開始したrequestがhidden後にsetStateしないよう無効化する。
+        requestGeneration += 1
+        return
+      }
+      // startPollingのintervalId guardで重複visible eventによる多重timerを防ぐ。
+      // 再開時はwriteを一時無効化して即時loadし、既存60秒cadenceへ戻る。
+      startPolling(true)
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    // 初期visible mountはOFF_STATUSを保つ既存Context契約のまま即時取得する。
+    // fail-closedにするのは、既知の状態がhidden中に陳腐化した復帰時だけに限定する。
+    startPolling()
 
     return () => {
       cancelled = true
-      clearInterval(intervalId)
+      requestGeneration += 1
+      stopPolling()
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
   }, [])
 

--- a/src/lib/overlay-history-cursor.ts
+++ b/src/lib/overlay-history-cursor.ts
@@ -1,0 +1,77 @@
+/**
+ * Normalize the public overlay history timestamp accepted by `/events`.
+ *
+ * This function is shared by the API, browser transport, and reload snapshot
+ * reader. A looser browser-only `Date.parse` check is unsafe: it can accept a
+ * value that the API rejects forever, pinning every later recovery request at
+ * HTTP 400. PostgreSQL's signed-offset/microsecond wire format is handled
+ * explicitly and returned as canonical UTC without truncating microseconds.
+ */
+export function normalizeOverlayHistoryTimestamp(value: unknown): string | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+
+  const match = value.match(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,6}))?(Z|([+-]| )(\d{2}):(\d{2}))$/,
+  );
+  if (!match) return null;
+
+  const [
+    ,
+    yearText,
+    monthText,
+    dayText,
+    hourText,
+    minuteText,
+    secondText,
+    fraction = "",
+    timezone,
+    offsetSign,
+    offsetHourText,
+    offsetMinuteText,
+  ] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  // PostgreSQL represents years before 1 CE with a separate BC suffix. Keep
+  // this public cursor grammar to four-digit, non-BC database values.
+  if (year < 1) return null;
+
+  // Date stores only milliseconds, so keep the authoritative fraction outside
+  // it. `setUTCFullYear` also avoids Date.UTC's 0-99 -> 1900-1999 remapping.
+  const localDate = new Date(0);
+  localDate.setUTCFullYear(year, month - 1, day);
+  localDate.setUTCHours(hour, minute, second, 0);
+  // Date setters normalize invalid calendar values (for example February 30),
+  // therefore compare every component before accepting a public cursor.
+  if (
+    localDate.getUTCFullYear() !== year
+    || localDate.getUTCMonth() !== month - 1
+    || localDate.getUTCDate() !== day
+    || localDate.getUTCHours() !== hour
+    || localDate.getUTCMinutes() !== minute
+    || localDate.getUTCSeconds() !== second
+  ) {
+    return null;
+  }
+
+  let offsetMinutes = 0;
+  if (timezone !== "Z") {
+    const offsetHours = Number(offsetHourText);
+    const offsetMinutePart = Number(offsetMinuteText);
+    if (offsetHours > 23 || offsetMinutePart > 59) return null;
+    // URLSearchParams can expose a literal `+` as a space. Only the strict
+    // timezone-sign position accepts that representation.
+    offsetMinutes =
+      (offsetSign === "-" ? -1 : 1)
+      * (offsetHours * 60 + offsetMinutePart);
+  }
+
+  const utcDate = new Date(localDate.getTime() - offsetMinutes * 60_000);
+  const utcYear = utcDate.getUTCFullYear();
+  if (utcYear < 1 || utcYear > 9999) return null;
+  const utcWholeSecond = utcDate.toISOString().slice(0, 19);
+  return `${utcWholeSecond}${fraction ? `.${fraction}` : ""}Z`;
+}

--- a/src/lib/overlay-realtime/contract.ts
+++ b/src/lib/overlay-realtime/contract.ts
@@ -30,6 +30,20 @@ export const OVERLAY_REALTIME_HEARTBEAT = 'heartbeat' as const
 export const OVERLAY_REALTIME_HEARTBEAT_MS = 60_000
 export const MAX_REALTIME_DRAWS = 15
 export const MAX_REALTIME_EVENT_BYTES = 64 * 1024
+/**
+ * Public build identifiers are currently 12-character Git SHAs (or `dev`).
+ * Keep protocol consumers tolerant of future formats while bounding any value
+ * copied into logs, callback state, or sessionStorage by an untrusted response.
+ */
+export const MAX_OVERLAY_VERSION_LENGTH = 128
+/**
+ * `gacha_history.id` is generated as an RFC 4122 UUID. The exact predicate is
+ * shared by the history API and browser checkpoint readers: accepting a value
+ * from sessionStorage that the API later rejects would pin every recovery
+ * request in a permanent HTTP 400 loop.
+ */
+const OVERLAY_HISTORY_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const MAX_PUBLIC_CARD_DESCRIPTION_LENGTH = 1_024
 const MAX_PUBLIC_CARD_IMAGE_URL_LENGTH = 2_048
 
@@ -155,6 +169,11 @@ export interface OverlayRealtimeConfigV1 {
     maxDelayMs: number
   }
   configVersion: string
+  /**
+   * App build served by this Worker. Optional so a new browser bundle remains
+   * compatible with an older realtime-config endpoint during deployment.
+   */
+  overlayVersion?: string
 }
 
 export interface PollingContractEvent {
@@ -181,6 +200,23 @@ function isBoundedString(value: unknown, maxLength: number): value is string {
 
 function isNullableBoundedString(value: unknown, maxLength: number): boolean {
   return value === null || (typeof value === 'string' && value.length <= maxLength)
+}
+
+/**
+ * Validate a public overlay build identifier at every network boundary.
+ *
+ * The value is intentionally format-agnostic because deployment systems may
+ * move beyond Git SHAs, but empty, whitespace-padded, and oversized strings are
+ * rejected so an optional compatibility field cannot become an unbounded input.
+ */
+export function isValidOverlayVersion(value: unknown): value is string {
+  return isBoundedString(value, MAX_OVERLAY_VERSION_LENGTH)
+    && value.trim() === value
+}
+
+/** Validate an exact `gacha_history.id` cursor at every public boundary. */
+export function isValidOverlayHistoryId(value: unknown): value is string {
+  return typeof value === 'string' && OVERLAY_HISTORY_ID_PATTERN.test(value)
 }
 
 export function isValidStreamerId(value: string): boolean {

--- a/src/lib/overlay-realtime/contract.ts
+++ b/src/lib/overlay-realtime/contract.ts
@@ -110,6 +110,15 @@ export interface GachaRealtimeDrawV1 {
 export interface GachaRealtimeEventV1 {
   schemaVersion: typeof OVERLAY_REALTIME_SCHEMA_VERSION
   type: 'gacha_result'
+  /**
+   * Optional delivery-only event kind.
+   *
+   * `demo` events are operator previews, not committed gacha history. Older
+   * clients safely ignore this additive field, while newer clients use it to
+   * avoid waiting for a DB reconciliation row that intentionally does not
+   * exist. Omission continues to mean authoritative committed history.
+   */
+  deliveryKind?: 'demo'
   /** Dedupe key for the first draw; every draw also carries its own eventId. */
   eventId: string
   /** Stable EventSub message ID or manual-draw ID shared by the whole batch. */
@@ -263,6 +272,9 @@ export function validateGachaRealtimeEvent(
     return { ok: false, error: 'unsupported schemaVersion' }
   }
   if (value.type !== 'gacha_result') return { ok: false, error: 'unsupported event type' }
+  if (value.deliveryKind !== undefined && value.deliveryKind !== 'demo') {
+    return { ok: false, error: 'invalid deliveryKind' }
+  }
   if (!isBoundedString(value.eventId, 256)) return { ok: false, error: 'invalid eventId' }
   if (!isBoundedString(value.batchId, 256)) return { ok: false, error: 'invalid batchId' }
   if (!isBoundedString(value.streamerId, 64) || !isValidStreamerId(value.streamerId)) {

--- a/src/lib/overlay-realtime/publisher.ts
+++ b/src/lib/overlay-realtime/publisher.ts
@@ -4,6 +4,7 @@ import { and, eq, inArray } from 'drizzle-orm'
 import { getDb } from '@/lib/db/client'
 import { gachaHistory } from '@/lib/db/schema'
 import { logger } from '@/lib/logger.server'
+import type { OverlayDemoEvent } from '@/lib/overlay/demo-event-store'
 import {
   OVERLAY_REALTIME_SCHEMA_VERSION,
   type GachaRealtimeEventV1,
@@ -225,6 +226,20 @@ function resolvePublishUrl(streamerId: string, base: string | undefined): URL | 
   }
 }
 
+function resolvePublisherTarget(
+  streamerId: string,
+  publisherEnv: OverlayRealtimePublisherEnvironment
+): { secret: string; url: URL } | null {
+  const secret = publisherEnv.publishSecret
+  const url = resolvePublishUrl(streamerId, publisherEnv.publishUrl)
+  if (
+    !secret
+    || !url
+    || (publisherEnv.runtime === 'workers' && !publisherEnv.publishService)
+  ) return null
+  return { secret, url }
+}
+
 function retryableStatus(status: number): boolean {
   return status === 408 || status === 429 || status >= 500
 }
@@ -241,6 +256,103 @@ async function discardResponseBody(response: Response): Promise<void> {
     // response must not be turned into a failed gacha notification because its
     // already-unused body stream was concurrently closed by the runtime.
   }
+}
+
+/**
+ * Send one already-validated public envelope through the authenticated room
+ * publisher.
+ *
+ * Committed gacha and operator demos intentionally share this transport layer:
+ * HMAC authentication, Service Binding routing, retry bounds, and response
+ * cleanup must not drift between two public event kinds. Their durability
+ * rules remain separate in the builders above/below this function — committed
+ * rows fall back to PlanetScale, while demos fall back to the short-lived KV
+ * latest-value record.
+ */
+async function publishValidatedEnvelope(
+  streamerId: string,
+  event: GachaRealtimeEventV1,
+  publisherEnv: OverlayRealtimePublisherEnvironment,
+  options: Pick<OverlayPublishOptions, 'maxRetries' | 'retryDelay'> = {}
+): Promise<OverlayPublishResult> {
+  const target = resolvePublisherTarget(streamerId, publisherEnv)
+  if (!target) {
+    logger.warn('[overlay-realtime] publisher configuration missing', { streamerId })
+    return { outcome: 'skipped', attempts: 0, errorCode: 'configuration-missing' }
+  }
+  const { secret, url } = target
+
+  const body = JSON.stringify(event)
+  const maxAttempts = Math.max(1, Math.min((options.maxRetries ?? 1) + 1, 3))
+  const retryDelay = Math.max(50, Math.min(options.retryDelay ?? 250, 1_000))
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const timestamp = String(Date.now())
+    const nonce = crypto.randomUUID()
+    const signature = await createPublishSignature(
+      secret,
+      url.pathname,
+      body,
+      timestamp,
+      nonce
+    )
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 1_500)
+
+    try {
+      const requestInit: RequestInit = {
+        method: 'POST',
+        body,
+        headers: {
+          'content-type': 'application/json',
+          'x-twica-timestamp': timestamp,
+          'x-twica-nonce': nonce,
+          'x-twica-signature': signature,
+        },
+        signal: controller.signal,
+      }
+      // Cloudflare rejects global fetch() calls from one Worker to another
+      // Worker on the same zone. The Service Binding is the supported,
+      // zero-network-hop path in deployed Workers; global fetch remains only
+      // for next dev and Vitest, where no Workers binding exists.
+      const response = publisherEnv.publishService
+        ? await publisherEnv.publishService.fetch(new Request(url, requestInit))
+        : await fetch(url, requestInit)
+      await discardResponseBody(response)
+      if (response.ok) return { outcome: 'accepted', attempts: attempt }
+      if (!retryableStatus(response.status) || attempt >= maxAttempts) {
+        logger.warn('[overlay-realtime] publish rejected', {
+          streamerId,
+          // Origin/path are public routing metadata and contain no signature,
+          // secret, or payload. Keeping them in the rejection log makes a
+          // stale cross-environment endpoint diagnosable safely.
+          targetOrigin: url.origin,
+          targetPath: url.pathname,
+          status: response.status,
+          attempt,
+        })
+        return { outcome: 'failed', attempts: attempt, errorCode: `http-${response.status}` }
+      }
+    } catch (error) {
+      if (attempt >= maxAttempts) {
+        logger.warn('[overlay-realtime] publish network failure', {
+          streamerId,
+          attempt,
+          error: error instanceof Error ? error.name : 'unknown',
+        })
+        return { outcome: 'failed', attempts: attempt, errorCode: 'network' }
+      }
+    } finally {
+      clearTimeout(timeout)
+    }
+
+    // Bounded jitter prevents simultaneous EventSub or demo deliveries from
+    // retrying the room endpoint in lockstep after a regional failure.
+    const jitter = Math.floor(Math.random() * retryDelay)
+    await new Promise((resolve) => setTimeout(resolve, retryDelay + jitter))
+  }
+
+  return { outcome: 'failed', attempts: maxAttempts, errorCode: 'unexpected' }
 }
 
 /**
@@ -266,13 +378,10 @@ export async function publishCommittedGachaBatch(
   }
 
   try {
-    const secret = publisherEnv.publishSecret
-    const url = resolvePublishUrl(streamerId, publisherEnv.publishUrl)
-    if (
-      !secret
-      || !url
-      || (publisherEnv.runtime === 'workers' && !publisherEnv.publishService)
-    ) {
+    // Keep the cheap fail-closed configuration gate ahead of the committed-row
+    // identity lookup. A disabled or partially rolled-out publisher must not
+    // add a PlanetScale query to every otherwise-successful redemption.
+    if (!resolvePublisherTarget(streamerId, publisherEnv)) {
       logger.warn('[overlay-realtime] publisher configuration missing', { streamerId })
       return { outcome: 'skipped', attempts: 0, errorCode: 'configuration-missing' }
     }
@@ -286,84 +395,85 @@ export async function publishCommittedGachaBatch(
       return { outcome: 'skipped', attempts: 0, errorCode: 'identity-unavailable' }
     }
 
-    const body = JSON.stringify(event)
-    const maxAttempts = Math.max(1, Math.min((options.maxRetries ?? 1) + 1, 3))
-    const retryDelay = Math.max(50, Math.min(options.retryDelay ?? 250, 1_000))
-
-    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-      const timestamp = String(Date.now())
-      const nonce = crypto.randomUUID()
-      const signature = await createPublishSignature(
-        secret,
-        url.pathname,
-        body,
-        timestamp,
-        nonce
-      )
-      const controller = new AbortController()
-      const timeout = setTimeout(() => controller.abort(), 1_500)
-
-      try {
-        const requestInit: RequestInit = {
-          method: 'POST',
-          body,
-          headers: {
-            'content-type': 'application/json',
-            'x-twica-timestamp': timestamp,
-            'x-twica-nonce': nonce,
-            'x-twica-signature': signature,
-          },
-          signal: controller.signal,
-        }
-        // Cloudflare rejects global fetch() calls from one Worker to another
-        // Worker on the same zone. The Service Binding is the supported,
-        // zero-network-hop path in deployed Workers; global fetch remains only
-        // for next dev and Vitest, where no Workers binding exists.
-        const response = publisherEnv.publishService
-          ? await publisherEnv.publishService.fetch(new Request(url, requestInit))
-          : await fetch(url, requestInit)
-        await discardResponseBody(response)
-        if (response.ok) return { outcome: 'accepted', attempts: attempt }
-        if (!retryableStatus(response.status) || attempt >= maxAttempts) {
-          logger.warn('[overlay-realtime] publish rejected', {
-            streamerId,
-            // Origin/path are public routing metadata and contain no signature,
-            // secret, or payload. Keeping them in the rejection log makes a
-            // stale cross-environment endpoint diagnosable without weakening
-            // the HMAC boundary or exposing viewer/card data.
-            targetOrigin: url.origin,
-            targetPath: url.pathname,
-            status: response.status,
-            attempt,
-          })
-          return { outcome: 'failed', attempts: attempt, errorCode: `http-${response.status}` }
-        }
-      } catch (error) {
-        if (attempt >= maxAttempts) {
-          logger.warn('[overlay-realtime] publish network failure', {
-            streamerId,
-            attempt,
-            error: error instanceof Error ? error.name : 'unknown',
-          })
-          return { outcome: 'failed', attempts: attempt, errorCode: 'network' }
-        }
-      } finally {
-        clearTimeout(timeout)
-      }
-
-      // Bounded jitter prevents simultaneous EventSub deliveries from retrying
-      // the room endpoint in lockstep after a transient regional failure.
-      const jitter = Math.floor(Math.random() * retryDelay)
-      await new Promise((resolve) => setTimeout(resolve, retryDelay + jitter))
-    }
-
-    return { outcome: 'failed', attempts: maxAttempts, errorCode: 'unexpected' }
+    return publishValidatedEnvelope(streamerId, event, publisherEnv, options)
   } catch (error) {
     // Immediate delivery is an optimization after the authoritative database
     // commit. No configuration, WebCrypto, or identity re-read failure may
     // turn an already-successful draw into an API 500; the polling cursor will
     // recover the committed history row on its next pass.
     logger.warn('[overlay-realtime] unexpected publisher failure; polling will recover', {
+      streamerId,
+      error: error instanceof Error ? error.name : 'unknown',
+    })
+    return { outcome: 'failed', attempts: 0, errorCode: 'unexpected' }
+  }
+}
+
+/**
+ * Immediately fan out an operator-triggered OBS demo through the same signed
+ * Durable Object channel as committed gacha events.
+ *
+ * Demo events intentionally have no PlanetScale row. The route writes the
+ * short-lived KV latest-value record first, then calls this function so an
+ * already-connected overlay sees the demo immediately while polling-only or
+ * briefly disconnected clients still have a bounded fallback. Reusing the
+ * existing authenticated publisher avoids creating a second unauthenticated
+ * ingress path merely for operational previews.
+ */
+export async function publishOverlayDemoRealtimeEvent(
+  streamerId: string,
+  demo: OverlayDemoEvent,
+  options: Pick<OverlayPublishOptions, 'maxRetries' | 'retryDelay'> = {}
+): Promise<OverlayPublishResult> {
+  const publisherEnv = await getPublisherEnvironment()
+  if (!isOverlayRealtimeStreamerEnabled(
+    publisherEnv.mode,
+    publisherEnv.streamerAllowlist,
+    streamerId
+  )) {
+    return { outcome: 'skipped', attempts: 0, errorCode: 'mode-disabled' }
+  }
+
+  try {
+    const occurredAt = normalizeTimestamp(demo.redeemedAt)
+    if (!occurredAt) {
+      return { outcome: 'failed', attempts: 0, errorCode: 'invalid-demo-event' }
+    }
+
+    const event: GachaRealtimeEventV1 = {
+      schemaVersion: OVERLAY_REALTIME_SCHEMA_VERSION,
+      type: 'gacha_result',
+      deliveryKind: 'demo',
+      eventId: demo.eventId,
+      batchId: demo.eventId,
+      streamerId,
+      occurredAt,
+      user: { twitchUsername: demo.userTwitchUsername },
+      draws: [{
+        eventId: demo.eventId,
+        drawId: demo.eventId,
+        drawIndex: 0,
+        // The KV demo identifier is deliberately reused as a transport-only
+        // history identity. New clients recognize deliveryKind=demo and never
+        // wait for this value in PlanetScale; older clients merely keep it in
+        // their bounded reconciliation set only for the short mixed-version
+        // rollout window, after which a reload or normal cache eviction drops
+        // it without affecting committed history.
+        historyId: demo.id,
+        card: normalizeOverlayRealtimeCard(demo.card),
+      }],
+      rewardId: null,
+      soundGroupId: demo.eventId,
+    }
+    if (!validateGachaRealtimeEvent(event, streamerId).ok) {
+      return { outcome: 'failed', attempts: 0, errorCode: 'invalid-demo-event' }
+    }
+
+    return publishValidatedEnvelope(streamerId, event, publisherEnv, options)
+  } catch (error) {
+    // A failed immediate demo fanout must not invalidate the KV fallback or
+    // turn the already-successful dashboard response into a server error.
+    logger.warn('[overlay-realtime] unexpected demo publisher failure; KV will recover', {
       streamerId,
       error: error instanceof Error ? error.name : 'unknown',
     })

--- a/src/lib/overlay-realtime/resolve-config.ts
+++ b/src/lib/overlay-realtime/resolve-config.ts
@@ -1,8 +1,26 @@
 import {
   OVERLAY_REALTIME_PROTOCOL_VERSION,
+  OVERLAY_REALTIME_SCHEMA_VERSION,
   type OverlayRealtimeConfigV1,
   isOverlayRealtimeStreamerEnabled,
 } from '@/lib/overlay-realtime/contract'
+
+type ResolvedOverlayRealtimePublicConfig = Omit<
+  OverlayRealtimeConfigV1,
+  'configVersion' | 'overlayVersion'
+>
+
+const OVERLAY_REALTIME_RETRY_POLICY = {
+  baseDelayMs: 500,
+  maxDelayMs: 30_000,
+} as const
+
+// Constructor form keeps this runtime-supported 64-bit arithmetic compatible
+// with the repository's pre-ES2020 TypeScript emit target, which rejects only
+// BigInt literal syntax (`123n`) rather than the platform BigInt API.
+const FNV1A_64_OFFSET_BASIS = BigInt('0xcbf29ce484222325')
+const FNV1A_64_PRIME = BigInt('0x100000001b3')
+const UTF8_ENCODER = new TextEncoder()
 
 /**
  * Single place where the app Worker decides a streamer's effective overlay
@@ -36,6 +54,106 @@ function websocketBaseUrl(): string | null {
 }
 
 /**
+ * Resolve every public field owned by this module before deriving its version.
+ *
+ * Keeping the effective mode, normalized URL, protocol, and retry policy in one
+ * value prevents the events signal from hashing one interpretation of the env
+ * while the config route returns another. `overlayVersion` remains outside
+ * this value because it already has its own build-change signal on both routes.
+ */
+function resolveOverlayRealtimePublicConfig(
+  streamerId: string
+): ResolvedOverlayRealtimePublicConfig {
+  const baseUrl = websocketBaseUrl()
+  const doEnabled =
+    isOverlayRealtimeStreamerEnabled(
+      process.env.OVERLAY_REALTIME_MODE,
+      process.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST,
+      streamerId
+    ) && baseUrl !== null
+
+  return {
+    schemaVersion: OVERLAY_REALTIME_SCHEMA_VERSION,
+    mode: doEnabled ? 'do-primary' : 'polling-only',
+    ...(doEnabled ? { webSocketUrl: baseUrl } : {}),
+    protocolVersion: OVERLAY_REALTIME_PROTOCOL_VERSION,
+    retryPolicy: { ...OVERLAY_REALTIME_RETRY_POLICY },
+  }
+}
+
+/**
+ * Canonical input for the public-config generation token.
+ *
+ * A fixed-position JSON tuple gives the current public fields one unambiguous,
+ * deterministic representation without depending on object property insertion
+ * order. JSON string escaping also prevents variable-length URL contents from
+ * creating delimiter ambiguity. Any future public field owned by this resolver
+ * must be added here so its semantic change also advances `configVersion`.
+ */
+function serializeOverlayRealtimePublicConfig(
+  config: ResolvedOverlayRealtimePublicConfig
+): string {
+  return JSON.stringify([
+    config.schemaVersion,
+    config.mode,
+    config.webSocketUrl ?? null,
+    config.protocolVersion,
+    config.retryPolicy.baseDelayMs,
+    config.retryPolicy.maxDelayMs,
+  ])
+}
+
+/**
+ * Compact, synchronous fingerprint for change detection only.
+ *
+ * FNV-1a is intentionally non-cryptographic: this token grants no authority,
+ * hides no data, and is never used to authenticate config. A 64-bit output can
+ * collide, but for two independently dispersed config states that chance is
+ * about 1 in 2^64 (with birthday risk becoming material around 2^32 distinct
+ * states), far beyond the number of operator config revisions expected here.
+ * The 16-character hexadecimal digest keeps the longest emitted token at 32
+ * characters (`polling-only-v2-` plus the digest), safely below the client's
+ * 128-character bound without putting the normalized URL itself in the token.
+ */
+function fingerprintPublicConfig(value: string): string {
+  let hash = FNV1A_64_OFFSET_BASIS
+  for (const octet of UTF8_ENCODER.encode(value)) {
+    hash ^= BigInt(octet)
+    hash = BigInt.asUintN(64, hash * FNV1A_64_PRIME)
+  }
+  return hash.toString(16).padStart(16, '0')
+}
+
+/**
+ * Preserve the deployed polling-only token for its unchanged public config.
+ *
+ * Polling-only clients have no WebSocket URL, so URL/env churn that remains
+ * ineffective must not create false config changes. If schema, protocol, or
+ * retry semantics change later, this exact baseline no longer matches and the
+ * fingerprinted generation below will correctly advance the signal.
+ */
+function isLegacyPollingOnlyConfig(
+  config: ResolvedOverlayRealtimePublicConfig
+): boolean {
+  return config.schemaVersion === 1
+    && config.mode === 'polling-only'
+    && config.webSocketUrl === undefined
+    && config.protocolVersion === 1
+    && config.retryPolicy.baseDelayMs === 500
+    && config.retryPolicy.maxDelayMs === 30_000
+}
+
+function configVersionFor(
+  config: ResolvedOverlayRealtimePublicConfig
+): string {
+  if (isLegacyPollingOnlyConfig(config)) return 'polling-only-v1'
+  const fingerprint = fingerprintPublicConfig(
+    serializeOverlayRealtimePublicConfig(config)
+  )
+  return `${config.mode}-v2-${fingerprint}`
+}
+
+/**
  * Resolve whether Durable Objects are the primary transport for this streamer.
  *
  * A missing/invalid `OVERLAY_REALTIME_WS_URL` degrades to polling even when the
@@ -43,13 +161,7 @@ function websocketBaseUrl(): string | null {
  * a reachable socket URL would strand it on the slow reconnect path.
  */
 export function resolveOverlayRealtimeEnabled(streamerId: string): boolean {
-  return (
-    isOverlayRealtimeStreamerEnabled(
-      process.env.OVERLAY_REALTIME_MODE,
-      process.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST,
-      streamerId
-    ) && websocketBaseUrl() !== null
-  )
+  return resolveOverlayRealtimePublicConfig(streamerId).mode === 'do-primary'
 }
 
 /**
@@ -62,34 +174,19 @@ export function resolveOverlayRealtimeEnabled(streamerId: string): boolean {
  * no secret material.
  */
 export function resolveOverlayRealtimeConfigVersion(streamerId: string): string {
-  return resolveOverlayRealtimeEnabled(streamerId)
-    ? 'do-primary-v1'
-    : 'polling-only-v1'
+  return configVersionFor(resolveOverlayRealtimePublicConfig(streamerId))
 }
 
 /** Full public runtime configuration for an OBS browser source. */
 export function resolveOverlayRealtimeConfig(
   streamerId: string
 ): OverlayRealtimeConfigV1 {
-  const baseUrl = websocketBaseUrl()
-  const doEnabled =
-    isOverlayRealtimeStreamerEnabled(
-      process.env.OVERLAY_REALTIME_MODE,
-      process.env.OVERLAY_REALTIME_STREAMER_ALLOWLIST,
-      streamerId
-    ) && baseUrl !== null
+  const config = resolveOverlayRealtimePublicConfig(streamerId)
 
   return {
-    schemaVersion: 1,
-    mode: doEnabled ? 'do-primary' : 'polling-only',
-    ...(doEnabled ? { webSocketUrl: baseUrl } : {}),
-    protocolVersion: OVERLAY_REALTIME_PROTOCOL_VERSION,
-    retryPolicy: {
-      baseDelayMs: 500,
-      maxDelayMs: 30_000,
-    },
+    ...config,
     // Changes with the effective public config and is deliberately free of
     // secret material. Clients use it for rollout/rollback detection.
-    configVersion: doEnabled ? 'do-primary-v1' : 'polling-only-v1',
+    configVersion: configVersionFor(config),
   }
 }

--- a/src/lib/overlay-realtime/resolve-config.ts
+++ b/src/lib/overlay-realtime/resolve-config.ts
@@ -55,9 +55,10 @@ export function resolveOverlayRealtimeEnabled(streamerId: string): boolean {
 /**
  * Public config version for a streamer.
  *
- * This is the value the events endpoint echoes so a connected overlay can
- * notice a rollout/rollback without polling the config endpoint on its own
- * timer. It is derived from the same predicate as the full config and contains
+ * This is the value the events endpoint echoes so polling-only/disconnected
+ * overlays notice a transport rollout without a second request. Connected
+ * overlays use the room notice plus the infrequent history reconciliation.
+ * The value is derived from the same predicate as the full config and contains
  * no secret material.
  */
 export function resolveOverlayRealtimeConfigVersion(streamerId: string): string {

--- a/src/lib/overlay-version.ts
+++ b/src/lib/overlay-version.ts
@@ -14,6 +14,9 @@
  * - location.reload() の実行
  */
 
+import { isValidOverlayHistoryId } from "@/lib/overlay-realtime/contract";
+import { normalizeOverlayHistoryTimestamp } from "@/lib/overlay-history-cursor";
+
 /** sessionStorage に保存するクールダウン記録(直前にリロードしたバージョンと時刻)の型 */
 export interface ReloadCooldownRecord {
   version: string;
@@ -23,6 +26,8 @@ export interface ReloadCooldownRecord {
 /** sessionStorage に退避するポーリング状態のスナップショット */
 export interface OverlayPollStateSnapshot {
   pollCursor: string;
+  /** Tie-breaker for rows that share the exact same redeemed_at value. */
+  pollHistoryId: string;
   seenHistoryIds: string[];
   savedAt: number;
 }
@@ -128,11 +133,15 @@ export function parseReloadCooldownRecord(
  */
 export function serializePollState(state: {
   pollCursor: string;
+  pollHistoryId?: string;
   seenHistoryIds: string[];
   savedAt: number;
 }): string {
   const snapshot: OverlayPollStateSnapshot = {
     pollCursor: state.pollCursor,
+    // Optional input keeps snapshots produced by the previous page contract
+    // readable while every new writer persists the exact DB tie-breaker.
+    pollHistoryId: state.pollHistoryId ?? "",
     seenHistoryIds: state.seenHistoryIds.slice(-MAX_PERSISTED_HISTORY_IDS),
     savedAt: state.savedAt,
   };
@@ -145,8 +154,8 @@ export function serializePollState(state: {
  * 扱う:
  * - raw が null/undefined/空文字列
  * - JSON として parse できない(壊れたデータ)
- * - 期待する形状(pollCursor: string, seenHistoryIds: string[], savedAt: number)
- *   を満たさない
+ * - 期待する形状(pollCursor: string, optional pollHistoryId: string,
+ *   seenHistoryIds: string[], savedAt: number)を満たさない
  * - pollCursor が日付として解釈できない(Date.parse が NaN)
  * - savedAt から now までの経過が ttlMs を超えている(TTL切れ)
  *
@@ -171,16 +180,20 @@ export function parsePollState(
   if (!parsed || typeof parsed !== "object") return null;
   const candidate = parsed as Record<string, unknown>;
 
-  if (typeof candidate.pollCursor !== "string") return null;
+  const normalizedPollCursor = normalizeOverlayHistoryTimestamp(candidate.pollCursor);
+  if (!normalizedPollCursor) return null;
+  if (
+    candidate.pollHistoryId !== undefined
+    && (
+      typeof candidate.pollHistoryId !== "string"
+      || (
+        candidate.pollHistoryId !== ""
+        && !isValidOverlayHistoryId(candidate.pollHistoryId)
+      )
+    )
+  ) return null;
   if (typeof candidate.savedAt !== "number") return null;
   if (!Array.isArray(candidate.seenHistoryIds)) return null;
-
-  // pollCursor は復元後そのまま次回ポーリングの ?since= としてサーバへ送られ、
-  // API 側(normalizeDateParam)は日付として解釈できない since を 400 で拒否する。
-  // 壊れた/外部から書き換えられた sessionStorage から不正な pollCursor を復元して
-  // しまうと以後のポーリングが全て 400 で失敗し続けるため、日付として解釈できない
-  // カーソルはここで捨てて「復元しない(今を起点に再開)」へ安全に倒す。
-  if (!Number.isFinite(Date.parse(candidate.pollCursor))) return null;
 
   if (now - candidate.savedAt > ttlMs) return null;
 
@@ -189,5 +202,16 @@ export function parsePollState(
     (id): id is string => typeof id === "string",
   );
 
-  return { pollCursor: candidate.pollCursor, seenHistoryIds, savedAt: candidate.savedAt };
+  return {
+    pollCursor: normalizedPollCursor,
+    // Old builds wrote timestamp-only snapshots. Preserve compatibility with
+    // an empty tie-breaker; page.tsx rewinds that legacy timestamp slightly so
+    // equal-time rows are re-read and deduped instead of skipped.
+    pollHistoryId:
+      typeof candidate.pollHistoryId === "string"
+        ? candidate.pollHistoryId
+        : "",
+    seenHistoryIds,
+    savedAt: candidate.savedAt,
+  };
 }

--- a/src/lib/overlay/demo-event-store.ts
+++ b/src/lib/overlay/demo-event-store.ts
@@ -2,7 +2,18 @@ import type { Card } from '@/types/database'
 
 const KV_BINDING_NAME = 'RATE_LIMIT_KV'
 const KEY_PREFIX = 'overlay:demo:'
-const DEMO_EVENT_TTL_SECONDS = 2 * 60
+// A healthy overlay performs a full HTTP reconciliation every 10 minutes, and
+// realtime liveness detection plus bounded reconnect retries can consume a
+// further 150 seconds before that fallback is consulted. Fifteen minutes is
+// deliberately longer than that 750-second recovery window, leaving another
+// 150 seconds for timer jitter and KV edge propagation, while still bounding
+// storage to one latest-value record per streamer instead of retaining demos.
+const DEMO_EVENT_TTL_SECONDS = 15 * 60
+
+type OverlayDemoCard = Pick<
+  Card,
+  'id' | 'name' | 'description' | 'image_url' | 'image_padding_color' | 'rarity'
+>
 
 interface KVNamespaceLike {
   put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>
@@ -10,12 +21,12 @@ interface KVNamespaceLike {
 }
 
 export interface OverlayDemoEvent {
-  id: string
-  eventId: string
-  redeemedAt: string
-  userTwitchUsername: string
-  rewardId: null
-  card: Pick<Card, 'id' | 'name' | 'description' | 'image_url' | 'image_padding_color' | 'rarity'>
+  readonly id: string
+  readonly eventId: string
+  readonly redeemedAt: string
+  readonly userTwitchUsername: string
+  readonly rewardId: null
+  readonly card: Readonly<OverlayDemoCard>
 }
 
 interface MemoryRecord {
@@ -51,6 +62,18 @@ async function getKvBinding(): Promise<KVNamespaceLike | null> {
   }
 }
 
+/**
+ * Freeze both levels of the transport value so KV serialization and realtime
+ * fanout cannot observe different card fields if a caller accidentally mutates
+ * its object after either asynchronous delivery has started.
+ */
+function freezeOverlayDemoEvent(event: OverlayDemoEvent): OverlayDemoEvent {
+  return Object.freeze({
+    ...event,
+    card: Object.freeze({ ...event.card }),
+  })
+}
+
 function parseEvent(value: string | null): OverlayDemoEvent | null {
   if (!value) return null
   try {
@@ -67,7 +90,7 @@ function parseEvent(value: string | null): OverlayDemoEvent | null {
     ) {
       return null
     }
-    return {
+    return freezeOverlayDemoEvent({
       id: parsed.id,
       eventId: parsed.eventId,
       redeemedAt: parsed.redeemedAt,
@@ -81,26 +104,20 @@ function parseEvent(value: string | null): OverlayDemoEvent | null {
         image_padding_color: parsed.card.image_padding_color ?? null,
         rarity: parsed.card.rarity,
       },
-    }
+    })
   } catch {
     return null
   }
 }
 
 /**
- * Publish the latest OBS demo for a streamer.
- *
- * One latest-value key per streamer is intentional: OBS demo is an operator UI
- * action, not an auditable business event. It avoids unbounded key creation and
- * preserves all real gacha history exclusively in PostgreSQL. The existing
- * endpoint rate limit prevents abusive overwrite loops.
+ * Create the single immutable value shared by fallback and realtime delivery.
+ * Identity and timestamp are sampled exactly once so both transports can be
+ * deduplicated and reconciled as representations of the same operator action.
  */
-export async function publishOverlayDemoEvent(
-  streamerId: string,
-  card: Pick<Card, 'id' | 'name' | 'description' | 'image_url' | 'image_padding_color' | 'rarity'>
-): Promise<OverlayDemoEvent> {
+export function createOverlayDemoEvent(card: OverlayDemoCard): OverlayDemoEvent {
   const id = `demo:${crypto.randomUUID()}`
-  const event: OverlayDemoEvent = {
+  return freezeOverlayDemoEvent({
     id,
     eventId: id,
     redeemedAt: new Date().toISOString(),
@@ -114,8 +131,21 @@ export async function publishOverlayDemoEvent(
       image_padding_color: card.image_padding_color ?? null,
       rarity: card.rarity,
     },
-  }
+  })
+}
 
+/**
+ * Store an already-created OBS demo as the streamer's bounded fallback.
+ *
+ * One latest-value key per streamer is intentional: OBS demo is an operator UI
+ * action, not an auditable business event. It avoids unbounded key creation and
+ * preserves all real gacha history exclusively in PostgreSQL. The existing
+ * endpoint rate limit prevents abusive overwrite loops.
+ */
+export async function storeOverlayDemoEvent(
+  streamerId: string,
+  event: OverlayDemoEvent
+): Promise<void> {
   const kv = await getKvBinding()
   if (kv) {
     await kv.put(buildKey(streamerId), JSON.stringify(event), {
@@ -131,7 +161,18 @@ export async function publishOverlayDemoEvent(
       expiresAt: Date.now() + DEMO_EVENT_TTL_SECONDS * 1000,
     })
   }
+}
 
+/**
+ * Backward-compatible convenience API for callers that still expect creation
+ * and fallback persistence to be one operation.
+ */
+export async function publishOverlayDemoEvent(
+  streamerId: string,
+  card: OverlayDemoCard
+): Promise<OverlayDemoEvent> {
+  const event = createOverlayDemoEvent(card)
+  await storeOverlayDemoEvent(streamerId, event)
   return event
 }
 

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -2,9 +2,11 @@
  * Overlay transport compatibility facade
  *
  * Durable Objects WebSocket is the low-latency primary when runtime config
- * enables it. PlanetScale-backed HTTP polling always runs as the durable gap
- * recovery path, so a DO outage or a stale OBS browser source cannot lose a
- * committed gacha result. No Supabase URL, key, SDK, or channel is used here.
+ * enables it. PlanetScale-backed HTTP polling runs while disconnected and for
+ * explicit reconnect/sequence-gap recovery. A ten-minute reconciliation also
+ * covers the gapless failure case where a committed row could not be published
+ * to the room at all; pushed events never advance that durable DB checkpoint.
+ * No Supabase URL, key, SDK, or channel is used.
  */
 
 import {
@@ -15,8 +17,11 @@ import {
   type GachaRealtimeEventV1,
   type OverlayRealtimeConfigV1,
   type OverlayRealtimeServerMessage,
+  isValidOverlayHistoryId,
+  isValidOverlayVersion,
   validateGachaRealtimeEvent,
 } from '@/lib/overlay-realtime/contract'
+import { normalizeOverlayHistoryTimestamp } from '@/lib/overlay-history-cursor'
 
 export interface GachaBroadcastPayload {
   type: 'gacha'
@@ -39,8 +44,9 @@ export interface GachaBroadcastPayload {
   /** Stable batch key used to suppress duplicate sound across recovery pages. */
   soundGroupId?: string
   /**
-   * Last authoritative history timestamp included in this payload.
-   * Demo events omit it and therefore never advance the business cursor.
+   * Event timestamp retained for callback compatibility and diagnostics.
+   * Cursor ownership remains inside the controller; callers must not treat a
+   * pushed timestamp as proof that all earlier DB rows reached the room.
    */
   historyCursor?: string
 }
@@ -61,7 +67,8 @@ interface PollingEvent {
   card: GachaBroadcastPayload['card']
 }
 
-interface PollingCursor {
+/** Exact PlanetScale history position used across reload/reconnect recovery. */
+export interface OverlayHistoryCursor {
   redeemedAt: string
   historyId: string
 }
@@ -69,15 +76,16 @@ interface PollingCursor {
 interface PollingResponse {
   events?: PollingEvent[]
   realtimeEvents?: GachaRealtimeEventV1[]
-  nextCursor?: PollingCursor | null
+  nextCursor?: OverlayHistoryCursor | null
   demoEvent?: PollingEvent | null
+  /** App build echoed by `/events`; optional for rolling compatibility. */
+  overlayVersion?: unknown
   /**
    * Effective overlay transport version, echoed by the events endpoint so a
-   * connected overlay notices a rollout/rollback without polling the config
-   * endpoint on its own timer. Optional so an overlay served by an older
-   * deployment keeps working unchanged.
+   * polling-only overlay notices a rollout without a second HTTP request.
+   * Optional so an overlay served by an older deployment keeps working.
    */
-  realtimeConfigVersion?: string
+  realtimeConfigVersion?: unknown
 }
 
 /**
@@ -102,17 +110,32 @@ export interface SubscribeOptions {
   onError?: (error: RealtimeError) => void
   onSuccess?: () => void
   onStatusChange?: (status: string) => void
+  /** Restores the exact DB position saved immediately before an overlay reload. */
+  initialHistoryCursor?: OverlayHistoryCursor
+  /** Reports each DB-confirmed cursor advance for persistence before reload. */
+  onHistoryCursor?: (cursor: OverlayHistoryCursor) => void
+  /** Receives a validated app build from either config or history recovery. */
+  onOverlayVersion?: (overlayVersion: string) => void
 }
 
-const MAX_SEEN_EVENT_IDS = 512
+// The reconciliation checkpoint intentionally trails live socket delivery.
+// Retain enough IDs across a reload for large N-draw bursts, and trigger an
+// early DB pass well before this bounded storage window can roll over.
+const MAX_SEEN_EVENT_IDS = 8_192
+const SOCKET_RECONCILIATION_TRIGGER_IDS = 512
+// Every validated event is at most 64 KiB. Thirty-two buffered envelopes cap a
+// recovery-order window at roughly 2 MiB before liveness takes precedence.
+const MAX_BUFFERED_SOCKET_EVENTS = 32
+const SOCKET_RECOVERY_BUFFER_MAX_MS = 10_000
 const SEEN_EVENT_TTL_MS = 24 * 60 * 60 * 1000
 /**
- * Safety net only. Rollout/rollback is normally noticed through the
- * `realtimeConfigVersion` echoed by the events endpoint on a request the
- * overlay already makes, so this timer exists purely for the case where
- * history polling itself is broken and can no longer carry the signal.
+ * Reconciliation cadence for a healthy DO connection. Ten minutes reduces the
+ * old fixed history traffic while preserving eventual delivery when the
+ * post-commit room publish fails before the room can assign a sequence number.
+ * The same `/events` response carries config/build versions, so this single
+ * request replaces a separate steady-state config refresh.
  */
-const CONFIG_SAFETY_REFRESH_MS = 5 * 60_000
+const CONNECTED_RECONCILIATION_MS = 10 * 60_000
 /**
  * Upper bound on how long DO reconnects stay suppressed after the room
  * reports itself disabled (see `disabledForConfigVersion` below).
@@ -120,22 +143,13 @@ const CONFIG_SAFETY_REFRESH_MS = 5 * 60_000
  * The suppression normally clears when the config endpoint returns a
  * different `configVersion`, but the app Worker's allowlist can be a
  * wildcard (`*`) that never changes per-streamer, in which case the operator
- * flipping the room-side allowlist back produces no new `configVersion` at
- * all — the client would otherwise stay on polling forever until reloaded
- * (issue #844). Reusing `CONFIG_SAFETY_REFRESH_MS` as the TTL means the
- * bounded retry piggybacks on the safety-net timer that already exists
- * instead of introducing a second one.
- *
- * This reuse is tighter than "share a number": the only thing that re-checks
- * the TTL is `refreshConfig()`, and while suppressed the only thing that
- * calls `refreshConfig()` on a timer is `configTimer`, armed for exactly
- * `CONFIG_SAFETY_REFRESH_MS` in its own `finally` block. Changing
- * SUPPRESSION_TTL_MS alone (e.g. to shorten it) would not shorten the actual
- * wait, because the next `refreshConfig()` call — the only place that reads
- * this constant — still would not happen until the unchanged safety timer
- * fires. Change both together, or give the suppression its own timer.
+ * flipping the room-side allowlist back produces no new `configVersion` at all
+ * — the client would otherwise stay on polling until reloaded (issue #844).
+ * This operational recovery TTL is intentionally independent from the normal
+ * ten-minute reconciliation cadence: while suppression is active the same timer
+ * is scheduled for this shorter five-minute interval.
  */
-const SUPPRESSION_TTL_MS = CONFIG_SAFETY_REFRESH_MS
+const DO_SUPPRESSION_TTL_MS = 5 * 60_000
 /**
  * Straight WS-open failures (never reached `onopen`) before falling back to
  * the slow TTL-gated retry instead of `scheduleReconnect`'s normal
@@ -158,6 +172,10 @@ const TRANSPORT_DISABLED_NOTICE = OVERLAY_REALTIME_TRANSPORT_DISABLED
  * change to be picked up on the first pass that observes it.
  */
 const CONFIG_CHANGE_REFETCH_FLOOR_MS = 30_000
+const MAX_CONFIG_VERSION_LENGTH = 128
+const MAX_CONFIG_URL_LENGTH = 2_048
+const MIN_CONFIG_RETRY_DELAY_MS = 100
+const MAX_CONFIG_RETRY_DELAY_MS = 5 * 60_000
 const WS_CONNECT_TIMEOUT_MS = 10_000
 /**
  * How long a healthy socket may stay silent before the client gives up on it.
@@ -167,16 +185,16 @@ const WS_CONNECT_TIMEOUT_MS = 10_000
  * but delivering nothing. Two intervals of slack keeps a single delayed wake or
  * a brief network stall from churning connections.
  *
- * This replaces the fixed 30-second history poll. A connected overlay now makes
- * no periodic HTTP request at all; it reloads history only when it reconnects
- * or when a sequence gap proves it missed a delivery.
+ * This replaces using a frequent history poll as a liveness check. A connected
+ * overlay reconciles only every ten minutes; heartbeats detect a half-open
+ * socket quickly instead of waiting for that low-frequency DB pass.
  */
 const SOCKET_LIVENESS_TIMEOUT_MS = OVERLAY_REALTIME_HEARTBEAT_MS * 2.5
 
 function eventUrl(
   streamerId: string,
-  cursor: PollingCursor,
-  demoCursor: PollingCursor
+  cursor: OverlayHistoryCursor,
+  demoCursor: OverlayHistoryCursor
 ): string {
   const url = new URL(`/api/overlay/${streamerId}/events`, window.location.origin)
   url.searchParams.set('since', cursor.redeemedAt)
@@ -260,7 +278,9 @@ function loadSeenEvents(streamerId: string): Map<string, number> {
     const raw = sessionStorage.getItem(seenStorageKey(streamerId))
     const records = raw ? JSON.parse(raw) as Array<[string, number]> : []
     const cutoff = Date.now() - SEEN_EVENT_TTL_MS
-    for (const [eventId, firstSeenAt] of records) {
+    // sessionStorage is not a trusted boundary. Bound work before iterating so
+    // a corrupted oversized array cannot turn an OBS reload into a CPU spike.
+    for (const [eventId, firstSeenAt] of records.slice(-MAX_SEEN_EVENT_IDS)) {
       if (typeof eventId === 'string' && Number.isFinite(firstSeenAt) && firstSeenAt >= cutoff) {
         seen.set(eventId, firstSeenAt)
       }
@@ -294,16 +314,83 @@ function rememberSeenId(seen: Map<string, number>, id: string): boolean {
   return true
 }
 
+function isBoundedConfigString(value: unknown, maxLength: number): value is string {
+  return typeof value === 'string'
+    && value.length > 0
+    && value.length <= maxLength
+    && value.trim() === value
+}
+
+function normalizeHistoryCursor(
+  value: unknown,
+  requireHistoryId = false
+): OverlayHistoryCursor | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null
+  const cursor = value as Record<string, unknown>
+  const redeemedAt = normalizeOverlayHistoryTimestamp(cursor.redeemedAt)
+  if (!redeemedAt || typeof cursor.historyId !== 'string') return null
+  if (cursor.historyId === '') {
+    return requireHistoryId ? null : { redeemedAt, historyId: '' }
+  }
+  return isValidOverlayHistoryId(cursor.historyId)
+    ? { redeemedAt, historyId: cursor.historyId }
+    : null
+}
+
+function isValidConfigWebSocketUrl(value: unknown): value is string {
+  if (!isBoundedConfigString(value, MAX_CONFIG_URL_LENGTH)) return false
+  try {
+    const url = new URL(value)
+    return (url.protocol === 'https:' || url.protocol === 'wss:' || url.protocol === 'ws:')
+      && url.username === ''
+      && url.password === ''
+  } catch {
+    return false
+  }
+}
+
 function validConfig(value: unknown): value is OverlayRealtimeConfigV1 {
-  if (!value || typeof value !== 'object') return false
-  const config = value as Partial<OverlayRealtimeConfigV1>
-  return config.schemaVersion === 1
-    && (config.mode === 'polling-only' || config.mode === 'do-primary')
-    && config.protocolVersion === OVERLAY_REALTIME_PROTOCOL_VERSION
-    && typeof config.retryPolicy?.baseDelayMs === 'number'
-    && typeof config.retryPolicy?.maxDelayMs === 'number'
-    && typeof config.configVersion === 'string'
-    && (config.mode !== 'do-primary' || typeof config.webSocketUrl === 'string')
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const config = value as Record<string, unknown>
+  if (
+    config.schemaVersion !== 1
+    || (config.mode !== 'polling-only' && config.mode !== 'do-primary')
+    || config.protocolVersion !== OVERLAY_REALTIME_PROTOCOL_VERSION
+    || !isBoundedConfigString(config.configVersion, MAX_CONFIG_VERSION_LENGTH)
+    || !config.retryPolicy
+    || typeof config.retryPolicy !== 'object'
+    || Array.isArray(config.retryPolicy)
+  ) {
+    return false
+  }
+
+  const retryPolicy = config.retryPolicy as Record<string, unknown>
+  const baseDelayMs = retryPolicy.baseDelayMs
+  const maxDelayMs = retryPolicy.maxDelayMs
+  if (
+    typeof baseDelayMs !== 'number'
+    || typeof maxDelayMs !== 'number'
+    || !Number.isInteger(baseDelayMs)
+    || !Number.isInteger(maxDelayMs)
+    || baseDelayMs < MIN_CONFIG_RETRY_DELAY_MS
+    || maxDelayMs < baseDelayMs
+    || maxDelayMs > MAX_CONFIG_RETRY_DELAY_MS
+  ) {
+    return false
+  }
+
+  if (
+    config.webSocketUrl !== undefined
+    && !isValidConfigWebSocketUrl(config.webSocketUrl)
+  ) {
+    return false
+  }
+  if (config.mode === 'do-primary' && config.webSocketUrl === undefined) {
+    return false
+  }
+
+  return config.overlayVersion === undefined
+    || isValidOverlayVersion(config.overlayVersion)
 }
 
 function websocketUrl(baseUrl: string, streamerId: string): string | null {
@@ -338,14 +425,33 @@ export function subscribeToGachaResults(
   let disposed = false
   let retryCount = 0
   let pollTimer: ReturnType<typeof setTimeout> | null = null
-  let configTimer: ReturnType<typeof setTimeout> | null = null
+  let safetyTimer: ReturnType<typeof setTimeout> | null = null
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null
   let connectTimeout: ReturnType<typeof setTimeout> | null = null
   let socket: WebSocket | null = null
   let socketGeneration = 0
   let reconnectAttempt = 0
   let pollInFlight = false
+  // Recovery requests can arrive while an earlier history snapshot is still
+  // in flight (most notably WebSocket onopen racing startup polling). Remember
+  // that edge instead of dropping it; one trailing empty-page read closes the
+  // commit window between the two snapshots.
+  let recoveryPollPending = false
+  // While a socket recovery is draining DB history, hold pushed frames so the
+  // authoritative `(redeemed_at, id)` order is displayed before the live tail.
+  let socketRecoveryActive = false
+  let bufferedSocketEvents: GachaRealtimeEventV1[] = []
+  let recoveryBufferTimer: ReturnType<typeof setTimeout> | null = null
+  // IDs delivered by DO but not yet observed in a DB response. This separate
+  // set prevents bounded general dedupe eviction from cascading into hundreds
+  // of duplicate renders while a multi-page reconciliation drains.
+  const unreconciledSocketEventIds = new Set<string>()
+  let highVolumeRecoveryRequested = false
   let currentConfig: OverlayRealtimeConfigV1 | null = null
+  // A present value followed by an absent value means this new client reached
+  // an older app Worker during rollback. One legacy `/events` probe preserves
+  // build-version rollback detection without a steady-state DB poll.
+  let configPreviouslyCarriedOverlayVersion = false
   /** Guards the change-triggered refetch against a config endpoint outage. */
   let lastConfigAttemptAt = 0
   let configRefreshInFlight = false
@@ -365,8 +471,8 @@ export function subscribeToGachaResults(
    * `do-primary` sends the client into a reconnect-with-backoff loop against
    * an endpoint that answers 503 — observed in preview during the kill-switch
    * test. Reconnecting is allowed again as soon as the operator publishes a
-   * different config, or after SUPPRESSION_TTL_MS regardless of config
-   * version — see SUPPRESSION_TTL_MS for why the version alone is not enough.
+   * different config, or after DO_SUPPRESSION_TTL_MS regardless of config
+   * version — see DO_SUPPRESSION_TTL_MS for why version alone is not enough.
    */
   let disabledForConfigVersion: string | null = null
   let disabledAt = 0
@@ -378,7 +484,7 @@ export function subscribeToGachaResults(
    * produces the exact same `onerror` + `onclose(1006)` the browser fires for
    * an ordinary transient drop; there is no way to tell them apart from the
    * close event alone. Without this counter, a room disabled for longer than
-   * SUPPRESSION_TTL_MS reconnects every ~15-30s indefinitely via the normal
+   * DO_SUPPRESSION_TTL_MS reconnects every ~15-30s indefinitely via the normal
    * exponential-backoff path in `scheduleReconnect` (this reoccurrence of the
    * loop ec6852f fixed was found in review, not in the preview test — the
    * preview run happened to have the room re-enabled before the gap showed).
@@ -387,23 +493,63 @@ export function subscribeToGachaResults(
    * TTL-gated retry instead of hammering an endpoint that keeps 503ing.
    */
   let consecutiveOpenFailures = 0
-  let historyCursor: PollingCursor = {
-    redeemedAt: new Date().toISOString(),
+  const startedAt = new Date().toISOString()
+  const restoredHistoryCursor = normalizeHistoryCursor(options.initialHistoryCursor)
+  let historyCursor: OverlayHistoryCursor = restoredHistoryCursor
+    ?? { redeemedAt: startedAt, historyId: '' }
+  // Demo delivery is independent from committed history. Restoring an old
+  // business cursor here would replay old operator demos after a build reload.
+  let demoCursor: OverlayHistoryCursor = {
+    redeemedAt: startedAt,
     historyId: '',
   }
-  let demoCursor: PollingCursor = { ...historyCursor }
 
-  const ingest = (event: GachaRealtimeEventV1, source: 'durable-object' | 'polling') => {
+  const reportHistoryCursor = (cursor: OverlayHistoryCursor) => {
+    historyCursor = { ...cursor }
+    options.onHistoryCursor?.({ ...historyCursor })
+  }
+
+  const ingest = (
+    event: GachaRealtimeEventV1,
+    source: 'durable-object' | 'polling'
+  ): 'invalid' | 'duplicate' | 'delivered' => {
     const validation = validateGachaRealtimeEvent(event, streamerId)
     if (!validation.ok) {
       options.onStatusChange?.(`INVALID_EVENT:${source}`)
-      return
+      return 'invalid'
     }
 
-    const unseenDraws = event.draws.filter((draw) => rememberSeenId(seenEventIds, draw.eventId))
+    const unseenDraws = event.draws.filter((draw) => {
+      // Seeing the exact ID in a polling envelope proves that this socket
+      // delivery is now behind the authoritative DB checkpoint. Treat it as a
+      // duplicate even if the general bounded cache has already evicted it.
+      const confirmedSocketDelivery = source === 'polling'
+        && unreconciledSocketEventIds.delete(draw.eventId)
+      if (confirmedSocketDelivery || seenEventIds.has(draw.eventId)) return false
+      if (!rememberSeenId(seenEventIds, draw.eventId)) return false
+
+      if (source === 'durable-object') {
+        unreconciledSocketEventIds.add(draw.eventId)
+        if (unreconciledSocketEventIds.size > MAX_SEEN_EVENT_IDS) {
+          // A sustained DB outage must not grow OBS memory without bound. This
+          // extreme degradation can replay an oldest draw after DB recovery,
+          // but never advances the checkpoint or loses an unseen committed row.
+          const oldest = unreconciledSocketEventIds.values().next().value
+          if (typeof oldest === 'string') unreconciledSocketEventIds.delete(oldest)
+          options.onStatusChange?.('DO_DEDUPE_WINDOW_TRUNCATED')
+        }
+      }
+      return true
+    })
+    if (
+      source === 'polling'
+      && unreconciledSocketEventIds.size < SOCKET_RECONCILIATION_TRIGGER_IDS
+    ) {
+      highVolumeRecoveryRequested = false
+    }
     if (unseenDraws.length === 0) {
       options.onStatusChange?.(`DUPLICATE_EVENT:${source}`)
-      return
+      return 'duplicate'
     }
     persistSeenEvents(streamerId, seenEventIds)
     callback({
@@ -415,17 +561,97 @@ export function subscribeToGachaResults(
       soundGroupId: event.soundGroupId,
       historyCursor: event.occurredAt,
     })
+    return 'delivered'
   }
+
+  const socketIsHealthy = () => (
+    currentConfig?.mode === 'do-primary'
+    && typeof WebSocket !== 'undefined'
+    && socket?.readyState === WebSocket.OPEN
+  )
 
   const schedulePoll = (delay: number) => {
     if (disposed) return
-    pollTimer = setTimeout(() => void poll(), delay)
+    if (pollTimer) clearTimeout(pollTimer)
+    pollTimer = setTimeout(() => {
+      pollTimer = null
+      void poll()
+    }, delay)
+  }
+
+  /**
+   * Request an authoritative history recovery without racing the one already
+   * running. `bufferLiveFrames` is used for startup/reconnect/gap boundaries:
+   * pushed events wait until DB pages have drained, preserving DB order.
+   */
+  const requestRecoveryPoll = (bufferLiveFrames = false) => {
+    if (disposed) return
+    if (bufferLiveFrames && !socketRecoveryActive) {
+      socketRecoveryActive = true
+      if (recoveryBufferTimer) clearTimeout(recoveryBufferTimer)
+      recoveryBufferTimer = setTimeout(() => {
+        releaseSocketRecoveryBuffer('timeout')
+      }, SOCKET_RECOVERY_BUFFER_MAX_MS)
+    }
+    if (pollInFlight) {
+      recoveryPollPending = true
+      return
+    }
+    schedulePoll(0)
+  }
+
+  function maybeRequestVolumeReconciliation(): void {
+    if (
+      disposed
+      || highVolumeRecoveryRequested
+      || unreconciledSocketEventIds.size < SOCKET_RECONCILIATION_TRIGGER_IDS
+    ) {
+      return
+    }
+    highVolumeRecoveryRequested = true
+    options.onStatusChange?.(
+      `DO_RECONCILE_VOLUME:${unreconciledSocketEventIds.size}`
+    )
+    requestRecoveryPoll()
+  }
+
+  function flushBufferedSocketEvents(): void {
+    const buffered = bufferedSocketEvents
+    bufferedSocketEvents = []
+    for (const event of buffered) {
+      // The authoritative reconciliation checkpoint advances only from an
+      // actual DB response. Even a newly delivered socket frame may have an
+      // earlier gapless publish failure behind it, so ingest it without moving
+      // the history cursor.
+      ingest(event, 'durable-object')
+    }
+    maybeRequestVolumeReconciliation()
+  }
+
+  function releaseSocketRecoveryBuffer(
+    degradedBy?: 'capacity' | 'timeout'
+  ): void {
+    if (recoveryBufferTimer) clearTimeout(recoveryBufferTimer)
+    recoveryBufferTimer = null
+    const hadRecovery = socketRecoveryActive || bufferedSocketEvents.length > 0
+    socketRecoveryActive = false
+    if (degradedBy && hadRecovery) {
+      options.onStatusChange?.(`DO_RECOVERY_DEGRADED:${degradedBy}`)
+    }
+    flushBufferedSocketEvents()
   }
 
   const poll = async () => {
-    if (disposed || pollInFlight) return
+    if (disposed) return
+    if (pollInFlight) {
+      recoveryPollPending = true
+      return
+    }
     pollInFlight = true
     options.onStatusChange?.('POLLING')
+    let historyPageHadRows = false
+    let failed = false
+    let retryDelayMs: number | null = null
     try {
       // History recovery and the rare operator demo share one HTTP response.
       // Keeping separate cursors in that response preserves the critical rule
@@ -434,6 +660,14 @@ export function subscribeToGachaResults(
       const historyResponse = await fetchJson<PollingResponse>(
         eventUrl(streamerId, historyCursor, demoCursor)
       )
+      if (disposed) return
+
+      // `/events` is an untrusted public boundary. Notify the page only after
+      // applying the same non-empty length bound as realtime-config; malformed
+      // optional metadata must not schedule a reload or break history recovery.
+      if (isValidOverlayVersion(historyResponse.overlayVersion)) {
+        options.onOverlayVersion?.(historyResponse.overlayVersion)
+      }
 
       const rawEvents = historyResponse.events ?? []
       const envelopes = historyResponse.realtimeEvents?.length
@@ -441,11 +675,31 @@ export function subscribeToGachaResults(
         : buildPollingRealtimeEvents(streamerId, rawEvents)
       for (const event of envelopes) ingest(event, 'polling')
 
-      if (historyResponse.nextCursor) {
-        historyCursor = historyResponse.nextCursor
+      if (historyResponse.nextCursor !== undefined && historyResponse.nextCursor !== null) {
+        const nextCursor = normalizeHistoryCursor(historyResponse.nextCursor, true)
+        if (!nextCursor) {
+          throw new Error('invalid history cursor')
+        }
+        reportHistoryCursor(nextCursor)
+        historyPageHadRows = true
       } else if (rawEvents.length > 0) {
         const last = rawEvents[rawEvents.length - 1]
-        historyCursor = { redeemedAt: last.redeemedAt, historyId: last.id }
+        const legacyCursor = normalizeHistoryCursor(
+          { redeemedAt: last.redeemedAt, historyId: last.id },
+          true
+        )
+        // Older app Workers omit `nextCursor`. Validate their last row with the
+        // same exact cursor contract before allowing it to become the next URL.
+        if (!legacyCursor) {
+          throw new Error('invalid legacy history cursor')
+        }
+        reportHistoryCursor(legacyCursor)
+        historyPageHadRows = true
+      } else if (envelopes.length > 0) {
+        // A V1 response with history but no exact cursor cannot be drained
+        // safely: retry rather than querying the same page forever or skipping
+        // rows that share a timestamp.
+        throw new Error('history response omitted next cursor')
       }
 
       const demoEvent = historyResponse.demoEvent ?? null
@@ -464,22 +718,12 @@ export function subscribeToGachaResults(
       }
 
       retryCount = 0
-      // A healthy socket schedules no further pass at all. History is reloaded
-      // only on reconnect (onopen polls immediately), on a sequence gap, or if
-      // the room stops proving liveness — so a connected overlay makes no
-      // periodic HTTP request. A room outage restores normal polling through
-      // onclose, which is also what the liveness deadline triggers.
-      const socketHealthy =
-        currentConfig?.mode === 'do-primary'
-        && typeof WebSocket !== 'undefined'
-        && socket?.readyState === WebSocket.OPEN
-      if (!socketHealthy) schedulePoll(intervalMs)
-
       // Rollout/rollback detection rides on this response instead of a separate
-      // config poll. refreshConfig() owns the socket and poll timers, so it is
-      // started after the next pass is scheduled and is allowed to override it.
+      // config poll. A refresh can itself request recovery; the pending flag is
+      // consumed in `finally` together with any onopen/gap request.
       maybeRefreshConfigFor(historyResponse.realtimeConfigVersion)
     } catch (error) {
+      failed = true
       retryCount += 1
       const exhausted = Number.isFinite(maxRetries) && retryCount > maxRetries
       if (exhausted) {
@@ -489,12 +733,41 @@ export function subscribeToGachaResults(
           error,
           isExpected: false,
         })
-        return
+      } else {
+        options.onStatusChange?.(`POLLING_RETRY:${retryCount}`)
+        retryDelayMs = Math.min(
+          intervalMs * 2 ** Math.max(0, retryCount - 1),
+          30_000
+        )
       }
-      options.onStatusChange?.(`POLLING_RETRY:${retryCount}`)
-      schedulePoll(Math.min(intervalMs * 2 ** Math.max(0, retryCount - 1), 30_000))
     } finally {
       pollInFlight = false
+      if (disposed) return
+
+      const trailingRecovery = recoveryPollPending
+      recoveryPollPending = false
+      if (failed) {
+        if (retryDelayMs !== null) schedulePoll(retryDelayMs)
+        return
+      }
+
+      // `nextCursor` means at least one DB row was read. Continue immediately
+      // until an empty page proves the 100-row API window has been drained.
+      // A request raised during the fetch likewise earns one trailing pass,
+      // closing the startup/reconnect snapshot race without concurrent reads.
+      if (historyPageHadRows || trailingRecovery) {
+        schedulePoll(0)
+        return
+      }
+
+      if (socketRecoveryActive) {
+        releaseSocketRecoveryBuffer()
+      }
+
+      // A healthy socket's low-frequency reconciliation is owned by the safety
+      // timer. Disconnected and polling-only modes retain the normal
+      // three-second cadence.
+      if (!socketIsHealthy()) schedulePoll(intervalMs)
     }
   }
 
@@ -518,8 +791,7 @@ export function subscribeToGachaResults(
         // Falling through to closeSocket still restores polling.
       }
       closeSocket()
-      if (pollTimer) clearTimeout(pollTimer)
-      schedulePoll(0)
+      requestRecoveryPoll()
       scheduleReconnect()
     }, SOCKET_LIVENESS_TIMEOUT_MS)
   }
@@ -592,9 +864,9 @@ export function subscribeToGachaResults(
           clientVersion: 'overlay-v1',
         }))
         // Immediate polling closes the gap between the previous socket's last
-        // frame and this connection becoming active.
-        if (pollTimer) clearTimeout(pollTimer)
-        schedulePoll(0)
+        // frame and this connection becoming active. If startup polling is
+        // still in flight, requestRecoveryPoll remembers a trailing snapshot.
+        requestRecoveryPoll(true)
       }
 
       nextSocket.onmessage = (message) => {
@@ -626,8 +898,7 @@ export function subscribeToGachaResults(
               disabledForConfigVersion = currentConfig?.configVersion ?? null
               disabledAt = Date.now()
               closeSocket()
-              if (pollTimer) clearTimeout(pollTimer)
-              schedulePoll(0)
+              requestRecoveryPoll()
               // Authoritative signal, so it bypasses the version-mismatch floor
               // instead of waiting for the next history pass to notice.
               void refreshConfig()
@@ -635,21 +906,47 @@ export function subscribeToGachaResults(
             return
           }
           if (parsed.type === 'gacha_result') {
+            // Validate before buffering, not only before display. Otherwise a
+            // malformed room frame could bypass the 64 KiB contract and make
+            // the count-bounded recovery queue consume unbounded memory.
+            const eventValidation = validateGachaRealtimeEvent(
+              parsed.event,
+              streamerId
+            )
+            if (!eventValidation.ok) {
+              options.onStatusChange?.('INVALID_EVENT:durable-object')
+              return
+            }
             // A jump proves this socket missed a delivery. That is the only
             // reason a healthy connection reloads history now that the fixed
             // 30-second pass is gone; the database still decides what was
             // actually missed, this only decides *when* to ask.
-            if (
+            const sequenceGap = (
               typeof parsed.seq === 'number'
               && lastSeq !== null
               && parsed.seq > lastSeq + 1
-            ) {
+            )
+            if (sequenceGap) {
               options.onStatusChange?.(`DO_SEQ_GAP:${lastSeq}->${parsed.seq}`)
-              if (pollTimer) clearTimeout(pollTimer)
-              schedulePoll(0)
+              requestRecoveryPoll(true)
             }
             if (typeof parsed.seq === 'number') lastSeq = parsed.seq
-            ingest(parsed.event, 'durable-object')
+            if (socketRecoveryActive) {
+              bufferedSocketEvents.push(parsed.event)
+              if (bufferedSocketEvents.length >= MAX_BUFFERED_SOCKET_EVENTS) {
+                // DB ordering is best-effort once the bounded recovery window
+                // fills. Release validated live events, retain their IDs for
+                // later DB dedupe, and keep the checkpoint unchanged.
+                releaseSocketRecoveryBuffer('capacity')
+              }
+              return
+            }
+            // A pushed event is low-latency delivery, not proof that every
+            // earlier committed row reached the room. Only `/events` may move
+            // the durable reconciliation checkpoint.
+            if (ingest(parsed.event, 'durable-object') === 'delivered') {
+              maybeRequestVolumeReconciliation()
+            }
           }
         } catch {
           options.onStatusChange?.('DO_MESSAGE_INVALID')
@@ -663,8 +960,7 @@ export function subscribeToGachaResults(
         if (disposed || generation !== socketGeneration) return
         socket = null
         options.onStatusChange?.(`DO_CLOSED:${event.code}`)
-        if (pollTimer) clearTimeout(pollTimer)
-        schedulePoll(0)
+        requestRecoveryPoll()
         // Policy/protocol violations require operator config correction. Keep
         // polling alive but avoid an infinite reconnect storm.
         if ([1002, 1003, 1008, 1009].includes(event.code)) return
@@ -689,7 +985,7 @@ export function subscribeToGachaResults(
         disabledForConfigVersion = currentConfig?.configVersion ?? null
         disabledAt = Date.now()
         // Anchors the TTL to this moment (mirrors the transport_disabled
-        // path): re-arms the safety timer for SUPPRESSION_TTL_MS from now
+        // path): re-arms the safety timer for DO_SUPPRESSION_TTL_MS from now
         // instead of leaving it on whatever schedule the last config fetch
         // happened to set.
         void refreshConfig()
@@ -700,22 +996,58 @@ export function subscribeToGachaResults(
     }
   }
 
-  const refreshConfig = async (expectedVersion?: string) => {
+  /**
+   * Re-arm the one steady-state timer without creating parallel config and
+   * history schedules. Healthy sockets reconcile history; suppressed or
+   * disconnected sockets refresh config so kill-switch recovery stays bounded.
+   */
+  function scheduleSafetyRefresh(delay: number): void {
+    if (disposed) return
+    if (safetyTimer) clearTimeout(safetyTimer)
+    safetyTimer = setTimeout(() => {
+      safetyTimer = null
+      if (disabledForConfigVersion === null && socketIsHealthy()) {
+        // Do not buffer healthy live delivery for a routine sweep. The DB
+        // checkpoint intentionally trails socket delivery, so dedupe can
+        // recover a gapless failed publish on this pass without skipping it.
+        requestRecoveryPoll()
+        scheduleSafetyRefresh(CONNECTED_RECONCILIATION_MS)
+        return
+      }
+      void refreshConfig()
+    }, delay)
+  }
+
+  async function refreshConfig(expectedVersion?: string): Promise<void> {
     if (disposed || configRefreshInFlight) return
     configRefreshInFlight = true
     lastConfigAttemptAt = Date.now()
     // A change-triggered refetch must not race the safety-net timer into two
     // concurrent config states; the timer is always re-armed in `finally`.
-    if (configTimer) clearTimeout(configTimer)
+    if (safetyTimer) clearTimeout(safetyTimer)
+    safetyTimer = null
     try {
       const config = await fetchJson<unknown>(
         configUrl(streamerId, expectedVersion),
         'default'
       )
       if (!validConfig(config)) throw new Error('invalid config')
+      if (disposed) return
       const previousMode = currentConfig?.mode
       const previousUrl = currentConfig?.webSocketUrl
       currentConfig = config
+      const needsLegacyVersionProbe =
+        configPreviouslyCarriedOverlayVersion
+        && config.overlayVersion === undefined
+      // Notify only for a successfully fetched and fully validated config.
+      // Safe fallback and malformed responses deliberately never carry a
+      // version signal that could schedule an unrelated page reload.
+      if (config.overlayVersion) {
+        configPreviouslyCarriedOverlayVersion = true
+        options.onOverlayVersion?.(config.overlayVersion)
+      } else if (needsLegacyVersionProbe) {
+        configPreviouslyCarriedOverlayVersion = false
+      }
       options.onStatusChange?.(`CONFIG:${config.mode}:${config.configVersion}`)
       if (
         previousMode !== config.mode
@@ -728,7 +1060,7 @@ export function subscribeToGachaResults(
       }
       // A new config supersedes whatever the room said about the old one.
       // The app Worker's allowlist can be a wildcard that never changes
-      // per-streamer, so also expire the suppression after SUPPRESSION_TTL_MS
+      // per-streamer, so also expire suppression after DO_SUPPRESSION_TTL_MS
       // regardless of config version — otherwise an operator flipping the
       // room-side allowlist back produces no signal this client can see
       // (issue #844) and it would stay on polling until reloaded.
@@ -736,7 +1068,7 @@ export function subscribeToGachaResults(
         disabledForConfigVersion !== null
         && (
           config.configVersion !== disabledForConfigVersion
-          || Date.now() - disabledAt >= SUPPRESSION_TTL_MS
+          || Date.now() - disabledAt >= DO_SUPPRESSION_TTL_MS
         )
       ) {
         disabledForConfigVersion = null
@@ -749,8 +1081,7 @@ export function subscribeToGachaResults(
           // committed event — rather than retrying a socket the server has
           // already said it will not serve.
           options.onStatusChange?.('DO_SUPPRESSED:room_disabled')
-          if (pollTimer) clearTimeout(pollTimer)
-          schedulePoll(0)
+          requestRecoveryPoll()
         } else if (
           previousMode !== config.mode
           || previousUrl !== config.webSocketUrl
@@ -761,9 +1092,16 @@ export function subscribeToGachaResults(
       } else {
         closeSocket()
         if (previousMode === 'do-primary') {
-          if (pollTimer) clearTimeout(pollTimer)
-          schedulePoll(0)
+          requestRecoveryPoll()
         }
+      }
+
+      // A new client can outlive an app-Worker rollback. Older config routes
+      // legitimately omit overlayVersion, while their `/events` response still
+      // carries it. Probe once on the present->absent capability transition;
+      // steady modern deployments use the ten-minute history reconciliation.
+      if (needsLegacyVersionProbe && socketIsHealthy()) {
+        requestRecoveryPoll(true)
       }
     } catch {
       const wasDoPrimary = currentConfig?.mode === 'do-primary'
@@ -776,17 +1114,19 @@ export function subscribeToGachaResults(
       }
       closeSocket()
       if (wasDoPrimary) {
-        if (pollTimer) clearTimeout(pollTimer)
-        schedulePoll(0)
+        requestRecoveryPoll()
       }
       options.onStatusChange?.('CONFIG_FALLBACK:POLLING_ONLY')
     } finally {
       configRefreshInFlight = false
       if (!disposed) {
-        configTimer = setTimeout(
-          () => void refreshConfig(),
-          CONFIG_SAFETY_REFRESH_MS
-        )
+        // A room refusal needs the five-minute recovery bound from #844. Once
+        // suppression clears, return to the lower-frequency reconciliation
+        // cadence instead of coupling these two operational controls again.
+        const nextRefreshMs = disabledForConfigVersion === null
+          ? CONNECTED_RECONCILIATION_MS
+          : DO_SUPPRESSION_TTL_MS
+        scheduleSafetyRefresh(nextRefreshMs)
       }
     }
   }
@@ -794,18 +1134,20 @@ export function subscribeToGachaResults(
   /**
    * Apply a config change that history polling reported.
    *
-   * The events endpoint echoes the effective config version on every pass the
-   * overlay already makes, so an operator flipping the allowlist is noticed
-   * without a dedicated 30-second config poll per overlay. Detection is
-   * therefore faster in polling-only mode (~3s) and unchanged while
-   * DO-connected (~30s), while removing roughly half of all overlay requests.
+   * The events endpoint echoes the effective config version on every pass a
+   * polling-only or disconnected overlay already makes. A healthy DO socket
+   * also performs one reconciliation pass every ten minutes, while its room
+   * notice handles an urgent disable without waiting for that cadence.
    *
    * The floor keeps a config endpoint outage from turning every polling pass
    * into a refetch: the safe fallback version never matches the server's, so an
    * ungated comparison would loop.
    */
-  const maybeRefreshConfigFor = (reportedVersion: string | undefined) => {
-    if (disposed || !reportedVersion) return
+  const maybeRefreshConfigFor = (reportedVersion: unknown) => {
+    if (
+      disposed
+      || !isBoundedConfigString(reportedVersion, MAX_CONFIG_VERSION_LENGTH)
+    ) return
     if (reportedVersion === currentConfig?.configVersion) return
     if (Date.now() - lastConfigAttemptAt < CONFIG_CHANGE_REFETCH_FLOOR_MS) return
     void refreshConfig(reportedVersion)
@@ -824,7 +1166,8 @@ export function subscribeToGachaResults(
     })
   } else {
     // Claim cursor ownership before async config/WebSocket work. The page's
-    // older loop becomes version-check-only and cannot duplicate events.
+    // older loop remains only as a disconnected emergency fallback and cannot
+    // duplicate events while this controller reports itself connected.
     options.onStatusChange?.('POLLING_ACTIVE')
     options.onSuccess?.()
     void poll()
@@ -833,11 +1176,16 @@ export function subscribeToGachaResults(
 
   return () => {
     disposed = true
+    recoveryPollPending = false
+    socketRecoveryActive = false
+    bufferedSocketEvents = []
+    unreconciledSocketEventIds.clear()
     if (pollTimer) clearTimeout(pollTimer)
-    if (configTimer) clearTimeout(configTimer)
+    if (safetyTimer) clearTimeout(safetyTimer)
     if (reconnectTimer) clearTimeout(reconnectTimer)
     if (connectTimeout) clearTimeout(connectTimeout)
     if (livenessTimer) clearTimeout(livenessTimer)
+    if (recoveryBufferTimer) clearTimeout(recoveryBufferTimer)
     closeSocket()
   }
 }

--- a/src/lib/realtime.ts
+++ b/src/lib/realtime.ts
@@ -172,6 +172,16 @@ const TRANSPORT_DISABLED_NOTICE = OVERLAY_REALTIME_TRANSPORT_DISABLED
  * change to be picked up on the first pass that observes it.
  */
 const CONFIG_CHANGE_REFETCH_FLOOR_MS = 30_000
+/**
+ * Minimum interval for DB-independent config probes after `/events` fails.
+ *
+ * A healthy old socket can keep heartbeating while its replacement URL has
+ * changed, so a PlanetScale outage must not make endpoint rotation unbounded.
+ * One probe immediately after the ten-minute reconciliation failure, then at
+ * most one per five minutes, preserves that recovery path without replacing
+ * the removed steady-state config poll with a degraded-mode request storm.
+ */
+const HISTORY_FAILURE_CONFIG_REFETCH_FLOOR_MS = 5 * 60_000
 const MAX_CONFIG_VERSION_LENGTH = 128
 const MAX_CONFIG_URL_LENGTH = 2_048
 const MIN_CONFIG_RETRY_DELAY_MS = 100
@@ -528,7 +538,12 @@ export function subscribeToGachaResults(
       if (confirmedSocketDelivery || seenEventIds.has(draw.eventId)) return false
       if (!rememberSeenId(seenEventIds, draw.eventId)) return false
 
-      if (source === 'durable-object') {
+      if (source === 'durable-object' && event.deliveryKind !== 'demo') {
+        // Committed socket events remain pending until the authoritative DB
+        // cursor observes their IDs. Operator demos deliberately have no
+        // gacha_history row (their bounded fallback is KV), so adding one here
+        // would manufacture permanent reconciliation debt and eventually
+        // trigger high-volume /events reads after enough dashboard previews.
         unreconciledSocketEventIds.add(draw.eventId)
         if (unreconciledSocketEventIds.size > MAX_SEEN_EVENT_IDS) {
           // A sustained DB outage must not grow OBS memory without bound. This
@@ -725,6 +740,12 @@ export function subscribeToGachaResults(
     } catch (error) {
       failed = true
       retryCount += 1
+      // `/events` normally carries the config generation for free, but a DB
+      // failure prevents that response from being produced. Probe the DB-free
+      // config endpoint only in this degraded case so a healthy socket on URL A
+      // still moves to B within a bounded interval. The helper is separately
+      // rate-limited and preserves the current socket if the probe itself fails.
+      maybeRefreshConfigAfterHistoryFailure()
       const exhausted = Number.isFinite(maxRetries) && retryCount > maxRetries
       if (exhausted) {
         options.onError?.({
@@ -1018,7 +1039,10 @@ export function subscribeToGachaResults(
     }, delay)
   }
 
-  async function refreshConfig(expectedVersion?: string): Promise<void> {
+  async function refreshConfig(
+    expectedVersion?: string,
+    preserveCurrentOnFailure = false
+  ): Promise<void> {
     if (disposed || configRefreshInFlight) return
     configRefreshInFlight = true
     lastConfigAttemptAt = Date.now()
@@ -1104,6 +1128,14 @@ export function subscribeToGachaResults(
         requestRecoveryPoll(true)
       }
     } catch {
+      if (preserveCurrentOnFailure && currentConfig !== null && socketIsHealthy()) {
+        // This was a DB-outage side probe, not evidence that the last validated
+        // config became invalid. Keep the heartbeating transport alive and let
+        // the bounded degraded retry try again; falling back here would discard
+        // the only working delivery path while both HTTP endpoints are impaired.
+        options.onStatusChange?.('CONFIG_REFRESH_FAILED:KEEP_CURRENT')
+        return
+      }
       const wasDoPrimary = currentConfig?.mode === 'do-primary'
       currentConfig = {
         schemaVersion: 1,
@@ -1129,6 +1161,20 @@ export function subscribeToGachaResults(
         scheduleSafetyRefresh(nextRefreshMs)
       }
     }
+  }
+
+  function maybeRefreshConfigAfterHistoryFailure(): void {
+    if (
+      disposed
+      || !socketIsHealthy()
+      || configRefreshInFlight
+      || Date.now() - lastConfigAttemptAt < HISTORY_FAILURE_CONFIG_REFETCH_FLOOR_MS
+    ) return
+    // Do not await inside the history retry owner. Config has its own in-flight
+    // guard and timer ownership, while pollInFlight continues to serialize all
+    // DB reads. Starting the probe here lets endpoint rotation proceed without
+    // delaying the existing bounded history backoff.
+    void refreshConfig(undefined, true)
   }
 
   /**

--- a/tests/unit/api/gacha-demo-route.test.ts
+++ b/tests/unit/api/gacha-demo-route.test.ts
@@ -3,17 +3,30 @@ import { NextRequest } from 'next/server'
 import { POST } from '@/app/api/gacha/demo/route'
 import { getSession } from '@/lib/session'
 import { getStreamerIdByTwitchUserId } from '@/lib/user-data'
-import { publishOverlayDemoEvent } from '@/lib/overlay/demo-event-store'
+import {
+  createOverlayDemoEvent,
+  storeOverlayDemoEvent,
+} from '@/lib/overlay/demo-event-store'
+import { publishOverlayDemoRealtimeEvent } from '@/lib/overlay-realtime/publisher'
+import { runInBackground } from '@/lib/background-task'
 import { checkRateLimit, getRateLimitIdentifier } from '@/lib/rate-limit'
 import { ERROR_MESSAGES } from '@/lib/constants'
+import { logger } from '@/lib/logger.server'
 
-vi.mock('@/lib/logger', () => ({
+vi.mock('@/lib/logger.server', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }))
 vi.mock('@/lib/session')
 vi.mock('@/lib/user-data')
 vi.mock('@/lib/overlay/demo-event-store', () => ({
-  publishOverlayDemoEvent: vi.fn().mockResolvedValue({ id: 'demo:1' }),
+  createOverlayDemoEvent: vi.fn(),
+  storeOverlayDemoEvent: vi.fn(),
+}))
+vi.mock('@/lib/overlay-realtime/publisher', () => ({
+  publishOverlayDemoRealtimeEvent: vi.fn(),
+}))
+vi.mock('@/lib/background-task', () => ({
+  runInBackground: vi.fn(),
 }))
 vi.mock('@/lib/rate-limit', () => ({
   checkRateLimit: vi.fn(),
@@ -24,9 +37,29 @@ vi.mock('@/lib/rate-limit', () => ({
 
 const mockGetSession = vi.mocked(getSession)
 const mockGetStreamerIdByTwitchUserId = vi.mocked(getStreamerIdByTwitchUserId)
-const mockPublishOverlayDemoEvent = vi.mocked(publishOverlayDemoEvent)
+const mockCreateOverlayDemoEvent = vi.mocked(createOverlayDemoEvent)
+const mockStoreOverlayDemoEvent = vi.mocked(storeOverlayDemoEvent)
+const mockPublishOverlayDemoRealtimeEvent = vi.mocked(publishOverlayDemoRealtimeEvent)
+const mockRunInBackground = vi.mocked(runInBackground)
 const mockCheckRateLimit = vi.mocked(checkRateLimit)
 const mockGetRateLimitIdentifier = vi.mocked(getRateLimitIdentifier)
+const mockLogger = vi.mocked(logger)
+
+const DEMO_EVENT = {
+  id: 'demo:history-1',
+  eventId: 'demo:event-1',
+  redeemedAt: '2026-07-24T01:02:03.000Z',
+  userTwitchUsername: 'DemoUser',
+  rewardId: null,
+  card: {
+    id: 'card-demo',
+    name: 'Demo Card',
+    description: null,
+    image_url: null,
+    image_padding_color: null,
+    rarity: 'common',
+  },
+} as const
 
 function makeRequest(body: unknown) {
   return new NextRequest('http://localhost/api/gacha/demo', {
@@ -39,7 +72,15 @@ function makeRequest(body: unknown) {
 describe('POST /api/gacha/demo: KV demo publication authorization', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockPublishOverlayDemoEvent.mockResolvedValue({ id: 'demo:1' } as any)
+    mockCreateOverlayDemoEvent.mockReturnValue(DEMO_EVENT)
+    mockStoreOverlayDemoEvent.mockResolvedValue(undefined)
+    mockPublishOverlayDemoRealtimeEvent.mockResolvedValue({
+      outcome: 'accepted',
+      attempts: 1,
+    })
+    mockRunInBackground.mockImplementation(async (_label, task) => {
+      await task
+    })
     mockGetRateLimitIdentifier.mockResolvedValue('user:twitch-1')
     mockCheckRateLimit.mockResolvedValue({
       success: true,
@@ -59,7 +100,8 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
     const response = await POST(makeRequest({ streamerId: 'streamer-1', broadcast: true }))
     expect(response.status).toBe(401)
     expect(await response.json()).toEqual({ error: ERROR_MESSAGES.UNAUTHORIZED })
-    expect(mockPublishOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockCreateOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockStoreOverlayDemoEvent).not.toHaveBeenCalled()
   })
 
   it('returns 403 when the requested streamer belongs to another user', async () => {
@@ -72,7 +114,8 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
 
     const response = await POST(makeRequest({ streamerId: 'streamer-2', broadcast: true }))
     expect(response.status).toBe(403)
-    expect(mockPublishOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockCreateOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockStoreOverlayDemoEvent).not.toHaveBeenCalled()
   })
 
   it('returns 403 for a user without a streamer profile', async () => {
@@ -85,10 +128,11 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
 
     const response = await POST(makeRequest({ streamerId: 'streamer-1', broadcast: true }))
     expect(response.status).toBe(403)
-    expect(mockPublishOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockCreateOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockStoreOverlayDemoEvent).not.toHaveBeenCalled()
   })
 
-  it('publishes an authorized demo to the polling store', async () => {
+  it('publishes an authorized demo to KV and the immediate realtime transport', async () => {
     mockGetSession.mockResolvedValue({
       twitchUserId: 'twitch-1',
       twitchUsername: 'user1',
@@ -101,9 +145,21 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
 
     expect(response.status).toBe(200)
     expect(body.card).toBeDefined()
-    expect(mockPublishOverlayDemoEvent).toHaveBeenCalledWith(
-      'streamer-1',
+    expect(mockCreateOverlayDemoEvent).toHaveBeenCalledWith(
       expect.objectContaining({ id: expect.any(String), rarity: expect.any(String) })
+    )
+    expect(mockStoreOverlayDemoEvent).toHaveBeenCalledWith('streamer-1', DEMO_EVENT)
+    expect(mockPublishOverlayDemoRealtimeEvent).toHaveBeenCalledWith(
+      'streamer-1',
+      DEMO_EVENT
+    )
+    // Referential identity is intentional: KV and realtime must serialize the
+    // exact same immutable event, not independently generated equivalents.
+    expect(mockStoreOverlayDemoEvent.mock.calls[0]?.[1]).toBe(DEMO_EVENT)
+    expect(mockPublishOverlayDemoRealtimeEvent.mock.calls[0]?.[1]).toBe(DEMO_EVENT)
+    expect(mockRunInBackground).toHaveBeenCalledWith(
+      'overlay demo delivery',
+      expect.any(Promise)
     )
     expect(mockGetRateLimitIdentifier).toHaveBeenCalledWith(
       expect.anything(),
@@ -137,7 +193,77 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
     expect(body.error).toBe(ERROR_MESSAGES.RATE_LIMIT_EXCEEDED)
     expect(response.headers.get('X-RateLimit-Limit')).toBe('30')
     expect(response.headers.get('X-RateLimit-Remaining')).toBe('0')
-    expect(mockPublishOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockCreateOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockStoreOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockPublishOverlayDemoRealtimeEvent).not.toHaveBeenCalled()
+  })
+
+  it('still starts realtime delivery and returns 200 when the KV write rejects', async () => {
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'twitch-1',
+      twitchUsername: 'user1',
+      broadcasterType: 'affiliate',
+    } as Awaited<ReturnType<typeof getSession>>)
+    mockGetStreamerIdByTwitchUserId.mockResolvedValue({ id: 'streamer-1' })
+    mockStoreOverlayDemoEvent.mockRejectedValue(new Error('KV unavailable'))
+
+    const response = await POST(makeRequest({ streamerId: 'streamer-1', broadcast: true }))
+
+    expect(response.status).toBe(200)
+    expect(mockPublishOverlayDemoRealtimeEvent).toHaveBeenCalledWith(
+      'streamer-1',
+      DEMO_EVENT
+    )
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Demo overlay KV fallback failed',
+      { streamerId: 'streamer-1', error: 'Error' }
+    )
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'Demo overlay realtime publish accepted',
+      { streamerId: 'streamer-1', attempts: 1, errorCode: undefined }
+    )
+  })
+
+  it('still stores the KV fallback and returns 200 when realtime rejects', async () => {
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'twitch-1',
+      twitchUsername: 'user1',
+      broadcasterType: 'affiliate',
+    } as Awaited<ReturnType<typeof getSession>>)
+    mockGetStreamerIdByTwitchUserId.mockResolvedValue({ id: 'streamer-1' })
+    mockPublishOverlayDemoRealtimeEvent.mockRejectedValue(new Error('DO unavailable'))
+
+    const response = await POST(makeRequest({ streamerId: 'streamer-1', broadcast: true }))
+
+    expect(response.status).toBe(200)
+    expect(mockStoreOverlayDemoEvent).toHaveBeenCalledWith('streamer-1', DEMO_EVENT)
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Demo overlay realtime publish rejected',
+      { streamerId: 'streamer-1', error: 'Error' }
+    )
+  })
+
+  it('logs a fulfilled failed outcome while keeping the KV fallback and 200 response', async () => {
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'twitch-1',
+      twitchUsername: 'user1',
+      broadcasterType: 'affiliate',
+    } as Awaited<ReturnType<typeof getSession>>)
+    mockGetStreamerIdByTwitchUserId.mockResolvedValue({ id: 'streamer-1' })
+    mockPublishOverlayDemoRealtimeEvent.mockResolvedValue({
+      outcome: 'failed',
+      attempts: 3,
+      errorCode: 'network',
+    })
+
+    const response = await POST(makeRequest({ streamerId: 'streamer-1', broadcast: true }))
+
+    expect(response.status).toBe(200)
+    expect(mockStoreOverlayDemoEvent).toHaveBeenCalledWith('streamer-1', DEMO_EVENT)
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Demo overlay realtime publish failed',
+      { streamerId: 'streamer-1', attempts: 3, errorCode: 'network' }
+    )
   })
 
   it('keeps the public non-publication demo available without a session', async () => {
@@ -149,7 +275,9 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
     expect(response.status).toBe(200)
     expect(body.card).toBeDefined()
     expect(mockGetSession).not.toHaveBeenCalled()
-    expect(mockPublishOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockCreateOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockStoreOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockPublishOverlayDemoRealtimeEvent).not.toHaveBeenCalled()
     // #735: broadcast専用の制限は通らないが、全リクエスト共通のIPベース制限は通る
     expect(mockCheckRateLimit).toHaveBeenCalledTimes(1)
     expect(mockGetRateLimitIdentifier).toHaveBeenCalledWith(expect.anything())
@@ -162,7 +290,8 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
     expect(response.status).toBe(200)
     expect(body.card).toBeDefined()
     expect(mockGetSession).not.toHaveBeenCalled()
-    expect(mockPublishOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockCreateOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockStoreOverlayDemoEvent).not.toHaveBeenCalled()
     expect(mockCheckRateLimit).toHaveBeenCalledTimes(1)
   })
 

--- a/tests/unit/components/maintenance-status-provider.test.tsx
+++ b/tests/unit/components/maintenance-status-provider.test.tsx
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react'
 import {
   MaintenanceStatusProvider,
   useMaintenanceStatus,
@@ -13,14 +13,29 @@ function StatusProbe() {
     <div>
       <span data-testid="mode">{status.mode}</span>
       <span data-testid="expected-end-at">{status.expectedEndAt ?? ''}</span>
+      <span data-testid="write-blocked">{String(status.mode !== 'off')}</span>
     </div>
   )
 }
 
 describe('MaintenanceStatusProvider', () => {
+  let visibilityState: DocumentVisibilityState
+
+  beforeEach(() => {
+    visibilityState = 'visible'
+    vi.spyOn(document, 'visibilityState', 'get').mockImplementation(
+      () => visibilityState
+    )
+  })
+
   afterEach(() => {
+    // Providerのeffect cleanup（interval解除・visibility listener解除）を、
+    // getter spyやfake timerを復元する前に必ず実行する。テスト間でDOMと
+    // Providerの状態を残さないことが、fetch回数やgetByTestIdの累積を防ぐ。
+    cleanup()
     vi.unstubAllGlobals()
     vi.useRealTimers()
+    vi.restoreAllMocks()
   })
 
   it('Provider の外で useMaintenanceStatus() を呼ぶと安全側のoffを返す（例外にしない）', () => {
@@ -28,13 +43,12 @@ describe('MaintenanceStatusProvider', () => {
     expect(screen.getByTestId('mode')).toHaveTextContent('off')
   })
 
-  it('マウント時に即座に1回fetchし、取得したstatusをcontext経由で配る', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({ mode: 'read-only', expectedEndAt: '2026-07-20T00:00:00.000Z' }),
-        { status: 200 }
-      )
-    )
+  it('初期visible mountは既存のoff契約を保って即時fetchし、取得したstatusを配る', async () => {
+    let resolveFetch!: (response: Response) => void
+    const fetchPromise = new Promise<Response>((resolve) => {
+      resolveFetch = resolve
+    })
+    const fetchMock = vi.fn().mockReturnValue(fetchPromise)
     vi.stubGlobal('fetch', fetchMock)
 
     render(
@@ -42,6 +56,17 @@ describe('MaintenanceStatusProvider', () => {
         <StatusProbe />
       </MaintenanceStatusProvider>
     )
+
+    // 初期mountはProvider外と同じOFF_STATUS契約を維持する。サーバー側guardWriteが
+    // 最終防御を担うため、hidden復帰向けの一時read-onlyはここへ波及させない。
+    expect(screen.getByTestId('mode')).toHaveTextContent('off')
+    expect(screen.getByTestId('write-blocked')).toHaveTextContent('false')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    resolveFetch(new Response(
+      JSON.stringify({ mode: 'read-only', expectedEndAt: '2026-07-20T00:00:00.000Z' }),
+      { status: 200 }
+    ))
 
     await waitFor(() => {
       expect(screen.getByTestId('mode')).toHaveTextContent('read-only')
@@ -51,6 +76,59 @@ describe('MaintenanceStatusProvider', () => {
       '/api/maintenance-status',
       expect.objectContaining({ cache: 'no-store' })
     )
+  })
+
+  it('hiddenからvisibleへの復帰確認中はwriteを無効化し、解決後のread-onlyを反映する', async () => {
+    let resolveRefresh!: (response: Response) => void
+    const refreshPromise = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve
+    })
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ mode: 'off' }), { status: 200 }))
+      .mockReturnValueOnce(refreshPromise)
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <MaintenanceStatusProvider>
+        <StatusProbe />
+      </MaintenanceStatusProvider>
+    )
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(screen.getByTestId('mode')).toHaveTextContent('off')
+    })
+
+    visibilityState = 'hidden'
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    visibilityState = 'visible'
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    // 復帰fetchのPromiseが未解決でも、全consumerと同じ `mode !== 'off'`
+    // 判定でwrite不可になる。hidden前の古いoffを再確認中に公開しない。
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(screen.getByTestId('mode')).toHaveTextContent('read-only')
+    expect(screen.getByTestId('write-blocked')).toHaveTextContent('true')
+    expect(screen.getByTestId('expected-end-at')).toBeEmptyDOMElement()
+
+    resolveRefresh(new Response(
+      JSON.stringify({
+        mode: 'read-only',
+        expectedEndAt: '2026-08-09T12:00:00.000Z',
+      }),
+      { status: 200 }
+    ))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mode')).toHaveTextContent('read-only')
+      expect(screen.getByTestId('expected-end-at')).toHaveTextContent(
+        '2026-08-09T12:00:00.000Z'
+      )
+    })
   })
 
   it('60秒間隔でポーリングし、状態変化がcontext消費者に反映される', async () => {
@@ -90,6 +168,136 @@ describe('MaintenanceStatusProvider', () => {
     expect(screen.getByTestId('mode')).toHaveTextContent('incident-read-only')
   })
 
+  it('hidden中は停止し、visible復帰時に即時fetchして単一の60秒pollを再開する', async () => {
+    vi.useFakeTimers()
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ mode: 'off' }), { status: 200 })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    visibilityState = 'hidden'
+    render(
+      <MaintenanceStatusProvider>
+        <StatusProbe />
+      </MaintenanceStatusProvider>
+    )
+
+    // 初期状態がhiddenなら、mount直後のfetchもpollingも開始しない。
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(0)
+
+    visibilityState = 'visible'
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    visibilityState = 'hidden'
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(180_000)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    visibilityState = 'visible'
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+      // Duplicate visible notifications must not create another immediate
+      // request or a second interval.
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(59_999)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('hidden前の遅いresponseがvisible復帰後の新しいstatusを上書きしない', async () => {
+    let resolveFirst!: (response: Response) => void
+    let resolveSecond!: (response: Response) => void
+    const first = new Promise<Response>((resolve) => {
+      resolveFirst = resolve
+    })
+    const second = new Promise<Response>((resolve) => {
+      resolveSecond = resolve
+    })
+    const fetchMock = vi.fn()
+      .mockReturnValueOnce(first)
+      .mockReturnValueOnce(second)
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <MaintenanceStatusProvider>
+        <StatusProbe />
+      </MaintenanceStatusProvider>
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    visibilityState = 'hidden'
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    visibilityState = 'visible'
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(screen.getByTestId('mode')).toHaveTextContent('read-only')
+    expect(screen.getByTestId('write-blocked')).toHaveTextContent('true')
+
+    await act(async () => {
+      resolveSecond(new Response(
+        JSON.stringify({
+          mode: 'read-only',
+          expectedEndAt: '2026-08-09T12:00:00.000Z',
+        }),
+        { status: 200 }
+      ))
+      await second
+    })
+    expect(screen.getByTestId('mode')).toHaveTextContent('read-only')
+    expect(screen.getByTestId('expected-end-at')).toHaveTextContent(
+      '2026-08-09T12:00:00.000Z'
+    )
+
+    await act(async () => {
+      resolveFirst(new Response(
+        JSON.stringify({
+          mode: 'incident-read-only',
+          expectedEndAt: '2026-08-09T10:00:00.000Z',
+        }),
+        { status: 200 }
+      ))
+      await first
+    })
+    expect(screen.getByTestId('mode')).toHaveTextContent('read-only')
+    expect(screen.getByTestId('expected-end-at')).toHaveTextContent(
+      '2026-08-09T12:00:00.000Z'
+    )
+  })
+
   it('アンマウント後はポーリングタイマーが止まる', async () => {
     vi.useFakeTimers()
     const fetchMock = vi.fn().mockResolvedValue(
@@ -109,6 +317,13 @@ describe('MaintenanceStatusProvider', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
 
     unmount()
+
+    // cleanup後のvisibility eventがlistenerを復活させたり、即時fetchを始めたり
+    // しないことも確認する。
+    visibilityState = 'hidden'
+    document.dispatchEvent(new Event('visibilitychange'))
+    visibilityState = 'visible'
+    document.dispatchEvent(new Event('visibilitychange'))
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(120_000)

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -7,6 +7,9 @@ import { pickSoundBearingCardIndex } from '@/lib/gacha-sound-rules'
 import { OVERLAY_EFFECT_PARTICLE_CONFIG } from '@/lib/overlay-effect'
 import { serializePollState } from '@/lib/overlay-version'
 
+const HISTORY_ID_BEFORE_RELOAD = '00000000-0000-4000-8000-000000000101'
+const HISTORY_ID_RESTORED = '00000000-0000-4000-8000-000000000102'
+
 const { subscribeMock } = vi.hoisted(() => ({
   subscribeMock: vi.fn(),
 }))
@@ -767,9 +770,9 @@ describe('OverlayPage', () => {
     const RELOAD_COOLDOWN_STORAGE_KEY = 'twica-overlay-reload'
     const POLLSTATE_STORAGE_KEY = 'twica-overlay-pollstate'
 
-    // page.tsx内部の時間定数(非export)と同じ値をテスト側でも保持する。
-    // 実装側(VERSION_CHECK_INTERVAL_MS/RELOAD_JITTER_MAX_MS/RELOAD_DEFER_RETRY_MS)
-    // を変更した場合は、ここも追随して更新すること。
+    // page.tsx内部のreload時間定数(非export)と同じ値をテスト側でも保持する。
+    // 実装側(RELOAD_JITTER_MAX_MS/RELOAD_DEFER_RETRY_MS)を変更した場合は、
+    // ここも追随して更新すること。
     const RELOAD_JITTER_MAX_MS = 10 * 60 * 1000
     const RELOAD_DEFER_RETRY_MS = 30 * 1000
 
@@ -831,7 +834,7 @@ describe('OverlayPage', () => {
     }
 
     /**
-     * overlay events ポーリング(かつsound-settings取得)の共通fetchレスポンスを
+     * disconnected emergency polling(かつsound-settings取得)の共通responseを
      * 組み立てる。このテストファイルの既存の流儀(fetchはURLを区別せず単一の
      * レスポンス形状を返す)に合わせ、events/overlayVersionとsoundUrl/soundEnabled
      * を同居させる。
@@ -849,6 +852,76 @@ describe('OverlayPage', () => {
       vi.stubGlobal('fetch', fetchMock)
       return fetchMock
     }
+
+    it('subscriptionのonOverlayVersionをref経由で処理し、再subscriptionせずreloadする', async () => {
+      vi.useFakeTimers()
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const reloadMock = stubLocationReload()
+      stubEventsFetch('v-a')
+      let onOverlayVersion: SubscribeOptions['onOverlayVersion']
+      let onHistoryCursor: SubscribeOptions['onHistoryCursor']
+
+      subscribeMock.mockImplementation((_streamerId, _callback, options: SubscribeOptions) => {
+        onOverlayVersion = options.onOverlayVersion
+        onHistoryCursor = options.onHistoryCursor
+        options.onSuccess?.()
+        return vi.fn()
+      })
+
+      render(<OverlayPageV />)
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      act(() => {
+        onHistoryCursor?.({
+          redeemedAt: '2026-06-01T00:00:00.123Z',
+          historyId: HISTORY_ID_BEFORE_RELOAD,
+        })
+        onOverlayVersion?.('v-b')
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      expect(reloadMock).toHaveBeenCalledTimes(1)
+      expect(subscribeMock).toHaveBeenCalledTimes(1)
+      expect(
+        JSON.parse(
+          sessionStorage.getItem(`${POLLSTATE_STORAGE_KEY}:streamer-1`) ?? '{}'
+        )
+      ).toMatchObject({
+        pollCursor: '2026-06-01T00:00:00.123Z',
+        pollHistoryId: HISTORY_ID_BEFORE_RELOAD,
+      })
+    })
+
+    it('connected中は旧loopを10分以上進めても/eventsへnetwork requestを出さない', async () => {
+      vi.useFakeTimers()
+      const fetchMock = stubEventsFetch('v-a')
+      subscribeMock.mockImplementation((_streamerId, _callback, options: SubscribeOptions) => {
+        options.onSuccess?.()
+        return vi.fn()
+      })
+
+      render(<OverlayPageV />)
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10 * 60 * 1000 + 3_000)
+      })
+
+      expect(
+        fetchMock.mock.calls.filter(([url]) =>
+          String(url).includes('/api/overlay/streamer-1/events')
+        )
+      ).toHaveLength(0)
+      expect(subscribeMock).toHaveBeenCalledTimes(1)
+    })
 
     it('フォールバックポーリングでoverlayVersion不一致を検出し、ジッター上限まで進めるとlocation.reloadが呼ばれる', async () => {
       vi.useFakeTimers()
@@ -973,21 +1046,27 @@ describe('OverlayPage', () => {
       expect(reloadMock).not.toHaveBeenCalled()
     })
 
-    it('mount時にsessionStorageのpollstateスナップショットを復元し、次のポーリングのsinceに反映する', async () => {
+    it('mount時にexact pollstateを復元して通常のtransport controllerへ渡す', async () => {
       vi.useFakeTimers()
 
       const restoredCursor = '2026-06-01T00:00:00.000Z'
+      const restoredHistoryId = HISTORY_ID_RESTORED
       sessionStorage.setItem(
-        POLLSTATE_STORAGE_KEY,
+        `${POLLSTATE_STORAGE_KEY}:streamer-1`,
         serializePollState({
           pollCursor: restoredCursor,
+          pollHistoryId: restoredHistoryId,
           seenHistoryIds: ['h-restored-1'],
           savedAt: Date.now(),
         }),
       )
-      // このテストはpollstate復元のみに関心があるため、overlayVersionは現行
-      // ビルド('v-a')と一致させリロード関連の副作用を起こさないようにする
-      const fetchMock = stubEventsFetch('v-a')
+      stubEventsFetch('v-a')
+      let subscriptionOptions: SubscribeOptions | undefined
+      subscribeMock.mockImplementation((_streamerId, _callback, options: SubscribeOptions) => {
+        subscriptionOptions = options
+        options.onSuccess?.()
+        return vi.fn()
+      })
 
       render(<OverlayPageV />)
 
@@ -996,16 +1075,13 @@ describe('OverlayPage', () => {
         await Promise.resolve()
       })
 
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(3000)
+      expect(subscriptionOptions?.initialHistoryCursor).toEqual({
+        redeemedAt: restoredCursor,
+        historyId: restoredHistoryId,
       })
-
-      const eventsCall = fetchMock.mock.calls.find(([url]) =>
-        String(url).includes('/api/overlay/streamer-1/events'),
-      )
-      expect(eventsCall).toBeDefined()
-      const requestedUrl = new URL(String(eventsCall?.[0]))
-      expect(requestedUrl.searchParams.get('since')).toBe(restoredCursor)
+      expect(
+        sessionStorage.getItem(`${POLLSTATE_STORAGE_KEY}:streamer-1`)
+      ).toBeNull()
     })
   })
 })

--- a/tests/unit/overlay-demo-event-store.test.ts
+++ b/tests/unit/overlay-demo-event-store.test.ts
@@ -1,11 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
+import { getCloudflareContext } from '@opennextjs/cloudflare'
 import {
   __clearOverlayDemoEventsForTests,
+  createOverlayDemoEvent,
   getOverlayDemoEvent,
   publishOverlayDemoEvent,
+  storeOverlayDemoEvent,
 } from '@/lib/overlay/demo-event-store'
 import { GET } from '@/app/api/overlay/[streamerId]/demo-events/route'
+
+vi.mock('@opennextjs/cloudflare', () => ({
+  getCloudflareContext: vi.fn(),
+}))
+
+const mockGetCloudflareContext = vi.mocked(getCloudflareContext)
 
 const CARD = {
   id: 'card-1',
@@ -19,9 +28,12 @@ const CARD = {
 beforeEach(() => {
   __clearOverlayDemoEventsForTests()
   vi.useRealTimers()
+  mockGetCloudflareContext.mockReset()
+  mockGetCloudflareContext.mockRejectedValue(new Error('not in Workers'))
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   vi.unstubAllEnvs()
 })
 
@@ -45,6 +57,50 @@ describe('overlay demo event store', () => {
 
     expect(second.id).not.toBe(first.id)
     expect(await getOverlayDemoEvent('streamer-1', first.redeemedAt)).toEqual(second)
+  })
+
+  it('creates a deeply immutable event before either transport receives it', () => {
+    const event = createOverlayDemoEvent(CARD)
+
+    expect(Object.isFrozen(event)).toBe(true)
+    expect(Object.isFrozen(event.card)).toBe(true)
+    expect(event.eventId).toBe(event.id)
+  })
+
+  it('retains the fallback through reconciliation and retry grace, then expires it', async () => {
+    const startedAt = Date.parse('2026-08-09T00:00:00.000Z')
+    vi.useFakeTimers()
+    vi.setSystemTime(startedAt)
+    const cursor = new Date(startedAt - 1).toISOString()
+    const event = await publishOverlayDemoEvent('streamer-1', CARD)
+
+    // The healthy socket's periodic full reconciliation occurs at 10 minutes.
+    vi.setSystemTime(startedAt + 10 * 60 * 1000)
+    expect(await getOverlayDemoEvent('streamer-1', cursor)).toEqual(event)
+
+    // Liveness detection and bounded reconnect retries may add another 150s.
+    vi.setSystemTime(startedAt + (10 * 60 + 150) * 1000)
+    expect(await getOverlayDemoEvent('streamer-1', cursor)).toEqual(event)
+
+    // The latest-value fallback remains bounded and disappears after 15m.
+    vi.setSystemTime(startedAt + 15 * 60 * 1000 + 1)
+    expect(await getOverlayDemoEvent('streamer-1', cursor)).toBeNull()
+  })
+
+  it('configures the shared KV fallback with the same bounded 15-minute TTL', async () => {
+    const put = vi.fn().mockResolvedValue(undefined)
+    mockGetCloudflareContext.mockResolvedValue({
+      env: { RATE_LIMIT_KV: { put } },
+    } as never)
+    const event = createOverlayDemoEvent(CARD)
+
+    await storeOverlayDemoEvent('streamer-1', event)
+
+    expect(put).toHaveBeenCalledWith(
+      'overlay:demo:streamer-1',
+      JSON.stringify(event),
+      { expirationTtl: 15 * 60 }
+    )
   })
 
   it('exposes the latest event through the overlay polling route', async () => {

--- a/tests/unit/overlay-history-cursor.test.ts
+++ b/tests/unit/overlay-history-cursor.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeOverlayHistoryTimestamp } from '@/lib/overlay-history-cursor'
+
+describe('normalizeOverlayHistoryTimestamp', () => {
+  it.each([
+    ['2026-07-24T00:00:01Z', '2026-07-24T00:00:01Z'],
+    ['2026-07-24T00:00:01.123456Z', '2026-07-24T00:00:01.123456Z'],
+    ['2026-07-24T09:00:01.123456+09:00', '2026-07-24T00:00:01.123456Z'],
+    // URLSearchParams can decode a literal plus into a space.
+    ['2026-07-24T09:00:01.123456 09:00', '2026-07-24T00:00:01.123456Z'],
+  ])('APIとbrowserで同じtimestampをcanonical UTCへ正規化する: %s', (raw, expected) => {
+    expect(normalizeOverlayHistoryTimestamp(raw)).toBe(expected)
+  })
+
+  it.each([
+    'July 24, 2026',
+    '2026-07-24',
+    '2026-02-30T00:00:00Z',
+    '2026-07-24T00:00:00.1234567Z',
+    '2026-07-24T00:00:00+24:00',
+    '',
+    null,
+  ])('Date.parseが受理し得てもAPI文法外の値を拒否する: %s', (raw) => {
+    expect(normalizeOverlayHistoryTimestamp(raw)).toBeNull()
+  })
+})

--- a/tests/unit/overlay-realtime-config-route.test.ts
+++ b/tests/unit/overlay-realtime-config-route.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { GET } from '@/app/api/overlay/[streamerId]/realtime-config/route'
+import { MAX_OVERLAY_VERSION_LENGTH } from '@/lib/overlay-realtime/contract'
 
 const STREAMER_ID = '123e4567-e89b-42d3-a456-426614174000'
 
@@ -29,6 +30,7 @@ describe('overlay realtime runtime config', () => {
     vi.stubEnv('OVERLAY_REALTIME_MODE', 'do-primary')
     vi.stubEnv('OVERLAY_REALTIME_STREAMER_ALLOWLIST', STREAMER_ID)
     vi.stubEnv('OVERLAY_REALTIME_WS_URL', 'https://realtime.example/base?secret=no')
+    vi.stubEnv('NEXT_PUBLIC_OVERLAY_VERSION', 'build-abc123')
     const response = await GET(new Request('https://app.example/config'), params())
     const body = await response.json()
 
@@ -37,7 +39,21 @@ describe('overlay realtime runtime config', () => {
       mode: 'do-primary',
       webSocketUrl: 'https://realtime.example',
       protocolVersion: 1,
+      overlayVersion: 'build-abc123',
     })
+  })
+
+  it('omits an oversized overlay version instead of reflecting unbounded config', async () => {
+    vi.stubEnv(
+      'NEXT_PUBLIC_OVERLAY_VERSION',
+      'v'.repeat(MAX_OVERLAY_VERSION_LENGTH + 1)
+    )
+
+    const response = await GET(new Request('https://app.example/config'), params())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).not.toHaveProperty('overlayVersion')
   })
 
   it('rejects an invalid public room ID', async () => {

--- a/tests/unit/overlay-realtime-config-signal.test.ts
+++ b/tests/unit/overlay-realtime-config-signal.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { GET as getRealtimeConfig } from '@/app/api/overlay/[streamerId]/realtime-config/route'
 import {
   resolveOverlayRealtimeConfig,
   resolveOverlayRealtimeConfigVersion,
@@ -7,6 +8,10 @@ import {
 
 const STREAMER_ID = '123e4567-e89b-42d3-a456-426614174000'
 const OTHER_STREAMER_ID = '223e4567-e89b-42d3-a456-426614174000'
+
+function params(streamerId = STREAMER_ID) {
+  return { params: Promise.resolve({ streamerId }) }
+}
 
 /**
  * The overlay stopped polling the config endpoint on its own timer and instead
@@ -28,12 +33,19 @@ describe('overlay realtime config change signal', () => {
     vi.stubEnv('OVERLAY_REALTIME_WS_URL', 'https://realtime.example')
   }
 
-  it('reports the same version the full config carries when enabled', () => {
+  it('reports the same version from the events signal resolver and config route', async () => {
     enableFor(STREAMER_ID)
-    expect(resolveOverlayRealtimeConfigVersion(STREAMER_ID)).toBe(
-      resolveOverlayRealtimeConfig(STREAMER_ID).configVersion
+    const eventsSignalVersion = resolveOverlayRealtimeConfigVersion(STREAMER_ID)
+    const response = await getRealtimeConfig(
+      new Request('https://app.example/config'),
+      params()
     )
-    expect(resolveOverlayRealtimeConfigVersion(STREAMER_ID)).toBe('do-primary-v1')
+    const config = await response.json()
+
+    expect(config.configVersion).toBe(eventsSignalVersion)
+    // Pin the canonical tuple and FNV generation format so an unchanged public
+    // config remains stable across independently deployed Worker processes.
+    expect(eventsSignalVersion).toBe('do-primary-v2-338ed91465e81b6b')
   })
 
   it('reports the same version the full config carries when not allowlisted', () => {
@@ -54,6 +66,49 @@ describe('overlay realtime config change signal', () => {
 
     expect(enabled).not.toBe(disabled)
     expect(disabled).toBe('polling-only-v1')
+  })
+
+  it('changes version when only the effective WebSocket base URL changes', () => {
+    enableFor(STREAMER_ID)
+    vi.stubEnv('OVERLAY_REALTIME_WS_URL', 'https://realtime-a.example/path')
+    const urlA = resolveOverlayRealtimeConfigVersion(STREAMER_ID)
+
+    vi.stubEnv('OVERLAY_REALTIME_WS_URL', 'https://realtime-b.example/path')
+    const urlB = resolveOverlayRealtimeConfigVersion(STREAMER_ID)
+
+    expect(urlA).not.toBe(urlB)
+  })
+
+  it('keeps the same version for the same normalized public config', () => {
+    enableFor(STREAMER_ID)
+    vi.stubEnv(
+      'OVERLAY_REALTIME_WS_URL',
+      'https://REALTIME.example:443/first?ignored=one#fragment'
+    )
+    const first = resolveOverlayRealtimeConfig(STREAMER_ID)
+
+    vi.stubEnv(
+      'OVERLAY_REALTIME_WS_URL',
+      'https://realtime.example/second?ignored=two'
+    )
+    const second = resolveOverlayRealtimeConfig(STREAMER_ID)
+
+    expect(first.webSocketUrl).toBe('https://realtime.example')
+    expect(second.webSocketUrl).toBe(first.webSocketUrl)
+    expect(second.configVersion).toBe(first.configVersion)
+  })
+
+  it('keeps the legacy polling-only version across ineffective URL changes', () => {
+    vi.stubEnv('OVERLAY_REALTIME_MODE', 'polling-only')
+    vi.stubEnv('OVERLAY_REALTIME_STREAMER_ALLOWLIST', STREAMER_ID)
+    vi.stubEnv('OVERLAY_REALTIME_WS_URL', 'https://realtime-a.example')
+    const urlA = resolveOverlayRealtimeConfigVersion(STREAMER_ID)
+
+    vi.stubEnv('OVERLAY_REALTIME_WS_URL', 'https://realtime-b.example')
+    const urlB = resolveOverlayRealtimeConfigVersion(STREAMER_ID)
+
+    expect(urlA).toBe('polling-only-v1')
+    expect(urlB).toBe(urlA)
   })
 
   it('degrades to polling-only when the WebSocket URL is missing or insecure', () => {

--- a/tests/unit/overlay-realtime-contract.test.ts
+++ b/tests/unit/overlay-realtime-contract.test.ts
@@ -110,6 +110,26 @@ describe('overlay realtime V1 contract', () => {
     ).toBe('drawIndex must be contiguous')
   })
 
+  it('accepts only the additive demo delivery marker', () => {
+    const [event] = buildPollingRealtimeEvents(STREAMER_ID, [{
+      id: 'history-demo',
+      eventId: 'demo:event-1',
+      redeemedAt: '2026-07-24T00:00:00.000Z',
+      userTwitchUsername: 'DemoUser',
+      rewardId: null,
+      card: CARD,
+    }])
+
+    expect(validateGachaRealtimeEvent({
+      ...event,
+      deliveryKind: 'demo',
+    }, STREAMER_ID)).toEqual({ ok: true })
+    expect(validateGachaRealtimeEvent({
+      ...event,
+      deliveryKind: 'committed',
+    }, STREAMER_ID).error).toBe('invalid deliveryKind')
+  })
+
   it('rejects oversized attacker-controlled public fields before fanout', () => {
     const [event] = buildPollingRealtimeEvents(STREAMER_ID, [{
       id: 'history-1',

--- a/tests/unit/overlay-realtime-publisher.test.ts
+++ b/tests/unit/overlay-realtime-publisher.test.ts
@@ -15,7 +15,10 @@ vi.mock('@/lib/logger', () => ({
   },
 }))
 
-import { publishCommittedGachaBatch } from '@/lib/overlay-realtime/publisher'
+import {
+  publishCommittedGachaBatch,
+  publishOverlayDemoRealtimeEvent,
+} from '@/lib/overlay-realtime/publisher'
 
 const STREAMER_ID = '123e4567-e89b-42d3-a456-426614174000'
 const ORIGINAL_ENV = { ...process.env }
@@ -109,6 +112,60 @@ describe('publishCommittedGachaBatch', () => {
       { eventId: 'batch-1', historyId: 'history-1' },
       { eventId: 'batch-1:2', historyId: 'history-2' },
     ])
+    const headers = init.headers as Record<string, string>
+    await expect(
+      verifyPublishSignature(
+        process.env.OVERLAY_REALTIME_PUBLISH_SECRET!,
+        url.pathname,
+        body,
+        headers['x-twica-timestamp'],
+        headers['x-twica-nonce'],
+        headers['x-twica-signature']
+      )
+    ).resolves.toBe(true)
+  })
+
+  it('signs a demo envelope without reading nonexistent committed history', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({ accepted: true }, { status: 202 })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      publishOverlayDemoRealtimeEvent(STREAMER_ID, {
+        id: 'demo:history-1',
+        eventId: 'demo:event-1',
+        redeemedAt: '2026-07-24T01:02:03.000Z',
+        userTwitchUsername: 'DemoUser',
+        rewardId: null,
+        card: {
+          id: 'card-demo',
+          name: 'Demo Card',
+          description: 'Operator preview',
+          image_url: null,
+          image_padding_color: '#000000',
+          rarity: 'rare',
+        },
+      })
+    ).resolves.toEqual({ outcome: 'accepted', attempts: 1 })
+
+    // A demo exists only in the bounded KV fallback. Querying gacha_history
+    // would either fail to publish or create a false durability dependency.
+    expect(getDb).not.toHaveBeenCalled()
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+    const body = String(init.body)
+    expect(JSON.parse(body)).toMatchObject({
+      deliveryKind: 'demo',
+      eventId: 'demo:event-1',
+      batchId: 'demo:event-1',
+      streamerId: STREAMER_ID,
+      occurredAt: '2026-07-24T01:02:03.000Z',
+      draws: [{
+        eventId: 'demo:event-1',
+        drawId: 'demo:event-1',
+        historyId: 'demo:history-1',
+      }],
+    })
     const headers = init.headers as Record<string, string>
     await expect(
       verifyPublishSignature(

--- a/tests/unit/overlay-version.test.ts
+++ b/tests/unit/overlay-version.test.ts
@@ -14,6 +14,9 @@ import {
 // 純粋関数群のユニットテスト。sessionStorageやタイマーには一切依存せず、
 // 全て引数として値を注入してテストする。
 
+const historyUuid = (index: number) =>
+  `00000000-0000-4000-8000-${index.toString(16).padStart(12, "0")}`;
+
 describe("shouldScheduleReload", () => {
   it("current/receivedが異なればtrueを返す", () => {
     expect(shouldScheduleReload("abc123def456", "def456abc789")).toBe(true);
@@ -126,6 +129,7 @@ describe("serializePollState / parsePollState (round-trip)", () => {
   it("シリアライズしたものをそのままパースすると同じ内容が復元される", () => {
     const state = {
       pollCursor: "2026-07-04T00:00:00.000Z",
+      pollHistoryId: historyUuid(3),
       seenHistoryIds: ["h1", "h2", "h3"],
       savedAt: 1_700_000_000_000,
     };
@@ -138,6 +142,7 @@ describe("serializePollState / parsePollState (round-trip)", () => {
     const ids = Array.from({ length: MAX_PERSISTED_HISTORY_IDS + 10 }, (_, i) => `h${i}`);
     const serialized = serializePollState({
       pollCursor: "2026-07-04T00:00:00.000Z",
+      pollHistoryId: historyUuid(4),
       seenHistoryIds: ids,
       savedAt: 0,
     });
@@ -149,14 +154,24 @@ describe("serializePollState / parsePollState (round-trip)", () => {
   });
 
   it("savedAtからちょうどttlMs経過した境界ではまだ有効(復元される)", () => {
-    const state = { pollCursor: "2026-07-04T00:00:00.000Z", seenHistoryIds: [], savedAt: 1000 };
+    const state = {
+      pollCursor: "2026-07-04T00:00:00.000Z",
+      pollHistoryId: historyUuid(5),
+      seenHistoryIds: [],
+      savedAt: 1000,
+    };
     const serialized = serializePollState(state);
     const now = 1000 + POLLSTATE_TTL_MS;
     expect(parsePollState(serialized, now, POLLSTATE_TTL_MS)).toEqual(state);
   });
 
   it("savedAtからttlMsを1msでも超えるとTTL切れでnullを返す", () => {
-    const state = { pollCursor: "2026-07-04T00:00:00.000Z", seenHistoryIds: [], savedAt: 1000 };
+    const state = {
+      pollCursor: "2026-07-04T00:00:00.000Z",
+      pollHistoryId: historyUuid(6),
+      seenHistoryIds: [],
+      savedAt: 1000,
+    };
     const serialized = serializePollState(state);
     const now = 1000 + POLLSTATE_TTL_MS + 1;
     expect(parsePollState(serialized, now, POLLSTATE_TTL_MS)).toBeNull();
@@ -233,6 +248,28 @@ describe("parsePollState: 壊れた入力への耐性", () => {
     expect(parsePollState(raw, 0, POLLSTATE_TTL_MS)).toBeNull();
   });
 
+  it("Date.parse可能でもAPI文法外のpollCursorは400ループを避けるため拒否する", () => {
+    const raw = JSON.stringify({
+      pollCursor: "July 24, 2026",
+      pollHistoryId: historyUuid(8),
+      seenHistoryIds: [],
+      savedAt: 0,
+    });
+    expect(parsePollState(raw, 0, POLLSTATE_TTL_MS)).toBeNull();
+  });
+
+  it("PostgreSQLのoffset/microsecond cursorをAPIと同じcanonical UTCで復元する", () => {
+    const raw = JSON.stringify({
+      pollCursor: "2026-07-24T09:00:01.123456+09:00",
+      pollHistoryId: historyUuid(9),
+      seenHistoryIds: [],
+      savedAt: 0,
+    });
+    expect(parsePollState(raw, 0, POLLSTATE_TTL_MS)?.pollCursor).toBe(
+      "2026-07-24T00:00:01.123456Z",
+    );
+  });
+
   it("pollCursorが正当なISO日付文字列なら復元される(妥当性検証のデグレ防止)", () => {
     const raw = JSON.stringify({
       pollCursor: "2026-07-04T12:34:56.789Z",
@@ -241,9 +278,43 @@ describe("parsePollState: 壊れた入力への耐性", () => {
     });
     expect(parsePollState(raw, 0, POLLSTATE_TTL_MS)).toEqual({
       pollCursor: "2026-07-04T12:34:56.789Z",
+      pollHistoryId: "",
       seenHistoryIds: ["h1"],
       savedAt: 0,
     });
+  });
+
+  it("pollHistoryIdがあるsnapshotは同一timestampのtie-breakerを保持する", () => {
+    const raw = JSON.stringify({
+      pollCursor: "2026-07-04T12:34:56.789Z",
+      pollHistoryId: historyUuid(7),
+      seenHistoryIds: [],
+      savedAt: 0,
+    });
+    expect(parsePollState(raw, 0, POLLSTATE_TTL_MS)).toMatchObject({
+      pollCursor: "2026-07-04T12:34:56.789Z",
+      pollHistoryId: historyUuid(7),
+    });
+  });
+
+  it("oversized pollHistoryIdは汚染snapshotとして拒否する", () => {
+    const raw = JSON.stringify({
+      pollCursor: "2026-07-04T12:34:56.789Z",
+      pollHistoryId: "h".repeat(129),
+      seenHistoryIds: [],
+      savedAt: 0,
+    });
+    expect(parsePollState(raw, 0, POLLSTATE_TTL_MS)).toBeNull();
+  });
+
+  it("APIが受理しない非UUID pollHistoryIdは400ループを避けるため拒否する", () => {
+    const raw = JSON.stringify({
+      pollCursor: "2026-07-04T12:34:56.789Z",
+      pollHistoryId: "history-not-a-uuid",
+      seenHistoryIds: [],
+      savedAt: 0,
+    });
+    expect(parsePollState(raw, 0, POLLSTATE_TTL_MS)).toBeNull();
   });
 
   it("seenHistoryIds配列内に文字列以外が混じっていても、文字列要素だけを残して復元する", () => {

--- a/tests/unit/realtime.test.ts
+++ b/tests/unit/realtime.test.ts
@@ -8,6 +8,10 @@ import {
   MAX_OVERLAY_VERSION_LENGTH,
   buildPollingRealtimeEvents,
 } from '@/lib/overlay-realtime/contract'
+import {
+  resolveOverlayRealtimeConfig,
+  resolveOverlayRealtimeConfigVersion,
+} from '@/lib/overlay-realtime/resolve-config'
 
 const STREAMER_ID = '123e4567-e89b-42d3-a456-426614174000'
 
@@ -675,6 +679,227 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     // A config endpoint change starts a fresh connection policy, so the next
     // outage uses the initial half-jitter delay (random is stubbed to zero).
     expect(statuses).toContain('DO_RECONNECT_WAIT:50')
+    cleanup()
+  })
+
+  it('reconnects to a URL-only runtime change while the old socket remains healthy', async () => {
+    class ControlledWebSocket {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+      static readonly instances: ControlledWebSocket[] = []
+      readyState = ControlledWebSocket.CONNECTING
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: { code: number }) => void) | null = null
+
+      constructor(readonly url: string) {
+        ControlledWebSocket.instances.push(this)
+        queueMicrotask(() => {
+          this.readyState = ControlledWebSocket.OPEN
+          this.onopen?.()
+        })
+      }
+
+      send() {}
+      close(code = 1000) {
+        this.readyState = 3
+        this.onclose?.({ code })
+      }
+      emit(message: unknown) {
+        this.onmessage?.({ data: JSON.stringify(message) })
+      }
+    }
+    vi.stubGlobal('WebSocket', ControlledWebSocket)
+    vi.stubEnv('OVERLAY_REALTIME_MODE', 'do-primary')
+    vi.stubEnv('OVERLAY_REALTIME_STREAMER_ALLOWLIST', STREAMER_ID)
+    vi.stubEnv('OVERLAY_REALTIME_WS_URL', 'https://realtime-a.example')
+
+    let configCalls = 0
+    let eventsCalls = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/realtime-config')) {
+        configCalls += 1
+        return jsonResponse(resolveOverlayRealtimeConfig(STREAMER_ID))
+      }
+      eventsCalls += 1
+      return jsonResponse({
+        realtimeEvents: [],
+        nextCursor: null,
+        realtimeConfigVersion: resolveOverlayRealtimeConfigVersion(STREAMER_ID),
+      })
+    }))
+
+    const cleanup = subscribeToGachaResults('ignored', vi.fn())
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+
+    expect(ControlledWebSocket.instances).toHaveLength(1)
+    expect(ControlledWebSocket.instances[0].url).toContain('realtime-a.example')
+    const oldSocket = ControlledWebSocket.instances[0]
+    oldSocket.emit({
+      type: 'welcome',
+      protocolVersion: 1,
+      connectionId: 'connection-url-a',
+      serverTime: '',
+      seq: 0,
+    })
+    const eventsAfterStartup = eventsCalls
+
+    // This is an environment-only endpoint rotation: mode, allowlist,
+    // protocol, retry policy, and application build all remain unchanged.
+    // Heartbeats prove endpoint A is healthy, so only the public-config token
+    // carried by the ten-minute safety read can move the client to B.
+    vi.stubEnv('OVERLAY_REALTIME_WS_URL', 'https://realtime-b.example')
+    for (let halfMinute = 0; halfMinute < 19; halfMinute += 1) {
+      await vi.advanceTimersByTimeAsync(30_000)
+      oldSocket.emit({ type: 'server_notice', code: 'heartbeat' })
+      await flushPromises()
+    }
+    expect(configCalls).toBe(1)
+    expect(eventsCalls).toBe(eventsAfterStartup)
+    expect(ControlledWebSocket.instances).toHaveLength(1)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    oldSocket.emit({ type: 'server_notice', code: 'heartbeat' })
+    await flushPromises()
+    await vi.advanceTimersToNextTimerAsync()
+    await flushPromises()
+
+    expect(configCalls).toBe(2)
+    expect(ControlledWebSocket.instances).toHaveLength(2)
+    expect(ControlledWebSocket.instances[1].url).toContain('realtime-b.example')
+    cleanup()
+  })
+
+  it('bounds URL-only rotation during a DB outage without hammering config or dropping the healthy socket', async () => {
+    class ControlledWebSocket {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+      static readonly instances: ControlledWebSocket[] = []
+      readyState = ControlledWebSocket.CONNECTING
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: { code: number }) => void) | null = null
+
+      constructor(readonly url: string) {
+        ControlledWebSocket.instances.push(this)
+        queueMicrotask(() => {
+          this.readyState = ControlledWebSocket.OPEN
+          this.onopen?.()
+        })
+      }
+
+      send() {}
+      close(code = 1000) {
+        this.readyState = 3
+        this.onclose?.({ code })
+      }
+      emit(message: unknown) {
+        this.onmessage?.({ data: JSON.stringify(message) })
+      }
+    }
+    vi.stubGlobal('WebSocket', ControlledWebSocket)
+    vi.stubEnv('OVERLAY_REALTIME_MODE', 'do-primary')
+    vi.stubEnv('OVERLAY_REALTIME_STREAMER_ALLOWLIST', STREAMER_ID)
+    vi.stubEnv('OVERLAY_REALTIME_WS_URL', 'https://realtime-a.example')
+
+    let configCalls = 0
+    let eventsCalls = 0
+    let failHistory = false
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/realtime-config')) {
+        configCalls += 1
+        // The first degraded probe also fails at the edge. It must not tear
+        // down a socket that is still proving liveness with heartbeats.
+        if (configCalls === 2) throw new Error('temporary config edge failure')
+        return jsonResponse(resolveOverlayRealtimeConfig(STREAMER_ID))
+      }
+      eventsCalls += 1
+      if (failHistory) throw new Error('PlanetScale unavailable')
+      return jsonResponse({
+        realtimeEvents: [],
+        nextCursor: null,
+        realtimeConfigVersion: resolveOverlayRealtimeConfigVersion(STREAMER_ID),
+      })
+    }))
+
+    const callback = vi.fn()
+    const statuses: string[] = []
+    const cleanup = subscribeToGachaResults('ignored', callback, {
+      onStatusChange: (status) => statuses.push(status),
+    })
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+
+    const oldSocket = ControlledWebSocket.instances[0]
+    oldSocket.emit({
+      type: 'welcome',
+      protocolVersion: 1,
+      connectionId: 'connection-db-outage-a',
+      serverTime: '',
+      seq: 0,
+    })
+    failHistory = true
+    vi.stubEnv('OVERLAY_REALTIME_WS_URL', 'https://realtime-b.example')
+
+    // The healthy ten-minute reconciliation fails before it can carry the new
+    // config generation. That failure triggers exactly one DB-independent
+    // config probe; the intentionally failed probe preserves socket A.
+    for (let halfMinute = 0; halfMinute < 20; halfMinute += 1) {
+      await vi.advanceTimersByTimeAsync(30_000)
+      oldSocket.emit({ type: 'server_notice', code: 'heartbeat' })
+      await flushPromises()
+    }
+    await vi.advanceTimersToNextTimerAsync()
+    await flushPromises()
+
+    expect(configCalls).toBe(2)
+    expect(ControlledWebSocket.instances).toHaveLength(1)
+    expect(statuses).toContain('CONFIG_REFRESH_FAILED:KEEP_CURRENT')
+
+    // History retries continue under their existing serialized backoff, but
+    // they may not turn into a config request every 30 seconds. The next probe
+    // is allowed only at the five-minute degraded-mode floor.
+    for (let halfMinute = 0; halfMinute < 9; halfMinute += 1) {
+      await vi.advanceTimersByTimeAsync(30_000)
+      oldSocket.emit({ type: 'server_notice', code: 'heartbeat' })
+      await flushPromises()
+    }
+    expect(configCalls).toBe(2)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    oldSocket.emit({ type: 'server_notice', code: 'heartbeat' })
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(30_000)
+    await flushPromises()
+
+    expect(configCalls).toBe(3)
+    expect(eventsCalls).toBeGreaterThan(2)
+    expect(ControlledWebSocket.instances).toHaveLength(2)
+    expect(ControlledWebSocket.instances[1].url).toContain('realtime-b.example')
+
+    const [event] = buildPollingRealtimeEvents(STREAMER_ID, [{
+      id: historyUuid(23),
+      eventId: 'batch-db-outage-url-switch',
+      redeemedAt: '2026-07-24T00:00:01.000Z',
+      userTwitchUsername: 'viewer',
+      card: CARD_A,
+    }])
+    oldSocket.emit({ type: 'gacha_result', seq: 1, event })
+    expect(callback).not.toHaveBeenCalled()
+    ControlledWebSocket.instances[1].emit({
+      type: 'welcome',
+      protocolVersion: 1,
+      connectionId: 'connection-db-outage-b',
+      serverTime: '',
+      seq: 0,
+    })
+    ControlledWebSocket.instances[1].emit({ type: 'gacha_result', seq: 1, event })
+    expect(callback).toHaveBeenCalledTimes(1)
     cleanup()
   })
 
@@ -1382,6 +1607,214 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     await flushPromises()
     expect(historyCalls).toBeGreaterThan(afterConnect)
     expect(statuses).toContain('DO_SEQ_GAP:7->9')
+    cleanup()
+  })
+
+  it('delivers signed demo frames immediately without manufacturing DB reconciliation debt', async () => {
+    class ControlledWebSocket {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+      static readonly instances: ControlledWebSocket[] = []
+      readyState = ControlledWebSocket.CONNECTING
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: { code: number }) => void) | null = null
+
+      constructor() {
+        ControlledWebSocket.instances.push(this)
+        queueMicrotask(() => {
+          this.readyState = ControlledWebSocket.OPEN
+          this.onopen?.()
+        })
+      }
+
+      send() {}
+      close(code = 1000) {
+        this.readyState = 3
+        this.onclose?.({ code })
+      }
+      emit(message: unknown) {
+        this.onmessage?.({ data: JSON.stringify(message) })
+      }
+    }
+    vi.stubGlobal('WebSocket', ControlledWebSocket)
+
+    let historyCalls = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/realtime-config')) {
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'do-primary',
+          webSocketUrl: 'https://realtime.example',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: 'do-primary-v1',
+        })
+      }
+      historyCalls += 1
+      return jsonResponse({
+        realtimeEvents: [],
+        nextCursor: null,
+        realtimeConfigVersion: 'do-primary-v1',
+      })
+    }))
+
+    const callback = vi.fn()
+    const statuses: string[] = []
+    const cleanup = subscribeToGachaResults('ignored', callback, {
+      onStatusChange: (status) => statuses.push(status),
+    })
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+
+    const historyAfterStartup = historyCalls
+    const socket = ControlledWebSocket.instances[0]
+    socket.emit({
+      type: 'welcome',
+      protocolVersion: 1,
+      connectionId: 'connection-demo',
+      serverTime: '',
+      seq: 0,
+    })
+
+    // Exercise the exact 512-event threshold that committed socket traffic
+    // uses to request an early DB reconciliation. Demos have only a bounded KV
+    // fallback and no gacha_history row, so even sustained operator previews
+    // must display synchronously without crossing that committed-data guard.
+    for (let index = 1; index <= 512; index += 1) {
+      const [baseEvent] = buildPollingRealtimeEvents(STREAMER_ID, [{
+        id: `demo:history-${index}`,
+        eventId: `demo:event-${index}`,
+        redeemedAt: `2026-07-24T00:00:${String(index % 60).padStart(2, '0')}.000Z`,
+        userTwitchUsername: 'DemoUser',
+        card: { ...CARD_A, id: `demo-card-${index}` },
+      }])
+      socket.emit({
+        type: 'gacha_result',
+        seq: index,
+        event: { ...baseEvent, deliveryKind: 'demo' },
+      })
+    }
+    await flushPromises()
+
+    expect(callback).toHaveBeenCalledTimes(512)
+    expect(callback.mock.calls[0][0].userTwitchUsername).toBe('DemoUser')
+    expect(historyCalls).toBe(historyAfterStartup)
+    expect(statuses.some((status) => status.startsWith('DO_RECONCILE_VOLUME:'))).toBe(false)
+    cleanup()
+  })
+
+  it.each([
+    ['recovers a missed immediate publish from KV at ten minutes', false],
+    ['deduplicates an immediate DO demo against its later KV fallback', true],
+  ])('%s', async (_label, deliverImmediately) => {
+    vi.setSystemTime(new Date('2026-07-24T00:00:00.000Z'))
+
+    class ControlledWebSocket {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+      static readonly instances: ControlledWebSocket[] = []
+      readyState = ControlledWebSocket.CONNECTING
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: { code: number }) => void) | null = null
+
+      constructor() {
+        ControlledWebSocket.instances.push(this)
+        queueMicrotask(() => {
+          this.readyState = ControlledWebSocket.OPEN
+          this.onopen?.()
+        })
+      }
+
+      send() {}
+      close(code = 1000) {
+        this.readyState = 3
+        this.onclose?.({ code })
+      }
+      emit(message: unknown) {
+        this.onmessage?.({ data: JSON.stringify(message) })
+      }
+    }
+    vi.stubGlobal('WebSocket', ControlledWebSocket)
+
+    const demoEvent = {
+      id: 'demo:history-fallback',
+      eventId: 'demo:event-fallback',
+      redeemedAt: '2026-07-24T00:00:01.000Z',
+      userTwitchUsername: 'DemoUser',
+      rewardId: null,
+      card: CARD_A,
+    }
+    const [socketEnvelope] = buildPollingRealtimeEvents(STREAMER_ID, [{
+      id: demoEvent.id,
+      eventId: demoEvent.eventId,
+      redeemedAt: demoEvent.redeemedAt,
+      userTwitchUsername: demoEvent.userTwitchUsername,
+      rewardId: null,
+      card: CARD_A,
+    }])
+    let fallbackAvailable = false
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/realtime-config')) {
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'do-primary',
+          webSocketUrl: 'https://realtime.example',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: 'do-primary-v1',
+        })
+      }
+      return jsonResponse({
+        realtimeEvents: [],
+        nextCursor: null,
+        demoEvent: fallbackAvailable ? demoEvent : null,
+        realtimeConfigVersion: 'do-primary-v1',
+      })
+    }))
+
+    const callback = vi.fn()
+    const cleanup = subscribeToGachaResults('ignored', callback)
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+
+    const socket = ControlledWebSocket.instances[0]
+    socket.emit({
+      type: 'welcome',
+      protocolVersion: 1,
+      connectionId: 'connection-demo-fallback',
+      serverTime: '',
+      seq: 0,
+    })
+    if (deliverImmediately) {
+      socket.emit({
+        type: 'gacha_result',
+        seq: 1,
+        event: { ...socketEnvelope, deliveryKind: 'demo' },
+      })
+      expect(callback).toHaveBeenCalledTimes(1)
+    }
+    fallbackAvailable = true
+
+    // The normal healthy-socket sweep is the longest client recovery path.
+    // The KV store keeps the same immutable event beyond this deadline; if DO
+    // fanout failed it appears here, and if DO succeeded the shared eventId
+    // makes this response a duplicate instead of a second overlay display.
+    for (let halfMinute = 0; halfMinute < 20; halfMinute += 1) {
+      await vi.advanceTimersByTimeAsync(30_000)
+      socket.emit({ type: 'server_notice', code: 'heartbeat' })
+      await flushPromises()
+    }
+    await vi.advanceTimersToNextTimerAsync()
+    await flushPromises()
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback.mock.calls[0][0].userTwitchUsername).toBe('DemoUser')
     cleanup()
   })
 

--- a/tests/unit/realtime.test.ts
+++ b/tests/unit/realtime.test.ts
@@ -4,9 +4,16 @@ import {
   type GachaBroadcastPayload,
   type SubscribeOptions,
 } from '@/lib/realtime'
-import { buildPollingRealtimeEvents } from '@/lib/overlay-realtime/contract'
+import {
+  MAX_OVERLAY_VERSION_LENGTH,
+  buildPollingRealtimeEvents,
+} from '@/lib/overlay-realtime/contract'
 
 const STREAMER_ID = '123e4567-e89b-42d3-a456-426614174000'
+
+function historyUuid(index: number): string {
+  return `00000000-0000-4000-8000-${index.toString(16).padStart(12, '0')}`
+}
 
 function subscribeToGachaResults(
   _streamerId: string,
@@ -57,11 +64,14 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
 
   it('groups N-draw history rows and consumes a demo from the same polling response', async () => {
     const redeemedAt = '2026-07-24T00:00:01.000Z'
-    const fetchMock = vi.fn(async (_input: RequestInfo | URL) =>
-      jsonResponse({
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      // Preserve the argument tuple for URL assertions below; the response is
+      // intentionally identical for config and events in this grouping test.
+      void input
+      return jsonResponse({
         events: [
           {
-            id: 'history-1',
+            id: historyUuid(1),
             eventId: 'event-1',
             redeemedAt,
             userTwitchUsername: 'viewer',
@@ -69,7 +79,7 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
             card: CARD_A,
           },
           {
-            id: 'history-2',
+            id: historyUuid(2),
             eventId: 'event-1:2',
             redeemedAt,
             userTwitchUsername: 'viewer',
@@ -86,7 +96,7 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
           card: CARD_A,
         },
       })
-    )
+    })
     vi.stubGlobal('fetch', fetchMock)
 
     const callback = vi.fn()
@@ -119,6 +129,132 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     expect(pollingUrl).toContain('demoSince=')
     expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/demo-events'))).toBe(false)
 
+    cleanup()
+  })
+
+  it('starts recovery from the restored exact cursor and keeps same-time rows ordered', async () => {
+    const restoredAt = '2026-07-24T00:00:01.000Z'
+    const restoredId = historyUuid(10)
+    const rows = [
+      {
+        id: historyUuid(11),
+        eventId: 'event-same-time-2',
+        redeemedAt: restoredAt,
+        userTwitchUsername: 'viewer',
+        card: CARD_A,
+      },
+      {
+        id: historyUuid(12),
+        eventId: 'event-same-time-3',
+        redeemedAt: restoredAt,
+        userTwitchUsername: 'viewer',
+        card: CARD_B,
+      },
+    ]
+    const requestedEventUrls: URL[] = []
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input))
+      if (url.pathname.includes('/realtime-config')) {
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'polling-only',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: 'polling-v1',
+          overlayVersion: 'build-current',
+        })
+      }
+      requestedEventUrls.push(url)
+      return jsonResponse({
+        realtimeEvents: buildPollingRealtimeEvents(STREAMER_ID, rows),
+        nextCursor: { redeemedAt: restoredAt, historyId: rows[1].id },
+      })
+    }))
+
+    const callback = vi.fn()
+    const onHistoryCursor = vi.fn()
+    const cleanup = subscribeToGachaResults('ignored', callback, {
+      initialHistoryCursor: { redeemedAt: restoredAt, historyId: restoredId },
+      onHistoryCursor,
+    })
+    await flushPromises()
+
+    expect(requestedEventUrls[0].searchParams.get('since')).toBe(restoredAt)
+    expect(requestedEventUrls[0].searchParams.get('afterId')).toBe(restoredId)
+    expect(callback.mock.calls.map(([payload]) => payload.card.id)).toEqual([
+      CARD_A.id,
+      CARD_B.id,
+    ])
+    expect(onHistoryCursor).toHaveBeenLastCalledWith({
+      redeemedAt: restoredAt,
+      historyId: rows[1].id,
+    })
+    cleanup()
+  })
+
+  it('notifies bounded overlay versions from both valid config and events responses', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/realtime-config')) {
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'polling-only',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: 'polling-v1',
+          overlayVersion: 'build-from-config',
+        })
+      }
+      return jsonResponse({
+        events: [],
+        overlayVersion: 'build-from-events',
+      })
+    }))
+
+    const onOverlayVersion = vi.fn()
+    const cleanup = subscribeToGachaResults('streamer-1', vi.fn(), {
+      onOverlayVersion,
+    })
+    await flushPromises()
+
+    expect(onOverlayVersion).toHaveBeenCalledTimes(2)
+    expect(onOverlayVersion.mock.calls.map(([version]) => version)).toEqual(
+      expect.arrayContaining(['build-from-config', 'build-from-events'])
+    )
+    cleanup()
+  })
+
+  it('does not notify from an invalid config, its safe fallback, or an unbounded events value', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/realtime-config')) {
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'polling-only',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          // The config itself is invalid even though overlayVersion is valid:
+          // unbounded configVersion must fail the complete response contract.
+          configVersion: 'c'.repeat(129),
+          // A valid-looking auxiliary value must not escape an otherwise
+          // invalid response before the safe fallback is selected.
+          overlayVersion: 'must-not-notify',
+        })
+      }
+      return jsonResponse({
+        events: [],
+        overlayVersion: 'v'.repeat(MAX_OVERLAY_VERSION_LENGTH + 1),
+      })
+    }))
+
+    const onOverlayVersion = vi.fn()
+    const onStatusChange = vi.fn()
+    const cleanup = subscribeToGachaResults('streamer-1', vi.fn(), {
+      onOverlayVersion,
+      onStatusChange,
+    })
+    await flushPromises()
+
+    expect(onOverlayVersion).not.toHaveBeenCalled()
+    expect(onStatusChange).toHaveBeenCalledWith('CONFIG_FALLBACK:POLLING_ONLY')
     cleanup()
   })
 
@@ -197,7 +333,7 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
 
   it('deduplicates rows returned again by a subsequent poll', async () => {
     const event = {
-      id: 'history-1',
+      id: historyUuid(20),
       eventId: 'event-1',
       redeemedAt: '2026-07-24T00:00:01.000Z',
       userTwitchUsername: 'viewer',
@@ -302,7 +438,7 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     vi.stubGlobal('WebSocket', FakeWebSocket)
 
     const pollingRow = {
-      id: 'history-ws-1',
+      id: historyUuid(21),
       eventId: 'batch-ws-1',
       redeemedAt: '2026-07-24T00:00:01.000Z',
       userTwitchUsername: 'viewer',
@@ -350,7 +486,7 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     cleanup()
   })
 
-  it('does not start a second polling request while reconnect recovery is in flight', async () => {
+  it('serializes an onopen recovery behind an in-flight snapshot and runs one trailing poll', async () => {
     class OpeningWebSocket {
       static readonly CONNECTING = 0
       static readonly OPEN = 1
@@ -406,6 +542,13 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     expect(historyCalls).toBe(1)
     resolveHistory(jsonResponse({ events: [] }))
     await flushPromises()
+
+    // onopen happened while the first request was unresolved. It must not
+    // start concurrently, but it also must not disappear: the trailing empty
+    // snapshot closes commits that landed after the first DB snapshot.
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+    expect(historyCalls).toBe(2)
     cleanup()
   })
 
@@ -446,6 +589,8 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0)
 
     let configCalls = 0
+    let eventsCalls = 0
+    let advertisedConfigVersion = 'test-v1'
     vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
       if (url.includes('/realtime-config')) {
@@ -462,11 +607,15 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
           configVersion: `test-v${configCalls}`,
         })
       }
-      return jsonResponse({ events: [] })
+      eventsCalls += 1
+      return jsonResponse({
+        events: [],
+        realtimeConfigVersion: advertisedConfigVersion,
+      })
     }))
 
     const [event] = buildPollingRealtimeEvents(STREAMER_ID, [{
-      id: 'history-stale-1',
+      id: historyUuid(22),
       eventId: 'batch-stale-1',
       redeemedAt: '2026-07-24T00:00:01.000Z',
       userTwitchUsername: 'viewer',
@@ -481,23 +630,592 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     await flushPromises()
     expect(ControlledWebSocket.instances).toHaveLength(1)
 
-    // Connected overlays no longer poll the config endpoint every 30 seconds;
-    // the change signal normally rides on history polling (covered by the test
-    // below). This case drives the five-minute safety-net refresh, which is the
-    // path that must still work when history polling cannot carry the signal.
+    // Opening the initial socket queues one immediate DB recovery. Drain that
+    // startup task before measuring the safety cadence so it cannot be mistaken
+    // for an early steady-state reconciliation.
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+    const eventsAfterStartup = eventsCalls
+    const safetyStartedAt = Date.now()
+
+    // Healthy overlays use one ten-minute history reconciliation as both the
+    // gapless-publish recovery path and the config/build change signal. There
+    // is no parallel steady-state config timer.
     await vi.advanceTimersByTimeAsync(5 * 60_000)
     await flushPromises()
+    expect(configCalls).toBe(1)
+    expect(eventsCalls).toBe(eventsAfterStartup)
+    expect(ControlledWebSocket.instances).toHaveLength(1)
+
+    advertisedConfigVersion = 'test-v2'
+    await vi.advanceTimersByTimeAsync(5 * 60_000)
+    await flushPromises()
+
+    // At the ten-minute deadline the safety callback queues the reconciliation
+    // as a separate zero-delay timer. Advance to that deadline without jumping
+    // to a later liveness timer; Promise flushing alone cannot run timers.
+    await vi.advanceTimersToNextTimerAsync()
+    await flushPromises()
+    expect(Date.now()).toBeGreaterThanOrEqual(safetyStartedAt + 10 * 60_000)
+    expect(Date.now()).toBeLessThan(safetyStartedAt + 10 * 60_000 + 1_000)
+    // One request detects the version change. Replacing the endpoint opens a
+    // new socket, whose mandatory boundary recovery is the second request.
+    expect(eventsCalls).toBe(eventsAfterStartup + 2)
+    expect(configCalls).toBe(2)
     expect(ControlledWebSocket.instances).toHaveLength(2)
 
     ControlledWebSocket.instances[0].emit({ type: 'gacha_result', event })
     expect(callback).not.toHaveBeenCalled()
     ControlledWebSocket.instances[1].emit({ type: 'gacha_result', event })
+    // The same-deadline endpoint-boundary recovery has already completed, so
+    // only the current socket may deliver this frame now.
     expect(callback).toHaveBeenCalledTimes(1)
 
     ControlledWebSocket.instances[1].onclose?.({ code: 1006 })
     // A config endpoint change starts a fresh connection policy, so the next
     // outage uses the initial half-jitter delay (random is stubbed to zero).
     expect(statuses).toContain('DO_RECONNECT_WAIT:50')
+    cleanup()
+  })
+
+  it('ten-minute reconciliation recovers a gapless failed publish behind a later socket event', async () => {
+    vi.setSystemTime(new Date('2026-07-24T00:00:00.000Z'))
+
+    class ControlledWebSocket {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+      static readonly instances: ControlledWebSocket[] = []
+      readyState = ControlledWebSocket.CONNECTING
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: { code: number }) => void) | null = null
+
+      constructor() {
+        ControlledWebSocket.instances.push(this)
+        queueMicrotask(() => {
+          this.readyState = ControlledWebSocket.OPEN
+          this.onopen?.()
+        })
+      }
+
+      send() {}
+      close(code = 1000) {
+        this.readyState = 3
+        this.onclose?.({ code })
+      }
+      emit(message: unknown) {
+        this.onmessage?.({ data: JSON.stringify(message) })
+      }
+    }
+    vi.stubGlobal('WebSocket', ControlledWebSocket)
+
+    const rows = [
+      {
+        id: historyUuid(40),
+        eventId: 'batch-publish-failed',
+        redeemedAt: '2026-07-24T00:00:01.000Z',
+        userTwitchUsername: 'viewer',
+        card: CARD_A,
+      },
+      {
+        id: historyUuid(41),
+        eventId: 'batch-publish-succeeded',
+        redeemedAt: '2026-07-24T00:00:02.000Z',
+        userTwitchUsername: 'viewer',
+        card: CARD_B,
+      },
+    ]
+    const [missedEvent, liveEvent] = rows.map((row) =>
+      buildPollingRealtimeEvents(STREAMER_ID, [row])[0]
+    )
+    let reconciliationEnabled = false
+    let reconciliationPage = 0
+    let firstReconciliationSince: string | null = null
+    let firstReconciliationAt: number | null = null
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input))
+      if (url.pathname.includes('/realtime-config')) {
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'do-primary',
+          webSocketUrl: 'https://realtime.example',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: 'do-primary-v1',
+          overlayVersion: 'build-current',
+        })
+      }
+      if (!reconciliationEnabled) {
+        return jsonResponse({ realtimeEvents: [], nextCursor: null })
+      }
+
+      reconciliationPage += 1
+      if (reconciliationPage === 1) {
+        firstReconciliationSince = url.searchParams.get('since')
+        firstReconciliationAt = Date.now()
+        return jsonResponse({
+          realtimeEvents: [missedEvent, liveEvent],
+          nextCursor: {
+            redeemedAt: rows[1].redeemedAt,
+            historyId: rows[1].id,
+          },
+        })
+      }
+      return jsonResponse({ realtimeEvents: [], nextCursor: null })
+    }))
+
+    const callback = vi.fn()
+    const onHistoryCursor = vi.fn()
+    const cleanup = subscribeToGachaResults('ignored', callback, {
+      onHistoryCursor,
+    })
+    await flushPromises()
+    for (let pass = 0; pass < 3; pass += 1) {
+      await vi.advanceTimersByTimeAsync(0)
+      await flushPromises()
+    }
+
+    const socket = ControlledWebSocket.instances[0]
+    socket.emit({
+      type: 'welcome',
+      protocolVersion: 1,
+      connectionId: 'connection-publisher-recovery',
+      serverTime: '',
+      seq: 0,
+    })
+    socket.emit({ type: 'gacha_result', seq: 1, event: liveEvent })
+    expect(callback.mock.calls.map(([payload]) => payload.card.id)).toEqual([
+      CARD_B.id,
+    ])
+    // Socket delivery is not a durable DB checkpoint: an earlier publish may
+    // have failed before the room could assign a sequence number.
+    expect(onHistoryCursor).not.toHaveBeenCalled()
+
+    reconciliationEnabled = true
+    for (let halfMinute = 0; halfMinute < 19; halfMinute += 1) {
+      await vi.advanceTimersByTimeAsync(30_000)
+      socket.emit({ type: 'server_notice', code: 'heartbeat' })
+      await flushPromises()
+    }
+
+    // A healthy socket must not touch history before the ten-minute safety
+    // deadline, even though liveness is being renewed every thirty seconds.
+    expect(firstReconciliationSince).toBeNull()
+    expect(reconciliationPage).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    socket.emit({ type: 'server_notice', code: 'heartbeat' })
+    await flushPromises()
+
+    // The deadline callback schedules the DB cycle at the next timer deadline.
+    // This avoids jumping to a later liveness deadline while still allowing the
+    // data page and its mandatory terminating empty page to drain together.
+    await vi.advanceTimersToNextTimerAsync()
+    await flushPromises()
+
+    expect(firstReconciliationSince).toBe('2026-07-24T00:00:00.000Z')
+    expect(firstReconciliationAt).toBeGreaterThanOrEqual(
+      new Date('2026-07-24T00:10:00.000Z').getTime()
+    )
+    expect(firstReconciliationAt).toBeLessThan(
+      new Date('2026-07-24T00:10:01.000Z').getTime()
+    )
+    expect(reconciliationPage).toBe(2)
+    expect(callback.mock.calls.map(([payload]) => payload.card.id)).toEqual([
+      CARD_B.id,
+      CARD_A.id,
+    ])
+    expect(onHistoryCursor).toHaveBeenLastCalledWith({
+      redeemedAt: rows[1].redeemedAt,
+      historyId: rows[1].id,
+    })
+    cleanup()
+  })
+
+  it('reconciles and reload-dedupes 513 socket draws without an eviction cascade', async () => {
+    vi.setSystemTime(new Date('2026-07-24T00:00:00.000Z'))
+
+    class ControlledWebSocket {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+      static readonly instances: ControlledWebSocket[] = []
+      readyState = ControlledWebSocket.CONNECTING
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: { code: number }) => void) | null = null
+
+      constructor() {
+        ControlledWebSocket.instances.push(this)
+        queueMicrotask(() => {
+          this.readyState = ControlledWebSocket.OPEN
+          this.onopen?.()
+        })
+      }
+
+      send() {}
+      close(code = 1000) {
+        this.readyState = 3
+        this.onclose?.({ code })
+      }
+      emit(message: unknown) {
+        this.onmessage?.({ data: JSON.stringify(message) })
+      }
+    }
+    vi.stubGlobal('WebSocket', ControlledWebSocket)
+
+    const rows = Array.from({ length: 513 }, (_, index) => ({
+      id: historyUuid(1_000 + index),
+      eventId: `batch-volume-${index}`,
+      redeemedAt: new Date(
+        new Date('2026-07-24T00:00:01.000Z').getTime() + index * 1_000
+      ).toISOString(),
+      userTwitchUsername: 'viewer',
+      card: { ...CARD_A, id: `card-volume-${index}` },
+    }))
+    const realtimeEvents = rows.map((row) =>
+      buildPollingRealtimeEvents(STREAMER_ID, [row])[0]
+    )
+    let historyReady = false
+    let pageIndex = 0
+    const historyPageSizes: number[] = []
+    let reloaded = false
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/realtime-config')) {
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: reloaded ? 'polling-only' : 'do-primary',
+          ...(reloaded ? {} : { webSocketUrl: 'https://realtime.example' }),
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: reloaded ? 'polling-v1' : 'do-primary-v1',
+        })
+      }
+      if (!historyReady) {
+        return jsonResponse({ realtimeEvents: [], nextCursor: null })
+      }
+      const pageEvents = realtimeEvents.slice(pageIndex * 100, (pageIndex + 1) * 100)
+      pageIndex += 1
+      historyPageSizes.push(pageEvents.length)
+      const last = pageEvents.at(-1)
+      return jsonResponse({
+        realtimeEvents: pageEvents,
+        nextCursor: last
+          ? {
+              redeemedAt: last.occurredAt,
+              historyId: last.draws.at(-1)?.historyId,
+            }
+          : null,
+      })
+    }))
+
+    const statuses: string[] = []
+    const callback = vi.fn()
+    const cleanup = subscribeToGachaResults('ignored', callback, {
+      onStatusChange: (status) => statuses.push(status),
+    })
+    await flushPromises()
+    for (let pass = 0; pass < 3; pass += 1) {
+      await vi.advanceTimersByTimeAsync(0)
+      await flushPromises()
+    }
+
+    const socket = ControlledWebSocket.instances[0]
+    socket.emit({
+      type: 'welcome',
+      protocolVersion: 1,
+      connectionId: 'connection-volume',
+      serverTime: '',
+      seq: 0,
+    })
+    historyReady = true
+    realtimeEvents.forEach((event, index) => {
+      socket.emit({ type: 'gacha_result', seq: index + 1, event })
+    })
+    expect(callback).toHaveBeenCalledTimes(513)
+    expect(statuses).toContain('DO_RECONCILE_VOLUME:512')
+
+    const expectedHistoryPageSizes = [100, 100, 100, 100, 100, 13, 0]
+    // Same-deadline pages may coalesce within one async timer advance. Stop on
+    // the observed seventh response, rather than advancing seven timers and
+    // crossing into the later liveness or steady-state polling deadlines.
+    const driveExpectedHistoryDrain = async () => {
+      for (
+        let advanceCount = 0;
+        advanceCount < expectedHistoryPageSizes.length
+          && historyPageSizes.length < expectedHistoryPageSizes.length;
+        advanceCount += 1
+      ) {
+        await vi.advanceTimersToNextTimerAsync()
+        await flushPromises()
+      }
+      expect(historyPageSizes).toEqual(expectedHistoryPageSizes)
+      expect(pageIndex).toBe(expectedHistoryPageSizes.length)
+    }
+    await driveExpectedHistoryDrain()
+    expect(callback).toHaveBeenCalledTimes(513)
+    cleanup()
+
+    // A version reload can happen before or after reconciliation. The bounded
+    // session cache must retain the whole >512 live window so restarting from
+    // the older DB checkpoint does not replay any draw.
+    reloaded = true
+    pageIndex = 0
+    historyPageSizes.length = 0
+    const reloadCallback = vi.fn()
+    const reloadCleanup = subscribeToGachaResults('ignored', reloadCallback, {
+      initialHistoryCursor: {
+        redeemedAt: '2026-07-24T00:00:00.000Z',
+        historyId: '',
+      },
+    })
+    await flushPromises()
+    await driveExpectedHistoryDrain()
+    expect(reloadCallback).not.toHaveBeenCalled()
+    reloadCleanup()
+  })
+
+  it('bounds recovery buffering and keeps DB recovery duplicate-free after degradation', async () => {
+    class ControlledWebSocket {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+      static readonly instances: ControlledWebSocket[] = []
+      readyState = ControlledWebSocket.CONNECTING
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: { code: number }) => void) | null = null
+
+      constructor() {
+        ControlledWebSocket.instances.push(this)
+        queueMicrotask(() => {
+          this.readyState = ControlledWebSocket.OPEN
+          this.onopen?.()
+        })
+      }
+
+      send() {}
+      close(code = 1000) {
+        this.readyState = 3
+        this.onclose?.({ code })
+      }
+      emit(message: unknown) {
+        this.onmessage?.({ data: JSON.stringify(message) })
+      }
+    }
+    vi.stubGlobal('WebSocket', ControlledWebSocket)
+
+    const rows = Array.from({ length: 34 }, (_, index) => ({
+      id: historyUuid(2_000 + index),
+      eventId: `batch-buffer-${index}`,
+      redeemedAt: `2026-07-24T00:00:${String(index + 1).padStart(2, '0')}.000Z`,
+      userTwitchUsername: 'viewer',
+      card: { ...CARD_A, id: `card-buffer-${index}` },
+    }))
+    const realtimeEvents = rows.map((row) =>
+      buildPollingRealtimeEvents(STREAMER_ID, [row])[0]
+    )
+    let recoveryPromise: Promise<Response> | null = null
+    let afterRecovery = false
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/realtime-config')) {
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'do-primary',
+          webSocketUrl: 'https://realtime.example',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: 'do-primary-v1',
+        })
+      }
+      if (recoveryPromise) {
+        const pending = recoveryPromise
+        recoveryPromise = null
+        return pending
+      }
+      return jsonResponse({
+        realtimeEvents: [],
+        nextCursor: null,
+        ...(afterRecovery ? { realtimeConfigVersion: 'do-primary-v1' } : {}),
+      })
+    }))
+
+    const callback = vi.fn()
+    const statuses: string[] = []
+    const cleanup = subscribeToGachaResults('ignored', callback, {
+      onStatusChange: (status) => statuses.push(status),
+    })
+    await flushPromises()
+    for (let pass = 0; pass < 3; pass += 1) {
+      await vi.advanceTimersByTimeAsync(0)
+      await flushPromises()
+    }
+
+    let resolveRecovery!: (response: Response) => void
+    recoveryPromise = new Promise<Response>((resolve) => {
+      resolveRecovery = resolve
+    })
+    const socket = ControlledWebSocket.instances[0]
+    socket.emit({
+      type: 'welcome',
+      protocolVersion: 1,
+      connectionId: 'connection-buffer',
+      serverTime: '',
+      seq: 0,
+    })
+    socket.emit({ type: 'gacha_result', seq: 2, event: realtimeEvents[0] })
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+
+    for (let index = 1; index < 33; index += 1) {
+      socket.emit({
+        type: 'gacha_result',
+        seq: index + 2,
+        event: realtimeEvents[index],
+      })
+    }
+    expect(statuses).toContain('DO_RECOVERY_DEGRADED:capacity')
+    expect(callback).toHaveBeenCalledTimes(33)
+
+    afterRecovery = true
+    resolveRecovery(jsonResponse({
+      realtimeEvents: realtimeEvents.slice(0, 33),
+      nextCursor: {
+        redeemedAt: rows[32].redeemedAt,
+        historyId: rows[32].id,
+      },
+    }))
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+    expect(callback).toHaveBeenCalledTimes(33)
+
+    // A later low-volume recovery proves the independent time bound: one live
+    // frame cannot remain hidden forever merely because its DB read is stuck.
+    recoveryPromise = new Promise<Response>(() => {})
+    // Leave seq 35 missing so this frame starts recovery buffering; a contiguous
+    // seq 35 would be delivered immediately and would not exercise the timeout.
+    socket.emit({ type: 'gacha_result', seq: 36, event: realtimeEvents[33] })
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+    expect(callback).toHaveBeenCalledTimes(33)
+    expect(statuses).not.toContain('DO_RECOVERY_DEGRADED:timeout')
+    await vi.advanceTimersByTimeAsync(9_999)
+    expect(callback).toHaveBeenCalledTimes(33)
+    expect(statuses).not.toContain('DO_RECOVERY_DEGRADED:timeout')
+    await vi.advanceTimersByTimeAsync(1)
+    await flushPromises()
+    expect(statuses).toContain('DO_RECOVERY_DEGRADED:timeout')
+    expect(callback).toHaveBeenCalledTimes(34)
+    cleanup()
+  })
+
+  it('probes legacy events once when a modern connected client reaches a rolled-back config route', async () => {
+    class ControlledWebSocket {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+      static readonly instances: ControlledWebSocket[] = []
+      readyState = ControlledWebSocket.CONNECTING
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: { code: number }) => void) | null = null
+
+      constructor() {
+        ControlledWebSocket.instances.push(this)
+        queueMicrotask(() => {
+          this.readyState = ControlledWebSocket.OPEN
+          this.onopen?.()
+        })
+      }
+
+      send() {}
+      close(code = 1000) {
+        this.readyState = 3
+        this.onclose?.({ code })
+      }
+      emit(message: unknown) {
+        this.onmessage?.({ data: JSON.stringify(message) })
+      }
+    }
+    vi.stubGlobal('WebSocket', ControlledWebSocket)
+
+    let configCalls = 0
+    let eventsCalls = 0
+    let rolledBack = false
+    const rolledBackEventCallTimes: number[] = []
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/realtime-config')) {
+        configCalls += 1
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'do-primary',
+          webSocketUrl: 'https://realtime.example',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: 'do-primary-v1',
+          ...(configCalls === 1 ? { overlayVersion: 'build-modern' } : {}),
+        })
+      }
+      eventsCalls += 1
+      if (rolledBack) rolledBackEventCallTimes.push(Date.now())
+      return jsonResponse({
+        realtimeEvents: [],
+        nextCursor: null,
+        overlayVersion: rolledBack ? 'build-rolled-back' : 'build-modern',
+        realtimeConfigVersion: rolledBack ? 'do-primary-v2' : 'do-primary-v1',
+      })
+    }))
+
+    const onOverlayVersion = vi.fn()
+    const cleanup = subscribeToGachaResults('ignored', vi.fn(), {
+      onOverlayVersion,
+    })
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+    const eventsAfterStartup = eventsCalls
+    const safetyStartedAt = Date.now()
+    onOverlayVersion.mockClear()
+    rolledBack = true
+
+    const socket = ControlledWebSocket.instances[0]
+    for (let halfMinute = 0; halfMinute < 19; halfMinute += 1) {
+      // Keep each heartbeat inside the 150-second liveness deadline so this
+      // remains a healthy connected rollback, not disconnect recovery.
+      await vi.advanceTimersByTimeAsync(30_000)
+      socket.emit({ type: 'server_notice', code: 'heartbeat' })
+      await flushPromises()
+    }
+
+    // The modern client must not reconcile or refetch config before ten minutes.
+    expect(configCalls).toBe(1)
+    expect(eventsCalls).toBe(eventsAfterStartup)
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    socket.emit({ type: 'server_notice', code: 'heartbeat' })
+    await flushPromises()
+
+    // Run the history cycle queued by the ten-minute safety callback. Its
+    // version mismatch refetches config; the present-to-absent overlayVersion
+    // transition then queues exactly one same-deadline legacy history probe.
+    await vi.advanceTimersToNextTimerAsync()
+    await flushPromises()
+
+    expect(ControlledWebSocket.instances).toHaveLength(1)
+    expect(configCalls).toBe(2)
+    expect(eventsCalls).toBe(eventsAfterStartup + 2)
+    expect(rolledBackEventCallTimes).toHaveLength(2)
+    expect(rolledBackEventCallTimes[0]).toBeGreaterThanOrEqual(
+      safetyStartedAt + 10 * 60_000
+    )
+    expect(rolledBackEventCallTimes[0]).toBeLessThan(
+      safetyStartedAt + 10 * 60_000 + 1_000
+    )
+    expect(onOverlayVersion).toHaveBeenCalledTimes(2)
+    expect(onOverlayVersion).toHaveBeenNthCalledWith(1, 'build-rolled-back')
+    expect(onOverlayVersion).toHaveBeenNthCalledWith(2, 'build-rolled-back')
     cleanup()
   })
 
@@ -564,7 +1282,7 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     expect(configCalls).toBe(1)
 
     // Operator enables this streamer. No config poll is scheduled for another
-    // five minutes, so only the history pass can carry this.
+    // ten minutes, so only the history pass can carry this promptly.
     serverVersion = 'do-primary-v1'
 
     await vi.advanceTimersByTimeAsync(30_000)
@@ -627,7 +1345,7 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     }))
 
     const [event] = buildPollingRealtimeEvents(STREAMER_ID, [{
-      id: 'history-seq-1',
+      id: historyUuid(30),
       eventId: 'batch-seq-1',
       redeemedAt: '2026-07-24T00:00:02.000Z',
       userTwitchUsername: 'viewer',
@@ -664,6 +1382,199 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     await flushPromises()
     expect(historyCalls).toBeGreaterThan(afterConnect)
     expect(statuses).toContain('DO_SEQ_GAP:7->9')
+    cleanup()
+  })
+
+  it('buffers the gap frame until DB recovery displays seq 8 then seq 9 exactly once', async () => {
+    class ControlledWebSocket {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+      static readonly instances: ControlledWebSocket[] = []
+      readyState = ControlledWebSocket.CONNECTING
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: { code: number }) => void) | null = null
+
+      constructor() {
+        ControlledWebSocket.instances.push(this)
+        queueMicrotask(() => {
+          this.readyState = ControlledWebSocket.OPEN
+          this.onopen?.()
+        })
+      }
+
+      send() {}
+      close(code = 1000) {
+        this.readyState = 3
+        this.onclose?.({ code })
+      }
+      emit(message: unknown) {
+        this.onmessage?.({ data: JSON.stringify(message) })
+      }
+    }
+    vi.stubGlobal('WebSocket', ControlledWebSocket)
+
+    const rows = [
+      {
+        id: historyUuid(38),
+        eventId: 'batch-seq-8',
+        redeemedAt: '2026-07-24T00:00:08.000Z',
+        userTwitchUsername: 'viewer',
+        card: CARD_A,
+      },
+      {
+        id: historyUuid(39),
+        eventId: 'batch-seq-9',
+        redeemedAt: '2026-07-24T00:00:09.000Z',
+        userTwitchUsername: 'viewer',
+        card: CARD_B,
+      },
+    ]
+    const [event8, event9] = rows.map((row) =>
+      buildPollingRealtimeEvents(STREAMER_ID, [row])[0]
+    )
+    let gapRecovery = false
+    let gapPage = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/realtime-config')) {
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'do-primary',
+          webSocketUrl: 'https://realtime.example',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: 'do-primary-v1',
+          overlayVersion: 'build-current',
+        })
+      }
+      if (!gapRecovery) return jsonResponse({ realtimeEvents: [], nextCursor: null })
+      gapPage += 1
+      if (gapPage === 1) {
+        return jsonResponse({
+          realtimeEvents: [event8, event9],
+          nextCursor: {
+            redeemedAt: rows[1].redeemedAt,
+            historyId: rows[1].id,
+          },
+        })
+      }
+      return jsonResponse({ realtimeEvents: [], nextCursor: null })
+    }))
+
+    const callback = vi.fn()
+    const cleanup = subscribeToGachaResults('ignored', callback)
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+
+    const socket = ControlledWebSocket.instances[0]
+    socket.emit({
+      type: 'welcome',
+      protocolVersion: 1,
+      connectionId: 'connection-gap',
+      serverTime: '',
+      seq: 7,
+    })
+    gapRecovery = true
+    socket.emit({ type: 'gacha_result', seq: 9, event: event9 })
+    expect(callback).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+
+    expect(callback.mock.calls.map(([payload]) => payload.card.id)).toEqual([
+      CARD_A.id,
+      CARD_B.id,
+    ])
+    cleanup()
+  })
+
+  it('drains a reconnect backlog larger than the 100-row API page in DB order', async () => {
+    class ControlledWebSocket {
+      static readonly CONNECTING = 0
+      static readonly OPEN = 1
+      static readonly instances: ControlledWebSocket[] = []
+      readyState = ControlledWebSocket.CONNECTING
+      onopen: (() => void) | null = null
+      onmessage: ((event: { data: string }) => void) | null = null
+      onerror: (() => void) | null = null
+      onclose: ((event: { code: number }) => void) | null = null
+
+      constructor() {
+        ControlledWebSocket.instances.push(this)
+        queueMicrotask(() => {
+          this.readyState = ControlledWebSocket.OPEN
+          this.onopen?.()
+        })
+      }
+
+      send() {}
+      close(code = 1000) {
+        this.readyState = 3
+        this.onclose?.({ code })
+      }
+    }
+    vi.stubGlobal('WebSocket', ControlledWebSocket)
+
+    const rows = Array.from({ length: 205 }, (_, index) => ({
+      id: historyUuid(100 + index),
+      eventId: `batch-backlog-${String(index).padStart(3, '0')}`,
+      redeemedAt: `2026-07-24T00:${String(Math.floor(index / 60)).padStart(2, '0')}:${String(index % 60).padStart(2, '0')}.000Z`,
+      userTwitchUsername: 'viewer',
+      card: { ...CARD_A, id: `card-backlog-${index}` },
+    }))
+    let recovering = false
+    let pageIndex = 0
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/realtime-config')) {
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'do-primary',
+          webSocketUrl: 'https://realtime.example',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: 'do-primary-v1',
+          overlayVersion: 'build-current',
+        })
+      }
+      if (!recovering) return jsonResponse({ realtimeEvents: [], nextCursor: null })
+
+      const pageRows = rows.slice(pageIndex * 100, (pageIndex + 1) * 100)
+      pageIndex += 1
+      const last = pageRows.at(-1)
+      return jsonResponse({
+        realtimeEvents: buildPollingRealtimeEvents(STREAMER_ID, pageRows),
+        nextCursor: last
+          ? { redeemedAt: last.redeemedAt, historyId: last.id }
+          : null,
+      })
+    }))
+
+    const callback = vi.fn()
+    const cleanup = subscribeToGachaResults('ignored', callback)
+    await flushPromises()
+    await vi.advanceTimersByTimeAsync(0)
+    await flushPromises()
+
+    recovering = true
+    ControlledWebSocket.instances[0].close(1006)
+    for (let pass = 0; pass < 4 && pageIndex < 4; pass += 1) {
+      // Each non-empty response queues the next page as a new timer task. Four
+      // responses cover 100 + 100 + 5 rows and the mandatory terminating empty
+      // page. Stop there instead of advancing into the later reconnect timer,
+      // whose onopen correctly starts a separate recovery snapshot.
+      await vi.advanceTimersToNextTimerAsync()
+      await flushPromises()
+    }
+
+    expect(pageIndex).toBe(4)
+    expect(callback).toHaveBeenCalledTimes(205)
+    expect(callback.mock.calls.map(([payload]) => payload.card.id)).toEqual(
+      rows.map((row) => row.card.id)
+    )
     cleanup()
   })
 
@@ -744,9 +1655,8 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     // produces no new configVersion this client can see. Without a TTL the
     // suppression above never clears and the client is stuck on polling
     // until reloaded — observed in preview (issue #844). Matches
-    // SUPPRESSION_TTL_MS in src/lib/realtime.ts, which reuses the same
-    // 5-minute value as the safety-net config refresh so this piggybacks on
-    // a timer that already exists rather than needing a second one.
+    // DO_SUPPRESSION_TTL_MS in src/lib/realtime.ts. It intentionally remains
+    // 5 minutes even though the normal config safety refresh is now 10 minutes.
     const SUPPRESSION_TTL_MS = 5 * 60_000
 
     class ControlledWebSocket {
@@ -1132,5 +2042,39 @@ describe('subscribeToGachaResults: HTTP polling transport', () => {
     cleanup()
     await vi.advanceTimersByTimeAsync(100)
     expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not notify an overlay version from an events request that settles after cleanup', async () => {
+    let resolveEvents!: (response: Response) => void
+    const pendingEvents = new Promise<Response>((resolve) => {
+      resolveEvents = resolve
+    })
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes('/realtime-config')) {
+        return jsonResponse({
+          schemaVersion: 1,
+          mode: 'polling-only',
+          protocolVersion: 1,
+          retryPolicy: { baseDelayMs: 100, maxDelayMs: 1_000 },
+          configVersion: 'polling-v1',
+        })
+      }
+      return pendingEvents
+    }))
+
+    const onOverlayVersion = vi.fn()
+    const cleanup = subscribeToGachaResults('streamer-1', vi.fn(), {
+      onOverlayVersion,
+    })
+    await flushPromises()
+
+    cleanup()
+    resolveEvents(jsonResponse({
+      events: [],
+      overlayVersion: 'late-build',
+    }))
+    await flushPromises()
+
+    expect(onOverlayVersion).not.toHaveBeenCalled()
   })
 })

--- a/workers/overlay-realtime/src/index.ts
+++ b/workers/overlay-realtime/src/index.ts
@@ -466,9 +466,9 @@ export class OverlayRoom {
     // (polling still recovers every committed event) and retry on the next
     // alarm rather than disconnecting a healthy room on a storage miss.
     if (!streamerId || realtimeEnabled(this.env, streamerId)) {
-      // Still allowed: prove liveness on the same wake. Clients stopped polling
-      // history on a timer, so this is what distinguishes "no gacha happened"
-      // from "this socket died without a close frame".
+      // Still allowed: prove liveness on the same wake. Clients reconcile
+      // history only every ten minutes, so this distinguishes "no gacha
+      // happened" from "this socket died" without waiting for that DB pass.
       const heartbeat = JSON.stringify({
         type: 'server_notice',
         code: OVERLAY_REALTIME_HEARTBEAT,

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,6 +6,12 @@ main = ".open-next/worker.js"
 compatibility_date = "2024-09-23"
 compatibility_flags = ["nodejs_compat"]
 
+# 2026-08-08時点のCloudflare直近7日計測はCPU P999が372ms、CPU超過が0件。P999の約2.7倍に
+# 当たる1000msなら観測tailへ余裕を残しつつ、既定30秒より暴走範囲を縮小できる。
+# cpu_msは実CPU時間の上限であり、外部I/OやDB応答を待つwall timeは含まれない。
+[limits]
+cpu_ms = 1000
+
 [observability]
 enabled = true
 


### PR DESCRIPTION
## 概要

Issue #906 の Cloudflare Worker CPU 課金を、実測に基づいて定常ポーリングとDBアクセスを減らすことで抑制します。

## 実測と判断

- Cloudflare直近7日: 315k invocations、CPU P50 6.7ms / P90 27.47ms / P99 227ms / P999 372ms、CPU超過0件
- Tailで高頻度だったのは `/api/maintenance-status`、次いでoverlay config/events
- 268ms級として疑われたoverlay eventsは、サンプルでwall 296ms / CPU 78msでした。CPU暴走ではなくDB待ちを含むwall timeであり、EXPLAIN根拠なしのindex追加は見送りました
- Workers Cache/KVはWorker invocation自体を回避せず、maintenance routeは環境変数読み取りのみです。ここへキャッシュ層を足すより、不要な呼び出しそのものを止めます

## 変更

- DO接続が健全なoverlayでは、旧3秒loopをnetwork前に終了
- controller側の健全時 `/events` DB history readを10分に1回へ削減し、reconnect / sequence gap / liveness失敗時は即時gap recovery
- DO pushではDB checkpointを進めず、10分照合で「commit後のroom publishがgapなく失敗した行」も回収。100行超backlogは空ページまで連続drain
- DO配信が512 drawに達したら即時DB照合し、reload dedupeを8,192件まで保持。大量N連でもbounded cache evictionによる重複再生を防止
- sequence-gap回復中のlive frameは最大32件・10秒に制限し、DB停止時もOBSのメモリ増大や無期限表示停止を防止。DB checkpointは進めず後続照合でdedupe
- DB-free `/realtime-config` に任意の `overlayVersion` を追加。startup/change-triggered readとし、健全時は同じ10分 `/events` 応答でbuild/config変更を検知。公開設定全体から決定的な世代tokenを生成するため、modeを変えないWebSocket URLだけの切替も検知。DB障害でevents応答が作れない場合だけ5分下限でconfigを直接確認し、旧socketが健全ならprobe失敗時も維持
- OBS DEMOは同一の不変eventを、15分KV fallbackと署名済みDO publishへ独立して即時配信。一方の障害が他方を抑止せず、健全なWebSocket接続中でも即時表示し、デモIDをDB未照合集合へ入れないため不要なhistory readを発生させない
- exact `(redeemed_at, history_id)` cursorをreload/reconnect間で維持。timestamp/UUIDの検証をAPI・browser・sessionStorageで共通化し、browserだけが受理するcursorによる恒久400を防止
- room disabled復旧TTLは5分を維持し、通常の照合cadenceとは分離
- hidden dashboard tabではmaintenance pollingを停止。visible復帰時は古い`off`を一時的にread-onlyへ倒して即時取得し、単一の60秒intervalを再開
- `wrangler.toml` に `limits.cpu_ms = 1000` を追加（7日CPU P999の約2.7倍）

健全なDO接続overlayの定常app Worker APIは、従来のconfig 12回/時 + version-only events 6回/時から、履歴・version・configを兼ねるevents 6回/時へ約67%削減する見込みです。hidden dashboard tabのmaintenance requestは60回/時から0回/時になります。

## 検証

- `git diff --check`
- changed-file ESLint
- `npm run lint:i18n`
- root ESLint（repo内のローカルnested worktreeのみ除外）: errors 0
- `npm run typecheck`
- `npm run overlay-realtime:typecheck`
- targeted realtime/config/demo: 9 files / 121 tests pass
- unit: 253 files / 3320 tests pass
- integration: 13 tests pass
- `npm run check:maintenance-surfaces`
- `npm run check:migration-order -- --base=origin/preview`
- CI同一ダミー環境でOpenNext Worker build
- auxiliary Workers production / preview dry-run build
- `npm run check:supabase-shutdown -- --require-open-next --require-aux-workers`
- 独立 `gpt-5.6-sol` xhigh review: 複数roundのHIGH/MEDIUMを全修正、最終212重点testsと全差分re-reviewで指摘なし・承認可

## リリース後確認

- previewで実際のTwitchチャネルポイント引き換えを複数回行い、overlay順次表示・Twitch chat・EventSub/log/outboxを確認
- preview確認後にmainへ昇格し、本番デプロイとsmoke test、Cloudflare指標を確認
- 次月請求の確認は観測期間が必要なため、Issue #906は即時closeせず追跡を継続

Refs #906
