### PR TITLE
feat(#740): ランキング期間切替と8月リリース告知を追加

### DIFF
--- a/db/planetscale/migrations/20260811130000_add_live_directory_ranking_periods.sql
+++ b/db/planetscale/migrations/20260811130000_add_live_directory_ranking_periods.sql
@@ -1,0 +1,206 @@
+-- migration-transaction: required
+-- migration-providers: planetscale
+--
+-- #740: /live ランキングへ「直近7日間 / 全期間」の集計期間を追加する。
+--
+-- 既存 get_live_directory_rankings() の返却形は変更しない。DB migration がアプリより
+-- 先に適用されるデプロイ窓で旧アプリを壊さず、ロールバック時も旧RPCを使い続けられる
+-- よう、期間対応は新しいRPCとして追加する。
+--
+-- 期間ごとの意味:
+-- - cardCount / last7Days: 直近7日間に追加され、現在も有効なカード種類数
+-- - cardCount / allTime: 現在有効なカード種類数（既存ランキングと同じ現在値）
+-- - redemptionCount / totalPoints: 期間内の reward_cost > 0 の実引き換え集計
+--
+-- 7日間は関数実行時のCURRENT_TIMESTAMPを共通の境界時刻にする。各CTEでnow()を
+-- 個別評価すると境界上の行が指標間で食い違う余地があるため、parameters CTEで1回だけ
+-- 確定する。全期間の引き換え集計は既存の累積テーブルを使い、履歴全走査を避ける。
+CREATE OR REPLACE FUNCTION get_live_directory_rankings_by_period()
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+WITH parameters AS (
+  SELECT CURRENT_TIMESTAMP - INTERVAL '7 days' AS last_7_days_start
+),
+card_counts AS (
+  SELECT
+    c.streamer_id,
+    COUNT(*) FILTER (WHERE c.is_active = TRUE)::INTEGER AS all_time_card_count,
+    COUNT(*) FILTER (
+      WHERE c.is_active = TRUE
+        AND c.created_at >= parameters.last_7_days_start
+    )::INTEGER AS last_7_days_card_count
+  FROM cards c
+  CROSS JOIN parameters
+  GROUP BY c.streamer_id
+),
+all_time_usage AS (
+  SELECT
+    usage.streamer_id,
+    COALESCE(SUM(usage.redemption_count), 0)::BIGINT AS redemption_count,
+    COALESCE(SUM(usage.total_points), 0)::BIGINT AS total_points
+  FROM channel_point_usage_stats usage
+  GROUP BY usage.streamer_id
+),
+last_7_days_usage AS (
+  SELECT
+    history.streamer_id,
+    COUNT(*)::BIGINT AS redemption_count,
+    COALESCE(SUM(history.reward_cost), 0)::BIGINT AS total_points
+  FROM gacha_history history
+  CROSS JOIN parameters
+  WHERE history.reward_cost > 0
+    AND history.redeemed_at >= parameters.last_7_days_start
+  GROUP BY history.streamer_id
+),
+aggregated AS (
+  SELECT
+    streamer.publish_stats,
+    streamer.twitch_username,
+    streamer.twitch_display_name,
+    streamer.twitch_profile_image_url,
+    COALESCE(cards.all_time_card_count, 0) AS all_time_card_count,
+    COALESCE(cards.last_7_days_card_count, 0) AS last_7_days_card_count,
+    COALESCE(all_usage.redemption_count, 0) AS all_time_redemption_count,
+    COALESCE(all_usage.total_points, 0) AS all_time_total_points,
+    COALESCE(recent_usage.redemption_count, 0) AS last_7_days_redemption_count,
+    COALESCE(recent_usage.total_points, 0) AS last_7_days_total_points
+  FROM streamers streamer
+  LEFT JOIN card_counts cards ON cards.streamer_id = streamer.id
+  LEFT JOIN all_time_usage all_usage ON all_usage.streamer_id = streamer.id
+  LEFT JOIN last_7_days_usage recent_usage ON recent_usage.streamer_id = streamer.id
+  WHERE streamer.is_active = TRUE
+),
+periodized AS (
+  SELECT
+    aggregated.publish_stats,
+    aggregated.twitch_username,
+    aggregated.twitch_display_name,
+    aggregated.twitch_profile_image_url,
+    period_values.period,
+    period_values.card_count,
+    period_values.redemption_count,
+    period_values.total_points
+  FROM aggregated
+  CROSS JOIN LATERAL (
+    VALUES
+      (
+        'last7Days'::TEXT,
+        aggregated.last_7_days_card_count,
+        aggregated.last_7_days_redemption_count,
+        aggregated.last_7_days_total_points
+      ),
+      (
+        'allTime'::TEXT,
+        aggregated.all_time_card_count,
+        aggregated.all_time_redemption_count,
+        aggregated.all_time_total_points
+      )
+  ) AS period_values(period, card_count, redemption_count, total_points)
+),
+ranked AS (
+  SELECT
+    periodized.*,
+    ROW_NUMBER() OVER (
+      PARTITION BY periodized.period
+      ORDER BY
+        periodized.card_count DESC,
+        periodized.redemption_count DESC,
+        periodized.total_points DESC,
+        CASE WHEN periodized.publish_stats THEN LOWER(periodized.twitch_username) END NULLS LAST,
+        CASE WHEN periodized.publish_stats THEN periodized.twitch_username END NULLS LAST
+    ) AS card_count_position,
+    ROW_NUMBER() OVER (
+      PARTITION BY periodized.period
+      ORDER BY
+        periodized.redemption_count DESC,
+        periodized.total_points DESC,
+        periodized.card_count DESC,
+        CASE WHEN periodized.publish_stats THEN LOWER(periodized.twitch_username) END NULLS LAST,
+        CASE WHEN periodized.publish_stats THEN periodized.twitch_username END NULLS LAST
+    ) AS redemption_count_position,
+    ROW_NUMBER() OVER (
+      PARTITION BY periodized.period
+      ORDER BY
+        periodized.total_points DESC,
+        periodized.redemption_count DESC,
+        periodized.card_count DESC,
+        CASE WHEN periodized.publish_stats THEN LOWER(periodized.twitch_username) END NULLS LAST,
+        CASE WHEN periodized.publish_stats THEN periodized.twitch_username END NULLS LAST
+    ) AS total_points_position
+  FROM periodized
+),
+selected AS (
+  SELECT
+    ranked.*,
+    ARRAY_REMOVE(ARRAY[
+      CASE
+        WHEN ranked.card_count > 0 AND ranked.card_count_position <= 100
+        THEN 'cardCount'
+      END,
+      CASE
+        WHEN ranked.redemption_count > 0 AND ranked.redemption_count_position <= 100
+        THEN 'redemptionCount'
+      END,
+      CASE
+        WHEN ranked.total_points > 0 AND ranked.total_points_position <= 100
+        THEN 'totalPoints'
+      END
+    ]::TEXT[], NULL) AS ranked_metrics
+  FROM ranked
+),
+period_catalog(period, sort_order) AS (
+  VALUES ('last7Days'::TEXT, 1), ('allTime'::TEXT, 2)
+),
+period_payloads AS (
+  SELECT
+    period_catalog.period,
+    period_catalog.sort_order,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'identity',
+            CASE WHEN selected.publish_stats THEN jsonb_build_object(
+              'twitchLogin', selected.twitch_username,
+              'displayName', selected.twitch_display_name,
+              'profileImageUrl', selected.twitch_profile_image_url
+            ) ELSE NULL END,
+          'cardCount', selected.card_count,
+          'redemptionCount', selected.redemption_count,
+          'totalPoints', selected.total_points,
+          'rankedMetrics', selected.ranked_metrics
+        )
+        -- 匿名行を内部ID順にすると既知IDとの相対位置が識別の手掛かりになるため、
+        -- 既存RPCと同じく公開値だけでレスポンス順を決める。
+        ORDER BY
+          selected.card_count DESC,
+          selected.redemption_count DESC,
+          selected.total_points DESC,
+          CASE WHEN selected.publish_stats THEN LOWER(selected.twitch_username) END NULLS LAST,
+          CASE WHEN selected.publish_stats THEN selected.twitch_username END NULLS LAST
+      ) FILTER (
+        WHERE selected.period IS NOT NULL
+          AND CARDINALITY(selected.ranked_metrics) > 0
+      ),
+      '[]'::JSONB
+    ) AS entries
+  FROM period_catalog
+  LEFT JOIN selected ON selected.period = period_catalog.period
+  GROUP BY period_catalog.period, period_catalog.sort_order
+)
+SELECT jsonb_object_agg(
+  period_payloads.period,
+  period_payloads.entries
+  ORDER BY period_payloads.sort_order
+)
+FROM period_payloads;
+$$;
+
+COMMENT ON FUNCTION get_live_directory_rankings_by_period() IS
+  '/live向け直近7日間・全期間の各指標上位100件。publish_stats=falseは識別情報を返さない (issue #740)';
+
+REVOKE ALL ON FUNCTION get_live_directory_rankings_by_period() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_live_directory_rankings_by_period() TO service_role;

