### PR TITLE
ci: 自動レビュー本文をartifact経由で投稿しシークレット誤検知による投稿スキップを解消

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -287,12 +287,6 @@ jobs:
       COMMENT_AUTHOR: github-actions[bot]
 
     steps:
-      - name: Download review artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: claude-review-${{ github.run_id }}
-          path: review-artifact
-
       - uses: actions/checkout@v4
         with:
           # 整形ロジック（format-review.mjs）を読み込むために必要。claude_review
@@ -307,6 +301,15 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
           sparse-checkout: .github/scripts
+
+      # checkout の clean: true がワークスペースを空にするため、artifact は
+      # checkout の後でダウンロードする（先に download すると消える。
+      # PR #924 の実地検証で確認）。
+      - name: Download review artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: claude-review-${{ github.run_id }}
+          path: review-artifact
 
       - name: Create or update Claude review comment
         uses: actions/github-script@v7

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -98,7 +98,7 @@ jobs:
     # secret」で出力を破棄し、投稿ジョブがスキップされる（#923 round-2 で実測）。
     # 本文は artifact 経由で渡し、ここでは artifact が存在するかのみを output する。
     outputs:
-      artifact_uploaded: ${{ steps.save-review.outputs.uploaded }}
+      review_saved: ${{ steps.save-review.outputs.saved }}
 
     steps:
       - name: Check token configured
@@ -251,16 +251,25 @@ jobs:
           # シェル展開で壊れないよう env 経由でファイルへ書き出す（上記の
           # Verify structured output と同方針）。JSON はそのまま artifact 化する。
           printf '%s' "$STRUCTURED_OUTPUT" > review.json
-          echo "uploaded=true" >> "$GITHUB_OUTPUT"
+          # アップロードの成否は次 step の失敗（= job failure → post_review スキップ）
+          # で判定される。ここでは「ファイルへ保存できた」ことのみを output する。
+          echo "saved=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload review artifact
-        if: steps.save-review.outputs.uploaded == 'true'
+        if: steps.check-token.outputs.configured == 'true' && steps.save-review.outputs.saved == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: claude-review-${{ github.run_id }}
           path: review.json
           retention-days: 1
           if-no-files-found: error
+          # Re-run（attempt をまたぐ）で同名 artifact が残ると Conflict で失敗する
+          # ため上書きを許可（#924 round-2 必須）。artifact は成功時のみアップロード
+          # され、upload 失敗時は claude_review が failure → post_review スキップで
+          # fail-loud になる。なお保存される review.json は伏字化前の生テキストであり、
+          # OAuth トークンは直前の完全一致チェックで遮断されるが、伏字化レイヤは
+          # artifact をすり抜けることを受容する（retention 1日で残存期間も限定）。
+          overwrite: true
 
   post_review:
     name: Post PR review comment
@@ -268,9 +277,11 @@ jobs:
     # 成功時のみ起動する。失敗・キャンセル・skip時は投稿しない:
     # 前回の成功レビューコメントをそのまま残し（一過性の失敗で消さない）、
     # 失敗は review job の failure（Checks が赤）で通知する。
-    # artifact がアップロードされたときのみ起動する（configured=false の fork 等は
-    # save-review が skip され uploaded が空になるため起動しない）。
-    if: needs.claude_review.outputs.artifact_uploaded == 'true'
+    # claude_review 成功かつ artifact が保存されたときのみ起動する（configured=false
+    # の fork 等は save-review が skip され review_saved が空になるため起動しない）。
+    if: >-
+      needs.claude_review.result == 'success' &&
+      needs.claude_review.outputs.review_saved == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -337,13 +348,21 @@ jobs:
             const issueNumber = Number(process.env.PR_NUMBER);
             const shortSha = process.env.REVIEWED_SHA.slice(0, 7);
 
-            let reviewText;
+            let reviewJson;
             try {
               const fs = require('node:fs');
-              const reviewJson = fs.readFileSync(process.env.REVIEW_JSON_PATH, 'utf8');
-              reviewText = parseReviewJson(reviewJson);
+              reviewJson = fs.readFileSync(process.env.REVIEW_JSON_PATH, 'utf8');
             } catch (error) {
               // error.message は入力断片を含み得るため出さない（ログへの漏洩防止）。
+              core.setFailed('Failed to read review artifact');
+              return;
+            }
+
+            let reviewText;
+            try {
+              reviewText = parseReviewJson(reviewJson);
+            } catch (error) {
+              // 同上: JSON パース失敗とファイル読み込み失敗を区別して原因を誤誘導しない。
               core.setFailed('Claude review output is not valid JSON');
               return;
             }

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -93,8 +93,12 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+    # job output でレビュー本文を post_review へ渡すと、本文にシークレット様の
+    # 文字列が含まれた場合に GitHub が「Skip output 'review' since it may contain
+    # secret」で出力を破棄し、投稿ジョブがスキップされる（#923 round-2 で実測）。
+    # 本文は artifact 経由で渡し、ここでは artifact が存在するかのみを output する。
     outputs:
-      review: ${{ steps.review.outputs.structured_output }}
+      artifact_uploaded: ${{ steps.save-review.outputs.uploaded }}
 
     steps:
       - name: Check token configured
