### PR TITLE
fix(#740): 配信中ページから視聴者数ソートを削除

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1519,7 +1519,6 @@
     "directoryHeading": "Live streams",
     "sort": {
       "label": "Sort by",
-      "viewers": "Viewers",
       "recentlyStarted": "Recently started",
       "cardCount": "Card types",
       "redemptionCount": "Channel point redemptions"

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1519,7 +1519,6 @@
     "directoryHeading": "ライブ配信一覧",
     "sort": {
       "label": "並び順",
-      "viewers": "視聴者数",
       "recentlyStarted": "配信開始が新しい順",
       "cardCount": "カード種類数",
       "redemptionCount": "チャネルポイント引換数"

--- a/src/components/LiveDirectory.tsx
+++ b/src/components/LiveDirectory.tsx
@@ -7,7 +7,6 @@ import { useTranslations } from "next-intl";
 import type { LiveDirectoryEntry } from "@/lib/live-directory";
 
 export type LiveDirectorySort =
-  | "viewers"
   | "recentlyStarted"
   | "cardCount"
   | "redemptionCount";
@@ -23,11 +22,10 @@ interface LiveDirectoryProps {
 }
 
 function compareFallback(a: LiveDirectoryEntry, b: LiveDirectoryEntry): number {
-  const viewerDifference = b.viewerCount - a.viewerCount;
-  if (viewerDifference !== 0) return viewerDifference;
-
-  // localeCompare() の既定ロケールはNode（SSR）とブラウザで異なり得る。
-  // UTF-16コード単位の比較に固定して、同率カードのhydration順を必ず一致させる。
+  // 視聴者数は変動が大きく、利用者が選択していない順位付けを同率時だけ
+  // 暗黙に行うと表示順の意図が分かりにくい。安定した識別情報だけを使い、
+  // SSRとクライアントで同じ決定的な順序に固定する。
+  // localeCompare() の既定ロケールも実行環境で異なり得るため使わない。
   if (a.displayName !== b.displayName) return a.displayName < b.displayName ? -1 : 1;
   if (a.streamerId !== b.streamerId) return a.streamerId < b.streamerId ? -1 : 1;
   return 0;
@@ -79,16 +77,15 @@ export function sortLiveDirectoryEntries(
         return compareStats(a, b, "cardCount");
       case "redemptionCount":
         return compareStats(a, b, "redemptionCount");
-      case "viewers":
       default:
-        return compareFallback(a, b);
+        return compareStartedAt(a, b);
     }
   });
 }
 
 export default function LiveDirectory({ entries, referenceTime }: LiveDirectoryProps) {
   const t = useTranslations("livePage");
-  const [sort, setSort] = useState<LiveDirectorySort>("viewers");
+  const [sort, setSort] = useState<LiveDirectorySort>("recentlyStarted");
   const sortedEntries = useMemo(
     () => sortLiveDirectoryEntries(entries, sort),
     [entries, sort],
@@ -111,7 +108,6 @@ export default function LiveDirectory({ entries, referenceTime }: LiveDirectoryP
             onChange={(event) => setSort(event.target.value as LiveDirectorySort)}
             className="min-h-11 min-w-0 flex-1 rounded-lg border border-gray-600 bg-gray-800 px-3 py-2 text-sm text-white outline-none transition focus:border-purple-400 focus:ring-2 focus:ring-purple-400/30 sm:min-w-64"
           >
-            <option value="viewers">{t("sort.viewers")}</option>
             <option value="recentlyStarted">{t("sort.recentlyStarted")}</option>
             <option value="cardCount">{t("sort.cardCount")}</option>
             <option value="redemptionCount">{t("sort.redemptionCount")}</option>

--- a/tests/unit/components/live-directory.test.tsx
+++ b/tests/unit/components/live-directory.test.tsx
@@ -70,8 +70,7 @@ function renderedCardIds(container: HTMLElement): string[] {
 }
 
 describe("sortLiveDirectoryEntries", () => {
-  it("sorts all four modes and keeps stats=null last for statistical modes", () => {
-    expect(idsFor("viewers")).toEqual(["bravo", "alpha", "charlie"]);
+  it("sorts all three modes and keeps stats=null last for statistical modes", () => {
     expect(idsFor("recentlyStarted")).toEqual(["bravo", "charlie", "alpha"]);
     expect(idsFor("cardCount")).toEqual(["charlie", "alpha", "bravo"]);
     expect(idsFor("redemptionCount")).toEqual(["alpha", "charlie", "bravo"]);
@@ -106,14 +105,29 @@ describe("sortLiveDirectoryEntries", () => {
       ),
     ).toEqual(["valid", "invalid"]);
   });
+
+  it("does not use viewer count as a hidden tie-breaker", () => {
+    const alpha = entry("alpha", { displayName: "Alpha", viewerCount: 1 });
+    const bravo = entry("bravo", { displayName: "Bravo", viewerCount: 999 });
+
+    expect(
+      sortLiveDirectoryEntries([bravo, alpha], "recentlyStarted").map(
+        (item) => item.streamerId,
+      ),
+    ).toEqual(["alpha", "bravo"]);
+  });
 });
 
 describe("LiveDirectory", () => {
-  it("uses viewer count initially and updates the DOM order through the labeled select", () => {
+  it("uses recently-started order initially and omits viewer-count sorting", () => {
     const { container } = renderDirectory();
-    expect(renderedCardIds(container)).toEqual(["bravo", "alpha", "charlie"]);
+    expect(renderedCardIds(container)).toEqual(["bravo", "charlie", "alpha"]);
 
-    fireEvent.change(screen.getByRole("combobox", { name: "並び順" }), {
+    const sortSelect = screen.getByRole("combobox", { name: "並び順" });
+    expect(sortSelect).toHaveValue("recentlyStarted");
+    expect(screen.queryByRole("option", { name: "視聴者数" })).not.toBeInTheDocument();
+
+    fireEvent.change(sortSelect, {
       target: { value: "cardCount" },
     });
     expect(renderedCardIds(container)).toEqual(["charlie", "alpha", "bravo"]);


### PR DESCRIPTION
## 変更内容

- 配信中ページのソート項目から「視聴者数」を削除
- 初期ソートを「配信開始が新しい順」へ変更
- 同率時の比較からも視聴者数を外し、表示名・streamer IDによる決定的な順序へ変更
- 日英メッセージとコンポーネントテストを新しい3種のソート契約へ更新

視聴者数は各ライブカード上の情報として引き続き表示します。

## 理由

視聴者数によるランキングを公開ディレクトリの並び順として提供しない、という実装後フィードバックを反映します。controlled `<select>` の値が実在する option と一致するよう、選択肢と初期stateを同時に変更しています。

## 検証

- `npm run test:all -- tests/unit/components/live-directory.test.tsx`（9件成功）
- `npm run test:all -- tests/unit/i18n-message-parity.test.ts`（4件成功）
- `npm run typecheck`
- `npm run lint:i18n`
- `npx eslint src/components/LiveDirectory.tsx tests/unit/components/live-directory.test.tsx`
- `git diff --check`

Refs #740