### PR TITLE
fix: 公開後のセキュリティ整備（PVR報告先・CSPRNG・KVレート制限）

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 This document tracks known security vulnerabilities and mitigation strategies in the twica application.
 
-### Current Vulnerabilities
+### Tracked Vulnerabilities
 
 #### undici < 6.23.0 (GHSA-g9mf-h72j-4rw9) - RESOLVED
 
@@ -64,13 +64,17 @@ An unbounded decompression chain in HTTP responses on Node.js Fetch API via Cont
 If you discover a security vulnerability in this application:
 
 1. **Do not create a public GitHub issue**
-2. Email security reports to: [SECURITY_EMAIL]
+2. Use GitHub Private Vulnerability Reporting: open the repository's
+   **Security** tab and select **Report a vulnerability**
 3. Include:
    - Description of the vulnerability
    - Steps to reproduce
    - Potential impact
    - Suggested fix (if known)
    - Your contact information for follow-up
+
+Private Vulnerability Reporting keeps the report confidential until it is
+triaged, and GitHub can notify the maintainers directly.
 
 ## Security Response Timeline
 
@@ -104,4 +108,4 @@ To automatically audit dependencies as part of CI/CD, consider adding to your wo
 
 ## Last Updated
 
-2026-01-20
+2026-08-12

--- a/src/lib/gacha.ts
+++ b/src/lib/gacha.ts
@@ -3,6 +3,22 @@ export interface WeightedCard {
   drop_rate: number
 }
 
+/**
+ * 0 <= result < max の一様整数を暗号学的に安全な乱数で返す。
+ * crypto.getRandomValues は CSPRNG であり Math.random と違い予測不能。
+ * 剰余バイアスを避けるため、上限を超える値は棄却して再抽選する。
+ */
+function secureRandomInt(max: number): number {
+  const limit = Math.floor(0x100000000 / max) * max
+  const buf = new Uint32Array(1)
+  let value: number
+  do {
+    crypto.getRandomValues(buf)
+    value = buf[0]
+  } while (value >= limit)
+  return value % max
+}
+
 export function selectWeightedCard<T extends WeightedCard>(items: T[]): T | null {
   if (items.length === 0) return null
 
@@ -14,7 +30,7 @@ export function selectWeightedCard<T extends WeightedCard>(items: T[]): T | null
     return null
   }
 
