### PR TITLE
ci: 関連ファイル変更時のみ各ジョブを実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,86 @@ on:
   pull_request:
     branches: [ main, preview ]
 
+# 変更ファイルの検出は job 単位で行う。workflow レベルの paths フィルタは
+# 全 job へ一律適用される上、required check が「報告待ち」で詰まったまま
+# マージをブロックし続ける既知の落とし穴があるため使わない。
+# dorny/paths-filter で job ごとに必要なファイル群を判定し、無関係な変更では
+# その job だけスキップする（skip された required check は成功扱いになる）。
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+      tests: ${{ steps.filter.outputs.tests }}
+      scripts: ${{ steps.filter.outputs.scripts }}
+      migrations: ${{ steps.filter.outputs.migrations }}
+      postgres_fixtures: ${{ steps.filter.outputs.postgres_fixtures }}
+      analysis: ${{ steps.filter.outputs.analysis }}
+      i18n: ${{ steps.filter.outputs.i18n }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # push イベントでは直前コミットとの差分検出に履歴が必要
+          # （PR イベントでは REST API を使うため不要だが、両対応で常に取得する）
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          # push: 同一ブランチの直前コミットとの差分 / PR: base ブランチとの差分
+          # （PR イベントではこの入力は無視される）
+          base: ${{ github.ref }}
+          filters: |
+            app:
+              - 'src/**'
+              - 'workers/**'
+              - 'messages/**'
+              - 'public/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig*.json'
+              - 'next.config.*'
+              - 'open-next.config.*'
+              - 'postcss.config.*'
+              - 'eslint*.config.*'
+              - 'vitest.config.*'
+              - 'wrangler.toml'
+            tests:
+              - 'tests/**'
+            scripts:
+              - 'scripts/**'
+              - 'config/**'
+            migrations:
+              - 'supabase/migrations/**'
+              - 'db/planetscale/**'
+              - 'scripts/db-migrate.js'
+              - 'scripts/lib/**'
+              - 'scripts/check-migration-order.js'
+            postgres_fixtures:
+              - 'tests/fixtures/analysis-dashboard-pagination-postgres.sql'
+              - 'tests/fixtures/transactional-chat-outbox-postgres.sql'
+              - 'tests/fixtures/transactional-chat-outbox-concurrency.sh'
+            analysis:
+              - 'analysis/**'
+              - 'scripts/check-analysis-browser-supabase.js'
+            i18n:
+              - 'src/**'
+              - 'eslint.i18n.config.mjs'
+              - 'scripts/i18n-debt-files.js'
+
   test:
+    needs: changes
+    # アプリ/テスト/スクリプト/migration のいずれにも触れない変更
+    # （ドキュメント等）ではスキップする。migration を含めるのは unit test が
+    # migration SQL を読み込むため（tests/unit/migration-filenames.test.ts 等）。
+    if: >-
+      needs.changes.outputs.app == 'true' ||
+      needs.changes.outputs.tests == 'true' ||
+      needs.changes.outputs.scripts == 'true' ||
+      needs.changes.outputs.migrations == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -65,8 +143,14 @@ jobs:
 
   supabase-shutdown-build:
     name: Application build without Supabase variables
-    needs: test
-    if: ${{ !failure() && !cancelled() }}
+    needs: [changes, test]
+    # test 成功時のみ（スキップ時も可）。app/scripts に触れない変更ではスキップ。
+    # test がスキップされるのは app/scripts 未変更時なので、結果的に
+    # 元の「test が失敗/キャンセルしたら回さない」を維持する。
+    if: >-
+      needs.test.result == 'success' &&
+      (needs.changes.outputs.app == 'true' ||
+       needs.changes.outputs.scripts == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -106,6 +190,8 @@ jobs:
 
   analysis:
     name: Analysis dashboard (guard / typecheck / build)
+    needs: changes
+    if: needs.changes.outputs.analysis == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -150,7 +236,14 @@ jobs:
           echo "OK: bundleにSupabase文字列は含まれていません (${#bundle_files[@]} ファイルを検証)"
 
   lint:
-    if: github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'preview'
+    needs: changes
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.base_ref == 'main' &&
+      github.head_ref == 'preview' &&
+      (needs.changes.outputs.app == 'true' ||
+       needs.changes.outputs.tests == 'true' ||
+       needs.changes.outputs.scripts == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -170,9 +263,12 @@ jobs:
 
   lint-i18n:
     name: Lint i18n (Japanese literals)
+    needs: changes
     # PRだけでなく、preview/mainへマージされたpushでも同じガードを実行する。
     # PR側のイベントが欠落した場合でも、デプロイ対象のコミットで回帰を検出できるようにする。
-    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    if: >-
+      (github.event_name == 'pull_request' || github.event_name == 'push') &&
+      needs.changes.outputs.i18n == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -194,7 +290,8 @@ jobs:
 
   migration-order-check:
     name: Migration order check
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: needs.changes.outputs.migrations == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -219,6 +316,10 @@ jobs:
 
   planetscale-migration-postgres:
     name: PlanetScale migration PostgreSQL 17
+    needs: changes
+    if: >-
+      needs.changes.outputs.migrations == 'true' ||
+      needs.changes.outputs.postgres_fixtures == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
 # マージをブロックし続ける既知の落とし穴があるため使わない。
 # dorny/paths-filter で job ごとに必要なファイル群を判定し、無関係な変更では
 # その job だけスキップする（skip された required check は成功扱いになる）。
+# ただし変更検出自体が失敗した場合まで検証をskipするとCIを迂回できるため、
+# 各依存jobは needs.changes.result != 'success' なら従来どおり実行する。
 jobs:
   changes:
     name: Detect changed paths
@@ -96,11 +98,13 @@ jobs:
     # analysis を含めるのは tests/unit/analysis-dashboard-pagination.test.ts が
     # analysis/src 配下のソースを直接assertするため。
     if: >-
-      needs.changes.outputs.app == 'true' ||
-      needs.changes.outputs.tests == 'true' ||
-      needs.changes.outputs.scripts == 'true' ||
-      needs.changes.outputs.migrations == 'true' ||
-      needs.changes.outputs.analysis == 'true'
+      !cancelled() &&
+      (needs.changes.result != 'success' ||
+       needs.changes.outputs.app == 'true' ||
+       needs.changes.outputs.tests == 'true' ||
+       needs.changes.outputs.scripts == 'true' ||
+       needs.changes.outputs.migrations == 'true' ||
+       needs.changes.outputs.analysis == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -159,12 +163,13 @@ jobs:
   supabase-shutdown-build:
     name: Application build without Supabase variables
     needs: [changes, test]
-    # test 成功時のみ（スキップ時も可）。app/scripts に触れない変更ではスキップ。
-    # test がスキップされるのは app/scripts 未変更時なので、結果的に
-    # 元の「test が失敗/キャンセルしたら回さない」を維持する。
+    # test成功時のみ実行する。変更検出に成功した場合はapp/scripts変更時だけ、
+    # 変更検出自体が失敗した場合は安全側へ倒してbuildも実行する。
     if: >-
+      !cancelled() &&
       needs.test.result == 'success' &&
-      (needs.changes.outputs.app == 'true' ||
+      (needs.changes.result != 'success' ||
+       needs.changes.outputs.app == 'true' ||
        needs.changes.outputs.scripts == 'true')
     runs-on: ubuntu-latest
 
@@ -206,7 +211,10 @@ jobs:
   analysis:
     name: Analysis dashboard (guard / typecheck / build)
     needs: changes
-    if: needs.changes.outputs.analysis == 'true'
+    if: >-
+      !cancelled() &&
+      (needs.changes.result != 'success' ||
+       needs.changes.outputs.analysis == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -253,10 +261,12 @@ jobs:
   lint:
     needs: changes
     if: >-
+      !cancelled() &&
       github.event_name == 'pull_request' &&
       github.base_ref == 'main' &&
       github.head_ref == 'preview' &&
-      (needs.changes.outputs.app == 'true' ||
+      (needs.changes.result != 'success' ||
+       needs.changes.outputs.app == 'true' ||
        needs.changes.outputs.tests == 'true' ||
        needs.changes.outputs.scripts == 'true')
     runs-on: ubuntu-latest
@@ -282,8 +292,10 @@ jobs:
     # PRだけでなく、preview/mainへマージされたpushでも同じガードを実行する。
     # PR側のイベントが欠落した場合でも、デプロイ対象のコミットで回帰を検出できるようにする。
     if: >-
+      !cancelled() &&
       (github.event_name == 'pull_request' || github.event_name == 'push') &&
-      needs.changes.outputs.i18n == 'true'
+      (needs.changes.result != 'success' ||
+       needs.changes.outputs.i18n == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -311,8 +323,10 @@ jobs:
     # スクリプト側は警告付きでルール2をスキップするだけの空振りになる）。
     # 元の実装（PRのみ実行）を維持する。
     if: >-
+      !cancelled() &&
       github.event_name == 'pull_request' &&
-      needs.changes.outputs.migrations == 'true'
+      (needs.changes.result != 'success' ||
+       needs.changes.outputs.migrations == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -339,8 +353,10 @@ jobs:
     name: PlanetScale migration PostgreSQL 17
     needs: changes
     if: >-
-      needs.changes.outputs.migrations == 'true' ||
-      needs.changes.outputs.postgres_fixtures == 'true'
+      !cancelled() &&
+      (needs.changes.result != 'success' ||
+       needs.changes.outputs.migrations == 'true' ||
+       needs.changes.outputs.postgres_fixtures == 'true')
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
               - 'workers/**'
               - 'messages/**'
               - 'public/**'
+              - 'types/**'
               - 'package.json'
               - 'package-lock.json'
               - 'tsconfig*.json'
@@ -53,15 +54,26 @@ jobs:
               - 'eslint*.config.*'
               - 'vitest.config.*'
               - 'wrangler.toml'
+              # tests/unit/cloudflare-proxy-migration.test.ts が本文を直接assertする。
+              - 'docs/cloudflare-proxy-migration.md'
             tests:
               - 'tests/**'
             scripts:
               - 'scripts/**'
               - 'config/**'
+              # scripts/check-supabase-shutdown.js（test jobで実行）が走査・assertする
+              # 対象。スクリプト本体だけでなく、これらのpathの変更でも同ガードを
+              # 再実行しないと、退役provider混入チェックが無検査ですり抜ける。
+              - '.github/workflows/**'
+              - '.opencode/plans/**'
+              - '.env.local.example'
             migrations:
               - 'supabase/migrations/**'
               - 'db/planetscale/**'
               - 'scripts/db-migrate.js'
+              # scripts/** と重複するが意図的: scripts カテゴリは test job を、
+              # こちらは migration-order-check / planetscale-migration-postgres を
+              # ゲートしており、それぞれ独立したoutputなので両方に列挙が必要。
               - 'scripts/lib/**'
               - 'scripts/check-migration-order.js'
             postgres_fixtures:
@@ -78,14 +90,17 @@ jobs:
 
   test:
     needs: changes
-    # アプリ/テスト/スクリプト/migration のいずれにも触れない変更
+    # アプリ/テスト/スクリプト/migration/analysis のいずれにも触れない変更
     # （ドキュメント等）ではスキップする。migration を含めるのは unit test が
     # migration SQL を読み込むため（tests/unit/migration-filenames.test.ts 等）。
+    # analysis を含めるのは tests/unit/analysis-dashboard-pagination.test.ts が
+    # analysis/src 配下のソースを直接assertするため。
     if: >-
       needs.changes.outputs.app == 'true' ||
       needs.changes.outputs.tests == 'true' ||
       needs.changes.outputs.scripts == 'true' ||
-      needs.changes.outputs.migrations == 'true'
+      needs.changes.outputs.migrations == 'true' ||
+      needs.changes.outputs.analysis == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -291,7 +306,13 @@ jobs:
   migration-order-check:
     name: Migration order check
     needs: changes
-    if: needs.changes.outputs.migrations == 'true'
+    # ルール2（採番の追い抜き検知）はbase branchとの比較が前提で、pull_request
+    # イベントでしか意味を持たない（push では github.base_ref が空になり、
+    # スクリプト側は警告付きでルール2をスキップするだけの空振りになる）。
+    # 元の実装（PRのみ実行）を維持する。
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.migrations == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       postgres_fixtures: ${{ steps.filter.outputs.postgres_fixtures }}
       analysis: ${{ steps.filter.outputs.analysis }}
       i18n: ${{ steps.filter.outputs.i18n }}
+      ci_workflow: ${{ steps.filter.outputs.ci_workflow }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,6 +63,9 @@ jobs:
               - 'tests/**'
             scripts:
               - 'scripts/**'
+              # tests/unit/claude-review-format.test.ts はレビュー整形処理を
+              # .github/scripts から直接importするため、変更時はunit testが必要。
+              - '.github/scripts/**'
               - 'config/**'
               # scripts/check-supabase-shutdown.js（test jobで実行）が走査・assertする
               # 対象。スクリプト本体だけでなく、これらのpathの変更でも同ガードを
@@ -89,6 +93,11 @@ jobs:
               - 'src/**'
               - 'eslint.i18n.config.mjs'
               - 'scripts/i18n-debt-files.js'
+            ci_workflow:
+              # job定義そのものを変えたPRでは、そのjobを実際に起動しないと
+              # step・env・serviceの誤りを検証できない。ci.ymlの変更は稀なので、
+              # コスト最適化より全jobの自己検証を優先する。
+              - '.github/workflows/ci.yml'
 
   test:
     needs: changes
@@ -104,7 +113,8 @@ jobs:
        needs.changes.outputs.tests == 'true' ||
        needs.changes.outputs.scripts == 'true' ||
        needs.changes.outputs.migrations == 'true' ||
-       needs.changes.outputs.analysis == 'true')
+       needs.changes.outputs.analysis == 'true' ||
+       needs.changes.outputs.ci_workflow == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -170,7 +180,8 @@ jobs:
       needs.test.result == 'success' &&
       (needs.changes.result != 'success' ||
        needs.changes.outputs.app == 'true' ||
-       needs.changes.outputs.scripts == 'true')
+       needs.changes.outputs.scripts == 'true' ||
+       needs.changes.outputs.ci_workflow == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -214,7 +225,8 @@ jobs:
     if: >-
       !cancelled() &&
       (needs.changes.result != 'success' ||
-       needs.changes.outputs.analysis == 'true')
+       needs.changes.outputs.analysis == 'true' ||
+       needs.changes.outputs.ci_workflow == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -268,7 +280,8 @@ jobs:
       (needs.changes.result != 'success' ||
        needs.changes.outputs.app == 'true' ||
        needs.changes.outputs.tests == 'true' ||
-       needs.changes.outputs.scripts == 'true')
+       needs.changes.outputs.scripts == 'true' ||
+       needs.changes.outputs.ci_workflow == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -295,7 +308,8 @@ jobs:
       !cancelled() &&
       (github.event_name == 'pull_request' || github.event_name == 'push') &&
       (needs.changes.result != 'success' ||
-       needs.changes.outputs.i18n == 'true')
+       needs.changes.outputs.i18n == 'true' ||
+       needs.changes.outputs.ci_workflow == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -326,7 +340,8 @@ jobs:
       !cancelled() &&
       github.event_name == 'pull_request' &&
       (needs.changes.result != 'success' ||
-       needs.changes.outputs.migrations == 'true')
+       needs.changes.outputs.migrations == 'true' ||
+       needs.changes.outputs.ci_workflow == 'true')
     runs-on: ubuntu-latest
 
     steps:
@@ -356,7 +371,8 @@ jobs:
       !cancelled() &&
       (needs.changes.result != 'success' ||
        needs.changes.outputs.migrations == 'true' ||
-       needs.changes.outputs.postgres_fixtures == 'true')
+       needs.changes.outputs.postgres_fixtures == 'true' ||
+       needs.changes.outputs.ci_workflow == 'true')
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/planetscale-migrate.yml
+++ b/.github/workflows/planetscale-migrate.yml
@@ -99,6 +99,10 @@ on:
       - 'db/planetscale/**'
       - 'scripts/db-migrate.js'
       - 'scripts/lib/**'
+      # runtime runnerはrootのpostgres packageを使う。依存更新で壊れた場合を
+      # 次のDDL適用時まで見逃さないよう、manifestとlockfileも実DBで検証する。
+      - 'package.json'
+      - 'package-lock.json'
 
   # 手動再実行ではGitHub UIでmainまたはpreviewのrefを選ぶ。Environmentを別inputで
   # 選ばせると「previewコード + production secret」のような危険な組合せを作れるため、

--- a/.github/workflows/planetscale-migrate.yml
+++ b/.github/workflows/planetscale-migrate.yml
@@ -88,13 +88,14 @@ on:
     # pushで毎回PlanetScaleへ接続するのは無駄なため。
     # （workflow_dispatch は手動実行のためパスフィルタを付けない）
     #
-    # 既知のエッジケース（GitHub公式ドキュメントで確認済み・受容する残余リスク）:
-    # 1回のpushのdiffが3,000ファイルを超え、かつmigration変更がその先頭3,000件に
-    # 含まれない場合、GitHub側の実装上このpathフィルタはfail-closed（実行されない）
-    # になる。本リポジトリの通常のPR/pushでこの規模のdiffは想定していないが、
-    # 万一発生した場合はDDLが未適用のまま気づかず進む。復旧経路は
-    # `workflow_dispatch` による手動再実行、または次のmigration付きpushでの
-    # まとめ適用（`db-migrate.js`は未適用分をすべて追いつかせる）。
+    # 既知のエッジケース（GitHub公式ドキュメント間で上限値が一致しないため安全側で運用）:
+    # Workflow Syntaxは先頭3,000ファイル、Troubleshootingは先頭300ファイルまでを
+    # path判定対象と記載している（2026-08-11確認）。低い300を実効上限として扱い、
+    # 1回のpushが300ファイルを超える場合は、migrationが含まれるかにかかわらず
+    # このworkflow runが作成されたことを運用者が確認する。runが無い場合は対象branchで
+    # `workflow_dispatch` を直ちに実行する。未適用分は`db-migrate.js`がまとめて追いつかせる。
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
+    # https://docs.github.com/en/actions/how-tos/troubleshoot-workflows#filtering-and-diff-limits
     #
     # また、従来の全push実行では一時的な接続断やadvisory lock待ちでapplyが
     # 失敗しても次のpushが自動リトライになっていたが、path限定後は無関係なpushでは

--- a/.github/workflows/planetscale-migrate.yml
+++ b/.github/workflows/planetscale-migrate.yml
@@ -23,7 +23,8 @@
 # 構造的に発生しなくなる。
 #
 # Applies `scripts/db-migrate.js apply --provider=planetscale` against the
-# branch-matched PlanetScale logical database on every push to main or preview.
+# branch-matched PlanetScale logical database when migration or runner paths
+# change on main or preview. Operators can retry explicitly with workflow_dispatch.
 #
 # Kept in its own file rather than as a job in deploy-cloudflare.yml because GitHub
 # Actions concurrency cancellation operates at the run level: a workflow-level
@@ -82,9 +83,9 @@ name: PlanetScale Migrations
 on:
   push:
     branches: [main, preview]
-    # migration そのものか runner スクリプトに変更が無い push ではスキップする。
-    # 実DBへのDDL適用は migration 変更時のみ必要であり、ドキュメント等だけの
-    # push で毎回 PlanetScale へ接続して適用/検証するのは無駄なため。
+    # migration・runner依存・workflow自身に関係しないpushではスキップする。
+    # 実DBへのapply/verifyはこれらの変更時に必要であり、無関係なドキュメント等だけの
+    # pushで毎回PlanetScaleへ接続するのは無駄なため。
     # （workflow_dispatch は手動実行のためパスフィルタを付けない）
     #
     # 既知のエッジケース（GitHub公式ドキュメントで確認済み・受容する残余リスク）:
@@ -94,11 +95,20 @@ on:
     # 万一発生した場合はDDLが未適用のまま気づかず進む。復旧経路は
     # `workflow_dispatch` による手動再実行、または次のmigration付きpushでの
     # まとめ適用（`db-migrate.js`は未適用分をすべて追いつかせる）。
+    #
+    # また、従来の全push実行では一時的な接続断やadvisory lock待ちでapplyが
+    # 失敗しても次のpushが自動リトライになっていたが、path限定後は無関係なpushでは
+    # 再実行されない。失敗を確認した運用者は、同じbranchのrunでRe-run failed jobsを
+    # 選ぶかworkflow_dispatchを実行する。アプリは未適用カラムをdeploy-window fallbackで
+    # 機能縮退させるためデータ破損には至らない一方、再実行まで機能無効が長引く残余リスクは
+    # 受容する。定期verify等の追加監視は、実測で必要になった時点の別Issueで検討する。
     paths:
       - 'supabase/migrations/**'
       - 'db/planetscale/**'
       - 'scripts/db-migrate.js'
       - 'scripts/lib/**'
+      # workflowのif/env/step変更を次のmigrationまで未実行にしない。
+      - '.github/workflows/planetscale-migrate.yml'
       # runtime runnerはrootのpostgres packageを使う。依存更新で壊れた場合を
       # 次のDDL適用時まで見逃さないよう、manifestとlockfileも実DBで検証する。
       - 'package.json'

--- a/.github/workflows/planetscale-migrate.yml
+++ b/.github/workflows/planetscale-migrate.yml
@@ -86,6 +86,14 @@ on:
     # 実DBへのDDL適用は migration 変更時のみ必要であり、ドキュメント等だけの
     # push で毎回 PlanetScale へ接続して適用/検証するのは無駄なため。
     # （workflow_dispatch は手動実行のためパスフィルタを付けない）
+    #
+    # 既知のエッジケース（GitHub公式ドキュメントで確認済み・受容する残余リスク）:
+    # 1回のpushのdiffが3,000ファイルを超え、かつmigration変更がその先頭3,000件に
+    # 含まれない場合、GitHub側の実装上このpathフィルタはfail-closed（実行されない）
+    # になる。本リポジトリの通常のPR/pushでこの規模のdiffは想定していないが、
+    # 万一発生した場合はDDLが未適用のまま気づかず進む。復旧経路は
+    # `workflow_dispatch` による手動再実行、または次のmigration付きpushでの
+    # まとめ適用（`db-migrate.js`は未適用分をすべて追いつかせる）。
     paths:
       - 'supabase/migrations/**'
       - 'db/planetscale/**'

--- a/.github/workflows/planetscale-migrate.yml
+++ b/.github/workflows/planetscale-migrate.yml
@@ -82,6 +82,15 @@ name: PlanetScale Migrations
 on:
   push:
     branches: [main, preview]
+    # migration そのものか runner スクリプトに変更が無い push ではスキップする。
+    # 実DBへのDDL適用は migration 変更時のみ必要であり、ドキュメント等だけの
+    # push で毎回 PlanetScale へ接続して適用/検証するのは無駄なため。
+    # （workflow_dispatch は手動実行のためパスフィルタを付けない）
+    paths:
+      - 'supabase/migrations/**'
+      - 'db/planetscale/**'
+      - 'scripts/db-migrate.js'
+      - 'scripts/lib/**'
 
   # 手動再実行ではGitHub UIでmainまたはpreviewのrefを選ぶ。Environmentを別inputで
   # 選ばせると「previewコード + production secret」のような危険な組合せを作れるため、

--- a/tests/unit/components/live-directory-settings.test.tsx
+++ b/tests/unit/components/live-directory-settings.test.tsx
@@ -119,9 +119,13 @@ describe("LiveDirectorySettings", () => {
         })
       );
     });
-    const [, statsToggle] = getToggles();
-    expect(statsToggle).toBeDisabled();
-    expect(statsToggle).not.toBeChecked();
+    // 保存完了後に publishStats=false が反映されるため、fetch の呼び出しだけでなく
+    // 依存トグルの最終状態まで待って、非同期な UI 契約を検証する。
+    await waitFor(() => {
+      const [, statsToggle] = getToggles();
+      expect(statsToggle).toBeDisabled();
+      expect(statsToggle).not.toBeChecked();
+    });
   });
 
   it("toggling stats alone sends only publishStats", async () => {


### PR DESCRIPTION
## 概要

`main` で確定済みのCIパス絞り込み（`06d4831` + `8468bbb`）を `preview` へ同期します。

- `dorny/paths-filter@v4` で変更ファイルを1回判定し、job単位の `if` で必要な処理だけ実行
- app / tests / scripts / migrations / PostgreSQL fixture / analysis / i18n を独立した対象パスへ分離
- migration order・PlanetScale PostgreSQL・analysis build・i18n lint・app buildを無関係な変更でスキップ
- 実DBへ接続する `PlanetScale Migrations` workflowは、migrationまたはrunner変更を含むpushだけで実行
- workflow-level `paths` でrequired checkがPendingになる問題を避け、CI本体は常に起動してjob単位でskip

## 検証

- `.github/workflows/ci.yml` / `planetscale-migrate.yml` は `origin/main` と完全一致
- YAML parse: success
- `git diff --check`: success
- GitHub公式のrequired check + workflow path filterの注意事項、および `dorny/paths-filter` v4のPR権限要件を再確認

## このPRで確認すること

workflowファイル変更なので `Detect changed paths`・test・application buildは実行されます。一方、migration / PostgreSQL fixture / analysis / i18n の対象ファイルは未変更のため、それぞれの専用jobがskipされることをCI結果で確認します。