### PR TITLE
feat: 配信中ページを実装

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -886,7 +886,8 @@
       "description4": "and build their collection.",
       "viewerGuide": "Viewer Guide",
       "streamerGuide": "Streamer Guide",
-      "viewGuide": "View Guide"
+      "viewGuide": "View Guide",
+      "liveDirectory": "Browse live channels"
     },
     "features": {
       "cardCollection": {
@@ -1129,7 +1130,8 @@
     "userSettings": "User Settings",
     "logout": "Logout",
     "announcements": "Announcements",
-    "streamerBadge": "Streamer"
+    "streamerBadge": "Streamer",
+    "live": "Live now"
   },
   "accountPage": {
     "title": "User Settings",
@@ -1505,16 +1507,68 @@
       "description": "See the usage guide for details on creating cards and setting them up on your stream."
     }
   },
+  "livePage": {
+    "metadata": {
+      "title": "Live now - TwiCa",
+      "description": "Discover TwiCa streamers who have chosen to be listed and are live right now."
+    },
+    "navigationLabel": "Live directory navigation",
+    "home": "Home",
+    "title": "Live now",
+    "description": "Discover TwiCa streamers who have chosen to be listed and are live right now.",
+    "directoryHeading": "Live streams",
+    "sort": {
+      "label": "Sort by",
+      "viewers": "Viewers",
+      "recentlyStarted": "Recently started",
+      "cardCount": "Card types",
+      "redemptionCount": "Channel point redemptions"
+    },
+    "card": {
+      "live": "LIVE",
+      "viewers": "{count, plural, one {# viewer} other {# viewers}}",
+      "thumbnailAlt": "Live stream thumbnail for {name}",
+      "thumbnailUnavailable": "Stream thumbnail unavailable",
+      "profileAlt": "Profile image for {name}",
+      "untitled": "Untitled stream",
+      "uncategorized": "No category",
+      "category": "Category: {name}",
+      "liveFor": "Live for {duration}",
+      "watchOnTwitchNewTab": "Watch {name} on Twitch (opens in a new tab)",
+      "viewCollection": "View collection"
+    },
+    "duration": {
+      "justStarted": "just started",
+      "minutes": "{minutes, plural, one {# min} other {# mins}}",
+      "hours": "{hours, plural, one {# hr} other {# hrs}}",
+      "hoursMinutes": "{hours, plural, one {# hr} other {# hrs}} {minutes, plural, one {# min} other {# mins}}",
+      "unknown": "start time unavailable"
+    },
+    "stats": {
+      "cardCount": "Card types",
+      "redemptionCount": "Channel point redemptions",
+      "value": "{count, number}",
+      "private": "Stats private"
+    },
+    "empty": {
+      "title": "No listed streams are live right now",
+      "description": "Streamers who opt in will appear here when they go live."
+    },
+    "listingCta": {
+      "lead": "Streaming with TwiCa?",
+      "link": "Streamers can opt in from settings"
+    }
+  },
   "liveDirectorySettings": {
     "title": "Live directory listing",
-      "description": "Choose whether this streamer will be listed on the live directory (/live) once it launches. Both toggles are off by default.",
+    "description": "Choose whether this streamer is listed on the live directory (/live). Both toggles are off by default.",
     "status": {
       "enabled": "Listed",
       "disabled": "Hidden"
     },
     "form": {
       "publishLiveStatus": "Publish my live status",
-        "publishLiveStatusHelp": "While on, this streamer will appear on /live once it launches (only while actually live).",
+      "publishLiveStatusHelp": "While on, this streamer appears on /live whenever the channel is live.",
       "publishStats": "Publish stats",
       "publishStatsHelp": "Show card count and channel point redemptions on /live.",
       "requiresPublishLiveStatus": "requires \"Publish my live status\""
@@ -1528,7 +1582,7 @@
     },
     "errors": {
       "saveFailed": "Failed to save settings",
-      "deployWindow": "The live directory feature is not ready yet, so your changes could not be saved. Please try again shortly."
+      "deployWindow": "Live directory settings are temporarily unavailable. Please try again shortly."
     }
   }
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -886,7 +886,8 @@
       "description4": "コレクションを構築できます。",
       "viewerGuide": "視聴者向け使い方",
       "streamerGuide": "配信者向け使い方",
-      "viewGuide": "使い方を見る"
+      "viewGuide": "使い方を見る",
+      "liveDirectory": "配信中を見る"
     },
     "features": {
       "cardCollection": {
@@ -1129,7 +1130,8 @@
     "userSettings": "ユーザー設定",
     "logout": "ログアウト",
     "announcements": "お知らせ",
-    "streamerBadge": "配信者"
+    "streamerBadge": "配信者",
+    "live": "配信中"
   },
   "accountPage": {
     "title": "ユーザー設定",
@@ -1505,16 +1507,68 @@
       "description": "カードの作り方や配信への組み込み方は、使い方ガイドで詳しく説明しています。"
     }
   },