--- a/db/planetscale/migrations/20260811140000_publish_live_directory_announcement.sql
+++ b/db/planetscale/migrations/20260811140000_publish_live_directory_announcement.sql
@@ -1,0 +1,29 @@
+-- migration-transaction: required
+-- migration-providers: planetscale
+--
+-- #740: チャネル・ランキングページ公開をダッシュボード利用者へ知らせる。
+-- schema変更ではなく、既存announcementsテーブルへ公開告知を1行だけ追加する。
+--
+-- 固定UUIDをidempotency keyにし、migration再実行や環境復元後の再適用でも重複を
+-- 作らない。公開・期限の基準には同一transaction内のDB時刻を使い、適用から正確に
+-- 7日間だけ未読バナーの対象にする。本文URLはAutoLinkTextが日本語句読点までURLへ
+-- 含めないよう末尾の独立行へ置く。
+INSERT INTO public.announcements (
+  id,
+  title,
+  body,
+  severity,
+  is_published,
+  published_at,
+  expires_at
+)
+VALUES (
+  'a8110000-0000-4000-8000-000000000001'::uuid,
+  'チャネル・ランキングページを公開しました',
+  E'TwiCaを利用中のチャネルと、カード引き換え数・チャネルポイント・カード種類数のランキングを確認できるページを公開しました。ランキングは直近7日間と全期間を切り替えられます。掲載設定とランキング上のチャネル表示は、ダッシュボードの配信設定から変更できます。\nhttps://twica.bluemoon.works/live',
+  'info',
+  true,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP + INTERVAL '7 days'
+)
+ON CONFLICT (id) DO NOTHING;

