### PR TITLE
fix: トップページの配信中CTA文言を明確化

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -888,7 +888,7 @@
       "viewerGuide": "Viewer Guide",
       "streamerGuide": "Streamer Guide",
       "viewGuide": "View Guide",
-      "liveDirectory": "Browse live channels"
+      "liveDirectory": "Browse TwiCa channels"
     },
     "features": {
       "cardCollection": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -888,7 +888,7 @@
       "viewerGuide": "視聴者向け使い方",
       "streamerGuide": "配信者向け使い方",
       "viewGuide": "使い方を見る",
-      "liveDirectory": "配信中を見る"
+      "liveDirectory": "利用中のチャネルを見る"
     },
     "features": {
       "cardCollection": {

--- a/tests/unit/public-help-pages.test.ts
+++ b/tests/unit/public-help-pages.test.ts
@@ -98,6 +98,13 @@ describe("FAQ page", () => {
     expect(home).toContain("border-gray-600 bg-gray-800");
     expect(dashboardNav).toContain('href: "/live"');
   });
+
+  it("describes the live-directory CTA as a TwiCa channel directory in both locales", () => {
+    // /live には配信中一覧だけでなく全アクティブチャネルのランキングもあるため、
+    // CTAを「配信中だけを見る」という旧来の意味へ戻さず、ロケール間でも対象を揃える。
+    expect(jaMessages.topPage.hero.liveDirectory).toBe("利用中のチャネルを見る");
+    expect(enMessages.topPage.hero.liveDirectory).toBe("Browse TwiCa channels");
+  });
 });
 
 /**


### PR DESCRIPTION
## 変更内容

- トップページの `/live` CTAを「配信中を見る」から「利用中のチャネルを見る」へ変更
- 英語も `Browse TwiCa channels` に揃え、両ロケールの対象を一致
- CTA文言を独立した公開ページの回帰テストで固定

## 理由

「配信中を見る」では閲覧対象が曖昧なため、利用中のチャネル一覧へ遷移するボタンであることを明確にします。

## 検証

- `npm run test:all -- tests/unit/public-help-pages.test.ts`（12 tests passed）
- `npm run lint:i18n`
- `git diff --check`

Follow-up to #740

Optional wording-system follow-up: #932