+  "livePage": {
+    "metadata": {
+      "title": "配信中 - TwiCa",
+      "description": "TwiCaを利用している配信者のうち、掲載を許可して現在ライブ配信中のチャンネルです。"
+    },
+    "navigationLabel": "配信中ページのナビゲーション",
+    "home": "ホーム",
+    "title": "配信中の配信者",
+    "description": "TwiCaを利用している配信者のうち、掲載を許可して現在ライブ配信中のチャンネルです。",
+    "directoryHeading": "ライブ配信一覧",
+    "sort": {
+      "label": "並び順",
+      "viewers": "視聴者数",
+      "recentlyStarted": "配信開始が新しい順",
+      "cardCount": "カード種類数",
+      "redemptionCount": "チャネルポイント引換数"
+    },
+    "card": {
+      "live": "LIVE",
+      "viewers": "{count, number}人が視聴中",
+      "thumbnailAlt": "{name}のライブ配信サムネイル",
+      "thumbnailUnavailable": "配信サムネイルを表示できません",
+      "profileAlt": "{name}のプロフィール画像",
+      "untitled": "タイトル未設定",
+      "uncategorized": "カテゴリ未設定",
+      "category": "カテゴリ: {name}",
+      "liveFor": "配信開始から {duration}",
+      "watchOnTwitchNewTab": "{name}の配信をTwitchで見る（新しいタブで開きます）",
+      "viewCollection": "コレクションを見る"
+    },
+    "duration": {
+      "justStarted": "開始したばかり",
+      "minutes": "{minutes}分",
+      "hours": "{hours}時間",
+      "hoursMinutes": "{hours}時間 {minutes}分",
+      "unknown": "開始時刻不明"
+    },
+    "stats": {
+      "cardCount": "カード種類数",
+      "redemptionCount": "チャネルポイント引換数",
+      "value": "{count, number}",
+      "private": "統計非公開"
+    },
+    "empty": {
+      "title": "現在掲載中の配信はありません",
+      "description": "掲載を許可した配信者がライブを開始すると、ここに表示されます。"
+    },
+    "listingCta": {
+      "lead": "TwiCaを利用している配信者の方へ",
+      "link": "配信者の方はこちらから掲載できます"
+    }
+  },
   "liveDirectorySettings": {
     "title": "配信中ページへの掲載",
-      "description": "「配信中ページ」（/live）公開時に、この配信者を掲載するかどうかを設定します。どちらも既定ではオフです。",
+    "description": "この配信者を「配信中ページ」（/live）に掲載するかどうかを設定します。どちらも既定ではオフです。",
     "status": {
       "enabled": "掲載中",
       "disabled": "非掲載"
     },
     "form": {
       "publishLiveStatus": "配信中を公表する",
-        "publishLiveStatusHelp": "オンの間、配信中ページ（/live）公開時にこの配信者が表示されます（現在ライブ配信中のときのみ）。",
+      "publishLiveStatusHelp": "オンの間、この配信者が現在ライブ配信中の場合に配信中ページ（/live）へ表示されます。",
       "publishStats": "統計を公開する",
       "publishStatsHelp": "カード種類数とチャネルポイント引換数を /live に表示します。",
       "requiresPublishLiveStatus": "「配信中を公表する」が必要"
@@ -1528,7 +1582,7 @@
     },
     "errors": {
       "saveFailed": "設定の保存に失敗しました",
-      "deployWindow": "配信中ページ機能が準備中のため、変更は保存できませんでした。しばらくしてから再度お試しください。"
+      "deployWindow": "配信中ページの設定を現在保存できません。しばらくしてから再度お試しください。"
     }
   }
 }