-  const random = Math.floor(Math.random() * totalWeightInt)
+  const random = secureRandomInt(totalWeightInt)
   let cumulative = 0
 
   for (const item of items) {

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -166,6 +166,37 @@ interface KVNamespace {
 let currentStorage: RateLimitStorage = new MemoryRateLimitStorage();
 
 /**
+ * KV ストレージへの初期化（一度だけ実行し、以後は結果を再利用する）。
+ *
+ * Cloudflare Workers（本番）では RATE_LIMIT_KV バインディングを解決して
+ * 分散環境で共有される KV ストレージへ切り替える。バインディングが無い環境
+ * （ローカル dev / 単体テスト）では解決に失敗して null が返るため、メモリ
+ * 実装をそのまま使う。初期化は冪等で、初回 checkRateLimitInternal 呼び出し時
+ * に一度だけ走る。
+ */
+let storageInitPromise: Promise<void> | null = null;
+
+async function ensureKvRateLimitStorage(): Promise<void> {
+  if (storageInitPromise) {
+    return storageInitPromise;
+  }
+  storageInitPromise = (async () => {
+    try {
+      const { getKvBinding } = await import("@/lib/cloudflare-kv");
+      const kv = await getKvBinding();
+      if (kv) {
+        // KVNamespaceLike は get/put/delete の最小契約のみ持つため、
+        // 実装上必要になる 'json' 型指定付き get を持つ形へ型を寄せる。
+        currentStorage = new KVRateLimitStorage(kv as unknown as KVNamespace);
+      }
+    } catch {
+      // バインディング解決失敗時はメモリ実装のまま継続（fail-open 契約を維持）
+    }
+  })();
+  return storageInitPromise;
+}
+
+/**
  * Set the rate limit storage backend
  * レート制限ストレージバックエンドを設定
  *
@@ -209,6 +240,10 @@ async function checkRateLimitInternal(
   windowMs: number,
   identifier: string
 ): Promise<RateLimitResult> {
+  // 初回呼び出し時に KV バインディングを確認し、利用可能なら KV ストレージへ
+  // 切り替える（分散環境でのレート制限共有。無ければメモリ実装のまま）。
+  await ensureKvRateLimitStorage();
+
   const now = Date.now();
   // エンドポイント名をキーに含めることで、異なるエンドポイント間でカウンタが共有されないようにする
   // Include endpoint name in key so counters are not shared across different endpoints

--- a/tests/unit/gacha-demo-driver-parity.test.ts
+++ b/tests/unit/gacha-demo-driver-parity.test.ts
@@ -123,7 +123,13 @@ describe('POST /api/gacha/demo: PlanetScale-only reads', () => {
 
   it('selects an active streamer card', async () => {
     primePgDb([{ rows: [CARD_ROW] }])
-    vi.spyOn(Math, 'random').mockReturnValue(0)
+    // 単一カードプールなので crypto 乱数の値は結果に影響しない（0で固定）
+    vi.spyOn(crypto, 'getRandomValues').mockImplementation((buf) => {
+      if (buf instanceof Uint32Array && buf.length >= 1) {
+        buf[0] = 0
+      }
+      return buf
+    })
 
     const response = await POST(request({ streamerId: 'streamer-1' }))
     const body = await response.json()

--- a/tests/unit/gacha-service.test.ts
+++ b/tests/unit/gacha-service.test.ts
@@ -127,6 +127,23 @@ function omitIssuanceLimit<T extends { max_issuance_count?: unknown }>(card: T) 
   return withoutIssuanceLimit
 }
 
+/**
+ * selectWeightedCard の暗号学的乱数化（crypto.getRandomValues + 剰余）に合わせ、
+ * 従来の Math.random フラクション(f)を「f × 合計重み(totalWeightInt)」の
+ * Uint32 値へ変換してモックする。totalWeightInt は各テストのプール重み合計
+ * （drop_rate × 10000 の合計）を明示指定する。
+ */
+function mockCryptoRandomFraction(fraction: number, totalWeightInt: number) {
+  const value = Math.floor(fraction * totalWeightInt)
+  vi.spyOn(crypto, 'getRandomValues').mockImplementation((buf) => {
+    // 対象は selectWeightedCard が使う Uint32Array(1) のみ
+    if (buf instanceof Uint32Array && buf.length >= 1) {
+      buf[0] = value
+    }
+    return buf
+  })
+}
+
 const testCards = [
   {
     id: 'card-1',
@@ -555,7 +572,8 @@ describe('GachaService.executeGacha: PlanetScale read/write', () => {
       [0.65, 'rare-1'],
     ])('global重みの境界でカードを選ぶ: random=%s', async (random, expectedId) => {
       installDbFixture({ tables: { cards: [{ value: packCards }] } })
-      vi.spyOn(Math, 'random').mockReturnValue(random)
+      // 有効重み合計 = common(0.3+0.3) + rare(0.4) = 1.0 → ×10000
+      mockCryptoRandomFraction(random, 10_000)
 
       const result = await new GachaService().executeGacha(
         'streamer-1',
@@ -589,7 +607,7 @@ describe('GachaService.executeGacha: PlanetScale read/write', () => {
           }],
         },
       })
-      vi.spyOn(Math, 'random').mockReturnValue(0.92)
+      mockCryptoRandomFraction(0.92, 10_000)
 
       const result = await new GachaService().executeGacha(
         'streamer-1', 'user-1', 'Viewer', 'event-manual', 100, 'weapons',
@@ -611,7 +629,7 @@ describe('GachaService.executeGacha: PlanetScale read/write', () => {
           }],
         },
       })
-      vi.spyOn(Math, 'random').mockReturnValue(0.5)
+      mockCryptoRandomFraction(0.5, 10_000)
 
       const result = await new GachaService().executeGacha(
         'streamer-1', 'user-1', 'Viewer', 'event-pack-weight', 100, DEFAULT_PACK_SENTINEL,
@@ -630,7 +648,7 @@ describe('GachaService.executeGacha: PlanetScale read/write', () => {
 
     it('per_packに対象パックが無ければglobal重みを継承する', async () => {
       installDbFixture({ tables: { cards: [{ value: packCards }] } })
-      vi.spyOn(Math, 'random').mockReturnValue(0.65)
+      mockCryptoRandomFraction(0.65, 10_000)
 
       const result = await new GachaService().executeGacha(
         'streamer-1', 'user-1', 'Viewer', 'event-inherited-weight', 100, 'weapons',
@@ -656,7 +674,7 @@ describe('GachaService.executeGacha: PlanetScale read/write', () => {
           }],
         },
       })
-      vi.spyOn(Math, 'random').mockReturnValue(0.92)
+      mockCryptoRandomFraction(0.92, 10_000)
 
       const result = await new GachaService().executeGacha(
         'streamer-1', 'user-1', 'Viewer', 'event-unrestricted-weight', 100, null,
@@ -1186,7 +1204,7 @@ describe('GachaService.executeGachaForEventSub', () => {
         }],
       },
     })
-    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    mockCryptoRandomFraction(0.5, 10_000)
 
     const result = await new GachaService().executeGachaForEventSub(
       baseEvent,

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -1,5 +1,145 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { retryAfterSeconds } from "@/lib/rate-limit";
+import {
+  KVRateLimitStorage,
+  checkRateLimit,
+  getRateLimitStorage,
+  rateLimits,
+  retryAfterSeconds,
+  setRateLimitStorage,
+} from "@/lib/rate-limit";
+
+function makeKv() {
+  const store = new Map<string, { value: string; ttl?: number }>();
+  return {
+    store,
+    get: vi.fn(async (key: string, type?: "json") => {
+      const entry = store.get(key);
+      if (!entry) return null;
+      return type === "json" ? JSON.parse(entry.value) : entry.value;
+    }),
+    put: vi.fn(async (key: string, value: string, options?: { expirationTtl?: number }) => {
+      store.set(key, { value, ttl: options?.expirationTtl });
+    }),
+    delete: vi.fn(async (key: string) => {
+      store.delete(key);
+    }),
+  };
+}
+
+describe("retryAfterSeconds", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("reset(epochミリ秒)と現在時刻の差分を秒(整数)に変換する", () => {
+    const reset = Date.now() + 60_000;
+    expect(retryAfterSeconds(reset)).toBe(60);
+  });
+
+  it("端数は切り上げる(59.2秒残 → 60秒)", () => {
+    const reset = Date.now() + 59_200;
+    expect(retryAfterSeconds(reset)).toBe(60);
+  });
+
+  it("1秒未満の正の残り時間は1秒に切り上げる", () => {
+    const reset = Date.now() + 500;
+    expect(retryAfterSeconds(reset)).toBe(1);
+  });
+
+  it("resetが現在時刻と同値の場合は0を返す", () => {
+    expect(retryAfterSeconds(Date.now())).toBe(0);
+  });
+
+  it("大きな残り時間も秒単位の整数に正しく変換する", () => {
+    const reset = Date.now() + 3_600_000;
+    expect(retryAfterSeconds(reset)).toBe(3600);
+  });
+
+  it("reset未指定時はフォールバック値(fallbackMs、デフォルト60000)を使う", () => {
+    expect(retryAfterSeconds()).toBe(60);
+    expect(retryAfterSeconds(undefined, 3_600_000)).toBe(3600);
+  });
+
+  it("resetが過去の場合は0にクランプする", () => {
+    expect(retryAfterSeconds(Date.now() - 5_000)).toBe(0);
+  });
+});
+
+describe("KVRateLimitStorage", () => {
+  let kv: ReturnType<typeof makeKv>;
+
+  beforeEach(() => {
+    kv = makeKv();
+  });
+
+  it("setはJSON文字列と秒単位TTLでKVへ書き込む", async () => {
+    const storage = new KVRateLimitStorage(kv as never);
+    await storage.set("ratelimit:test", { count: 3, resetTime: 12345 }, 90_000);
+
+    expect(kv.put).toHaveBeenCalledWith(
+      "ratelimit:test",
+      JSON.stringify({ count: 3, resetTime: 12345 }),
+      { expirationTtl: 90 },
+    );
+  });
+
+  it("TTLはミリ秒から秒へ切り上げる", async () => {
+    const storage = new KVRateLimitStorage(kv as never);
+    await storage.set("ratelimit:test", { count: 1, resetTime: 1 }, 1);
+    expect(kv.put).toHaveBeenCalledWith(
+      "ratelimit:test",
+      JSON.stringify({ count: 1, resetTime: 1 }),
+      { expirationTtl: 1 },
+    );
+  });
+
+  it("getはJSONを復元し、未登録ならnullを返す", async () => {
+    const storage = new KVRateLimitStorage(kv as never);
+    expect(await storage.get("ratelimit:missing")).toBeNull();
+
+    await storage.set("ratelimit:test", { count: 5, resetTime: 999 }, 60_000);
+    expect(await storage.get("ratelimit:test")).toEqual({ count: 5, resetTime: 999 });
+  });
+
+  it("deleteでKVエントリを削除する", async () => {
+    const storage = new KVRateLimitStorage(kv as never);
+    await storage.set("ratelimit:test", { count: 1, resetTime: 1 }, 60_000);
+    await storage.delete("ratelimit:test");
+    expect(kv.delete).toHaveBeenCalledWith("ratelimit:test");
+    expect(await storage.get("ratelimit:test")).toBeNull();
+  });
+});
+
+describe("rate limit storage 切り替え", () => {
+  let kv: ReturnType<typeof makeKv>;
+
+  beforeEach(() => {
+    kv = makeKv();
+    // テスト間でモジュールレベルのストレージをメモリ実装へ戻す
+    setRateLimitStorage(getRateLimitStorage());
+  });
+
+  it("KVストレージ設定後はcheckRateLimitがKVを経由してカウントする", async () => {
+    setRateLimitStorage(new KVRateLimitStorage(kv as never));
+
+    const first = await checkRateLimit(rateLimits.authLogin, "user:test");
+    expect(first.success).toBe(true);
+    expect(kv.put).toHaveBeenCalledTimes(1);
+    expect(kv.get).toHaveBeenCalledWith("ratelimit:authLogin:user:test", "json");
+
+    // 上限(5回/分)を超えるまで繰り返すと拒否される
+    for (let i = 0; i < 4; i++) {
+      await checkRateLimit(rateLimits.authLogin, "user:test");
+    }
+    const blocked = await checkRateLimit(rateLimits.authLogin, "user:test");
+    expect(blocked.success).toBe(false);
+  });
+});
 
 describe("retryAfterSeconds", () => {
   beforeEach(() => {


### PR DESCRIPTION
## 概要
public 化後のセキュリティ監査指摘（#3/#4/#5）への対応です。

## 変更内容
- SECURITY.md: 報告先を [SECURITY_EMAIL] から GitHub Private Vulnerability Reporting へ置き換え
- gacha.ts: ガチャ抽選を Math.random() から crypto.getRandomValues()（CSPRNG・剰余バイアス回避の棄却サンプリング）へ変更
- rate-limit.ts: 初回チェック時に KV バインディング（RATE_LIMIT_KV）を解決し、分散環境で KV ストレージへ自動切り替え。KV が無い環境は従来どおりメモリ実装へフォールバック

## 検証
- ユニットテスト: 265 files / 3418 tests passed
- typecheck 成功、eslint エラーなし