--- a/messages/en.json
+++ b/messages/en.json
@@ -29,7 +29,7 @@
   },
   "navigation": {
     "overview": "Overview",
-    "live": "Live now",
+    "live": "Channels & Rankings",
     "cardManagement": "Card Management",
     "settings": "Stream Settings",
     "gachaHistory": "Gacha History",
@@ -1509,15 +1509,15 @@
   },
   "livePage": {
     "metadata": {
-      "title": "Live now - TwiCa",
-      "description": "See TwiCa channels that are live now and rankings for card activity."
+      "title": "TwiCa channels and rankings",
+      "description": "Browse channels using TwiCa and rankings for card activity."
     },
-    "navigationLabel": "Live directory navigation",
+    "navigationLabel": "Channel and ranking page navigation",
     "home": "Home",
-    "title": "Live now",
-    "description": "See TwiCa channels that are live now and rankings for card activity.",
+    "title": "TwiCa channels and rankings",
+    "description": "Browse channels using TwiCa and rankings for each streamer's card activity.",
     "consentNotice": "The live list only shows channels that have explicitly agreed to be listed.",
-    "rankingNotice": "Rankings include all active channels and show the top 100 for each metric. Channels that have not agreed to be identified appear anonymously.",
+    "rankingNotice": "Rankings include all active channels and show the top 100 for each metric in the selected period. Channels that have not agreed to be identified appear anonymously.",
     "directoryHeading": "Live channels and rankings",
     "tabs": {
       "label": "View",
@@ -1525,6 +1525,19 @@
       "redemptionCount": "Card redemption ranking",
       "totalPoints": "Channel point ranking",
       "cardCount": "Card type ranking"
+    },
+    "period": {
+      "label": "Ranking period",
+      "last7Days": "Last 7 days",
+      "allTime": "All time",
+      "usageHelp": {
+        "last7Days": "Counts card redemptions recorded in the last 7 days.",
+        "allTime": "Counts card redemptions recorded across all time in TwiCa."
+      },
+      "cardCountHelp": {
+        "last7Days": "Counts active card types added in the last 7 days.",
+        "allTime": "Counts card types that are currently active."
+      }
     },
     "card": {
       "live": "LIVE",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -29,7 +29,7 @@
   },
   "navigation": {
     "overview": "概要",
-    "live": "配信中",
+    "live": "チャネル・ランキング",
     "cardManagement": "カード管理",
     "settings": "配信設定",
     "gachaHistory": "ガチャ履歴",
@@ -1509,15 +1509,15 @@
   },
   "livePage": {
     "metadata": {
-      "title": "配信中 - TwiCa",
-      "description": "配信中のTwiCaチャネルと、カード利用状況のランキングを確認できます。"
+      "title": "チャネルとランキング - TwiCa",
+      "description": "TwiCaを利用中のチャネルと、カード利用状況のランキングを確認できます。"
     },
-    "navigationLabel": "配信中ページのナビゲーション",
+    "navigationLabel": "チャネル・ランキングページのナビゲーション",
     "home": "ホーム",
-    "title": "配信中の配信者",
-    "description": "配信中のTwiCaチャネルと、カード利用状況のランキングを確認できます。",
+    "title": "TwiCaチャネルとランキング",
+    "description": "TwiCaを利用中のチャネルと、配信者ごとのカード利用状況ランキングを確認できます。",
     "consentNotice": "配信中の一覧には、明示的に掲載を許可したチャネルだけが表示されています。",
-    "rankingNotice": "ランキングは全アクティブチャネルを集計対象とし、各指標の上位100件を、チャネル表示を許可していない場合は匿名で表示します。",
+    "rankingNotice": "ランキングは全アクティブチャネルを集計対象とし、選択した期間の各指標上位100件を、チャネル表示を許可していない場合は匿名で表示します。",
     "directoryHeading": "配信中チャネルとランキング",
     "tabs": {
       "label": "表示内容",
@@ -1525,6 +1525,19 @@
       "redemptionCount": "カード引き換え数ランキング",
       "totalPoints": "チャネルポイントランキング",
       "cardCount": "種類数ランキング"
+    },
+    "period": {
+      "label": "集計期間",
+      "last7Days": "直近7日間",
+      "allTime": "全期間",
+      "usageHelp": {
+        "last7Days": "直近7日間に記録されたカード引き換えを集計しています。",
+        "allTime": "TwiCaに記録されている全期間のカード引き換えを集計しています。"
+      },
+      "cardCountHelp": {
+        "last7Days": "直近7日間に追加され、現在も有効なカード種類数です。",
+        "allTime": "現在有効なカード種類数です。"
+      }
     },
     "card": {
       "live": "LIVE",

--- a/src/app/releases/page.tsx
+++ b/src/app/releases/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
 
 /**
  * リリースノートページ
+ * 2026年8月: チャネル・ランキング公開、画像取り込み、ガチャ/Twitch連携、運用保全
  * 2026年7月: カードパック初リリース・支援特典の拡充・内部安定性向上
  * 2026年3月〜6月: v1.31.0以降のカード管理・ガチャ体験・セキュリティ改善
  * v1.31.0: カード排出確率自動設定・コレクションコンプリート・ガチャ履歴フィルタ
@@ -50,6 +51,159 @@ export default async function ReleasesPage() {
           <h1 className="mb-10 text-3xl font-bold text-white">
             TwiCa リリースノート
           </h1>
+
+          {/* 2026年8月 - 前回（7月）以降の変更を、内部実装ではなく利用者成果単位で整理 */}
+          <div className="mb-16">
+            <div className="mb-8">
+              <div className="mb-2 inline-block rounded-full bg-emerald-700 px-3 py-1 text-sm font-medium text-white">
+                2026年8月アップデート
+              </div>
+              <p className="mt-2 text-sm text-gray-500">2026-08-12</p>
+            </div>
+
+            <p className="mb-10 leading-relaxed text-gray-400">
+              前回のリリースノート以降、TwiCaを利用中のチャネルやカードの活動を
+              見つけられる公開ページを追加しました。カード画像の取り込み、ガチャ演出、
+              Twitch連携の復旧導線も改善し、メンテナンスやデータベース切り替え時に
+              引き換えを失わないための仕組みを強化しています。
+            </p>
+
+            <section className="mb-10">
+              <h2 className="mb-6 border-b border-gray-700 pb-3 text-2xl font-bold text-white">
+                新機能と使いやすさ
+              </h2>
+
+              <div className="space-y-6">
+                <div className="rounded-xl bg-gray-800 p-6">
+                  <h3 className="mb-2 text-lg font-semibold text-white">
+                    TwiCaチャネルとランキング
+                  </h3>
+                  <p className="text-gray-400">
+                    <Link
+                      href="/live"
+                      className="font-medium text-emerald-300 underline decoration-emerald-500/60 underline-offset-4 hover:text-emerald-200"
+                    >
+                      チャネル・ランキングページ
+                    </Link>
+                    で、掲載を許可したライブ中のチャネルと、カード引き換え数、
+                    使用チャネルポイント、カード種類数のランキングを確認できるようになりました。
+                    ランキングは直近7日間と全期間を切り替えられます。
+                  </p>
+                  <p className="mt-3 text-gray-400">
+                    ランキングの集計対象は全アクティブチャネルです。チャネル表示を許可して
+                    いない場合も集計値は匿名で掲載し、配信中一覧は明示的に掲載を許可した
+                    チャネルだけを表示します。どちらの設定も既定ではオフです。
+                  </p>
+                </div>
+
+                <div className="rounded-xl bg-gray-800 p-6">
+                  <h3 className="mb-2 text-lg font-semibold text-white">
+                    カード画像の取り込みと表示方法
+                  </h3>
+                  <p className="text-gray-400">
+                    iPhoneなどで撮影したHEIC・HEIF画像を、ブラウザ内でJPEGへ変換して
+                    カードへ登録できるようになりました。変換が止まった場合はフォームを
+                    操作可能な状態へ戻し、やり直せるようにしています。
+                  </p>
+                  <p className="mt-3 text-gray-400">
+                    正方形以外の画像は、切り抜かず全体を見せるフィット表示と余白色を
+                    選べるようになりました。従来どおりのトリミング表示も選択できます。
+                  </p>
+                </div>
+
+                <div className="rounded-xl bg-gray-800 p-6">
+                  <h3 className="mb-2 text-lg font-semibold text-white">
+                    おすすめの使い方
+                  </h3>
+                  <p className="text-gray-400">
+                    <Link
+                      href="/usages"
+                      className="font-medium text-emerald-300 underline decoration-emerald-500/60 underline-offset-4 hover:text-emerald-200"
+                    >
+                      おすすめの使い方ページ
+                    </Link>
+                    を追加しました。話題デッキ、ファンアート、旅行の記録など、
+                    配信内容に合わせたカード活用例を確認できます。
+                  </p>
+                </div>
+
+                <div className="rounded-xl bg-gray-800 p-6">
+                  <h3 className="mb-2 text-lg font-semibold text-white">
+                    配信者機能の利用対象を拡大
+                  </h3>
+                  <p className="text-gray-400">
+                    Twitchの「Monetization for All」に合わせ、アフィリエイト／パートナーで
+                    なくても、Twitch上でチャネルポイントを利用できることを確認できれば、
+                    TwiCaの配信者機能を明示的に有効化できるようになりました。
+                  </p>
+                  <p className="mt-3 text-gray-400">
+                    ユーザー設定の「チャネルポイント / 配信者機能」から確認と有効化を
+                    行えます。詳しい手順は
+                    <Link
+                      href="/guide"
+                      className="ml-1 font-medium text-emerald-300 underline decoration-emerald-500/60 underline-offset-4 hover:text-emerald-200"
+                    >
+                      配信者向け使い方
+                    </Link>
+                    に掲載しています。
+                  </p>
+                </div>
+
+                <div className="rounded-xl bg-gray-800 p-6">
+                  <h3 className="mb-2 text-lg font-semibold text-white">
+                    ガチャ演出と連続引き換え
+                  </h3>
+                  <p className="text-gray-400">
+                    レアリティ別の演出設定を追加しました。複数枚の引き換えが途中で失敗した
+                    場合は未完了分から再開でき、初入手カードがない場合もチャット通知の
+                    テンプレートで自然に表現できるようになりました。
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className="mb-10">
+              <h2 className="mb-6 border-b border-gray-700 pb-3 text-2xl font-bold text-white">
+                安定性と安全性
+              </h2>
+
+              <div className="space-y-6">
+                <div className="rounded-xl bg-gray-800 p-6">
+                  <h3 className="mb-2 text-lg font-semibold text-white">
+                    メンテナンス中の引き換え保全
+                  </h3>
+                  <p className="text-gray-400">
+                    メンテナンス中は変更操作を事前に止めて状態を案内し、その間に届いた
+                    Twitchの引き換え通知は退避して、復旧後に再処理できるようにしました。
+                    データベースをPlanetScaleへ切り替えた後も、カード付与、オーバーレイ、
+                    チャット通知を一貫して処理できる構成へ移行しています。
+                  </p>
+                </div>
+
+                <div className="rounded-xl bg-gray-800 p-6">
+                  <h3 className="mb-2 text-lg font-semibold text-white">
+                    Twitch連携の復旧案内
+                  </h3>
+                  <p className="text-gray-400">
+                    チャット送信に必要な権限が不足した場合、ダッシュボードから再認証へ
+                    進めるようになりました。ログイン処理が止まった場合や、Twitchから
+                    不正な応答を受けた場合も、再試行できる状態へ戻るよう改善しています。
+                  </p>
+                </div>
+
+                <div className="rounded-xl bg-gray-800 p-6">
+                  <h3 className="mb-2 text-lg font-semibold text-white">
+                    セキュリティと長時間運用
+                  </h3>
+                  <p className="text-gray-400">
+                    アップロード、カード情報、設定API、EventSubの認可と入力検証を
+                    強化しました。オーバーレイのポーリングとキャッシュも見直し、
+                    リアルタイム表示を維持しながら不要な処理を抑えています。
+                  </p>
+                </div>
+              </div>
+            </section>
+          </div>
 
           {/* 2026年7月 - 初リリース機能を支援機能/通常機能で分類し、同じ機能群の改善をまとめて説明 */}
           <div className="mb-16">

--- a/src/components/LiveDirectory.tsx
+++ b/src/components/LiveDirectory.tsx
@@ -8,6 +8,8 @@ import type {
   LiveDirectoryEntry,
   LiveDirectoryRankingEntry,
   LiveDirectoryRankingMetric,
+  LiveDirectoryRankingPeriod,
+  LiveDirectoryRankingsByPeriod,
 } from "@/lib/live-directory";
 
 export type LiveDirectoryView =
@@ -18,7 +20,7 @@ export type LiveDirectoryView =
 
 interface LiveDirectoryProps {
   entries: LiveDirectoryEntry[];
-  rankings: LiveDirectoryRankingEntry[];
+  rankings: LiveDirectoryRankingsByPeriod;
   /**
    * Server Component で確定した描画時刻。
    * Client Component 内で Date.now() を呼ぶとSSRとhydrationの分境界で表示が変わり、
@@ -39,6 +41,14 @@ const VIEWS: ReadonlyArray<{
   { id: "redemptionCount", labelKey: "tabs.redemptionCount" },
   { id: "totalPoints", labelKey: "tabs.totalPoints" },
   { id: "cardCount", labelKey: "tabs.cardCount" },
+];
+
+const RANKING_PERIODS: ReadonlyArray<{
+  id: LiveDirectoryRankingPeriod;
+  labelKey: "period.last7Days" | "period.allTime";
+}> = [
+  { id: "last7Days", labelKey: "period.last7Days" },
+  { id: "allTime", labelKey: "period.allTime" },
 ];
 
 function compareFallback(a: LiveDirectoryEntry, b: LiveDirectoryEntry): number {
@@ -123,6 +133,10 @@ export default function LiveDirectory({
 }: LiveDirectoryProps) {
   const t = useTranslations("livePage");
   const [view, setView] = useState<LiveDirectoryView>("recentlyStarted");
+  // 既存ランキングは全期間だったため初期値を維持する。期間を明示して選べるように
+  // しつつ、リリース直後に順位の見え方が突然変わる退行を避ける。
+  const [rankingPeriod, setRankingPeriod] =
+    useState<LiveDirectoryRankingPeriod>("allTime");
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const sortedEntries = useMemo(() => sortLiveDirectoryEntries(entries), [entries]);
 
@@ -197,7 +211,44 @@ export default function LiveDirectory({
         {view === "recentlyStarted" ? (
           <LiveStreamGrid entries={sortedEntries} referenceTime={referenceTime} />
         ) : (
-          <LiveDirectoryRanking entries={rankings} metric={view} />
+          <>
+            <div className="mb-6 flex flex-col gap-3 border-b border-gray-800 pb-5 sm:flex-row sm:items-end sm:justify-between">
+              <fieldset>
+                <legend className="mb-2 text-sm font-medium text-gray-300">
+                  {t("period.label")}
+                </legend>
+                <div className="inline-flex overflow-hidden rounded-lg border border-gray-600 bg-gray-800 p-1">
+                  {RANKING_PERIODS.map((period) => (
+                    <label
+                      key={period.id}
+                      className="relative cursor-pointer rounded-md focus-within:ring-2 focus-within:ring-purple-400"
+                    >
+                      <input
+                        type="radio"
+                        name="live-directory-ranking-period"
+                        value={period.id}
+                        checked={rankingPeriod === period.id}
+                        onChange={() => setRankingPeriod(period.id)}
+                        className="peer sr-only"
+                      />
+                      <span className="flex min-h-9 items-center justify-center px-4 text-sm font-medium text-gray-400 transition peer-checked:bg-gray-600 peer-checked:text-white peer-focus-visible:outline-none">
+                        {t(period.labelKey)}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </fieldset>
+              <p className="max-w-2xl text-xs leading-5 text-gray-400 sm:text-right">
+                {view === "cardCount"
+                  ? t(`period.cardCountHelp.${rankingPeriod}`)
+                  : t(`period.usageHelp.${rankingPeriod}`)}
+              </p>
+            </div>
+            <LiveDirectoryRanking
+              entries={rankings[rankingPeriod]}
+              metric={view}
+            />
+          </>
         )}
       </div>
 

--- a/src/lib/live-directory.ts
+++ b/src/lib/live-directory.ts
@@ -9,7 +9,8 @@ import { fetchTwitchApi } from "@/lib/twitch/app-token";
  * 配信中ページ（/live）のデータ層（issue #739 / 親 #632）。
  *
  * 「オプトイン配信者のうち現在Twitchでライブ中の一覧」と、全アクティブ
- * 配信者を母集団にした各指標上位100件の匿名化済みランキングを返す。
+ * 配信者を母集団にした直近7日間・全期間それぞれの各指標上位100件の
+ * 匿名化済みランキングを返す。
  * 方式は設計で確定済みの Helix GET /streams ポーリング + KVキャッシュ(60s)。
  * EventSub stream.online/offline は購読ライフサイクル管理が過剰なため不採用。
  *
@@ -51,6 +52,10 @@ export const LIVE_DIRECTORY_RANKING_METRICS = [
 export type LiveDirectoryRankingMetric =
   (typeof LIVE_DIRECTORY_RANKING_METRICS)[number];
 
+export const LIVE_DIRECTORY_RANKING_PERIODS = ["last7Days", "allTime"] as const;
+export type LiveDirectoryRankingPeriod =
+  (typeof LIVE_DIRECTORY_RANKING_PERIODS)[number];
+
 export interface LiveDirectoryRankingEntry {
   /** nullならDB境界で識別情報を除去済みの匿名行。 */
   identity: LiveDirectoryRankingIdentity | null;
@@ -60,6 +65,11 @@ export interface LiveDirectoryRankingEntry {
   /** SQL側の各指標上位100件のうち、この行を表示するランキング。 */
   rankedMetrics: LiveDirectoryRankingMetric[];
 }
+
+export type LiveDirectoryRankingsByPeriod = Record<
+  LiveDirectoryRankingPeriod,
+  LiveDirectoryRankingEntry[]
+>;
 
 /** RPC get_live_directory_streamers() の返却行（migration 側の JSONB 形状）。 */
 interface LiveDirectoryRpcRow {
@@ -82,14 +92,14 @@ interface HelixStream {
 }
 
 const LIVE_DIRECTORY_KV_KEY = "live-directory:v1";
-const LIVE_DIRECTORY_RANKINGS_KV_KEY = "live-directory:rankings:v2";
+const LIVE_DIRECTORY_RANKINGS_KV_KEY = "live-directory:rankings:v3";
 const LIVE_DIRECTORY_TTL_SECONDS = 60;
 const HELIX_STREAMS_BATCH_SIZE = 100;
 
 /** KV なし環境（ローカル next dev）用のメモリキャッシュ。 */
 let memoryCache: { entries: LiveDirectoryEntry[]; expiresAt: number } | null = null;
 let rankingsMemoryCache: {
-  entries: LiveDirectoryRankingEntry[];
+  entries: LiveDirectoryRankingsByPeriod;
   expiresAt: number;
 } | null = null;
 
@@ -297,18 +307,36 @@ function normalizeRankingEntries(value: unknown): LiveDirectoryRankingEntry[] {
   });
 }
 
+/**
+ * 期間別RPC/KV payloadを、列挙済みの2期間と公開ランキング行だけへ絞り込む。
+ *
+ * Recordへの型assertionだけでは、将来RPCへ追加された期間名や内部fieldがRSCへ
+ * そのまま流れる。期間キーも明示的に再構築し、欠損・破損した期間は空配列として
+ * 公開ページ自体を維持する。
+ */
+function normalizeRankingsByPeriod(value: unknown): LiveDirectoryRankingsByPeriod {
+  const source = value && typeof value === "object"
+    ? value as Record<string, unknown>
+    : {};
+
+  return {
+    last7Days: normalizeRankingEntries(source.last7Days),
+    allTime: normalizeRankingEntries(source.allTime),
+  };
+}
+
 interface LiveDirectoryRankingsFetchResult {
-  entries: LiveDirectoryRankingEntry[];
+  entries: LiveDirectoryRankingsByPeriod;
   /** falseならRPC障害。障害による空配列はキャッシュしない。 */
   ok: boolean;
 }
 
 async function fetchLiveDirectoryRankingsUncached(): Promise<LiveDirectoryRankingsFetchResult> {
   const { data: rpcRows, error: rpcError } = await executeDashboardRpcPg(
-    "get_live_directory_rankings(pg)",
+    "get_live_directory_rankings_by_period(pg)",
     async (sql) => {
       const rows = await sql<Array<{ result: unknown }>>`
-        select get_live_directory_rankings() as result
+        select get_live_directory_rankings_by_period() as result
       `;
       return rows[0]?.result;
     },
@@ -319,24 +347,28 @@ async function fetchLiveDirectoryRankingsUncached(): Promise<LiveDirectoryRankin
       new Error(`Live directory rankings RPC failed: ${rpcError.message}`),
       { context: "liveDirectory:rankingsRpc" },
     );
-    return { entries: [], ok: false };
+    return {
+      entries: { last7Days: [], allTime: [] },
+      ok: false,
+    };
   }
 
-  return { entries: normalizeRankingEntries(rpcRows), ok: true };
+  return { entries: normalizeRankingsByPeriod(rpcRows), ok: true };
 }
 
 /**
- * 各指標の正値上位100件に入る配信者の匿名化済みランキング集計を返す。
+ * 直近7日間・全期間それぞれについて、各指標の正値上位100件に入る配信者の
+ * 匿名化済みランキング集計を返す。
  * ライブ一覧とはDB同意・障害境界が異なるため別キャッシュにし、新RPCが未反映の
  * デプロイ窓でも既存のライブ一覧キャッシュを巻き込んで無効化しない。
  */
-export async function getLiveDirectoryRankings(): Promise<LiveDirectoryRankingEntry[]> {
+export async function getLiveDirectoryRankings(): Promise<LiveDirectoryRankingsByPeriod> {
   try {
     const kv = await getKvBinding();
     if (kv) {
       const raw = await kv.get(LIVE_DIRECTORY_RANKINGS_KV_KEY);
       if (raw) {
-        return normalizeRankingEntries(JSON.parse(raw));
+        return normalizeRankingsByPeriod(JSON.parse(raw));
       }
     }
   } catch (error) {

--- a/tests/unit/components/dashboard-nav-live-link.test.tsx
+++ b/tests/unit/components/dashboard-nav-live-link.test.tsx
@@ -38,7 +38,9 @@ describe("DashboardNav live directory link", () => {
   it("keeps the public /live route available to non-streamer users", () => {
     renderNav(false);
 
-    expect(screen.getAllByRole("link", { name: "配信中" })).toHaveLength(2);
+    expect(
+      screen.getAllByRole("link", { name: "チャネル・ランキング" }),
+    ).toHaveLength(2);
     expect(screen.queryByRole("link", { name: "カード管理" })).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/components/live-directory.test.tsx
+++ b/tests/unit/components/live-directory.test.tsx
@@ -86,12 +86,16 @@ const rankings: LiveDirectoryRankingEntry[] = [
 function renderDirectory(
   streamItems: LiveDirectoryEntry[] = entries,
   rankingItems: LiveDirectoryRankingEntry[] = rankings,
+  recentRankingItems: LiveDirectoryRankingEntry[] = rankingItems,
 ) {
   return render(
     <NextIntlClientProvider locale="ja" messages={jaMessages}>
       <LiveDirectory
         entries={streamItems}
-        rankings={rankingItems}
+        rankings={{
+          last7Days: recentRankingItems,
+          allTime: rankingItems,
+        }}
         referenceTime={REFERENCE_TIME}
       />
     </NextIntlClientProvider>,
@@ -203,6 +207,37 @@ describe("LiveDirectory", () => {
     // 可視名とsr-onlyの操作説明がリンク名を担うため、avatarは三重読み上げを
     // 避ける装飾画像として扱う。
     expect(alphaLink.querySelector("img")).toHaveAttribute("alt", "");
+  });
+
+  it("switches ranking aggregation between all time and the last 7 days", () => {
+    const recentRankings: LiveDirectoryRankingEntry[] = [
+      {
+        identity: rankings[0].identity,
+        cardCount: 1,
+        redemptionCount: 2,
+        totalPoints: 345,
+        rankedMetrics: ["cardCount", "redemptionCount", "totalPoints"],
+      },
+    ];
+    renderDirectory(entries, rankings, recentRankings);
+    fireEvent.click(screen.getByRole("tab", { name: "チャネルポイントランキング" }));
+
+    expect(screen.getByRole("group", { name: "集計期間" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "全期間" })).toBeChecked();
+    expect(screen.getByText("30,000ポイント")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: "直近7日間" }));
+
+    expect(screen.getByRole("radio", { name: "直近7日間" })).toBeChecked();
+    expect(screen.getByText("345ポイント")).toBeInTheDocument();
+    expect(
+      screen.getByText("直近7日間に記録されたカード引き換えを集計しています。"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "種類数ランキング" }));
+    expect(
+      screen.getByText("直近7日間に追加され、現在も有効なカード種類数です。"),
+    ).toBeInTheDocument();
   });
 
   it("excludes rows outside each metric candidate set before calculating ranks", () => {

--- a/tests/unit/live-directory-announcement-migration.test.ts
+++ b/tests/unit/live-directory-announcement-migration.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  join(
+    process.cwd(),
+    "db/planetscale/migrations/20260811140000_publish_live_directory_announcement.sql",
+  ),
+  "utf8",
+);
+
+describe("live directory announcement migration", () => {
+  it("publishes one idempotent informational announcement", () => {
+    expect(migration).toMatch(
+      /^-- migration-transaction: required\n-- migration-providers: planetscale/,
+    );
+    expect(migration).toContain("INSERT INTO public.announcements");
+    expect(migration).toContain("'チャネル・ランキングページを公開しました'");
+    expect(migration).toMatch(/'info',\s*true,/i);
+    expect(migration).toContain("ON CONFLICT (id) DO NOTHING");
+  });
+
+  it("is visible immediately and expires exactly seven days after publication", () => {
+    // published_atとexpires_atを同じDB基準時刻から計算し、アプリサーバーとの
+    // clock skewやmigration実行時刻のハードコードを避ける。
+    expect(migration).toMatch(
+      /CURRENT_TIMESTAMP,\s*CURRENT_TIMESTAMP \+ INTERVAL '7 days'/i,
+    );
+  });
+
+  it("links to the production live page without trailing punctuation", () => {
+    expect(migration).toContain("\\nhttps://twica.bluemoon.works/live'");
+  });
+});

--- a/tests/unit/live-directory-ranking-periods-migration.test.ts
+++ b/tests/unit/live-directory-ranking-periods-migration.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const migration = readFileSync(
+  join(
+    process.cwd(),
+    "db/planetscale/migrations/20260811130000_add_live_directory_ranking_periods.sql",
+  ),
+  "utf8",
+);
+
+describe("live directory ranking periods migration", () => {
+  it("adds a backward-compatible period RPC for PlanetScale", () => {
+    expect(migration).toMatch(
+      /^-- migration-transaction: required\n-- migration-providers: planetscale/,
+    );
+    expect(migration).toContain(
+      "CREATE OR REPLACE FUNCTION get_live_directory_rankings_by_period()",
+    );
+    expect(migration).not.toMatch(
+      /CREATE OR REPLACE FUNCTION get_live_directory_rankings\(\)/,
+    );
+  });
+
+  it("uses one seven-day boundary for cards, redemptions, and points", () => {
+    // 境界時刻をparameters CTEへ一元化し、同じレスポンス内で指標ごとの期間が
+    // 数ミリ秒ずれる回帰を防ぐ。
+    expect(migration).toMatch(
+      /CURRENT_TIMESTAMP - INTERVAL '7 days' AS last_7_days_start/i,
+    );
+    expect(migration).toMatch(
+      /c\.created_at >= parameters\.last_7_days_start/i,
+    );
+    expect(migration).toMatch(
+      /history\.redeemed_at >= parameters\.last_7_days_start/i,
+    );
+    expect(migration).toMatch(/history\.reward_cost > 0/i);
+    expect(migration).toMatch(/SUM\(history\.reward_cost\)/i);
+  });
+
+  it("keeps existing all-time semantics without scanning all redemption history", () => {
+    expect(migration).toMatch(
+      /COUNT\(\*\) FILTER \(WHERE c\.is_active = TRUE\)::INTEGER AS all_time_card_count/i,
+    );
+    expect(migration).toMatch(/FROM channel_point_usage_stats usage/i);
+    expect(migration).toMatch(/SUM\(usage\.redemption_count\)/i);
+    expect(migration).toMatch(/SUM\(usage\.total_points\)/i);
+  });
+
+  it("ranks each period independently and returns both period keys", () => {
+    expect(migration.match(/PARTITION BY periodized\.period/g)).toHaveLength(3);
+    expect(migration).toMatch(
+      /ranked\.card_count > 0 AND ranked\.card_count_position <= 100/i,
+    );
+    expect(migration).toMatch(
+      /ranked\.redemption_count > 0 AND ranked\.redemption_count_position <= 100/i,
+    );
+    expect(migration).toMatch(
+      /ranked\.total_points > 0 AND ranked\.total_points_position <= 100/i,
+    );
+    expect(migration).toContain("VALUES ('last7Days'::TEXT, 1), ('allTime'::TEXT, 2)");
+    expect(migration).toMatch(/jsonb_object_agg\(/i);
+  });
+
+  it("removes identity unless opted in and keeps the RPC service-role only", () => {
+    const identityExpression = migration.match(
+      /'identity',\s*CASE WHEN selected\.publish_stats THEN jsonb_build_object\(([\s\S]*?)\) ELSE NULL END/i,
+    );
+
+    expect(identityExpression).not.toBeNull();
+    expect(
+      [...(identityExpression?.[1].matchAll(/'([^']+)'/g) ?? [])].map(
+        (match) => match[1],
+      ),
+    ).toEqual(["twitchLogin", "displayName", "profileImageUrl"]);
+    expect(migration).not.toContain("'streamerId'");
+    expect(migration).not.toContain("'twitchUserId'");
+    expect(migration).toMatch(/SECURITY DEFINER\s+SET search_path = public/i);
+    expect(migration).toContain(
+      "REVOKE ALL ON FUNCTION get_live_directory_rankings_by_period() FROM PUBLIC;",
+    );
+    expect(migration).toContain(
+      "GRANT EXECUTE ON FUNCTION get_live_directory_rankings_by_period() TO service_role;",
+    );
+  });
+});

--- a/tests/unit/live-directory.test.ts
+++ b/tests/unit/live-directory.test.ts
@@ -300,32 +300,37 @@ describe("getLiveDirectoryRankings", () => {
     vi.mocked(getKvBinding).mockResolvedValue(kv as never);
     sqlMock = vi.fn().mockResolvedValue([
       {
-        result: [
-          null,
-          "malformed-row",
-          {
-            identity: {
-              twitchLogin: "public_login",
-              displayName: "Public Channel",
-              profileImageUrl: "https://example.com/public.png",
-              unexpectedSecret: "drop-me",
+        result: {
+          last7Days: [
+            null,
+            "malformed-row",
+            {
+              identity: {
+                twitchLogin: "public_login",
+                displayName: "Public Channel",
+                profileImageUrl: "https://example.com/public.png",
+                unexpectedSecret: "drop-me",
+              },
+              cardCount: 12,
+              redemptionCount: 34,
+              totalPoints: 5600,
+              rankedMetrics: ["cardCount", "redemptionCount", "totalPoints", "unknownMetric"],
+              unexpectedInternalId: "drop-me-too",
             },
-            cardCount: 12,
-            redemptionCount: 34,
-            totalPoints: 5600,
-            rankedMetrics: ["cardCount", "redemptionCount", "totalPoints", "unknownMetric"],
-            unexpectedInternalId: "drop-me-too",
-          },
-          {
-            identity: null,
-            cardCount: 7,
-            redemptionCount: 8,
-            totalPoints: 900,
-            rankedMetrics: ["redemptionCount", "unknownMetric"],
-            streamerId: "must-not-leak",
-            twitchUserId: "must-not-leak",
-          },
-        ],
+          ],
+          allTime: [
+            {
+              identity: null,
+              cardCount: 7,
+              redemptionCount: 8,
+              totalPoints: 900,
+              rankedMetrics: ["redemptionCount", "unknownMetric"],
+              streamerId: "must-not-leak",
+              twitchUserId: "must-not-leak",
+            },
+          ],
+          unexpectedPeriod: [{ streamerId: "must-not-leak" }],
+        },
       },
     ]);
     vi.mocked(getDb).mockResolvedValue({ db: {}, sql: sqlMock } as never);
@@ -334,29 +339,34 @@ describe("getLiveDirectoryRankings", () => {
   it("whitelists public identity and allowed ranking metrics for every row", async () => {
     const rankings = await getLiveDirectoryRankings();
 
-    expect(rankings).toEqual([
-      {
-        identity: {
-          twitchLogin: "public_login",
-          displayName: "Public Channel",
-          profileImageUrl: "https://example.com/public.png",
+    expect(rankings).toEqual({
+      last7Days: [
+        {
+          identity: {
+            twitchLogin: "public_login",
+            displayName: "Public Channel",
+            profileImageUrl: "https://example.com/public.png",
+          },
+          cardCount: 12,
+          redemptionCount: 34,
+          totalPoints: 5600,
+          rankedMetrics: ["cardCount", "redemptionCount", "totalPoints"],
         },
-        cardCount: 12,
-        redemptionCount: 34,
-        totalPoints: 5600,
-        rankedMetrics: ["cardCount", "redemptionCount", "totalPoints"],
-      },
-      {
-        identity: null,
-        cardCount: 7,
-        redemptionCount: 8,
-        totalPoints: 900,
-        rankedMetrics: ["redemptionCount"],
-      },
-    ]);
-    expect(JSON.stringify(rankings[1])).not.toContain("must-not-leak");
+      ],
+      allTime: [
+        {
+          identity: null,
+          cardCount: 7,
+          redemptionCount: 8,
+          totalPoints: 900,
+          rankedMetrics: ["redemptionCount"],
+        },
+      ],
+    });
+    expect(JSON.stringify(rankings)).not.toContain("must-not-leak");
+    expect(JSON.stringify(rankings)).not.toContain("unexpectedPeriod");
     expect(kv.put).toHaveBeenCalledWith(
-      "live-directory:rankings:v2",
+      "live-directory:rankings:v3",
       JSON.stringify(rankings),
       { expirationTtl: 60 },
     );
@@ -365,29 +375,38 @@ describe("getLiveDirectoryRankings", () => {
   it("drops a row when every selected metric normalizes to zero", async () => {
     sqlMock.mockResolvedValue([
       {
-        result: [
-          {
-            identity: null,
-            cardCount: -1,
-            redemptionCount: "12",
-            totalPoints: Number.MAX_SAFE_INTEGER + 1,
-            rankedMetrics: ["cardCount", "notAllowed"],
-          },
-        ],
+        result: {
+          last7Days: [
+            {
+              identity: null,
+              cardCount: -1,
+              redemptionCount: "12",
+              totalPoints: Number.MAX_SAFE_INTEGER + 1,
+              rankedMetrics: ["cardCount", "notAllowed"],
+            },
+          ],
+          allTime: [],
+        },
       },
     ]);
 
-    await expect(getLiveDirectoryRankings()).resolves.toEqual([]);
+    await expect(getLiveDirectoryRankings()).resolves.toEqual({
+      last7Days: [],
+      allTime: [],
+    });
   });
 
   it("does not cache an RPC failure and reports the ranking-specific context", async () => {
     sqlMock.mockRejectedValue(
-      Object.assign(new Error("function get_live_directory_rankings() does not exist"), {
+      Object.assign(new Error("function get_live_directory_rankings_by_period() does not exist"), {
         code: "42883",
       }),
     );
 
-    await expect(getLiveDirectoryRankings()).resolves.toEqual([]);
+    await expect(getLiveDirectoryRankings()).resolves.toEqual({
+      last7Days: [],
+      allTime: [],
+    });
     expect(reportError).toHaveBeenCalledWith(expect.any(Error), {
       context: "liveDirectory:rankingsRpc",
     });
@@ -396,27 +415,34 @@ describe("getLiveDirectoryRankings", () => {
 
   it("normalizes cached rows and avoids an RPC read on a KV hit", async () => {
     kv.get.mockResolvedValue(
-      JSON.stringify([
+      JSON.stringify({
+        last7Days: [
+          {
+            identity: null,
+            cardCount: 1,
+            redemptionCount: 2,
+            totalPoints: 3,
+            rankedMetrics: ["totalPoints", "unknownMetric"],
+            hidden: "not-returned",
+          },
+        ],
+        allTime: [],
+        secretPeriod: [{ identity: { twitchLogin: "hidden" } }],
+      }),
+    );
+
+    await expect(getLiveDirectoryRankings()).resolves.toEqual({
+      last7Days: [
         {
           identity: null,
           cardCount: 1,
           redemptionCount: 2,
           totalPoints: 3,
-          rankedMetrics: ["totalPoints", "unknownMetric"],
-          hidden: "not-returned",
+          rankedMetrics: ["totalPoints"],
         },
-      ]),
-    );
-
-    await expect(getLiveDirectoryRankings()).resolves.toEqual([
-      {
-        identity: null,
-        cardCount: 1,
-        redemptionCount: 2,
-        totalPoints: 3,
-        rankedMetrics: ["totalPoints"],
-      },
-    ]);
+      ],
+      allTime: [],
+    });
     expect(getDb).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/live-page.test.tsx
+++ b/tests/unit/live-page.test.tsx
@@ -17,9 +17,15 @@ vi.mock("next-intl/server", () => ({
   getTranslations: mocks.getTranslations,
 }));
 vi.mock("@/components/LiveDirectory", () => ({
-  default: ({ entries, rankings }: { entries: unknown[]; rankings: unknown[] }) => (
+  default: ({
+    entries,
+    rankings,
+  }: {
+    entries: unknown[];
+    rankings: { last7Days: unknown[]; allTime: unknown[] };
+  }) => (
     <div data-testid="live-directory">
-      entries:{entries.length};rankings:{rankings.length}
+      entries:{entries.length};rankings:{rankings.last7Days.length}/{rankings.allTime.length}
     </div>
   ),
 }));
@@ -31,15 +37,15 @@ import LivePage, { generateMetadata } from "@/app/live/page";
 
 const translations: Record<string, Record<string, string>> = {
   livePage: {
-    "metadata.title": "配信中 - TwiCa",
+    "metadata.title": "チャネルとランキング - TwiCa",
     "metadata.description": "metadata description",
     navigationLabel: "navigation",
     home: "ホーム",
-    title: "配信中の配信者",
+    title: "TwiCaチャネルとランキング",
     description: "page description",
     consentNotice: "明示的に掲載を許可したチャネルだけが表示されています。",
     rankingNotice:
-      "ランキングは全アクティブチャネルを集計対象とし、各指標の上位100件を、チャネル表示を許可していない場合は匿名で表示します。",
+      "ランキングは全アクティブチャネルを集計対象とし、選択した期間の各指標上位100件を、チャネル表示を許可していない場合は匿名で表示します。",
   },
   header: {
     dashboard: "ダッシュボード",
@@ -56,7 +62,10 @@ describe("LivePage", () => {
       return (key: string) => translations[namespace]?.[key] ?? key;
     });
     mocks.getLiveDirectory.mockResolvedValue([{ streamerId: "streamer-1" }]);
-    mocks.getLiveDirectoryRankings.mockResolvedValue([{ identity: null }]);
+    mocks.getLiveDirectoryRankings.mockResolvedValue({
+      last7Days: [{ identity: null }],
+      allTime: [{ identity: null }, { identity: null }],
+    });
   });
 
   it("renders the full directory without redirecting when no session exists", async () => {
@@ -67,16 +76,18 @@ describe("LivePage", () => {
     expect(mocks.getSession).toHaveBeenCalledOnce();
     expect(mocks.getLiveDirectory).toHaveBeenCalledOnce();
     expect(mocks.getLiveDirectoryRankings).toHaveBeenCalledOnce();
-    expect(screen.getByRole("heading", { name: "配信中の配信者" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "TwiCaチャネルとランキング" }),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("live-directory")).toHaveTextContent(
-      "entries:1;rankings:1",
+      "entries:1;rankings:1/2",
     );
     expect(
       screen.getByText("明示的に掲載を許可したチャネルだけが表示されています。"),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "ランキングは全アクティブチャネルを集計対象とし、各指標の上位100件を、チャネル表示を許可していない場合は匿名で表示します。",
+        "ランキングは全アクティブチャネルを集計対象とし、選択した期間の各指標上位100件を、チャネル表示を許可していない場合は匿名で表示します。",
       ),
     ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "ホーム" })).toHaveAttribute("href", "/");
@@ -96,7 +107,7 @@ describe("LivePage", () => {
 
   it("builds localized metadata from the livePage namespace", async () => {
     await expect(generateMetadata()).resolves.toEqual({
-      title: "配信中 - TwiCa",
+      title: "チャネルとランキング - TwiCa",
       description: "metadata description",
     });
   });

--- a/tests/unit/releases-page.test.ts
+++ b/tests/unit/releases-page.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = readFileSync(
+  join(process.cwd(), "src/app/releases/page.tsx"),
+  "utf8",
+);
+
+describe("releases page", () => {
+  it("places the August release ahead of the previous July release", () => {
+    const august = source.indexOf("2026年8月アップデート");
+    const july = source.indexOf("2026年7月アップデート");
+
+    expect(august).toBeGreaterThanOrEqual(0);
+    expect(july).toBeGreaterThan(august);
+    expect(source).toContain("2026-08-12");
+  });
+
+  it("documents the main user-facing changes since the previous release", () => {
+    // コミット名の羅列ではなく、利用者が確認・操作できる成果と恒久ページへの
+    // 導線を固定する。内部CIだけの変更はリリースノート契約に含めない。
+    expect(source).toContain('href="/live"');
+    expect(source).toContain("ランキングは直近7日間と全期間を切り替えられます");
+    expect(source).toContain("HEIC・HEIF画像");
+    expect(source).toContain('href="/usages"');
+    expect(source).toContain("配信者機能の利用対象を拡大");
+    expect(source).toContain('href="/guide"');
+    expect(source).toContain("メンテナンス中の引き換え保全");
+    expect(source).toContain("Twitch連携の復旧案内");
+    expect(source).toContain("セキュリティと長時間運用");
+  });
+});


### PR DESCRIPTION
## 概要

#740 の配信中一覧・ランキングを、現在のページ内容に合う「TwiCaチャネルとランキング」へ整理し、ランキングを「直近7日間 / 全期間」で切り替えられるようにします。あわせて前回リリースノート以降の変更を8月分としてまとめ、ダッシュボードのAnnouncementsへ適用から1週間の告知を追加します。

## 変更内容

- `/live` のH1を「TwiCaチャネルとランキング」、ダッシュボード導線を「チャネル・ランキング」へ変更
- ランキングにネイティブradioベースの期間セグメントを追加
  - 初期値は既存挙動を維持する「全期間」
  - 直近7日間はrolling 7 days
  - 引き換え数・ポイント数は期間内の実引き換え
  - 種類数は直近7日間では期間内に追加され現在も有効なカード、全期間では現在有効なカード
- 期間対応RPC `get_live_directory_rankings_by_period()` を追加
  - 旧RPCはデプロイ/rollback互換性のため維持
  - 全期間の利用集計は累積テーブル、7日間は日時indexのある履歴を利用
  - 各期間・各指標の正値上位100件
  - `publish_stats=false` はDB境界でidentityをNULL化
  - アプリ/KV境界でも期間・fieldをホワイトリスト化
- 2026-08-12のリリースノートを追加
  - チャネル・ランキング
  - HEIC/HEIFと画像フィット
  - おすすめの使い方
  - 非Affiliate/Partner向け配信者機能
  - ガチャ/Twitch連携・メンテナンス・セキュリティ改善
- Announcementsへ公開告知を追加
  - severity: info
  - `published_at = CURRENT_TIMESTAMP`
  - `expires_at = CURRENT_TIMESTAMP + INTERVAL '7 days'`
  - 固定UUID + `ON CONFLICT DO NOTHING`

## 検証

- `npm run test:unit`: 266 files / 3,434 tests passed
- 対象テスト: 8 files / 55 tests passed
- `npm run typecheck`
- 変更ファイルのESLint
- `npm run lint:i18n`
- `npm run check:migration-order`
- migration descriptor: errors 0 / duplicate versions 0
- `npm run build`
- `git diff --check`

## 自己レビュー

### 必須（マージブロッカー）

なし。

### 任意（改善推奨）

旧 `get_live_directory_rankings()` は互換性のため意図的に維持しています。全環境の安定稼働後にcontract migrationで整理する作業を #933 へ退避しました。

Closes #740
Related: #932, #933