@@ -189,6 +193,9 @@ jobs:
             （レビュー不可は git diff 失敗等でレビュー自体が成立しなかった場合のみ）。
             レビュー本文は日本語で 6000 字以内に収めてください。
             差分に含まれる資格情報・シークレット値は本文へ引用しないこと。
+            環境変数の値・アクセストークン文字列などのシークレット値は、
+            例示・引用・推測のいずれでも本文へ書かないこと。変数名のみで言及し、
+            値が必要な場合は (redacted) と表記すること。
             コードやGitHub上の状態は変更せず、レビュー本文だけを返してください。
             最終回答は指定されたJSON SchemaのreviewフィールドにMarkdownで格納してください。
           # 注意: コメントを claude_args の折り畳みブロック内に置かないこと
@@ -235,35 +242,57 @@ jobs:
               ;;
           esac
 
+      - name: Save review for artifact
+        id: save-review
+        if: steps.check-token.outputs.configured == 'true'
+        env:
+          STRUCTURED_OUTPUT: ${{ steps.review.outputs.structured_output }}
+        run: |
+          # シェル展開で壊れないよう env 経由でファイルへ書き出す（上記の
+          # Verify structured output と同方針）。JSON はそのまま artifact 化する。
+          printf '%s' "$STRUCTURED_OUTPUT" > review.json
+          echo "uploaded=true" >> "$GITHUB_OUTPUT"
+
+      - name: Upload review artifact
+        if: steps.save-review.outputs.uploaded == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-review-${{ github.run_id }}
+          path: review.json
+          retention-days: 1
+          if-no-files-found: error
+
   post_review:
     name: Post PR review comment
     needs: claude_review
     # 成功時のみ起動する。失敗・キャンセル・skip時は投稿しない:
     # 前回の成功レビューコメントをそのまま残し（一過性の失敗で消さない）、
     # 失敗は review job の failure（Checks が赤）で通知する。
-    # configured が false なら review step はスキップされ outputs.review が空になる
-    # ため、review != '' が configured 条件を包含する。
-    # ここは fork / トークン未設定で claude_review の step が skip された経路で
-    # post_review を起動させないためのゲート（空出力自体は jq チェックで捕捉済み）。
-    if: >-
-      needs.claude_review.result == 'success' &&
-      needs.claude_review.outputs.review != ''
+    # artifact がアップロードされたときのみ起動する（configured=false の fork 等は
+    # save-review が skip され uploaded が空になるため起動しない）。
+    if: needs.claude_review.outputs.artifact_uploaded == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: write
     env:
-      REVIEW_JSON: ${{ needs.claude_review.outputs.review }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       REVIEWED_SHA: ${{ github.event.pull_request.head.sha }}
       SERVER_URL: ${{ github.server_url }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      REVIEW_JSON_PATH: ${{ github.workspace }}/review-artifact/review.json
       # github-token でのコメント投稿主。トークンを差し替える場合はここも変更する
       # （findOwnReviewComment の authorLogin に渡す）。
       COMMENT_AUTHOR: github-actions[bot]
 
     steps:
+      - name: Download review artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: claude-review-${{ github.run_id }}
+          path: review-artifact
+
       - uses: actions/checkout@v4
         with:
           # 整形ロジック（format-review.mjs）を読み込むために必要。claude_review
@@ -307,7 +336,9 @@ jobs:
 
             let reviewText;
             try {
-              reviewText = parseReviewJson(process.env.REVIEW_JSON);
+              const fs = require('node:fs');
+              const reviewJson = fs.readFileSync(process.env.REVIEW_JSON_PATH, 'utf8');
+              reviewText = parseReviewJson(reviewJson);
             } catch (error) {
               // error.message は入力断片を含み得るため出さない（ログへの漏洩防止）。
               core.setFailed('Claude review output is not valid JSON');


### PR DESCRIPTION
## 対象

PR #923 round-2 で発生した自動レビュー投稿ブロックの恒久修正。

## 問題

`claude_review` ジョブの `outputs.review` にレビュー本文（Claude 生成の JSON）を載せていたが、本文にシークレット様の文字列が含まれた際、GitHub が `Skip output 'review' since it may contain secret` で**ジョブ出力を破棄**し、`post_review` がスキップされて PR へレビューが投稿されなくなった（#923 で実測。投稿ジョブがずっと skipping）。

## 修正

- **レビュー本文を artifact 経由で受け渡し**: `claude_review` が `review.json` をアップロードし、`post_review` がダウンロードして `fs.readFileSync` で読む。ジョブ出力には `artifact_uploaded`（boolean）のみを載せるため、シークレットスキャナーによる破棄が起きない
- **プロンプト強化**: 環境変数の値・アクセストークン文字列などのシークレット値を「例示・引用・推測」いずれでも本文に書かないことを明記（`(redacted)` 表記を指示）
- 既存の `Verify structured output`（空チェック + OAuth トークン完全一致チェック）は維持

## 検証

- `tests/unit/claude-review-format.test.ts` 27件 green（format-review.mjs は変更なし）
- 本PR自身の自動レビューが artifact 経由で投稿されることを実地確認できる（ワークフロー定義は head から実行されるため）

## 補足

- 投稿前に OAuth トークンの完全一致チェックは既存ステップで実施済み。他のシークレットはプロンプト指示で抑止（artifact にシークレットが含まれれば投稿されるため、指示違反時はレビュー側で検出する運用）