--- a/src/app/live/page.tsx
+++ b/src/app/live/page.tsx
@@ -1,0 +1,79 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { getTranslations } from "next-intl/server";
+import LiveDirectory from "@/components/LiveDirectory";
+import PublicFooter from "@/components/PublicFooter";
+import { getLiveDirectory } from "@/lib/live-directory";
+import { getSession } from "@/lib/session";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("livePage");
+  return {
+    title: t("metadata.title"),
+    description: t("metadata.description"),
+  };
+}
+
+/**
+ * 公開の配信中ディレクトリ。
+ *
+ * getSession() は既存公開ページと同じくヘッダー導線の出し分けだけに使う。
+ * 未ログインをredirectしないため、一覧・統計・ソートは認証なしで閲覧できる。
+ * ページrevalidateはOpenNext本番構成で機能しないため追加せず、鮮度と外部API原価は
+ * getLiveDirectory() のCloudflare KV 60秒キャッシュへ一元化している。
+ */
+export default async function LivePage() {
+  const [session, entries, t, tHeader] = await Promise.all([
+    getSession(),
+    getLiveDirectory(),
+    getTranslations("livePage"),
+    getTranslations("header"),
+  ]);
+
+  // Serverで基準時刻を1回だけ確定し、Client ComponentのSSR/hydration間で
+  // 配信経過時間がずれないようにする。
+  const referenceTime = new Date().toISOString();
+
+  return (
+    <div className="min-h-screen bg-gray-900">
+      <header className="border-b border-gray-800">
+        <div className="container mx-auto max-w-7xl px-4 py-4">
+          <nav
+            aria-label={t("navigationLabel")}
+            className="flex items-center justify-between gap-4"
+          >
+            <Link href="/" className="text-xl font-bold text-white">
+              TwiCa
+            </Link>
+            {session ? (
+              <Link
+                href="/dashboard"
+                className="rounded-lg bg-purple-600 px-4 py-2 text-white transition hover:bg-purple-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400"
+              >
+                {tHeader("dashboard")}
+              </Link>
+            ) : (
+              <Link
+                href="/"
+                className="text-gray-400 transition hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400"
+              >
+                {t("home")}
+              </Link>
+            )}
+          </nav>
+        </div>
+      </header>
+
+      <main className="container mx-auto max-w-7xl px-4 py-10 sm:py-12">
+        <div className="mb-10 max-w-3xl">
+          <h1 className="text-3xl font-bold text-white sm:text-4xl">{t("title")}</h1>
+          <p className="mt-3 text-base leading-7 text-gray-400">{t("description")}</p>
+        </div>
+
+        <LiveDirectory entries={entries} referenceTime={referenceTime} />
+      </main>
+
+      <PublicFooter />
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -74,44 +74,54 @@ export default async function Home({ searchParams }: { searchParams: SearchParam
             {t("hero.description4")}
           </p>
 
-          {/* ログイン状態に応じて表示を切り替え */}
-          {session ? (
-            // ログイン済み: 視聴者/配信者向けガイドへのリンクボタンを中央に表示
-            <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
-              <Link
-                href="/guide#viewer"
-                className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-8 py-3 font-medium text-white transition hover:bg-purple-700"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                </svg>
-                {t("hero.viewerGuide")}
-              </Link>
-              <Link
-                href="/guide#streamer"
-                className="inline-flex items-center gap-2 rounded-lg border border-purple-600 bg-transparent px-8 py-3 font-medium text-purple-400 transition hover:bg-purple-600 hover:text-white"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                </svg>
-                {t("hero.streamerGuide")}
-              </Link>
-            </div>
-          ) : (
-            // 未ログイン: Twitchログインボタンと使い方リンクを表示
-            <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
-              <TwitchLoginButtonWithIcon
-                className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-8 py-3 font-medium text-white transition hover:bg-purple-700 disabled:opacity-50"
-              />
-              <Link
-                href="/guide"
-                className="inline-flex items-center gap-2 rounded-lg border border-gray-600 px-8 py-3 font-medium text-gray-300 transition hover:bg-gray-800 hover:text-white"
-              >
-                {t("hero.viewGuide")}
-              </Link>
-            </div>
-          )}
+          <div className="flex flex-col items-center gap-4 sm:flex-row sm:flex-wrap sm:justify-center">
+            <Link
+              href="/live"
+              className="inline-flex min-h-12 items-center gap-2 rounded-lg bg-red-600 px-8 py-3 font-medium text-white transition hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-300"
+            >
+              <span className="h-2.5 w-2.5 rounded-full bg-white" aria-hidden="true" />
+              {t("hero.liveDirectory")}
+            </Link>
+
+            {/* ログイン状態に応じて残りの導線を切り替える */}
+            {session ? (
+              // ログイン済み: 視聴者/配信者向けガイドへのリンクボタンを表示
+              <>
+                <Link
+                  href="/guide#viewer"
+                  className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-8 py-3 font-medium text-white transition hover:bg-purple-700"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                  </svg>
+                  {t("hero.viewerGuide")}
+                </Link>
+                <Link
+                  href="/guide#streamer"
+                  className="inline-flex items-center gap-2 rounded-lg border border-purple-600 bg-transparent px-8 py-3 font-medium text-purple-400 transition hover:bg-purple-600 hover:text-white"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                  </svg>
+                  {t("hero.streamerGuide")}
+                </Link>
+              </>
+            ) : (
+              // 未ログイン: Twitchログインボタンと使い方リンクを表示
+              <>
+                <TwitchLoginButtonWithIcon
+                  className="inline-flex items-center gap-2 rounded-lg bg-purple-600 px-8 py-3 font-medium text-white transition hover:bg-purple-700 disabled:opacity-50"
+                />
+                <Link
+                  href="/guide"
+                  className="inline-flex items-center gap-2 rounded-lg border border-gray-600 px-8 py-3 font-medium text-gray-300 transition hover:bg-gray-800 hover:text-white"
+                >
+                  {t("hero.viewGuide")}
+                </Link>
+              </>
+            )}
+          </div>
         </div>
 
         <div className="mt-20 grid gap-6 md:grid-cols-2">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,11 +25,22 @@ export default async function Header({ session, unreadAnnouncementsCount = 0 }: 
 
   return (
     <header className="border-b border-gray-800 bg-gray-900/95 backdrop-blur">
-      <div className="container mx-auto flex items-center justify-between px-4 py-3">
-        {/* ロゴ */}
-        <Link href="/" className="text-xl font-bold text-white sm:text-2xl">
-          TwiCa
-        </Link>
+      <div className="container mx-auto flex items-center justify-between gap-3 px-4 py-3">
+        <div className="flex min-w-0 items-center gap-3 sm:gap-5">
+          {/* ロゴ */}
+          <Link href="/" className="shrink-0 text-xl font-bold text-white sm:text-2xl">
+            TwiCa
+          </Link>
+          {/* mobileは可視のLIVEドット、sm以上はテキストも表示して横幅を安定させる。 */}
+          <Link
+            href="/live"
+            className="inline-flex min-h-9 shrink-0 items-center gap-1.5 rounded-lg px-2 text-sm font-medium text-gray-300 transition-colors hover:bg-gray-800 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400"
+            title={t("live")}
+          >
+            <span className="h-2.5 w-2.5 rounded-full bg-red-500" aria-hidden="true" />
+            <span className="sr-only sm:not-sr-only">{t("live")}</span>
+          </Link>
+        </div>
 
         {/* 右側: ユーザー情報とアイコンボタン */}
         <div className="flex items-center gap-2 sm:gap-4">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -45,7 +45,7 @@ export default async function Header({ session, unreadAnnouncementsCount = 0 }: 
         {/* 右側: ユーザー情報とアイコンボタン */}
         <div className="flex items-center gap-2 sm:gap-4">
           {/* ユーザー情報 */}
-          <div className="flex items-center gap-2">
+          <div className="flex min-w-0 items-center gap-2">
             {session.twitchProfileImageUrl && (
               // unoptimized: Twitch CDNから取得済みの画像のため、Vercel Image Transformationsをスキップしてコスト削減
               <Image
@@ -57,15 +57,16 @@ export default async function Header({ session, unreadAnnouncementsCount = 0 }: 
                 unoptimized
               />
             )}
-            {/* モバイルでは名前を短縮表示、PCではフル表示 */}
-            <span className="hidden text-white sm:inline">{session.twitchDisplayName}</span>
-            <span className="max-w-[80px] truncate text-sm text-white sm:hidden">
+            {/* LIVE導線と固定幅操作群を同じ行へ収めるため、狭幅では名前を視覚的に隠す。
+                md以上でも長い表示名は上限を持たせ、バッジや操作ボタンを押し出さない。 */}
+            <span className="hidden max-w-48 truncate text-white md:inline">
               {session.twitchDisplayName}
             </span>
+            <span className="sr-only md:hidden">{session.twitchDisplayName}</span>
             {/* 配信者バッジ - PCのみ表示。broadcasterTypeが空(非Affiliateオプトイン)の
                 場合に空文字を表示しないよう、常にi18n済みラベルを使う。 */}
             {isStreamer && (
-              <span className="hidden rounded bg-purple-600 px-2 py-0.5 text-xs text-white sm:inline">
+              <span className="hidden rounded bg-purple-600 px-2 py-0.5 text-xs text-white md:inline">
                 {session.broadcasterType || t("streamerBadge")}
               </span>
             )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -59,7 +59,7 @@ export default async function Header({ session, unreadAnnouncementsCount = 0 }: 
             )}
             {/* LIVE導線と固定幅操作群を同じ行へ収めるため、狭幅では名前を視覚的に隠す。
                 md以上でも長い表示名は上限を持たせ、バッジや操作ボタンを押し出さない。 */}
-            <span className="hidden max-w-48 truncate text-white md:inline">
+            <span className="hidden max-w-48 truncate text-white md:inline-block">
               {session.twitchDisplayName}
             </span>
             <span className="sr-only md:hidden">{session.twitchDisplayName}</span>

--- a/src/components/LiveDirectory.tsx
+++ b/src/components/LiveDirectory.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import type { LiveDirectoryEntry } from "@/lib/live-directory";
+
+export type LiveDirectorySort =
+  | "viewers"
+  | "recentlyStarted"
+  | "cardCount"
+  | "redemptionCount";
+
+interface LiveDirectoryProps {
+  entries: LiveDirectoryEntry[];
+  /**
+   * Server Component で確定した描画時刻。
+   * Client Component 内で Date.now() を呼ぶとSSRとhydrationの分境界で表示が変わり、
+   * hydration mismatch が起こり得るため、配信経過時間の基準をシリアライズして渡す。
+   */
+  referenceTime: string;
+}
+
+function compareFallback(a: LiveDirectoryEntry, b: LiveDirectoryEntry): number {
+  const viewerDifference = b.viewerCount - a.viewerCount;
+  if (viewerDifference !== 0) return viewerDifference;
+
+  // localeCompare() の既定ロケールはNode（SSR）とブラウザで異なり得る。
+  // UTF-16コード単位の比較に固定して、同率カードのhydration順を必ず一致させる。
+  if (a.displayName !== b.displayName) return a.displayName < b.displayName ? -1 : 1;
+  if (a.streamerId !== b.streamerId) return a.streamerId < b.streamerId ? -1 : 1;
+  return 0;
+}
+
+function compareStartedAt(a: LiveDirectoryEntry, b: LiveDirectoryEntry): number {
+  const aTime = Date.parse(a.startedAt);
+  const bTime = Date.parse(b.startedAt);
+  const aValid = Number.isFinite(aTime);
+  const bValid = Number.isFinite(bTime);
+
+  // Helix はRFC3339を返すが、境界値が混入しても comparator が NaN を返さず、
+  // 不正値だけを末尾へ送る。NaN comparator はブラウザごとの並びを不定にするため避ける。
+  if (aValid !== bValid) return aValid ? -1 : 1;
+  if (aValid && bValid && aTime !== bTime) return bTime - aTime;
+  return compareFallback(a, b);
+}
+
+function compareStats(
+  a: LiveDirectoryEntry,
+  b: LiveDirectoryEntry,
+  key: "cardCount" | "redemptionCount",
+): number {
+  // null（統計非公開）と公開値0は意味が異なる。0への丸め込みで公開範囲を
+  // 誤認させず、非公開者は数値に関係なく常に末尾へ置く。
+  if (a.stats === null && b.stats !== null) return 1;
+  if (a.stats !== null && b.stats === null) return -1;
+  if (a.stats !== null && b.stats !== null) {
+    const difference = b.stats[key] - a.stats[key];
+    if (difference !== 0) return difference;
+  }
+  return compareFallback(a, b);
+}
+
+/**
+ * 受け取った配列を変更せず、選択された基準で決定的に並べ替える。
+ * tie-break を固定し、KVの返却順やJavaScript実装差でカードが再描画ごとに
+ * 入れ替わるのを防ぐ。
+ */
+export function sortLiveDirectoryEntries(
+  entries: readonly LiveDirectoryEntry[],
+  sort: LiveDirectorySort,
+): LiveDirectoryEntry[] {
+  return [...entries].sort((a, b) => {
+    switch (sort) {
+      case "recentlyStarted":
+        return compareStartedAt(a, b);
+      case "cardCount":
+        return compareStats(a, b, "cardCount");
+      case "redemptionCount":
+        return compareStats(a, b, "redemptionCount");
+      case "viewers":
+      default:
+        return compareFallback(a, b);
+    }
+  });
+}
+
+export default function LiveDirectory({ entries, referenceTime }: LiveDirectoryProps) {
+  const t = useTranslations("livePage");
+  const [sort, setSort] = useState<LiveDirectorySort>("viewers");
+  const sortedEntries = useMemo(
+    () => sortLiveDirectoryEntries(entries, sort),
+    [entries, sort],
+  );
+
+  return (
+    <section aria-labelledby="live-directory-heading">
+      <h2 id="live-directory-heading" className="sr-only">
+        {t("directoryHeading")}
+      </h2>
+
+      <div className="mb-6 flex justify-end">
+        <div className="flex w-full items-center gap-3 sm:w-auto">
+          <label htmlFor="live-directory-sort" className="shrink-0 text-sm text-gray-300">
+            {t("sort.label")}
+          </label>
+          <select
+            id="live-directory-sort"
+            value={sort}
+            onChange={(event) => setSort(event.target.value as LiveDirectorySort)}
+            className="min-h-11 min-w-0 flex-1 rounded-lg border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-white outline-none transition focus:border-purple-400 focus:ring-2 focus:ring-purple-400/30 sm:min-w-64"
+          >
+            <option value="viewers">{t("sort.viewers")}</option>
+            <option value="recentlyStarted">{t("sort.recentlyStarted")}</option>
+            <option value="cardCount">{t("sort.cardCount")}</option>
+            <option value="redemptionCount">{t("sort.redemptionCount")}</option>
+          </select>
+        </div>
+      </div>
+
+      {sortedEntries.length === 0 ? (
+        <div className="border-y border-gray-800 py-16 text-center">
+          <h3 className="text-xl font-semibold text-white">{t("empty.title")}</h3>
+          <p className="mx-auto mt-2 max-w-xl text-sm leading-6 text-gray-400">
+            {t("empty.description")}
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {sortedEntries.map((entry) => (
+            <LiveDirectoryCard
+              key={entry.streamerId}
+              entry={entry}
+              referenceTime={referenceTime}
+            />
+          ))}
+        </div>
+      )}
+
+      <div className="mt-10 border-t border-gray-800 pt-8 text-center">
+        <p className="text-sm text-gray-400">{t("listingCta.lead")}</p>
+        <Link
+          href="/dashboard/settings"
+          className="mt-3 inline-flex min-h-11 items-center justify-center rounded-lg border border-purple-500 px-5 py-2 text-sm font-medium text-purple-300 transition hover:bg-purple-500/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400"
+        >
+          {t("listingCta.link")}
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+function LiveDirectoryCard({
+  entry,
+  referenceTime,
+}: {
+  entry: LiveDirectoryEntry;
+  referenceTime: string;
+}) {
+  const t = useTranslations("livePage");
+  const channelUrl = `https://www.twitch.tv/${encodeURIComponent(entry.twitchLogin)}`;
+  const title = entry.title || t("card.untitled");
+  const gameName = entry.gameName || t("card.uncategorized");
+  const elapsed = formatElapsed(entry.startedAt, referenceTime, t);
+
+  return (
+    <article
+      data-streamer-id={entry.streamerId}
+      className="flex min-w-0 flex-col overflow-hidden rounded-lg border border-gray-700 bg-gray-800 shadow-sm transition hover:border-gray-600"
+    >
+      {/*
+        主リンクとコレクション副リンクは兄弟要素にする。カード全体をLinkで包むと
+        <a>が入れ子になり、クリック領域とスクリーンリーダーの解釈が壊れるため。
+      */}
+      <a
+        href={channelUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={t("card.watchOnTwitchNewTab", { name: entry.displayName })}
+        className="group block flex-1 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-purple-400"
+      >
+        <div className="relative aspect-video overflow-hidden bg-gray-950">
+          {entry.thumbnailUrl ? (
+            <Image
+              src={entry.thumbnailUrl}
+              alt={t("card.thumbnailAlt", { name: entry.displayName })}
+              fill
+              sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+              className="object-cover transition duration-200 group-hover:scale-[1.02]"
+              // Twitchのframeは数分単位で更新される。Image最適化キャッシュで古いframeを
+              // 長く保持せず、既存Twitch画像と同様に変換コストも発生させない。
+              unoptimized
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center px-4 text-center text-sm text-gray-500">
+              {t("card.thumbnailUnavailable")}
+            </div>
+          )}
+
+          <span className="absolute left-3 top-3 inline-flex items-center gap-1.5 rounded bg-red-600 px-2 py-1 text-xs font-bold text-white shadow">
+            <span className="h-2 w-2 rounded-full bg-white" aria-hidden="true" />
+            {t("card.live")}
+          </span>
+          <span className="absolute bottom-3 right-3 rounded bg-black/80 px-2 py-1 text-xs font-medium text-white shadow">
+            {t("card.viewers", { count: entry.viewerCount })}
+          </span>
+        </div>
+
+        <div className="p-4">
+          <div className="flex min-w-0 items-center gap-3">
+            {entry.profileImageUrl ? (
+              <Image
+                src={entry.profileImageUrl}
+                alt={t("card.profileAlt", { name: entry.displayName })}
+                width={40}
+                height={40}
+                className="h-10 w-10 shrink-0 rounded-full object-cover"
+                unoptimized
+              />
+            ) : (
+              <span
+                aria-hidden="true"
+                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gray-700 text-sm font-semibold text-gray-300"
+              >
+                {entry.displayName.slice(0, 1).toUpperCase()}
+              </span>
+            )}
+            <p className="min-w-0 flex-1 truncate font-semibold text-white">
+              {entry.displayName}
+              <span className="ml-1.5 text-gray-400" aria-hidden="true">
+                ↗
+              </span>
+            </p>
+          </div>
+
+          <h3 className="mt-3 line-clamp-2 min-h-12 text-sm font-medium leading-6 text-gray-100">
+            {title}
+          </h3>
+          <p className="mt-2 truncate text-sm text-cyan-300">
+            {t("card.category", { name: gameName })}
+          </p>
+          <time dateTime={entry.startedAt} className="mt-1 block text-xs text-gray-400">
+            {t("card.liveFor", { duration: elapsed })}
+          </time>
+        </div>
+      </a>
+
+      <div className="border-t border-gray-700 p-4">
+        {entry.stats ? (
+          <dl className="grid grid-cols-2 gap-3">
+            <div className="min-w-0">
+              <dt className="min-h-10 break-words text-xs leading-5 text-gray-400">
+                {t("stats.cardCount")}
+              </dt>
+              <dd className="mt-1 text-lg font-semibold tabular-nums text-emerald-300">
+                {t("stats.value", { count: entry.stats.cardCount })}
+              </dd>
+            </div>
+            <div className="min-w-0">
+              <dt className="min-h-10 break-words text-xs leading-5 text-gray-400">
+                {t("stats.redemptionCount")}
+              </dt>
+              <dd className="mt-1 text-lg font-semibold tabular-nums text-amber-300">
+                {t("stats.value", { count: entry.stats.redemptionCount })}
+              </dd>
+            </div>
+          </dl>
+        ) : (
+          <p className="flex min-h-[4.5rem] items-center text-sm text-gray-500">
+            {t("stats.private")}
+          </p>
+        )}
+
+        <Link
+          href={`/collection/${encodeURIComponent(entry.streamerId)}`}
+          className="mt-4 inline-flex min-h-11 w-full items-center justify-center rounded-lg bg-gray-700 px-4 py-2 text-sm font-medium text-white transition hover:bg-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400"
+        >
+          {t("card.viewCollection")}
+        </Link>
+      </div>
+    </article>
+  );
+}
+
+function formatElapsed(
+  startedAt: string,
+  referenceTime: string,
+  t: ReturnType<typeof useTranslations<"livePage">>,
+): string {
+  const start = Date.parse(startedAt);
+  const reference = Date.parse(referenceTime);
+  if (!Number.isFinite(start) || !Number.isFinite(reference)) {
+    return t("duration.unknown");
+  }
+
+  const totalMinutes = Math.max(0, Math.floor((reference - start) / 60_000));
+  if (totalMinutes === 0) return t("duration.justStarted");
+  if (totalMinutes < 60) return t("duration.minutes", { minutes: totalMinutes });
+
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (minutes === 0) return t("duration.hours", { hours });
+  return t("duration.hoursMinutes", { hours, minutes });
+}

--- a/src/components/LiveDirectory.tsx
+++ b/src/components/LiveDirectory.tsx
@@ -177,7 +177,6 @@ function LiveDirectoryCard({
         href={channelUrl}
         target="_blank"
         rel="noopener noreferrer"
-        aria-label={t("card.watchOnTwitchNewTab", { name: entry.displayName })}
         className="group block flex-1 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-purple-400"
       >
         <div className="relative aspect-video overflow-hidden bg-gray-950">
@@ -244,6 +243,11 @@ function LiveDirectoryCard({
             {t("card.liveFor", { duration: elapsed })}
           </time>
         </div>
+        {/* aria-label は子孫の可視情報をアクセシブル名から除外するため使わない。
+            新規タブの補足だけを子要素として足し、配信タイトル等を支援技術へ残す。 */}
+        <span className="sr-only">
+          {t("card.watchOnTwitchNewTab", { name: entry.displayName })}
+        </span>
       </a>
 
       <div className="border-t border-gray-700 p-4">

--- a/src/components/TopPageHeader.tsx
+++ b/src/components/TopPageHeader.tsx
@@ -64,6 +64,19 @@ function LogoutIcon() {
   )
 }
 
+function LiveDirectoryLink({ label }: { label: string }) {
+  return (
+    <Link
+      href="/live"
+      className="inline-flex min-h-10 items-center gap-1.5 rounded-lg px-2 text-sm font-medium text-gray-200 transition hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-300 sm:px-3"
+      title={label}
+    >
+      <span className="h-2.5 w-2.5 rounded-full bg-red-500" aria-hidden="true" />
+      <span className="sr-only sm:not-sr-only">{label}</span>
+    </Link>
+  )
+}
+
 export default function TopPageHeader({ initialSession }: TopPageHeaderProps) {
   // Trust the server-side session data passed from RSC
   // Don't re-fetch on client side as API routes have different cookie handling
@@ -83,6 +96,8 @@ export default function TopPageHeader({ initialSession }: TopPageHeaderProps) {
   if (session) {
     return (
       <div className="flex items-center gap-2 sm:gap-4">
+        <LiveDirectoryLink label={t('live')} />
+
         {/* ユーザー名：スマホでは非表示、sm以上で表示 */}
         <span className="hidden text-white sm:block">{session.twitchDisplayName}</span>
 
@@ -119,7 +134,11 @@ export default function TopPageHeader({ initialSession }: TopPageHeaderProps) {
     )
   }
 
-  // 未ログインユーザーの場合は言語切り替えのみ表示
-  // For logged-out users, only show the language switcher
-  return <LanguageSwitcherDark />
+  // 未ログインでも公開ディレクトリへ移動できる。言語切り替えと同じ共通導線として表示。
+  return (
+    <div className="flex items-center gap-2 sm:gap-4">
+      <LiveDirectoryLink label={t('live')} />
+      <LanguageSwitcherDark />
+    </div>
+  )
 }

--- a/tests/unit/components/live-directory-settings.test.tsx
+++ b/tests/unit/components/live-directory-settings.test.tsx
@@ -93,7 +93,9 @@ describe("LiveDirectorySettings", () => {
     fireEvent.click(liveToggle);
 
     await waitFor(() => {
-      expect(screen.getByText(/準備中/)).toBeInTheDocument();
+      expect(
+        screen.getByText("配信中ページの設定を現在保存できません。しばらくしてから再度お試しください。")
+      ).toBeInTheDocument();
     });
     expect(screen.queryByText("配信中ページへの掲載設定をオンにしました")).not.toBeInTheDocument();
     const [liveToggleAfter] = getToggles();

--- a/tests/unit/components/live-directory.test.tsx
+++ b/tests/unit/components/live-directory.test.tsx
@@ -138,6 +138,8 @@ describe("LiveDirectory", () => {
     expect(twitchLink).toHaveAttribute("href", "https://www.twitch.tv/alpha");
     expect(twitchLink).toHaveAttribute("target", "_blank");
     expect(twitchLink).toHaveAttribute("rel", "noopener noreferrer");
+    expect(twitchLink).not.toHaveAttribute("aria-label");
+    expect(twitchLink).toHaveAccessibleName(/alpha stream/);
     expect(twitchLink.parentElement).toBe(collectionLink.parentElement?.parentElement);
     expect(screen.getByText("LIVE")).toBeInTheDocument();
     expect(screen.getByAltText("Alphaのライブ配信サムネイル")).toBeInTheDocument();

--- a/tests/unit/components/live-directory.test.tsx
+++ b/tests/unit/components/live-directory.test.tsx
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import LiveDirectory, {
+  sortLiveDirectoryEntries,
+  type LiveDirectorySort,
+} from "@/components/LiveDirectory";
+import type { LiveDirectoryEntry } from "@/lib/live-directory";
+import jaMessages from "../../../messages/ja.json";
+
+const REFERENCE_TIME = "2026-08-11T03:00:00Z";
+
+function entry(
+  id: string,
+  overrides: Partial<LiveDirectoryEntry> = {},
+): LiveDirectoryEntry {
+  return {
+    streamerId: id,
+    twitchUserId: `twitch-${id}`,
+    twitchLogin: id,
+    displayName: id,
+    profileImageUrl: `https://example.com/${id}-profile.png`,
+    title: `${id} stream`,
+    gameName: "Game",
+    viewerCount: 0,
+    startedAt: "2026-08-11T01:00:00Z",
+    thumbnailUrl: `https://example.com/${id}-thumbnail.jpg`,
+    stats: { cardCount: 0, redemptionCount: 0 },
+    ...overrides,
+  };
+}
+
+const entries = [
+  entry("alpha", {
+    displayName: "Alpha",
+    viewerCount: 20,
+    startedAt: "2026-08-11T01:30:00Z",
+    stats: { cardCount: 4, redemptionCount: 90 },
+  }),
+  entry("bravo", {
+    displayName: "Bravo",
+    viewerCount: 50,
+    startedAt: "2026-08-11T02:30:00Z",
+    stats: null,
+  }),
+  entry("charlie", {
+    displayName: "Charlie",
+    viewerCount: 10,
+    startedAt: "2026-08-11T02:00:00Z",
+    stats: { cardCount: 12, redemptionCount: 30 },
+  }),
+];
+
+function idsFor(sort: LiveDirectorySort): string[] {
+  return sortLiveDirectoryEntries(entries, sort).map((item) => item.streamerId);
+}
+
+function renderDirectory(items: LiveDirectoryEntry[] = entries) {
+  return render(
+    <NextIntlClientProvider locale="ja" messages={jaMessages}>
+      <LiveDirectory entries={items} referenceTime={REFERENCE_TIME} />
+    </NextIntlClientProvider>,
+  );
+}
+
+function renderedCardIds(container: HTMLElement): string[] {
+  return [...container.querySelectorAll("article[data-streamer-id]")].map(
+    (card) => card.getAttribute("data-streamer-id") ?? "",
+  );
+}
+
+describe("sortLiveDirectoryEntries", () => {
+  it("sorts all four modes and keeps stats=null last for statistical modes", () => {
+    expect(idsFor("viewers")).toEqual(["bravo", "alpha", "charlie"]);
+    expect(idsFor("recentlyStarted")).toEqual(["bravo", "charlie", "alpha"]);
+    expect(idsFor("cardCount")).toEqual(["charlie", "alpha", "bravo"]);
+    expect(idsFor("redemptionCount")).toEqual(["alpha", "charlie", "bravo"]);
+  });
+
+  it("does not mutate the entries prop and distinguishes public zero from private stats", () => {
+    const publicZero = entry("public-zero", {
+      viewerCount: 1,
+      stats: { cardCount: 0, redemptionCount: 0 },
+    });
+    const privateHighViewers = entry("private", {
+      viewerCount: 999,
+      stats: null,
+    });
+    const input = [privateHighViewers, publicZero];
+    const snapshot = [...input];
+
+    expect(sortLiveDirectoryEntries(input, "cardCount").map((item) => item.streamerId)).toEqual([
+      "public-zero",
+      "private",
+    ]);
+    expect(input).toEqual(snapshot);
+  });
+
+  it("places invalid startedAt values last without returning an unstable NaN comparator", () => {
+    const invalid = entry("invalid", { startedAt: "not-a-date", viewerCount: 100 });
+    const valid = entry("valid", { startedAt: "2026-08-11T02:00:00Z", viewerCount: 1 });
+
+    expect(
+      sortLiveDirectoryEntries([invalid, valid], "recentlyStarted").map(
+        (item) => item.streamerId,
+      ),
+    ).toEqual(["valid", "invalid"]);
+  });
+});
+
+describe("LiveDirectory", () => {
+  it("uses viewer count initially and updates the DOM order through the labeled select", () => {
+    const { container } = renderDirectory();
+    expect(renderedCardIds(container)).toEqual(["bravo", "alpha", "charlie"]);
+
+    fireEvent.change(screen.getByRole("combobox", { name: "並び順" }), {
+      target: { value: "cardCount" },
+    });
+    expect(renderedCardIds(container)).toEqual(["charlie", "alpha", "bravo"]);
+  });
+
+  it("renders public stats and explicitly identifies private stats", () => {
+    renderDirectory();
+
+    expect(screen.getByText("統計非公開")).toBeInTheDocument();
+    expect(screen.getAllByText("カード種類数").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("チャネルポイント引換数").length).toBeGreaterThan(0);
+  });
+
+  it("keeps Twitch and collection anchors as siblings with secure external-link attributes", () => {
+    const { container } = renderDirectory([entries[0]]);
+    expect(container.querySelectorAll("a a")).toHaveLength(0);
+
+    const twitchLink = screen.getByRole("link", {
+      name: /Alphaの配信をTwitchで見る/,
+    });
+    const collectionLink = screen.getByRole("link", { name: "コレクションを見る" });
+    expect(twitchLink).toHaveAttribute("href", "https://www.twitch.tv/alpha");
+    expect(twitchLink).toHaveAttribute("target", "_blank");
+    expect(twitchLink).toHaveAttribute("rel", "noopener noreferrer");
+    expect(twitchLink.parentElement).toBe(collectionLink.parentElement?.parentElement);
+    expect(screen.getByText("LIVE")).toBeInTheDocument();
+    expect(screen.getByAltText("Alphaのライブ配信サムネイル")).toBeInTheDocument();
+  });
+
+  it("shows the empty state and listing CTA even when no streams are live", () => {
+    renderDirectory([]);
+
+    expect(screen.getByRole("heading", { name: "現在掲載中の配信はありません" })).toBeInTheDocument();
+    const cta = screen.getByRole("link", {
+      name: "配信者の方はこちらから掲載できます",
+    });
+    expect(cta).toHaveAttribute("href", "/dashboard/settings");
+  });
+
+  it("shows a stable elapsed duration based on the server-provided reference time", () => {
+    renderDirectory([entries[0]]);
+
+    const card = screen.getByRole("article");
+    expect(within(card).getByText("配信開始から 1時間 30分")).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/top-page-header-live-link.test.tsx
+++ b/tests/unit/components/top-page-header-live-link.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import TopPageHeader from "@/components/TopPageHeader";
+import jaMessages from "../../../messages/ja.json";
+
+vi.mock("@/components/LanguageSwitcher", () => ({
+  LanguageSwitcherDark: () => <button type="button">language</button>,
+}));
+
+vi.mock("@/components/LogoutButton", () => ({
+  LogoutButton: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+function renderHeader(initialSession: Parameters<typeof TopPageHeader>[0]["initialSession"]) {
+  render(
+    <NextIntlClientProvider locale="ja" messages={jaMessages}>
+      <TopPageHeader initialSession={initialSession} />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe("TopPageHeader live directory navigation", () => {
+  it("shows /live to logged-out visitors", () => {
+    renderHeader(null);
+
+    expect(screen.getByRole("link", { name: "配信中" })).toHaveAttribute("href", "/live");
+    expect(screen.getByRole("button", { name: "language" })).toBeInTheDocument();
+  });
+
+  it("keeps /live available beside the authenticated dashboard route", () => {
+    renderHeader({
+      twitchUserId: "user-1",
+      twitchUsername: "alpha",
+      twitchDisplayName: "Alpha",
+      twitchProfileImageUrl: "https://example.com/alpha.png",
+      broadcasterType: "affiliate",
+    });
+
+    expect(screen.getByRole("link", { name: "配信中" })).toHaveAttribute("href", "/live");
+    expect(screen.getByRole("link", { name: "ダッシュボード" })).toHaveAttribute(
+      "href",
+      "/dashboard",
+    );
+  });
+});

--- a/tests/unit/live-page.test.tsx
+++ b/tests/unit/live-page.test.tsx
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  getLiveDirectory: vi.fn(),
+  getTranslations: vi.fn(),
+}));
+
+vi.mock("@/lib/session", () => ({ getSession: mocks.getSession }));
+vi.mock("@/lib/live-directory", () => ({
+  getLiveDirectory: mocks.getLiveDirectory,
+}));
+vi.mock("next-intl/server", () => ({
+  getTranslations: mocks.getTranslations,
+}));
+vi.mock("@/components/LiveDirectory", () => ({
+  default: ({ entries }: { entries: unknown[] }) => (
+    <div data-testid="live-directory">entries:{entries.length}</div>
+  ),
+}));
+vi.mock("@/components/PublicFooter", () => ({
+  default: () => <footer>public footer</footer>,
+}));
+
+import LivePage, { generateMetadata } from "@/app/live/page";
+
+const translations: Record<string, Record<string, string>> = {
+  livePage: {
+    "metadata.title": "配信中 - TwiCa",
+    "metadata.description": "metadata description",
+    navigationLabel: "navigation",
+    home: "ホーム",
+    title: "配信中の配信者",
+    description: "page description",
+  },
+  header: {
+    dashboard: "ダッシュボード",
+  },
+};
+
+describe("LivePage", () => {
+  beforeEach(() => {
+    mocks.getSession.mockReset();
+    mocks.getLiveDirectory.mockReset();
+    mocks.getTranslations.mockReset();
+    mocks.getTranslations.mockImplementation(async (namespace: string) => {
+      return (key: string) => translations[namespace]?.[key] ?? key;
+    });
+    mocks.getLiveDirectory.mockResolvedValue([{ streamerId: "streamer-1" }]);
+  });
+
+  it("renders the full directory without redirecting when no session exists", async () => {
+    mocks.getSession.mockResolvedValue(null);
+
+    render(await LivePage());
+
+    expect(mocks.getSession).toHaveBeenCalledOnce();
+    expect(mocks.getLiveDirectory).toHaveBeenCalledOnce();
+    expect(screen.getByRole("heading", { name: "配信中の配信者" })).toBeInTheDocument();
+    expect(screen.getByTestId("live-directory")).toHaveTextContent("entries:1");
+    expect(screen.getByRole("link", { name: "ホーム" })).toHaveAttribute("href", "/");
+    expect(screen.getByText("public footer")).toBeInTheDocument();
+  });
+
+  it("uses the dashboard header route for an authenticated visitor", async () => {
+    mocks.getSession.mockResolvedValue({ twitchUserId: "user-1" });
+
+    render(await LivePage());
+
+    expect(screen.getByRole("link", { name: "ダッシュボード" })).toHaveAttribute(
+      "href",
+      "/dashboard",
+    );
+  });
+
+  it("builds localized metadata from the livePage namespace", async () => {
+    await expect(generateMetadata()).resolves.toEqual({
+      title: "配信中 - TwiCa",
+      description: "metadata description",
+    });
+  });
+});

--- a/tests/unit/public-help-pages.test.ts
+++ b/tests/unit/public-help-pages.test.ts
@@ -60,6 +60,7 @@ describe("FAQ page", () => {
       "src/app/releases/page.tsx",
       "src/app/plans/page.tsx",
       "src/app/faq/page.tsx",
+      "src/app/live/page.tsx",
     ];
 
     for (const page of pages) {
@@ -82,6 +83,12 @@ describe("FAQ page", () => {
     expect(source).toContain('href: "/about"');
     expect(source).toContain('href: "/privacy"');
     expect(source).toContain('href: "/releases"');
+  });
+
+  it("links to the public live directory from authenticated and top-page headers", () => {
+    expect(readSource("src/components/Header.tsx")).toContain('href="/live"');
+    expect(readSource("src/components/TopPageHeader.tsx")).toContain('href="/live"');
+    expect(readSource("src/app/page.tsx")).toContain('href="/live"');
   });
 });
 


### PR DESCRIPTION
## 概要

- 認証不要の公開ページ `/live` を追加し、オプトイン済みで現在配信中の配信者を一覧表示
- 視聴者数・配信開始・カード種類数・チャネルポイント引換数の4ソートを実装
- 統計公開/非公開、Twitch外部リンク、コレクション導線、空状態、掲載設定CTAを #737 の確定仕様どおり実装
- `Header` / `TopPageHeader` / トップページへ「配信中」導線を追加
- ja/en の `livePage` 文言と、公開後の設定画面文言を追加
- Server/Client境界、決定的かつ非破壊なソート、アンカー非入れ子、SSR/hydrationで安定する経過時間をテストで固定

## 検証

- `npm run test:all -- tests/unit/components/live-directory.test.tsx tests/unit/live-page.test.tsx tests/unit/components/top-page-header-live-link.test.tsx tests/unit/components/live-directory-settings.test.tsx tests/unit/public-help-pages.test.ts tests/unit/i18n-message-parity.test.ts`（37 tests）
- 全 unit: 260 files / 3402 tests
- `npm run typecheck`
- `npm run lint -- src tests`（0 errors、既存 warning 10件）
- `npm run build`
- `npm run check:migration-order`
- ローカル `/live` とトップページをデスクトップ/390pxで実画面確認（横スクロール・ブラウザconsole errorなし）

## レビュー

- 厳格な自己レビュー: 必須指摘 0件
- ローカル専用のネストworktreeまで既定lintが走査する任意改善は #921 に退避済み

Closes #740