### PR TITLE
feat(#739): 配信中ページC ライブ状態データ取得基盤（app-token共通化 + Helix + KVキャッシュ）

### DIFF
--- a/src/app/api/twitch/channel-point-bootstrap/route.ts
+++ b/src/app/api/twitch/channel-point-bootstrap/route.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/twitch/eventsub-status";
 import { logPerf, perfStart } from "@/lib/perf";
 import { logger } from "@/lib/logger.server";
+import { fetchTwitchApi } from "@/lib/twitch/app-token";
 // チャネルポイント連携の読み取りは PlanetScale の単一接続を使う。
 // getDb() は withDbRetry の queryFn 内で取得する。
 import { asc, eq } from "drizzle-orm";
@@ -88,27 +89,7 @@ async function getTwitchRewards(twitchUserId: string): Promise<TwitchRewardsResu
   return { rewards: data.data || [] };
 }
 
-async function getAppAccessToken(): Promise<string> {
-  const response = await fetch("https://id.twitch.tv/oauth2/token", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      client_id: process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-      client_secret: process.env.TWITCH_CLIENT_SECRET!,
-      grant_type: "client_credentials",
-    }),
-  });
-
-  if (!response.ok) {
-    throw new Error("Failed to get app access token");
-  }
-
-  const data = await response.json();
-  return data.access_token;
-}
-
 async function getSubscriptionsByUserId(
-  appAccessToken: string,
   userId: string,
 ): Promise<EventSubSubscriptionForStatus[]> {
   const allData: EventSubSubscriptionForStatus[] = [];
@@ -120,12 +101,7 @@ async function getSubscriptionsByUserId(
     url.searchParams.set("first", "100");
     if (cursor) url.searchParams.set("after", cursor);
 
-    const response = await fetch(url, {
-      headers: {
-        "Authorization": `Bearer ${appAccessToken}`,
-        "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-      },
-    });
+    const response = await fetchTwitchApi(url.toString());
 
     if (!response.ok) {
       throw new Error(`Failed to fetch EventSub subscriptions: status=${response.status}`);
@@ -377,8 +353,7 @@ export async function GET(request: NextRequest) {
       if (streamerError) return handleDatabaseError(streamerError, "Channel Point Bootstrap API");
       if (!streamer) return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
 
-      const appAccessToken = await getAppAccessToken();
-      const subscriptions = await getSubscriptionsByUserId(appAccessToken, session.twitchUserId);
+      const subscriptions = await getSubscriptionsByUserId(session.twitchUserId);
       const expectedCallbackUrl = `${process.env.NEXT_PUBLIC_APP_URL}/api/twitch/eventsub`;
       const subscriptionsWithDebug = subscriptions.map((sub) => ({
         ...sub,

--- a/src/app/api/twitch/eventsub/debug/route.ts
+++ b/src/app/api/twitch/eventsub/debug/route.ts
@@ -5,6 +5,7 @@ import { ERROR_MESSAGES } from "@/lib/constants";
 import { logger } from "@/lib/logger.server";
 import { validateCSRFToken } from "@/lib/csrf";
 import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
+import { fetchTwitchApi } from "@/lib/twitch/app-token";
 
 const TWITCH_API_URL = "https://api.twitch.tv/helix";
 
@@ -12,27 +13,6 @@ const TWITCH_API_URL = "https://api.twitch.tv/helix";
  * EventSubサブスクリプションのデバッグ用エンドポイント
  * 現在のサブスクリプション状態を詳細に取得する
  */
-async function getAppAccessToken(): Promise<string> {
-  const response = await fetch("https://id.twitch.tv/oauth2/token", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: new URLSearchParams({
-      client_id: process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-      client_secret: process.env.TWITCH_CLIENT_SECRET!,
-      grant_type: "client_credentials",
-    }),
-  });
-
-  if (!response.ok) {
-    throw new Error("Failed to get app access token");
-  }
-
-  const data = await response.json();
-  return data.access_token;
-}
-
 // EventSubサブスクリプションの型定義（デバッグ用）
 type EventSubSubscription = {
   id: string;
@@ -45,7 +25,7 @@ type EventSubSubscription = {
 
 // すべてのEventSubサブスクリプションを取得（デバッグ用・ページネーション対応）
 // subscribe/route.tsと同様に配列を返すように統一
-async function getAllSubscriptions(appAccessToken: string): Promise<EventSubSubscription[]> {
+async function getAllSubscriptions(): Promise<EventSubSubscription[]> {
   const allData: EventSubSubscription[] = [];
   let cursor: string | undefined;
 
@@ -54,12 +34,7 @@ async function getAllSubscriptions(appAccessToken: string): Promise<EventSubSubs
       ? `${TWITCH_API_URL}/eventsub/subscriptions?after=${cursor}`
       : `${TWITCH_API_URL}/eventsub/subscriptions`;
 
-    const response = await fetch(url, {
-      headers: {
-        "Authorization": `Bearer ${appAccessToken}`,
-        "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-      },
-    });
+    const response = await fetchTwitchApi(url);
 
     if (!response.ok) {
       throw new Error(`Failed to fetch subscriptions: ${response.status}`);
@@ -81,7 +56,6 @@ async function getAllSubscriptions(appAccessToken: string): Promise<EventSubSubs
 // マッチするため、呼び出し側で condition.broadcaster_user_id の一致を
 // 別途確認すること。
 async function getSubscriptionsByBroadcaster(
-  appAccessToken: string,
   broadcasterUserId: string
 ): Promise<EventSubSubscription[]> {
   const allData: EventSubSubscription[] = [];
@@ -91,12 +65,7 @@ async function getSubscriptionsByBroadcaster(
     const baseUrl = `${TWITCH_API_URL}/eventsub/subscriptions?user_id=${broadcasterUserId}`;
     const url = cursor ? `${baseUrl}&after=${cursor}` : baseUrl;
 
-    const response = await fetch(url, {
-      headers: {
-        "Authorization": `Bearer ${appAccessToken}`,
-        "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-      },
-    });
+    const response = await fetchTwitchApi(url);
 
     if (!response.ok) {
       throw new Error(`Failed to fetch subscriptions: ${response.status}`);
@@ -110,7 +79,7 @@ async function getSubscriptionsByBroadcaster(
   return allData;
 }
 
-export async function GET(request: NextRequest) {
+export async function GET() {
   const session = await getSession();
 
   if (!session || !canUseStreamerFeatures(session)) {
@@ -118,10 +87,8 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const appAccessToken = await getAppAccessToken();
-
     // ページネーションを使ってすべてのサブスクリプションを取得
-    const allSubscriptions = await getAllSubscriptions(appAccessToken);
+    const allSubscriptions = await getAllSubscriptions();
 
     // このbroadcasterのサブスクリプションのみフィルタ
     const mySubscriptions = allSubscriptions.filter(
@@ -191,30 +158,22 @@ export async function DELETE(request: NextRequest) {
     const subscriptionId = searchParams.get("id");
     const deleteAll = searchParams.get("all") === "true";
 
-    const appAccessToken = await getAppAccessToken();
-
     if (deleteAll) {
       // すべてのサブスクリプションを削除
       // user_idで絞り込んだページネーション対応の取得を使う (#831)。旧実装は
       // 1ページ分の生fetchのみで、購読数がページ上限を超えると一部しか削除
       // されないのに成功報告してしまっていた。また全app分を取得してから
       // クライアント側フィルタするより、Twitch API側で絞り込む方が効率的。
-      const candidateSubscriptions = await getSubscriptionsByBroadcaster(appAccessToken, session.twitchUserId);
+      const candidateSubscriptions = await getSubscriptionsByBroadcaster(session.twitchUserId);
       const mySubscriptions = candidateSubscriptions.filter(
         (sub) => sub.condition.broadcaster_user_id === session.twitchUserId
       );
 
       const results = [];
       for (const sub of mySubscriptions) {
-        const deleteResponse = await fetch(
+        const deleteResponse = await fetchTwitchApi(
           `${TWITCH_API_URL}/eventsub/subscriptions?id=${sub.id}`,
-          {
-            method: "DELETE",
-            headers: {
-              "Authorization": `Bearer ${appAccessToken}`,
-              "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-            },
-          }
+          { method: "DELETE" },
         );
         results.push({
           id: sub.id,
@@ -240,7 +199,7 @@ export async function DELETE(request: NextRequest) {
     // app access tokenで削除できてしまっていた。
     // user_idで絞り込んだ取得を使うことで、削除対象のid1件を探すためだけに
     // app全体(全streamer分)のサブスクリプションを毎回列挙することを避ける。
-    const candidateSubscriptions = await getSubscriptionsByBroadcaster(appAccessToken, session.twitchUserId);
+    const candidateSubscriptions = await getSubscriptionsByBroadcaster(session.twitchUserId);
     const targetSubscription = candidateSubscriptions.find((sub) => sub.id === subscriptionId);
 
     if (!targetSubscription || targetSubscription.condition.broadcaster_user_id !== session.twitchUserId) {
@@ -249,15 +208,9 @@ export async function DELETE(request: NextRequest) {
     }
 
     // 単一のサブスクリプションを削除
-    const deleteResponse = await fetch(
+    const deleteResponse = await fetchTwitchApi(
       `${TWITCH_API_URL}/eventsub/subscriptions?id=${subscriptionId}`,
-      {
-        method: "DELETE",
-        headers: {
-          "Authorization": `Bearer ${appAccessToken}`,
-          "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-        },
-      }
+      { method: "DELETE" },
     );
 
     if (deleteResponse.status === 204) {

--- a/src/app/api/twitch/eventsub/subscribe/route.ts
+++ b/src/app/api/twitch/eventsub/subscribe/route.ts
@@ -5,33 +5,12 @@ import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-l
 import { ERROR_MESSAGES, TWITCH_SUBSCRIPTION_TYPE } from "@/lib/constants";
 import { logger } from "@/lib/logger.server";
 import { validateCSRFToken } from "@/lib/csrf";
+import { fetchTwitchApi } from "@/lib/twitch/app-token";
 // 配信者の存在確認は getStreamerIdByTwitchUserId() に集約する。
 // この Route は DB クライアントを直接扱わず、接続方式をヘルパー内へ閉じ込める。
 import { getStreamerIdByTwitchUserId } from "@/lib/user-data";
 
 const TWITCH_API_URL = "https://api.twitch.tv/helix";
-
-// Get app access token for EventSub subscriptions
-async function getAppAccessToken(): Promise<string> {
-  const response = await fetch("https://id.twitch.tv/oauth2/token", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    body: new URLSearchParams({
-      client_id: process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-      client_secret: process.env.TWITCH_CLIENT_SECRET!,
-      grant_type: "client_credentials",
-    }),
-  });
-
-  if (!response.ok) {
-    throw new Error("Failed to get app access token");
-  }
-
-  const data = await response.json();
-  return data.access_token;
-}
 
 // ページネーション対応でEventSubサブスクリプションを取得
 // Twitch APIは一度に最大100件しか返さないため、cursorを使って全ページを取得
@@ -120,21 +99,14 @@ function buildRaidSubscriptionResult(
   };
 }
 
-async function deleteEventSubSubscription(appAccessToken: string, subscriptionId: string) {
-  return fetch(
+async function deleteEventSubSubscription(subscriptionId: string) {
+  return fetchTwitchApi(
     `${TWITCH_API_URL}/eventsub/subscriptions?id=${subscriptionId}`,
-    {
-      method: "DELETE",
-      headers: {
-        "Authorization": `Bearer ${appAccessToken}`,
-        "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-      },
-    },
+    { method: "DELETE" },
   );
 }
 
 async function createEventSubSubscription(
-  appAccessToken: string,
   body: {
     type: string;
     version: string;
@@ -142,11 +114,9 @@ async function createEventSubSubscription(
     transport: { method: "webhook"; callback: string; secret: string | undefined };
   },
 ) {
-  return fetch(`${TWITCH_API_URL}/eventsub/subscriptions`, {
+  return fetchTwitchApi(`${TWITCH_API_URL}/eventsub/subscriptions`, {
     method: "POST",
     headers: {
-      "Authorization": `Bearer ${appAccessToken}`,
-      "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
       "Content-Type": "application/json",
     },
     body: JSON.stringify(body),
@@ -154,7 +124,6 @@ async function createEventSubSubscription(
 }
 
 async function ensureRaidSubscription(
-  appAccessToken: string,
   userSubscriptions: EventSubSubscription[],
   broadcasterUserId: string,
   callbackUrl: string,
@@ -172,7 +141,7 @@ async function ensureRaidSubscription(
 
   for (const sub of recreatableSubs) {
     logger.info(`Deleting failed raid EventSub before recreation: id=${sub.id}, status=${sub.status}`);
-    const deleteResponse = await deleteEventSubSubscription(appAccessToken, sub.id);
+    const deleteResponse = await deleteEventSubSubscription(sub.id);
     if (!deleteResponse.ok && deleteResponse.status !== 404) {
       const error = await deleteResponse.json().catch(() => ({}));
       logger.warn("Failed to delete failed raid EventSub subscription before recreation", {
@@ -200,7 +169,7 @@ async function ensureRaidSubscription(
     await new Promise(resolve => setTimeout(resolve, 500));
   }
 
-  const response = await createEventSubSubscription(appAccessToken, {
+  const response = await createEventSubSubscription({
     type: TWITCH_SUBSCRIPTION_TYPE.CHANNEL_RAID,
     version: "1",
     condition: {
@@ -240,7 +209,6 @@ async function ensureRaidSubscription(
 }
 
 async function getSubscriptionsByUserId(
-  appAccessToken: string,
   userId: string
 ): Promise<EventSubSubscription[]> {
   const allData: EventSubSubscription[] = [];
@@ -252,12 +220,7 @@ async function getSubscriptionsByUserId(
     const baseUrl = `${TWITCH_API_URL}/eventsub/subscriptions?user_id=${userId}`;
     const url = cursor ? `${baseUrl}&after=${cursor}` : baseUrl;
 
-    const response = await fetch(url, {
-      headers: {
-        "Authorization": `Bearer ${appAccessToken}`,
-        "Client-Id": process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
-      },
-    });
+    const response = await fetchTwitchApi(url);
 
     if (!response.ok) {
       logger.error(`Failed to fetch subscriptions page: ${response.status}`);
@@ -324,16 +287,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 });
     }
 
-    // Get app access token
-    const appAccessToken = await getAppAccessToken();
-
     // Callback URL for EventSub
     const callbackUrl = `${process.env.NEXT_PUBLIC_APP_URL}/api/twitch/eventsub`;
 
     // user_idパラメータで対象ユーザーのサブスクリプションのみを取得
     // Twitch API側でフィルタリングされるため、全件取得より効率的
-    const userSubscriptions = await getSubscriptionsByUserId(appAccessToken, session.twitchUserId);
-    const refreshUserSubscriptions = () => getSubscriptionsByUserId(appAccessToken, session.twitchUserId);
+    const userSubscriptions = await getSubscriptionsByUserId(session.twitchUserId);
+    const refreshUserSubscriptions = () => getSubscriptionsByUserId(session.twitchUserId);
 
     // 既存サブスクリプション数と状態をログに記録
     // channel_points_custom_reward_redemption.addタイプのサブスクリプションをフィルタリング
@@ -357,7 +317,7 @@ export async function POST(request: NextRequest) {
     // 対象報酬のサブスクリプションのみ削除
     for (const sub of subscriptionsToDelete) {
       logger.info(`Deleting existing EventSub for target reward: id=${sub.id}, status=${sub.status}, rewardId=${sub.condition.reward_id}, callback=${sub.transport.callback}`);
-      const deleteResponse = await deleteEventSubSubscription(appAccessToken, sub.id);
+      const deleteResponse = await deleteEventSubSubscription(sub.id);
 
       // 削除結果を確認（204は成功、404は既に削除済み）
       if (!deleteResponse.ok && deleteResponse.status !== 404) {
@@ -378,7 +338,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Create new subscription
-    const subscribeResponse = await createEventSubSubscription(appAccessToken, {
+    const subscribeResponse = await createEventSubSubscription({
       type: TWITCH_SUBSCRIPTION_TYPE.CHANNEL_POINTS_REDEMPTION_ADD,
       version: "1",
       condition: {
@@ -396,7 +356,7 @@ export async function POST(request: NextRequest) {
       const error = await subscribeResponse.json();
 
       // #788 子E #793 Fableレビュー Major-1: このEventSub作成呼び出しはapp access
-      // token（getAppAccessToken()、L333）で認証しており、配信者本人のUser Access
+      // token（fetchTwitchApi が内部で取得）で認証しており、配信者本人のUser Access
       // Tokenではない。401はアプリ側credentialの問題であって配信者本人のCapabilityとは
       // 無関係のため、ここでrecordChannelPointsApiFailure()を呼ぶとアプリ障害の瞬間に
       // subscribeを叩いた全ユーザーの確定'available'状態を誤って破壊してしまう
@@ -414,7 +374,7 @@ export async function POST(request: NextRequest) {
         );
 
         // user_idパラメータで対象ユーザーのサブスクリプションを再取得
-        const recheckUserSubs = await getSubscriptionsByUserId(appAccessToken, session.twitchUserId);
+        const recheckUserSubs = await getSubscriptionsByUserId(session.twitchUserId);
 
         // channel_points_custom_reward_redemption.addタイプのサブスクリプションをフィルタリング（デバッグ用）
         const allMySubs = recheckUserSubs.filter(
@@ -436,7 +396,6 @@ export async function POST(request: NextRequest) {
 
         if (existingSub) {
           const raidSubscription = await ensureRaidSubscription(
-            appAccessToken,
             recheckUserSubs,
             session.twitchUserId,
             callbackUrl,
@@ -470,7 +429,7 @@ export async function POST(request: NextRequest) {
           logger.info(`Found ${allMySubs.length} subscriptions for other rewards, attempting cleanup`);
 
           for (const sub of allMySubs) {
-            const delResponse = await deleteEventSubSubscription(appAccessToken, sub.id);
+            const delResponse = await deleteEventSubSubscription(sub.id);
             logger.info(`Cleanup delete: id=${sub.id}, status=${delResponse.status}`);
           }
 
@@ -478,7 +437,7 @@ export async function POST(request: NextRequest) {
           await new Promise(resolve => setTimeout(resolve, 1000));
 
           // 再試行
-          const retryResponse = await createEventSubSubscription(appAccessToken, {
+          const retryResponse = await createEventSubSubscription({
             type: TWITCH_SUBSCRIPTION_TYPE.CHANNEL_POINTS_REDEMPTION_ADD,
             version: "1",
             condition: {
@@ -495,7 +454,6 @@ export async function POST(request: NextRequest) {
           if (retryResponse.ok) {
             const retryData = await retryResponse.json();
             const raidSubscription = await ensureRaidSubscription(
-              appAccessToken,
               recheckUserSubs,
               session.twitchUserId,
               callbackUrl,
@@ -533,7 +491,6 @@ export async function POST(request: NextRequest) {
 
     const subscriptionData = await subscribeResponse.json();
     const raidSubscription = await ensureRaidSubscription(
-      appAccessToken,
       userSubscriptions,
       session.twitchUserId,
       callbackUrl,
@@ -604,14 +561,13 @@ export async function DELETE(request: NextRequest) {
   }
 
   try {
-    const appAccessToken = await getAppAccessToken();
     const url = new URL(request.url);
     const specificRewardId = url.searchParams.get("rewardId");
     const callbackUrl = `${process.env.NEXT_PUBLIC_APP_URL}/api/twitch/eventsub`;
 
     // 対象ユーザーのサブスクリプションを取得
     // Get subscriptions for this user using user_id filter
-    const userSubscriptions = await getSubscriptionsByUserId(appAccessToken, session.twitchUserId);
+    const userSubscriptions = await getSubscriptionsByUserId(session.twitchUserId);
 
     // channel_points_custom_reward_redemption.add タイプのみフィルタ
     // Filter to only channel point redemption subscriptions
@@ -645,7 +601,7 @@ export async function DELETE(request: NextRequest) {
     // Delete each subscription
     const results = [];
     for (const sub of mySubscriptions) {
-      const deleteResponse = await deleteEventSubSubscription(appAccessToken, sub.id);
+      const deleteResponse = await deleteEventSubSubscription(sub.id);
 
       // 204: 成功、404: 既に削除済み（どちらも成功扱い）
       // 204: Success, 404: Already deleted (both count as success)
@@ -706,12 +662,10 @@ export async function GET(request: Request) {
   }
 
   try {
-    const appAccessToken = await getAppAccessToken();
-
     // user_idパラメータで対象ユーザーのサブスクリプションのみを取得
     // Twitch API側でフィルタリングされるため、全件取得→メモリ内フィルタリングが不要
     // これによりAPIコールとデータ転送量を大幅に削減
-    const mySubscriptions = await getSubscriptionsByUserId(appAccessToken, session.twitchUserId);
+    const mySubscriptions = await getSubscriptionsByUserId(session.twitchUserId);
 
     // 現在の設定されているcallback URLをデバッグ情報として追加
     const expectedCallbackUrl = `${process.env.NEXT_PUBLIC_APP_URL}/api/twitch/eventsub`;

--- a/src/lib/cloudflare-kv.ts
+++ b/src/lib/cloudflare-kv.ts
@@ -1,0 +1,38 @@
+/**
+ * Cloudflare KV binding 取得ヘルパー（r2-client.ts の R2BucketLike パターン踏襲）。
+ *
+ * RATE_LIMIT_KV は wrangler.toml で prod/preview の両方に宣言済み（レート制限・
+ * maintenance EventSub parking・短命OBSデモイベントとキーprefixで分離して共有）。
+ * ローカル（next dev）ではバインディングが無いため null を返し、呼び出し側が
+ * メモリキャッシュ等へフォールバックする。
+ */
+
+/** Cloudflare Workers KV API の最小インターフェース（tsconfig に型を要求しない）。 */
+export interface KVNamespaceLike {
+  get(key: string): Promise<string | null>
+  put(
+    key: string,
+    value: string,
+    options?: { expirationTtl?: number },
+  ): Promise<void>
+  delete(key: string): Promise<void>
+}
+
+/**
+ * Workers 環境から KV バインディングを取得する。Workers 以外では null。
+ * getCloudflareContext はビルド時に @opennextjs/cloudflare を解決しないよう
+ * 動的 import する（r2-client.ts と同じ理由）。
+ */
+export async function getKvBinding(
+  bindingName = "RATE_LIMIT_KV",
+): Promise<KVNamespaceLike | null> {
+  try {
+    const { getCloudflareContext } = await import("@opennextjs/cloudflare")
+    const ctx = await getCloudflareContext({ async: true })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const binding = (ctx.env as any)[bindingName] as KVNamespaceLike | undefined
+    return binding ?? null
+  } catch {
+    return null
+  }
+}

--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -370,7 +370,7 @@ interface DashboardRpcDriverError {
  * 規約: getDb() は queryFn の中で呼ぶ（リクエストスコープ破棄からの回復には
  * クライアント再取得が必要。src/lib/db/retry.ts 参照）。
  */
-async function executeDashboardRpcPg<T>(
+export async function executeDashboardRpcPg<T>(
   context: string,
   runQuery: (sql: DbHandle["sql"]) => Promise<T>,
 ): Promise<{ data: T | null; error: DashboardRpcDriverError | null }> {

--- a/src/lib/live-directory.ts
+++ b/src/lib/live-directory.ts
@@ -75,27 +75,47 @@ async function fetchStreamsForUserIds(
 
   for (let i = 0; i < userIds.length; i += HELIX_STREAMS_BATCH_SIZE) {
     const batch = userIds.slice(i, i + HELIX_STREAMS_BATCH_SIZE);
-    const params = new URLSearchParams();
-    for (const userId of batch) {
-      params.append("user_id", userId);
-    }
+    // Get Streams の first デフォルトは20件のため、100件バッチでは明示的に
+    // first=100 を付与する。さらに pagination.cursor を辿って同じ user_id 集合の
+    // ライブを全件取得する（同時配信者が21人以上でも欠落させない）。
+    let cursor: string | undefined;
+    do {
+      const params = new URLSearchParams();
+      params.set("first", String(HELIX_STREAMS_BATCH_SIZE));
+      for (const userId of batch) {
+        params.append("user_id", userId);
+      }
+      if (cursor) {
+        params.set("after", cursor);
+      }
 
-    const response = await fetchTwitchApi(
-      `https://api.twitch.tv/helix/streams?${params.toString()}`,
-    );
-    if (!response.ok) {
-      throw new Error(`Helix GET /streams failed: status=${response.status}`);
-    }
-    const data = (await response.json()) as { data: HelixStream[] };
-    for (const stream of data.data ?? []) {
-      liveByUserId.set(stream.user_id, stream);
-    }
+      const response = await fetchTwitchApi(
+        `https://api.twitch.tv/helix/streams?${params.toString()}`,
+      );
+      if (!response.ok) {
+        throw new Error(`Helix GET /streams failed: status=${response.status}`);
+      }
+      const data = (await response.json()) as {
+        data: HelixStream[];
+        pagination?: { cursor?: string };
+      };
+      for (const stream of data.data ?? []) {
+        liveByUserId.set(stream.user_id, stream);
+      }
+      cursor = data.pagination?.cursor;
+    } while (cursor);
   }
 
   return liveByUserId;
 }
 
-async function fetchLiveDirectoryUncached(): Promise<LiveDirectoryEntry[]> {
+interface LiveDirectoryFetchResult {
+  entries: LiveDirectoryEntry[];
+  /** false のときは障害（RPC/Helix）による空配列。キャッシュへ書き込まない。 */
+  ok: boolean;
+}
+
+async function fetchLiveDirectoryUncached(): Promise<LiveDirectoryFetchResult> {
   const { data: rpcRows, error: rpcError } = await executeDashboardRpcPg(
     "get_live_directory_streamers(pg)",
     async (sql) => {
@@ -107,16 +127,19 @@ async function fetchLiveDirectoryUncached(): Promise<LiveDirectoryEntry[]> {
   );
 
   if (rpcError) {
-    reportError("Live directory RPC failed", { error: rpcError });
-    return [];
+    reportError(
+      new Error(`Live directory RPC failed: ${rpcError.message}`),
+      { context: "liveDirectory:rpc" },
+    );
+    return { entries: [], ok: false };
   }
 
   const streamers = Array.isArray(rpcRows)
     ? (rpcRows as LiveDirectoryRpcRow[])
     : [];
   if (streamers.length === 0) {
-    // オプトイン0件: Helix を呼ばない。
-    return [];
+    // オプトイン0件は正常な空状態のためキャッシュしてよい。
+    return { entries: [], ok: true };
   }
 
   let liveByUserId: Map<string, HelixStream>;
@@ -125,38 +148,46 @@ async function fetchLiveDirectoryUncached(): Promise<LiveDirectoryEntry[]> {
       streamers.map((s) => s.twitchUserId),
     );
   } catch (error) {
-    reportError("Live directory Helix streams failed", { error });
-    return [];
+    reportError(
+      error instanceof Error ? error : new Error(String(error)),
+      { context: "liveDirectory:helix" },
+    );
+    return { entries: [], ok: false };
   }
 
-  return streamers
-    .filter((s) => liveByUserId.has(s.twitchUserId))
-    .map((s) => {
-      const stream = liveByUserId.get(s.twitchUserId)!;
-      return {
-        streamerId: s.streamerId,
-        twitchUserId: s.twitchUserId,
-        twitchLogin: stream.user_login,
-        displayName: s.twitchDisplayName,
-        profileImageUrl: s.twitchProfileImageUrl ?? "",
-        title: stream.title,
-        gameName: stream.game_name,
-        viewerCount: stream.viewer_count,
-        startedAt: stream.started_at,
-        thumbnailUrl: stream.thumbnail_url
-          .replace("{width}", "320")
-          .replace("{height}", "180"),
-        stats: s.publishStats
-          ? { cardCount: s.cardCount ?? 0, redemptionCount: s.redemptionCount ?? 0 }
-          : null,
-      } satisfies LiveDirectoryEntry;
-    });
+  return {
+    entries: streamers
+      .filter((s) => liveByUserId.has(s.twitchUserId))
+      .map((s) => {
+        const stream = liveByUserId.get(s.twitchUserId)!;
+        return {
+          streamerId: s.streamerId,
+          twitchUserId: s.twitchUserId,
+          twitchLogin: stream.user_login,
+          displayName: s.twitchDisplayName,
+          profileImageUrl: s.twitchProfileImageUrl ?? "",
+          title: stream.title,
+          gameName: stream.game_name,
+          viewerCount: stream.viewer_count,
+          startedAt: stream.started_at,
+          thumbnailUrl: stream.thumbnail_url
+            .replace("{width}", "320")
+            .replace("{height}", "180"),
+          stats: s.publishStats
+            ? { cardCount: s.cardCount ?? 0, redemptionCount: s.redemptionCount ?? 0 }
+            : null,
+        } satisfies LiveDirectoryEntry;
+      }),
+    ok: true,
+  };
 }
 
 /**
  * ライブ中のオプトイン配信者一覧を返す。KVキャッシュ(60s) → メモリ → 実取得。
  * KV get/put の例外は miss 扱いで続行し reportError で通知する（/live を
  * KV 障害で 500 にしない。キャッシュ前提が崩れたことは Sentry で気づける）。
+ * RPC/Helix 障害による空配列はキャッシュへ書き込まない（瞬断が最大60秒の
+ * 「誰も配信していない」表示に化けるのを防ぐ）。
  */
 export async function getLiveDirectory(): Promise<LiveDirectoryEntry[]> {
   try {
@@ -168,30 +199,38 @@ export async function getLiveDirectory(): Promise<LiveDirectoryEntry[]> {
       }
     }
   } catch (error) {
-    reportError("Live directory KV read failed", { error });
+    reportError(
+      error instanceof Error ? error : new Error(String(error)),
+      { context: "liveDirectory:kvRead" },
+    );
   }
 
   if (memoryCache && memoryCache.expiresAt > Date.now()) {
     return memoryCache.entries;
   }
 
-  const entries = await fetchLiveDirectoryUncached();
+  const { entries, ok } = await fetchLiveDirectoryUncached();
 
-  try {
-    const kv = await getKvBinding();
-    if (kv) {
-      await kv.put(LIVE_DIRECTORY_KV_KEY, JSON.stringify(entries), {
-        expirationTtl: LIVE_DIRECTORY_TTL_SECONDS,
-      });
+  if (ok) {
+    try {
+      const kv = await getKvBinding();
+      if (kv) {
+        await kv.put(LIVE_DIRECTORY_KV_KEY, JSON.stringify(entries), {
+          expirationTtl: LIVE_DIRECTORY_TTL_SECONDS,
+        });
+      }
+    } catch (error) {
+      reportError(
+        error instanceof Error ? error : new Error(String(error)),
+        { context: "liveDirectory:kvWrite" },
+      );
     }
-  } catch (error) {
-    reportError("Live directory KV write failed", { error });
+    memoryCache = {
+      entries,
+      expiresAt: Date.now() + LIVE_DIRECTORY_TTL_SECONDS * 1000,
+    };
   }
 
-  memoryCache = {
-    entries,
-    expiresAt: Date.now() + LIVE_DIRECTORY_TTL_SECONDS * 1000,
-  };
   return entries;
 }
 

--- a/src/lib/live-directory.ts
+++ b/src/lib/live-directory.ts
@@ -41,7 +41,6 @@ export interface LiveDirectoryEntry {
 interface LiveDirectoryRpcRow {
   streamerId: string;
   twitchUserId: string;
-  twitchUsername: string;
   twitchDisplayName: string;
   twitchProfileImageUrl: string | null;
   publishStats: boolean;
@@ -75,35 +74,26 @@ async function fetchStreamsForUserIds(
 
   for (let i = 0; i < userIds.length; i += HELIX_STREAMS_BATCH_SIZE) {
     const batch = userIds.slice(i, i + HELIX_STREAMS_BATCH_SIZE);
-    // Get Streams の first デフォルトは20件のため、100件バッチでは明示的に
-    // first=100 を付与する。さらに pagination.cursor を辿って同じ user_id 集合の
-    // ライブを全件取得する（同時配信者が21人以上でも欠落させない）。
-    let cursor: string | undefined;
-    do {
-      const params = new URLSearchParams();
-      params.set("first", String(HELIX_STREAMS_BATCH_SIZE));
-      for (const userId of batch) {
-        params.append("user_id", userId);
-      }
-      if (cursor) {
-        params.set("after", cursor);
-      }
+    // Get Streams の first デフォルトは20件のため、明示的に first=100 を付与する。
+    // 1 user_id につきライブは高々1本で user_id は最大100件のため、first=100 の
+    // 初回ページで全件が揃う。cursor 追従は「結果を返し切った後も cursor を返す」
+    // という Twitch の挙動で無限ループの余地があるため行わない（#739 レビュー必須）。
+    const params = new URLSearchParams();
+    params.set("first", String(HELIX_STREAMS_BATCH_SIZE));
+    for (const userId of batch) {
+      params.append("user_id", userId);
+    }
 
-      const response = await fetchTwitchApi(
-        `https://api.twitch.tv/helix/streams?${params.toString()}`,
-      );
-      if (!response.ok) {
-        throw new Error(`Helix GET /streams failed: status=${response.status}`);
-      }
-      const data = (await response.json()) as {
-        data: HelixStream[];
-        pagination?: { cursor?: string };
-      };
-      for (const stream of data.data ?? []) {
-        liveByUserId.set(stream.user_id, stream);
-      }
-      cursor = data.pagination?.cursor;
-    } while (cursor);
+    const response = await fetchTwitchApi(
+      `https://api.twitch.tv/helix/streams?${params.toString()}`,
+    );
+    if (!response.ok) {
+      throw new Error(`Helix GET /streams failed: status=${response.status}`);
+    }
+    const data = (await response.json()) as { data: HelixStream[] };
+    for (const stream of data.data ?? []) {
+      liveByUserId.set(stream.user_id, stream);
+    }
   }
 
   return liveByUserId;
@@ -127,7 +117,7 @@ async function fetchLiveDirectoryUncached(): Promise<LiveDirectoryFetchResult> {
   );
 
   if (rpcError) {
-    reportError(
+    await reportError(
       new Error(`Live directory RPC failed: ${rpcError.message}`),
       { context: "liveDirectory:rpc" },
     );
@@ -148,7 +138,7 @@ async function fetchLiveDirectoryUncached(): Promise<LiveDirectoryFetchResult> {
       streamers.map((s) => s.twitchUserId),
     );
   } catch (error) {
-    reportError(
+    await reportError(
       error instanceof Error ? error : new Error(String(error)),
       { context: "liveDirectory:helix" },
     );
@@ -199,7 +189,7 @@ export async function getLiveDirectory(): Promise<LiveDirectoryEntry[]> {
       }
     }
   } catch (error) {
-    reportError(
+    await reportError(
       error instanceof Error ? error : new Error(String(error)),
       { context: "liveDirectory:kvRead" },
     );
@@ -220,7 +210,7 @@ export async function getLiveDirectory(): Promise<LiveDirectoryEntry[]> {
         });
       }
     } catch (error) {
-      reportError(
+      await reportError(
         error instanceof Error ? error : new Error(String(error)),
         { context: "liveDirectory:kvWrite" },
       );

--- a/src/lib/live-directory.ts
+++ b/src/lib/live-directory.ts
@@ -1,0 +1,201 @@
+import "server-only";
+
+import { getKvBinding } from "@/lib/cloudflare-kv";
+import { executeDashboardRpcPg } from "@/lib/dashboard-data";
+import { reportError } from "@/lib/sentry/error-handler";
+import { fetchTwitchApi } from "@/lib/twitch/app-token";
+
+/**
+ * 配信中ページ（/live）のデータ層（issue #739 / 親 #632）。
+ *
+ * 「オプトイン配信者のうち現在Twitchでライブ中の一覧 + 公開統計」を返す。
+ * 方式は設計で確定済みの Helix GET /streams ポーリング + KVキャッシュ(60s)。
+ * EventSub stream.online/offline は購読ライフサイクル管理が過剰なため不採用。
+ *
+ * キャッシュは KV 自前実装（unstable_cache / ページ revalidate は本番
+ * @opennextjs/cloudflare で no-op のため使わない）。KV は RATE_LIMIT_KV
+ * namespace を使う（wrangler.toml で prod/preview 両方に宣言済み。本機能が
+ * この namespace の最初の本番コンシューマ）。ローカル（next dev）はプロセス内
+ * メモ化へフォールバックする。
+ *
+ * 障害時方針: RPC/DB 障害（migration 未適用の 42883 含む）も Helix 障害も
+ * throw せず空配列 + reportError（公開ページを 500 にしない。「誰も配信して
+ * いない」と障害を Sentry で区別する）。オプトイン 0 件なら Helix を呼ばない。
+ */
+
+export interface LiveDirectoryEntry {
+  streamerId: string;
+  twitchUserId: string;
+  twitchLogin: string;
+  displayName: string;
+  profileImageUrl: string;
+  title: string;
+  gameName: string;
+  viewerCount: number;
+  startedAt: string;
+  thumbnailUrl: string;
+  stats: { cardCount: number; redemptionCount: number } | null;
+}
+
+/** RPC get_live_directory_streamers() の返却行（migration 側の JSONB 形状）。 */
+interface LiveDirectoryRpcRow {
+  streamerId: string;
+  twitchUserId: string;
+  twitchUsername: string;
+  twitchDisplayName: string;
+  twitchProfileImageUrl: string | null;
+  publishStats: boolean;
+  cardCount: number | null;
+  redemptionCount: number | null;
+}
+
+/** Helix GET /streams の1行（必要なフィールドのみ）。 */
+interface HelixStream {
+  user_id: string;
+  user_login: string;
+  user_name: string;
+  title: string;
+  game_name: string;
+  viewer_count: number;
+  started_at: string;
+  thumbnail_url: string;
+}
+
+const LIVE_DIRECTORY_KV_KEY = "live-directory:v1";
+const LIVE_DIRECTORY_TTL_SECONDS = 60;
+const HELIX_STREAMS_BATCH_SIZE = 100;
+
+/** KV なし環境（ローカル next dev）用のメモリキャッシュ。 */
+let memoryCache: { entries: LiveDirectoryEntry[]; expiresAt: number } | null = null;
+
+async function fetchStreamsForUserIds(
+  userIds: string[],
+): Promise<Map<string, HelixStream>> {
+  const liveByUserId = new Map<string, HelixStream>();
+
+  for (let i = 0; i < userIds.length; i += HELIX_STREAMS_BATCH_SIZE) {
+    const batch = userIds.slice(i, i + HELIX_STREAMS_BATCH_SIZE);
+    const params = new URLSearchParams();
+    for (const userId of batch) {
+      params.append("user_id", userId);
+    }
+
+    const response = await fetchTwitchApi(
+      `https://api.twitch.tv/helix/streams?${params.toString()}`,
+    );
+    if (!response.ok) {
+      throw new Error(`Helix GET /streams failed: status=${response.status}`);
+    }
+    const data = (await response.json()) as { data: HelixStream[] };
+    for (const stream of data.data ?? []) {
+      liveByUserId.set(stream.user_id, stream);
+    }
+  }
+
+  return liveByUserId;
+}
+
+async function fetchLiveDirectoryUncached(): Promise<LiveDirectoryEntry[]> {
+  const { data: rpcRows, error: rpcError } = await executeDashboardRpcPg(
+    "get_live_directory_streamers(pg)",
+    async (sql) => {
+      const rows = await sql<Array<{ result: unknown }>>`
+        select get_live_directory_streamers() as result
+      `;
+      return rows[0]?.result;
+    },
+  );
+
+  if (rpcError) {
+    reportError("Live directory RPC failed", { error: rpcError });
+    return [];
+  }
+
+  const streamers = Array.isArray(rpcRows)
+    ? (rpcRows as LiveDirectoryRpcRow[])
+    : [];
+  if (streamers.length === 0) {
+    // オプトイン0件: Helix を呼ばない。
+    return [];
+  }
+
+  let liveByUserId: Map<string, HelixStream>;
+  try {
+    liveByUserId = await fetchStreamsForUserIds(
+      streamers.map((s) => s.twitchUserId),
+    );
+  } catch (error) {
+    reportError("Live directory Helix streams failed", { error });
+    return [];
+  }
+
+  return streamers
+    .filter((s) => liveByUserId.has(s.twitchUserId))
+    .map((s) => {
+      const stream = liveByUserId.get(s.twitchUserId)!;
+      return {
+        streamerId: s.streamerId,
+        twitchUserId: s.twitchUserId,
+        twitchLogin: stream.user_login,
+        displayName: s.twitchDisplayName,
+        profileImageUrl: s.twitchProfileImageUrl ?? "",
+        title: stream.title,
+        gameName: stream.game_name,
+        viewerCount: stream.viewer_count,
+        startedAt: stream.started_at,
+        thumbnailUrl: stream.thumbnail_url
+          .replace("{width}", "320")
+          .replace("{height}", "180"),
+        stats: s.publishStats
+          ? { cardCount: s.cardCount ?? 0, redemptionCount: s.redemptionCount ?? 0 }
+          : null,
+      } satisfies LiveDirectoryEntry;
+    });
+}
+
+/**
+ * ライブ中のオプトイン配信者一覧を返す。KVキャッシュ(60s) → メモリ → 実取得。
+ * KV get/put の例外は miss 扱いで続行し reportError で通知する（/live を
+ * KV 障害で 500 にしない。キャッシュ前提が崩れたことは Sentry で気づける）。
+ */
+export async function getLiveDirectory(): Promise<LiveDirectoryEntry[]> {
+  try {
+    const kv = await getKvBinding();
+    if (kv) {
+      const raw = await kv.get(LIVE_DIRECTORY_KV_KEY);
+      if (raw) {
+        return JSON.parse(raw) as LiveDirectoryEntry[];
+      }
+    }
+  } catch (error) {
+    reportError("Live directory KV read failed", { error });
+  }
+
+  if (memoryCache && memoryCache.expiresAt > Date.now()) {
+    return memoryCache.entries;
+  }
+
+  const entries = await fetchLiveDirectoryUncached();
+
+  try {
+    const kv = await getKvBinding();
+    if (kv) {
+      await kv.put(LIVE_DIRECTORY_KV_KEY, JSON.stringify(entries), {
+        expirationTtl: LIVE_DIRECTORY_TTL_SECONDS,
+      });
+    }
+  } catch (error) {
+    reportError("Live directory KV write failed", { error });
+  }
+
+  memoryCache = {
+    entries,
+    expiresAt: Date.now() + LIVE_DIRECTORY_TTL_SECONDS * 1000,
+  };
+  return entries;
+}
+
+/** テスト専用: メモリキャッシュをリセットする。 */
+export function __resetLiveDirectoryCacheForTests(): void {
+  memoryCache = null;
+}

--- a/src/lib/twitch/app-token.ts
+++ b/src/lib/twitch/app-token.ts
@@ -1,0 +1,156 @@
+import "server-only";
+
+import { getKvBinding } from "@/lib/cloudflare-kv";
+import { reportError } from "@/lib/sentry/error-handler";
+
+/**
+ * Twitch app access token 共通ヘルパー（issue #739）。
+ *
+ * client_credentials の発行は eventsub/subscribe・eventsub/debug・
+ * channel-point-bootstrap の3ルートに重複していたため、ここへ集約する。
+ *
+ * - KVキャッシュ: キー `twitch:app-token`、TTL = min(expires_in × 0.8, 4時間)。
+ *   expires_in は約60日あるため上限を短く固定し、死んだトークンの長期残留を防ぐ。
+ * - 401自己回復: Helix/EventSub 呼び出しが 401 を返したら KV キーを削除して
+ *   1回だけ再発行・リトライする（TWITCH_CLIENT_SECRET ローテーション時に既存の
+ *   本番経路を壊さないため。旧実装は毎回新規発行だったため自己回復不要だった）。
+ *   リトライ後も 401 ならそのレスポンスを返す（無限ループしない）。
+ * - リクエスト内トークン伝播: メモリキャッシュにより同一リクエスト内の複数回の
+ *   API 呼び出しは同じトークンを使い、401 で再発行した場合は以降の呼び出しに
+ *   新トークンが渡る。Workers isolate はリクエスト間で再利用されるため、
+ *   メモリキャッシュは expiresAt で期限検証してから使う。
+ * - トークンはサーバ側 KV のみに保存し、クライアントへ渡さない。
+ */
+
+const APP_TOKEN_KV_KEY = "twitch:app-token";
+const APP_TOKEN_MAX_TTL_SECONDS = 4 * 60 * 60;
+
+interface CachedAppToken {
+  accessToken: string;
+  expiresAt: number;
+}
+
+/** リクエスト内伝播・KVなし環境（next dev）用のメモリキャッシュ。 */
+let memoryToken: CachedAppToken | null = null;
+
+async function issueAppAccessToken(): Promise<CachedAppToken> {
+  const response = await fetch("https://id.twitch.tv/oauth2/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!,
+      client_secret: process.env.TWITCH_CLIENT_SECRET!,
+      grant_type: "client_credentials",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to get app access token");
+  }
+
+  const data = (await response.json()) as { access_token: string; expires_in?: number };
+  // expires_in 欠落・不正値（0以下 / NaN）は上限TTLへフォールバックする
+  // （キャッシュの有効期限が NaN になると毎回再発行されるのを防ぐ）。
+  const expiresInSeconds = Number(data.expires_in);
+  const ttlSeconds = Math.min(
+    Number.isFinite(expiresInSeconds) && expiresInSeconds > 0
+      ? expiresInSeconds * 0.8
+      : APP_TOKEN_MAX_TTL_SECONDS,
+    APP_TOKEN_MAX_TTL_SECONDS,
+  );
+  return {
+    accessToken: data.access_token,
+    expiresAt: Date.now() + ttlSeconds * 1000,
+  };
+}
+
+/**
+ * 現在有効な app access token を返す。優先順は メモリ → KV → 新規発行。
+ * KV の読み書き失敗は発行済みトークンで継続し（旧実装の毎回発行と同じ挙動）、
+ * reportError で KV 不調を通知する。
+ */
+export async function getTwitchAppAccessToken(): Promise<string> {
+  if (memoryToken && memoryToken.expiresAt > Date.now()) {
+    return memoryToken.accessToken;
+  }
+
+  try {
+    const kv = await getKvBinding();
+    if (kv) {
+      const raw = await kv.get(APP_TOKEN_KV_KEY);
+      if (raw) {
+        const cached = JSON.parse(raw) as CachedAppToken;
+        if (cached.expiresAt > Date.now()) {
+          memoryToken = cached;
+          return cached.accessToken;
+        }
+      }
+    }
+  } catch (error) {
+    reportError("Twitch app token KV read failed", { error });
+  }
+
+  const token = await issueAppAccessToken();
+  memoryToken = token;
+
+  try {
+    const kv = await getKvBinding();
+    if (kv) {
+      await kv.put(APP_TOKEN_KV_KEY, JSON.stringify(token), {
+        expirationTtl: Math.max(1, Math.floor((token.expiresAt - Date.now()) / 1000)),
+      });
+    }
+  } catch (error) {
+    reportError("Twitch app token KV write failed", { error });
+  }
+
+  return token.accessToken;
+}
+
+/** メモリと KV の両方からキャッシュ済みトークンを破棄する。 */
+export async function invalidateTwitchAppToken(): Promise<void> {
+  memoryToken = null;
+  try {
+    const kv = await getKvBinding();
+    if (kv) {
+      await kv.delete(APP_TOKEN_KV_KEY);
+    }
+  } catch (error) {
+    reportError("Twitch app token KV delete failed", { error });
+  }
+}
+
+/**
+ * Helix API 呼び出し。app access token を自動付与し、401 の場合はキャッシュを
+ * 破棄して 1回だけ再発行・リトライする。再試行後も 401 ならそのレスポンスを
+ * 返すため、無限ループにはならない。
+ */
+export async function fetchTwitchApi(
+  url: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const doFetch = (accessToken: string) => {
+    // plain object / Headers インスタンスのどちらが渡されても Authorization と
+    // Client-Id を付与できるよう、Headers へ正規化してから組み立てる。
+    const headers = new Headers(init.headers);
+    headers.set("Authorization", `Bearer ${accessToken}`);
+    headers.set("Client-Id", process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID!);
+    return fetch(url, {
+      ...init,
+      headers,
+    });
+  };
+
+  const response = await doFetch(await getTwitchAppAccessToken());
+  if (response.status === 401) {
+    await invalidateTwitchAppToken();
+    return doFetch(await getTwitchAppAccessToken());
+  }
+  return response;
+}
+
+/** テスト専用: メモリキャッシュをリセットする（analysis-admin-db-driver の
+ * `__setAnalysisSqlFactoryForTests` と同じ注入フック規約）。 */
+export function __resetTwitchAppTokenForTests(): void {
+  memoryToken = null;
+}

--- a/src/lib/twitch/app-token.ts
+++ b/src/lib/twitch/app-token.ts
@@ -48,7 +48,12 @@ async function issueAppAccessToken(): Promise<CachedAppToken> {
     throw new Error("Failed to get app access token");
   }
 
-  const data = (await response.json()) as { access_token: string; expires_in?: number };
+  const data = (await response.json()) as { access_token?: string; expires_in?: number };
+  if (typeof data.access_token !== "string" || data.access_token.length === 0) {
+    // 200 でも access_token 欠落のボディが返る異常系。不正値を KV へ4時間
+    // キャッシュしない（#739 レビュー指摘）。
+    throw new Error("App access token response is missing access_token");
+  }
   // expires_in 欠落・不正値（0以下 / NaN）は上限TTLへフォールバックする
   // （キャッシュの有効期限が NaN になると毎回再発行されるのを防ぐ）。
   const expiresInSeconds = Number(data.expires_in);

--- a/src/lib/twitch/app-token.ts
+++ b/src/lib/twitch/app-token.ts
@@ -69,25 +69,33 @@ async function issueAppAccessToken(): Promise<CachedAppToken> {
  * KV の読み書き失敗は発行済みトークンで継続し（旧実装の毎回発行と同じ挙動）、
  * reportError で KV 不調を通知する。
  */
-export async function getTwitchAppAccessToken(): Promise<string> {
-  if (memoryToken && memoryToken.expiresAt > Date.now()) {
-    return memoryToken.accessToken;
-  }
+export async function getTwitchAppAccessToken(options?: {
+  /** キャッシュ（メモリ/KV）を読まず強制的に再発行する（401自己回復用）。 */
+  forceRefresh?: boolean;
+}): Promise<string> {
+  if (!options?.forceRefresh) {
+    if (memoryToken && memoryToken.expiresAt > Date.now()) {
+      return memoryToken.accessToken;
+    }
 
-  try {
-    const kv = await getKvBinding();
-    if (kv) {
-      const raw = await kv.get(APP_TOKEN_KV_KEY);
-      if (raw) {
-        const cached = JSON.parse(raw) as CachedAppToken;
-        if (cached.expiresAt > Date.now()) {
-          memoryToken = cached;
-          return cached.accessToken;
+    try {
+      const kv = await getKvBinding();
+      if (kv) {
+        const raw = await kv.get(APP_TOKEN_KV_KEY);
+        if (raw) {
+          const cached = JSON.parse(raw) as CachedAppToken;
+          if (cached.expiresAt > Date.now()) {
+            memoryToken = cached;
+            return cached.accessToken;
+          }
         }
       }
+    } catch (error) {
+      reportError(
+        error instanceof Error ? error : new Error(String(error)),
+        { context: "twitchAppToken:kvRead" },
+      );
     }
-  } catch (error) {
-    reportError("Twitch app token KV read failed", { error });
   }
 
   const token = await issueAppAccessToken();
@@ -97,11 +105,15 @@ export async function getTwitchAppAccessToken(): Promise<string> {
     const kv = await getKvBinding();
     if (kv) {
       await kv.put(APP_TOKEN_KV_KEY, JSON.stringify(token), {
-        expirationTtl: Math.max(1, Math.floor((token.expiresAt - Date.now()) / 1000)),
+        // Cloudflare KV の expirationTtl 最小値は60秒。
+        expirationTtl: Math.max(60, Math.floor((token.expiresAt - Date.now()) / 1000)),
       });
     }
   } catch (error) {
-    reportError("Twitch app token KV write failed", { error });
+    reportError(
+      error instanceof Error ? error : new Error(String(error)),
+      { context: "twitchAppToken:kvWrite" },
+    );
   }
 
   return token.accessToken;
@@ -116,7 +128,10 @@ export async function invalidateTwitchAppToken(): Promise<void> {
       await kv.delete(APP_TOKEN_KV_KEY);
     }
   } catch (error) {
-    reportError("Twitch app token KV delete failed", { error });
+    reportError(
+      error instanceof Error ? error : new Error(String(error)),
+      { context: "twitchAppToken:kvDelete" },
+    );
   }
 }
 
@@ -144,7 +159,9 @@ export async function fetchTwitchApi(
   const response = await doFetch(await getTwitchAppAccessToken());
   if (response.status === 401) {
     await invalidateTwitchAppToken();
-    return doFetch(await getTwitchAppAccessToken());
+    // 強制再発行: KV の delete がエッジへ伝播していない場合でも、キャッシュを
+    // 読み戻さず新トークンを発行してリトライする（#739 レビュー指摘）。
+    return doFetch(await getTwitchAppAccessToken({ forceRefresh: true }));
   }
   return response;
 }

--- a/tests/unit/api/eventsub-debug-delete-ownership.test.ts
+++ b/tests/unit/api/eventsub-debug-delete-ownership.test.ts
@@ -5,6 +5,7 @@ import { validateCSRFToken } from '@/lib/csrf'
 import { getSession, canUseStreamerFeatures } from '@/lib/session'
 import { checkRateLimit, getRateLimitIdentifier } from '@/lib/rate-limit'
 import { ERROR_MESSAGES } from '@/lib/constants'
+import { __resetTwitchAppTokenForTests } from '@/lib/twitch/app-token'
 
 // Issue #831: DELETE /api/twitch/eventsub/debug の
 // (1) 所有権検証欠落、(2) CSRF/レートリミット欠落、(3) 全削除のページネーション未対応
@@ -38,12 +39,17 @@ function createDeleteRequest(query = ''): NextRequest {
 }
 
 function mockAppAccessTokenFetch() {
-  return new Response(JSON.stringify({ access_token: 'app-token' }), { status: 200 })
+  // expires_in は app-token ヘルパーのキャッシュTTL計算に使われる（#739）。
+  return new Response(
+    JSON.stringify({ access_token: 'app-token', expires_in: 3600 }),
+    { status: 200 },
+  )
 }
 
 describe('DELETE /api/twitch/eventsub/debug (#831)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    __resetTwitchAppTokenForTests()
     process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'client-id'
     process.env.TWITCH_CLIENT_SECRET = 'client-secret'
     mockGetSession.mockResolvedValue({

--- a/tests/unit/channel-point-bootstrap-api.test.ts
+++ b/tests/unit/channel-point-bootstrap-api.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { getDb } from '@/lib/db/client'
+import { __resetTwitchAppTokenForTests } from '@/lib/twitch/app-token'
 
 vi.mock('@/lib/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -52,6 +53,7 @@ function request(url = 'http://localhost:3000/api/twitch/channel-point-bootstrap
 describe('GET /api/twitch/channel-point-bootstrap', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
+    __resetTwitchAppTokenForTests()
     process.env.NEXT_PUBLIC_APP_URL = 'https://example.com'
     vi.stubGlobal('fetch', vi.fn())
     const { getSession, canUseStreamerFeatures } = await import('@/lib/session')

--- a/tests/unit/channel-point-bootstrap-driver-parity.test.ts
+++ b/tests/unit/channel-point-bootstrap-driver-parity.test.ts
@@ -23,6 +23,7 @@ import { checkRateLimit, getRateLimitIdentifier } from '@/lib/rate-limit'
 import { hasScope, getTwitchAccessToken } from '@/lib/twitch/token-manager'
 import { getDb } from '@/lib/db/client'
 import { ERROR_MESSAGES } from '@/lib/constants'
+import { __resetTwitchAppTokenForTests } from '@/lib/twitch/app-token'
 import {
   streamers as streamersTable,
   streamerAdditionalGachaRewards as streamerAdditionalGachaRewardsTable,
@@ -190,6 +191,7 @@ function createDrizzleBootstrapDbMock(
 
 beforeEach(() => {
   vi.clearAllMocks()
+  __resetTwitchAppTokenForTests()
   process.env.NEXT_PUBLIC_APP_URL = 'https://example.com'
   process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'client-id'
   vi.stubGlobal('fetch', vi.fn())

--- a/tests/unit/eventsub-subscribe-csrf.test.ts
+++ b/tests/unit/eventsub-subscribe-csrf.test.ts
@@ -6,6 +6,7 @@ import { getSession, canUseStreamerFeatures } from '@/lib/session'
 import { checkRateLimit, getRateLimitIdentifier } from '@/lib/rate-limit'
 import { ERROR_MESSAGES } from '@/lib/constants'
 import { getDb } from '@/lib/db/client'
+import { __resetTwitchAppTokenForTests } from '@/lib/twitch/app-token'
 
 // Issue #399 に対応するテスト: 状態変更 API (EventSub 登録/解除) が CSRF 検証失敗時に 403 を返すこと。
 // 正常系の詳細（Twitch API との連携）は既存 E2E の対象であり、ここでは CSRF ゲートのみ検証する。
@@ -67,6 +68,7 @@ function createDeleteRewardRequest(rewardId: string): NextRequest {
 describe('EventSub subscribe API - CSRF enforcement (issue #399)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    __resetTwitchAppTokenForTests()
     primeStreamerExists()
     mockGetSession.mockResolvedValue({
       twitchUserId: '123456789',

--- a/tests/unit/eventsub-subscribe-driver-parity.test.ts
+++ b/tests/unit/eventsub-subscribe-driver-parity.test.ts
@@ -14,6 +14,7 @@ import { checkRateLimit, getRateLimitIdentifier } from '@/lib/rate-limit'
 import { ERROR_MESSAGES } from '@/lib/constants'
 import { getDb } from '@/lib/db/client'
 import { streamers as streamersTable } from '@/lib/db/schema'
+import { __resetTwitchAppTokenForTests } from '@/lib/twitch/app-token'
 
 vi.mock('@/lib/csrf')
 vi.mock('@/lib/session')
@@ -96,6 +97,7 @@ function createDrizzleStreamerErrorDbMock(error: unknown) {
 describe('POST /api/twitch/eventsub/subscribe: PlanetScaleのstreamer存在確認 (#690/#708)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    __resetTwitchAppTokenForTests()
     process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = 'client-id'
     process.env.TWITCH_CLIENT_SECRET = 'client-secret'
     process.env.TWITCH_EVENTSUB_SECRET = 'eventsub-secret'

--- a/tests/unit/live-directory.test.ts
+++ b/tests/unit/live-directory.test.ts
@@ -40,7 +40,6 @@ const RPC_ROWS = [
   {
     streamerId: "s1",
     twitchUserId: "u1",
-    twitchUsername: "live_one",
     twitchDisplayName: "Live One",
     twitchProfileImageUrl: "https://example.com/a.png",
     publishStats: true,
@@ -50,7 +49,6 @@ const RPC_ROWS = [
   {
     streamerId: "s2",
     twitchUserId: "u2",
-    twitchUsername: "offline_two",
     twitchDisplayName: "Offline Two",
     twitchProfileImageUrl: null,
     publishStats: false,
@@ -140,7 +138,6 @@ describe("getLiveDirectory", () => {
     const rows = Array.from({ length: 101 }, (_, i) => ({
       streamerId: `s${i}`,
       twitchUserId: `u${i}`,
-      twitchUsername: `login_${i}`,
       twitchDisplayName: `Name ${i}`,
       twitchProfileImageUrl: null,
       publishStats: true,
@@ -165,7 +162,7 @@ describe("getLiveDirectory", () => {
     expect(new URL(secondUrl).searchParams.get("first")).toBe("100");
   });
 
-  it("同じ user_id 集合で pagination.cursor を辿りライブを全件取得する", async () => {
+  it("レスポンスに cursor が含まれても追加リクエストせず単発で終わる（無限ループ防止）", async () => {
     vi.mocked(fetchTwitchApi)
       .mockResolvedValueOnce(
         new Response(
@@ -175,23 +172,13 @@ describe("getLiveDirectory", () => {
           }),
           { status: 200 },
         ) as never,
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            data: [streamResponse(["u2"]).data[0]],
-            pagination: {},
-          }),
-          { status: 200 },
-        ) as never,
       );
 
     const entries = await getLiveDirectory();
 
-    expect(fetchTwitchApi).toHaveBeenCalledTimes(2);
-    const secondUrl = String(vi.mocked(fetchTwitchApi).mock.calls[1][0]);
-    expect(new URL(secondUrl).searchParams.get("after")).toBe("next-page");
-    expect(entries.map((e) => e.twitchUserId)).toEqual(["u1", "u2"]);
+    // cursor が返っても2回目を呼ばない（#739 レビュー必須: 無限ループ防止）
+    expect(fetchTwitchApi).toHaveBeenCalledTimes(1);
+    expect(entries.map((e) => e.twitchUserId)).toEqual(["u1"]);
   });
 
   it("Helix 障害時は空配列を返し reportError で通知する", async () => {

--- a/tests/unit/live-directory.test.ts
+++ b/tests/unit/live-directory.test.ts
@@ -136,7 +136,7 @@ describe("getLiveDirectory", () => {
     });
   });
 
-  it("オプトイン101人を100件ずつ2リクエストに分割する", async () => {
+  it("オプトイン101人を100件ずつ2リクエストに分割し、first=100 を付与する", async () => {
     const rows = Array.from({ length: 101 }, (_, i) => ({
       streamerId: `s${i}`,
       twitchUserId: `u${i}`,
@@ -160,6 +160,38 @@ describe("getLiveDirectory", () => {
     const countParams = (url: string) => new URL(url).searchParams.getAll("user_id").length;
     expect(countParams(firstUrl)).toBe(100);
     expect(countParams(secondUrl)).toBe(1);
+    // Get Streams の first デフォルトは20件のため、明示指定を固定する（#739必須）。
+    expect(new URL(firstUrl).searchParams.get("first")).toBe("100");
+    expect(new URL(secondUrl).searchParams.get("first")).toBe("100");
+  });
+
+  it("同じ user_id 集合で pagination.cursor を辿りライブを全件取得する", async () => {
+    vi.mocked(fetchTwitchApi)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [streamResponse(["u1"]).data[0]],
+            pagination: { cursor: "next-page" },
+          }),
+          { status: 200 },
+        ) as never,
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: [streamResponse(["u2"]).data[0]],
+            pagination: {},
+          }),
+          { status: 200 },
+        ) as never,
+      );
+
+    const entries = await getLiveDirectory();
+
+    expect(fetchTwitchApi).toHaveBeenCalledTimes(2);
+    const secondUrl = String(vi.mocked(fetchTwitchApi).mock.calls[1][0]);
+    expect(new URL(secondUrl).searchParams.get("after")).toBe("next-page");
+    expect(entries.map((e) => e.twitchUserId)).toEqual(["u1", "u2"]);
   });
 
   it("Helix 障害時は空配列を返し reportError で通知する", async () => {
@@ -170,10 +202,11 @@ describe("getLiveDirectory", () => {
     const entries = await getLiveDirectory();
 
     expect(entries).toEqual([]);
-    expect(reportError).toHaveBeenCalledWith(
-      "Live directory Helix streams failed",
-      expect.any(Object),
-    );
+    expect(reportError).toHaveBeenCalledWith(expect.any(Error), {
+      context: "liveDirectory:helix",
+    });
+    // 障害による空配列はキャッシュへ書き込まない（瞬断が60秒の「誰もいない」に化けない）
+    expect(kv.put).not.toHaveBeenCalled();
   });
 
   it("RPC 障害（42883）時は空配列を返し Helix を呼ばない", async () => {
@@ -186,20 +219,25 @@ describe("getLiveDirectory", () => {
     const entries = await getLiveDirectory();
 
     expect(entries).toEqual([]);
-    expect(reportError).toHaveBeenCalledWith(
-      "Live directory RPC failed",
-      expect.any(Object),
-    );
+    expect(reportError).toHaveBeenCalledWith(expect.any(Error), {
+      context: "liveDirectory:rpc",
+    });
     expect(fetchTwitchApi).not.toHaveBeenCalled();
+    expect(kv.put).not.toHaveBeenCalled();
   });
 
-  it("オプトイン0件なら Helix を呼ばない", async () => {
+  it("オプトイン0件なら Helix を呼ばず、正常な空状態はキャッシュする", async () => {
     sqlMock.mockResolvedValue([{ result: [] }]);
 
     const entries = await getLiveDirectory();
 
     expect(entries).toEqual([]);
     expect(fetchTwitchApi).not.toHaveBeenCalled();
+    expect(kv.put).toHaveBeenCalledWith(
+      "live-directory:v1",
+      "[]",
+      { expirationTtl: 60 },
+    );
   });
 
   it("KV キャッシュ hit 時は RPC/Helix へ再到達しない", async () => {
@@ -219,10 +257,9 @@ describe("getLiveDirectory", () => {
     const entries = await getLiveDirectory();
 
     expect(entries).toHaveLength(1);
-    expect(reportError).toHaveBeenCalledWith(
-      "Live directory KV read failed",
-      expect.any(Object),
-    );
+    expect(reportError).toHaveBeenCalledWith(expect.any(Error), {
+      context: "liveDirectory:kvRead",
+    });
   });
 
   it("KV なし環境（ローカル）はメモリキャッシュで2回目の再取得を防ぐ", async () => {

--- a/tests/unit/live-directory.test.ts
+++ b/tests/unit/live-directory.test.ts
@@ -1,0 +1,239 @@
+/**
+ * #739: 配信中ページ（/live）データ層 getLiveDirectory() のテスト。
+ *
+ * RPC+Helix 合成 / Helix バッチ分割（101人→2リクエスト）/ 障害時空配列 +
+ * reportError / publish_stats=false の NULL マスク / KV キャッシュ / ローカル
+ * メモ化を検証する。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getKvBinding } from "@/lib/cloudflare-kv";
+import { getDb } from "@/lib/db/client";
+import {
+  __resetLiveDirectoryCacheForTests,
+  getLiveDirectory,
+} from "@/lib/live-directory";
+import { reportError } from "@/lib/sentry/error-handler";
+import { fetchTwitchApi } from "@/lib/twitch/app-token";
+
+vi.mock("@/lib/cloudflare-kv", () => ({
+  getKvBinding: vi.fn(),
+}));
+vi.mock("@/lib/twitch/app-token", () => ({
+  fetchTwitchApi: vi.fn(),
+}));
+vi.mock("@/lib/sentry/error-handler", () => ({
+  reportError: vi.fn(),
+}));
+vi.mock("@/lib/db/client", () => ({
+  getDb: vi.fn(),
+}));
+
+function makeKv() {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+const RPC_ROWS = [
+  {
+    streamerId: "s1",
+    twitchUserId: "u1",
+    twitchUsername: "live_one",
+    twitchDisplayName: "Live One",
+    twitchProfileImageUrl: "https://example.com/a.png",
+    publishStats: true,
+    cardCount: 5,
+    redemptionCount: 3,
+  },
+  {
+    streamerId: "s2",
+    twitchUserId: "u2",
+    twitchUsername: "offline_two",
+    twitchDisplayName: "Offline Two",
+    twitchProfileImageUrl: null,
+    publishStats: false,
+    cardCount: null,
+    redemptionCount: null,
+  },
+];
+
+function streamResponse(userIds: string[]) {
+  return {
+    data: userIds.map((userId, index) => ({
+      user_id: userId,
+      user_login: `login_${userId}`,
+      user_name: `Name ${index}`,
+      title: `Title ${index}`,
+      game_name: "Just Chatting",
+      viewer_count: 10 + index,
+      started_at: `2026-08-11T00:0${index}:00Z`,
+      thumbnail_url: "https://example.com/thumb_{width}x{height}.jpg",
+    })),
+  };
+}
+
+describe("getLiveDirectory", () => {
+  let kv: ReturnType<typeof makeKv>;
+  let sqlMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetLiveDirectoryCacheForTests();
+    kv = makeKv();
+    vi.mocked(getKvBinding).mockResolvedValue(kv as never);
+    sqlMock = vi.fn().mockResolvedValue([{ result: RPC_ROWS }]);
+    vi.mocked(getDb).mockResolvedValue({ db: {}, sql: sqlMock } as never);
+    vi.mocked(fetchTwitchApi).mockResolvedValue(
+      new Response(JSON.stringify(streamResponse(["u1"])), { status: 200 }) as never,
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("オプトインかつライブ中の配信者のみ返し、ライブ外は除外する", async () => {
+    const entries = await getLiveDirectory();
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      streamerId: "s1",
+      twitchUserId: "u1",
+      twitchLogin: "login_u1",
+      displayName: "Live One",
+      profileImageUrl: "https://example.com/a.png",
+      title: "Title 0",
+      gameName: "Just Chatting",
+      viewerCount: 10,
+      startedAt: "2026-08-11T00:00:00Z",
+      thumbnailUrl: "https://example.com/thumb_320x180.jpg",
+      stats: { cardCount: 5, redemptionCount: 3 },
+    });
+    // KV へキャッシュ書き込み
+    expect(kv.put).toHaveBeenCalledWith(
+      "live-directory:v1",
+      expect.any(String),
+      { expirationTtl: 60 },
+    );
+  });
+
+  it("publish_stats=false の配信者は stats を null で返す", async () => {
+    vi.mocked(fetchTwitchApi).mockResolvedValue(
+      new Response(JSON.stringify(streamResponse(["u1", "u2"])), {
+        status: 200,
+      }) as never,
+    );
+
+    const entries = await getLiveDirectory();
+
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toMatchObject({
+      streamerId: "s2",
+      stats: null,
+      profileImageUrl: "",
+    });
+  });
+
+  it("オプトイン101人を100件ずつ2リクエストに分割する", async () => {
+    const rows = Array.from({ length: 101 }, (_, i) => ({
+      streamerId: `s${i}`,
+      twitchUserId: `u${i}`,
+      twitchUsername: `login_${i}`,
+      twitchDisplayName: `Name ${i}`,
+      twitchProfileImageUrl: null,
+      publishStats: true,
+      cardCount: i,
+      redemptionCount: 0,
+    }));
+    sqlMock.mockResolvedValue([{ result: rows }]);
+    vi.mocked(fetchTwitchApi).mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 }) as never,
+    );
+
+    await getLiveDirectory();
+
+    expect(fetchTwitchApi).toHaveBeenCalledTimes(2);
+    const firstUrl = String(vi.mocked(fetchTwitchApi).mock.calls[0][0]);
+    const secondUrl = String(vi.mocked(fetchTwitchApi).mock.calls[1][0]);
+    const countParams = (url: string) => new URL(url).searchParams.getAll("user_id").length;
+    expect(countParams(firstUrl)).toBe(100);
+    expect(countParams(secondUrl)).toBe(1);
+  });
+
+  it("Helix 障害時は空配列を返し reportError で通知する", async () => {
+    vi.mocked(fetchTwitchApi).mockResolvedValue(
+      new Response(null, { status: 500 }) as never,
+    );
+
+    const entries = await getLiveDirectory();
+
+    expect(entries).toEqual([]);
+    expect(reportError).toHaveBeenCalledWith(
+      "Live directory Helix streams failed",
+      expect.any(Object),
+    );
+  });
+
+  it("RPC 障害（42883）時は空配列を返し Helix を呼ばない", async () => {
+    sqlMock.mockRejectedValue(
+      Object.assign(new Error('function get_live_directory_streamers() does not exist'), {
+        code: "42883",
+      }),
+    );
+
+    const entries = await getLiveDirectory();
+
+    expect(entries).toEqual([]);
+    expect(reportError).toHaveBeenCalledWith(
+      "Live directory RPC failed",
+      expect.any(Object),
+    );
+    expect(fetchTwitchApi).not.toHaveBeenCalled();
+  });
+
+  it("オプトイン0件なら Helix を呼ばない", async () => {
+    sqlMock.mockResolvedValue([{ result: [] }]);
+
+    const entries = await getLiveDirectory();
+
+    expect(entries).toEqual([]);
+    expect(fetchTwitchApi).not.toHaveBeenCalled();
+  });
+
+  it("KV キャッシュ hit 時は RPC/Helix へ再到達しない", async () => {
+    const cached = JSON.stringify([{ streamerId: "s1", twitchUserId: "u1" }]);
+    kv.get.mockResolvedValue(cached);
+
+    const entries = await getLiveDirectory();
+
+    expect(entries).toEqual([{ streamerId: "s1", twitchUserId: "u1" }]);
+    expect(getDb).not.toHaveBeenCalled();
+    expect(fetchTwitchApi).not.toHaveBeenCalled();
+  });
+
+  it("KV 読み取り例外は miss 扱いで続行し reportError で通知する", async () => {
+    kv.get.mockRejectedValue(new Error("kv down"));
+
+    const entries = await getLiveDirectory();
+
+    expect(entries).toHaveLength(1);
+    expect(reportError).toHaveBeenCalledWith(
+      "Live directory KV read failed",
+      expect.any(Object),
+    );
+  });
+
+  it("KV なし環境（ローカル）はメモリキャッシュで2回目の再取得を防ぐ", async () => {
+    vi.mocked(getKvBinding).mockResolvedValue(null);
+
+    const first = await getLiveDirectory();
+    const second = await getLiveDirectory();
+
+    expect(first).toHaveLength(1);
+    expect(second).toEqual(first);
+    expect(fetchTwitchApi).toHaveBeenCalledTimes(1);
+    expect(getDb).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/twitch-app-token.test.ts
+++ b/tests/unit/twitch-app-token.test.ts
@@ -1,0 +1,158 @@
+/**
+ * #739: Twitch app access token 共通化ヘルパーのテスト。
+ *
+ * キャッシュ再利用 / 401自己回復（1回だけ再発行）/ 2連続401で無限ループしない /
+ * KV障害時のフォールバックを検証する。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getKvBinding } from "@/lib/cloudflare-kv";
+import { reportError } from "@/lib/sentry/error-handler";
+import {
+  __resetTwitchAppTokenForTests,
+  fetchTwitchApi,
+  getTwitchAppAccessToken,
+} from "@/lib/twitch/app-token";
+
+vi.mock("@/lib/cloudflare-kv", () => ({
+  getKvBinding: vi.fn(),
+}));
+vi.mock("@/lib/sentry/error-handler", () => ({
+  reportError: vi.fn(),
+}));
+
+function makeKv() {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function tokenResponse() {
+  return new Response(
+    JSON.stringify({ access_token: "token-1", expires_in: 3600 }),
+    { status: 200 },
+  );
+}
+
+describe("Twitch app access token", () => {
+  let kv: ReturnType<typeof makeKv>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetTwitchAppTokenForTests();
+    process.env.NEXT_PUBLIC_TWITCH_CLIENT_ID = "client-id";
+    process.env.TWITCH_CLIENT_SECRET = "client-secret";
+    kv = makeKv();
+    vi.mocked(getKvBinding).mockResolvedValue(kv as never);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("キャッシュ再利用: 2回目は発行 fetch を呼ばず同じトークンを返す", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(tokenResponse() as never);
+
+    const first = await getTwitchAppAccessToken();
+    const second = await getTwitchAppAccessToken();
+
+    expect(first).toBe("token-1");
+    expect(second).toBe("token-1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://id.twitch.tv/oauth2/token",
+      expect.objectContaining({ method: "POST" }),
+    );
+    // KV へは put 済み（TTL は expires_in × 0.8 以下）
+    expect(kv.put).toHaveBeenCalledWith(
+      "twitch:app-token",
+      expect.any(String),
+      expect.objectContaining({
+        expirationTtl: expect.any(Number),
+      }),
+    );
+  });
+
+  it("KV に有効なトークンがあればそれを返し発行 fetch を呼ばない", async () => {
+    kv.get.mockResolvedValue(
+      JSON.stringify({
+        accessToken: "cached-token",
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    const token = await getTwitchAppAccessToken();
+
+    expect(token).toBe("cached-token");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("401 でキャッシュを破棄し、1回だけ再発行してリトライする", async () => {
+    vi.spyOn(globalThis, "fetch")
+      // 1回目: トークン発行
+      .mockResolvedValueOnce(tokenResponse() as never)
+      // 2回目: Helix 401
+      .mockResolvedValueOnce(
+        new Response(null, { status: 401 }) as never,
+      )
+      // 3回目: 再発行（新トークン）
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ access_token: "token-2", expires_in: 3600 }),
+          { status: 200 },
+        ) as never,
+      )
+      // 4回目: 新トークンで再試行 → 成功
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: [{ ok: true }] }), {
+          status: 200,
+        }) as never,
+      );
+
+    const response = await fetchTwitchApi("https://api.twitch.tv/helix/streams");
+
+    expect(response.status).toBe(200);
+    // 発行 fetch は2回（初回 + 再発行）。Helix は2回（401 + リトライ）。
+    expect(globalThis.fetch).toHaveBeenCalledTimes(4);
+    // 401 で KV キャッシュが破棄されている
+    expect(kv.delete).toHaveBeenCalledWith("twitch:app-token");
+  });
+
+  it("再発行後も 401 ならそのレスポンスを返し、無限ループしない", async () => {
+    vi.spyOn(globalThis, "fetch")
+      // トークン発行（初回）
+      .mockResolvedValueOnce(tokenResponse() as never)
+      // Helix 401
+      .mockResolvedValueOnce(new Response(null, { status: 401 }) as never)
+      // 再発行
+      .mockResolvedValueOnce(tokenResponse() as never)
+      // リトライも 401
+      .mockResolvedValueOnce(new Response(null, { status: 401 }) as never);
+
+    const response = await fetchTwitchApi("https://api.twitch.tv/helix/streams");
+
+    expect(response.status).toBe(401);
+    // 発行 fetch は2回で停止（3回目の発行はしない）
+    const tokenFetches = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+      ([url]) => String(url) === "https://id.twitch.tv/oauth2/token",
+    );
+    expect(tokenFetches).toHaveLength(2);
+  });
+
+  it("KV 読み取りが例外を投げても発行して継続し reportError で通知する", async () => {
+    vi.mocked(getKvBinding).mockRejectedValue(new Error("kv down"));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(tokenResponse() as never);
+
+    const token = await getTwitchAppAccessToken();
+
+    expect(token).toBe("token-1");
+    expect(reportError).toHaveBeenCalledWith(
+      "Twitch app token KV read failed",
+      expect.any(Object),
+    );
+  });
+});

--- a/tests/unit/twitch-app-token.test.ts
+++ b/tests/unit/twitch-app-token.test.ts
@@ -120,6 +120,29 @@ describe("Twitch app access token", () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(4);
     // 401 で KV キャッシュが破棄されている
     expect(kv.delete).toHaveBeenCalledWith("twitch:app-token");
+    // 再発行は強制パス（KV read をバイパス）のため、get は初回のキャッシュ確認1回のみ
+    expect(kv.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("Headers インスタンスを渡しても Authorization / Client-Id を付与できる", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(tokenResponse() as never)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: [] }), { status: 200 }) as never,
+      );
+
+    const headers = new Headers({ "Content-Type": "application/json" });
+    const response = await fetchTwitchApi(
+      "https://api.twitch.tv/helix/streams",
+      { headers },
+    );
+
+    expect(response.status).toBe(200);
+    const helixCall = fetchMock.mock.calls[1];
+    const sentHeaders = new Headers(helixCall[1]?.headers as HeadersInit);
+    expect(sentHeaders.get("Authorization")).toBe("Bearer token-1");
+    expect(sentHeaders.get("Client-Id")).toBe("client-id");
+    expect(sentHeaders.get("Content-Type")).toBe("application/json");
   });
 
   it("再発行後も 401 ならそのレスポンスを返し、無限ループしない", async () => {
@@ -150,9 +173,26 @@ describe("Twitch app access token", () => {
     const token = await getTwitchAppAccessToken();
 
     expect(token).toBe("token-1");
-    expect(reportError).toHaveBeenCalledWith(
-      "Twitch app token KV read failed",
-      expect.any(Object),
+    expect(reportError).toHaveBeenCalledWith(expect.any(Error), {
+      context: "twitchAppToken:kvRead",
+    });
+  });
+
+  it("expirationTtl は Cloudflare KV の最小値60秒を下回らない", async () => {
+    // expires_in 30秒（0.8倍で24秒 < 60秒）でも TTL は60秒になる
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({ access_token: "token-1", expires_in: 30 }),
+        { status: 200 },
+      ) as never,
+    );
+
+    await getTwitchAppAccessToken();
+
+    expect(kv.put).toHaveBeenCalledWith(
+      "twitch:app-token",
+      expect.any(String),
+      expect.objectContaining({ expirationTtl: 60 }),
     );
   });
 });

--- a/tests/unit/twitch-app-token.test.ts
+++ b/tests/unit/twitch-app-token.test.ts
@@ -76,6 +76,26 @@ describe("Twitch app access token", () => {
     );
   });
 
+  it("KV のトークンをルートをまたいで再利用する（発行せず Authorization に使う）", async () => {
+    kv.get.mockResolvedValue(
+      JSON.stringify({
+        accessToken: "kv-token",
+        expiresAt: Date.now() + 60_000,
+      }),
+    );
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 }) as never,
+    );
+
+    const response = await fetchTwitchApi("https://api.twitch.tv/helix/streams");
+
+    expect(response.status).toBe(200);
+    // 発行 fetch は一切呼ばれない
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const sentHeaders = new Headers(fetchMock.mock.calls[0][1]?.headers as HeadersInit);
+    expect(sentHeaders.get("Authorization")).toBe("Bearer kv-token");
+  });
+
   it("KV に有効なトークンがあればそれを返し発行 fetch を呼ばない", async () => {
     kv.get.mockResolvedValue(
       JSON.stringify({
@@ -194,5 +214,16 @@ describe("Twitch app access token", () => {
       expect.any(String),
       expect.objectContaining({ expirationTtl: 60 }),
     );
+  });
+
+  it("200 でも access_token 欠落のボディなら throw してキャッシュしない", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ expires_in: 3600 }), { status: 200 }) as never,
+    );
+
+    await expect(getTwitchAppAccessToken()).rejects.toThrow(
+      "App access token response is missing access_token",
+    );
+    expect(kv.put).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/twitch-disable-subscription-api.test.ts
+++ b/tests/unit/twitch-disable-subscription-api.test.ts
@@ -5,6 +5,7 @@ import { getSession } from '@/lib/session'
 import { checkRateLimit, getRateLimitIdentifier } from '@/lib/rate-limit'
 import { ERROR_MESSAGES } from '@/lib/constants'
 import { getDb } from '@/lib/db/client'
+import { __resetTwitchAppTokenForTests } from '@/lib/twitch/app-token'
 
 vi.mock('@/lib/csrf')
 vi.mock('@/lib/session')
@@ -49,6 +50,7 @@ function createDbMock(rows: unknown[], updateError?: unknown) {
 describe('POST /api/auth/twitch/disable-subscription', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    __resetTwitchAppTokenForTests()
 
     mockValidateCSRFToken.mockResolvedValue({ valid: true })
     mockGetSession.mockResolvedValue({

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -32,8 +32,10 @@ enabled = true
 directory = ".open-next/assets"
 binding = "ASSETS"
 
-# Distributed rate limiting, maintenance EventSub parking, and short-lived OBS
-# demo events share this namespace with disjoint key prefixes.
+# Distributed rate limiting, maintenance EventSub parking, short-lived OBS
+# demo events, the Twitch app token cache (`twitch:app-token`), and the live
+# directory cache (`live-directory:v1`) share this namespace with disjoint key
+# prefixes.
 [[kv_namespaces]]
 binding = "RATE_LIMIT_KV"
 id = "2dadcd9aa89b466d9c860a8930d458fa"


### PR DESCRIPTION
## 対象

Closes #739（配信中ページ C: ライブ状態データ取得基盤。親 issue #632）

## 変更内容

### Twitch app access token 共通化（`src/lib/twitch/app-token.ts` 新規）

- `client_credentials` 発行が3ルートに重複していたものを集約（eventsub/subscribe・eventsub/debug・channel-point-bootstrap のローカル `getAppAccessToken` を削除）
- KVキャッシュ: キー `twitch:app-token`、TTL = min(expires_in × 0.8, 4時間)
- **401自己回復**: Helix 呼び出しが 401 を返したらキャッシュを破棄して1回だけ再発行・リトライ（2連続401は無限ループしない）
- リクエスト内トークン伝播: メモリキャッシュにより同一リクエストの後続呼び出しに新トークンが渡る
- `fetchTwitchApi()` 共通ヘルパー: Authorization / Client-Id を自動付与し、401リトライを内包

### ライブディレクトリデータ層（`src/lib/live-directory.ts` 新規）

- `getLiveDirectory(): Promise<LiveDirectoryEntry[]>` を実装（公開JSON APIは追加しない）
- KVキャッシュ（`RATE_LIMIT_KV`、キー `live-directory:v1`、TTL 60s）+ ローカルメモ化フォールバック
- cache miss時: RPC `get_live_directory_streamers()`（pg直結 `executeDashboardRpcPg` 経由）→ Helix `GET /streams` を100件バッチ
- 障害時方針: RPC/DB障害（42883含む）・Helix障害とも空配列 + `reportError`（/liveを500にしない）
- オプトイン0件なら Helix を呼ばない

### 共通KVヘルパー（`src/lib/cloudflare-kv.ts` 新規）

- `RATE_LIMIT_KV` バインディング取得（r2-client.ts のパターン踏襲、ローカルは null）

## 検証

- `npx tsc --noEmit` / eslint / `lint:i18n` / `check:migration-order` 全て green
- 新規ユニットテスト14件:
  - `twitch-app-token.test.ts`: キャッシュ再利用 / KVヒット / 401→1回だけ再発行リトライ / 2連続401で停止 / KV例外フォールバック
  - `live-directory.test.ts`: RPC+Helix合成 / stats NULLマスク / 101人→2リクエスト分割 / Helix・RPC障害で空配列+reportError / KVヒット・例外 / ローカルメモ化
- 既存Twitchルートのregressionテスト（eventsub-debug / subscribe / channel-point-bootstrap 系）を app-token キャッシュリセット付きで更新し、全3385件 green

## レビュー時の明示確認事項（issue #739 指定）

1. 同時401発生時の挙動: fetchTwitchApi は401ごとにキャッシュ破棄→再発行（KVに新トークンが入るため、他isolateも次回から新トークン）
2. KV書き込み失敗時のフォールバック: 発行済みトークンで継続 + reportError
3. 3呼び出し箇所すべての401判定網羅性: 全ルートが fetchTwitchApi 経由に統一済み