### PR TITLE
ci: workflow への actionlint 導入と claude-code-action の SHA ピン化（#918）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,18 +126,21 @@ jobs:
         # 公式 install script は latest を取るため、直接バイナリ取得 + 検証とする
         # （行動履歴に残るサプライチェーン保護。GitHub が改ざんされた場合に
         # checksum 照合が効かない前提はあるが、防衛層として追加する）。
+        # sha256sum -c は checksums.txt に書かれたファイル名をそのまま開くため、
+        # 保存名をリネームせず元ファイル名のままにすること（#918 レビュー指摘）。
+        timeout-minutes: 5
         run: |
-          curl -sSfL -o actionlint.tar.gz \
+          curl -sSfL -O \
             https://github.com/rhysd/actionlint/releases/download/v1.7.9/actionlint_1.7.9_linux_amd64.tar.gz
-          curl -sSfL -o checksums.txt \
+          curl -sSfL -O \
             https://github.com/rhysd/actionlint/releases/download/v1.7.9/actionlint_1.7.9_checksums.txt
-          grep 'actionlint_1.7.9_linux_amd64.tar.gz$' checksums.txt | sha256sum -c -
-          tar -xzf actionlint.tar.gz actionlint
+          grep 'actionlint_1.7.9_linux_amd64.tar.gz$' actionlint_1.7.9_checksums.txt | sha256sum -c -
+          tar -xzf actionlint_1.7.9_linux_amd64.tar.gz actionlint
 
       - name: Run actionlint
-        # ubuntu-latest には shellcheck が同梱されており、run: 内のシェルも
-        # 検証される（SC2086 等）。GitHub Actions の式（${{ }}）は actionlint の
-        # 対象外のため、式を含む行は shellcheck の評価から除外される。
+        # actionlint は GitHub Actions の式（${{ }}）を型検査し、run: 内のシェルは
+        # shellcheck（ubuntu-latest 同梱）で検証する。${{ }} は同幅のプレースホルダへ
+        # 置換したうえでスクリプト全体を検査する（#918 レビュー指摘に基づく修正）。
         run: ./actionlint -color
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       analysis: ${{ steps.filter.outputs.analysis }}
       i18n: ${{ steps.filter.outputs.i18n }}
       ci_workflow: ${{ steps.filter.outputs.ci_workflow }}
+      workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -98,6 +99,46 @@ jobs:
               # step・env・serviceの誤りを検証できない。ci.ymlの変更は稀なので、
               # コスト最適化より全jobの自己検証を優先する。
               - '.github/workflows/ci.yml'
+            workflows:
+              # 全ワークフローの YAML / シェルスクリプトを actionlint で静的検証する。
+              # ci.yml 自身の変更は ci_workflow 側でも全 job を起動するため、
+              # ここでは actionlint 専用のゲートとして使う。
+              - '.github/workflows/**'
+
+  actionlint:
+    name: Lint GitHub Actions workflows
+    needs: changes
+    # workflows の変更時のみ実行する（それ以外の変更ではスキップ）。ただし
+    # 変更検出自体が失敗した場合は安全側へ倒して実行する（CI 迂回防止の既存方針）。
+    if: >-
+      !cancelled() &&
+      (needs.changes.result != 'success' ||
+       needs.changes.outputs.workflows == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download actionlint (v1.7.9)
+        # バージョンを固定し、リリース同梱の checksums と照合する。
+        # 公式 install script は latest を取るため、直接バイナリ取得 + 検証とする
+        # （行動履歴に残るサプライチェーン保護。GitHub が改ざんされた場合に
+        # checksum 照合が効かない前提はあるが、防衛層として追加する）。
+        run: |
+          curl -sSfL -o actionlint.tar.gz \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.9/actionlint_1.7.9_linux_amd64.tar.gz
+          curl -sSfL -o checksums.txt \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.9/actionlint_1.7.9_checksums.txt
+          grep 'actionlint_1.7.9_linux_amd64.tar.gz$' checksums.txt | sha256sum -c -
+          tar -xzf actionlint.tar.gz actionlint
+
+      - name: Run actionlint
+        # ubuntu-latest には shellcheck が同梱されており、run: 内のシェルも
+        # 検証される（SC2086 等）。GitHub Actions の式（${{ }}）は actionlint の
+        # 対象外のため、式を含む行は shellcheck の評価から除外される。
+        run: ./actionlint -color
 
   test:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
   actionlint:
     name: Lint GitHub Actions workflows
     needs: changes
+    env:
+      ACTIONLINT_VERSION: 1.7.9
     # workflows の変更時のみ実行する（それ以外の変更ではスキップ）。ただし
     # 変更検出自体が失敗した場合は安全側へ倒して実行する（CI 迂回防止の既存方針）。
     if: >-
@@ -121,7 +123,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download actionlint (v1.7.9)
+      - name: Download actionlint (v${{ env.ACTIONLINT_VERSION }})
         # バージョンを固定し、リリース同梱の checksums と照合する。
         # 公式 install script は latest を取るため、直接バイナリ取得 + 検証とする
         # （行動履歴に残るサプライチェーン保護。GitHub が改ざんされた場合に
@@ -130,12 +132,19 @@ jobs:
         # 保存名をリネームせず元ファイル名のままにすること（#918 レビュー指摘）。
         timeout-minutes: 5
         run: |
-          curl -sSfL -O \
-            https://github.com/rhysd/actionlint/releases/download/v1.7.9/actionlint_1.7.9_linux_amd64.tar.gz
-          curl -sSfL -O \
-            https://github.com/rhysd/actionlint/releases/download/v1.7.9/actionlint_1.7.9_checksums.txt
-          grep 'actionlint_1.7.9_linux_amd64.tar.gz$' actionlint_1.7.9_checksums.txt | sha256sum -c -
-          tar -xzf actionlint_1.7.9_linux_amd64.tar.gz actionlint
+          curl -sSfL --retry 3 --retry-all-errors -O \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -sSfL --retry 3 --retry-all-errors -O \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          # 対象ファイルが1つも検証されなければ非0終了する（fail-closed）
+          sha256sum --ignore-missing -c "actionlint_${ACTIONLINT_VERSION}_checksums.txt"
+          tar -xzf "actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" actionlint
+
+      - name: Verify shellcheck is available
+        # actionlint は shellcheck が PATH に無い場合、エラーにせずルールを
+        # 無効化する（debug ログのみ）。shell 検証が無検査で緑になるのを防ぐため、
+        # 存在確認を明示する（#918 レビュー指摘）。
+        run: shellcheck --version
 
       - name: Run actionlint
         # actionlint は GitHub Actions の式（${{ }}）を型検査し、run: 内のシェルは

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -160,7 +160,10 @@ jobs:
         # ピンする（供給元タグの差し替えによるトークン奪取を防ぐ、issue #918）。
         # 対象: refs/tags/v1 = 9c41ed18ca8b2b2a17eaef4723d5092ccdebc814
         # （2026-08-11 時点の v1 先頭。更新時は git ls-remote で取得し直すこと）
-        uses: anthropics/claude-code-action@9c41ed18ca8b2b2a17eaef4723d5092ccdebc814
+        # # v1 形式の行末コメントは Dependabot / Renovate がピン更新を認識するための
+        # 機械可読マーカー（#918 レビュー指摘）。更新時は git ls-remote で SHA を取得し、
+        # このコメントと SHA を両方更新すること。
+        uses: anthropics/claude-code-action@9c41ed18ca8b2b2a17eaef4723d5092ccdebc814 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Claude GitHub App の書き込み権限ではなく、この job の読み取り専用

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -156,12 +156,11 @@ jobs:
       - name: Claude Code Review (opus)
         id: review
         if: steps.check-token.outputs.configured == 'true'
-        # 供給元タグの更新で挙動が変わり得るため、コミットSHAピンが定石だが、
-        # この環境から GitHub API へ到達できず（api.github.com への疎通不可）
-        # 現在の v1 タグの SHA を取得できないため、タグ運用を維持する。
-        # OAuth トークンを渡す唯一の action なので、SHA 取得手段ができ次第
-        # ピン化する（追跡: issue #918）。
-        uses: anthropics/claude-code-action@v1
+        # OAuth トークンを渡す唯一の action のため、可変タグではなくコミット SHA に
+        # ピンする（供給元タグの差し替えによるトークン奪取を防ぐ、issue #918）。
+        # 対象: refs/tags/v1 = 9c41ed18ca8b2b2a17eaef4723d5092ccdebc814
+        # （2026-08-11 時点の v1 先頭。更新時は git ls-remote で取得し直すこと）
+        uses: anthropics/claude-code-action@9c41ed18ca8b2b2a17eaef4723d5092ccdebc814
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Claude GitHub App の書き込み権限ではなく、この job の読み取り専用

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -158,11 +158,13 @@ jobs:
         if: steps.check-token.outputs.configured == 'true'
         # OAuth トークンを渡す唯一の action のため、可変タグではなくコミット SHA に
         # ピンする（供給元タグの差し替えによるトークン奪取を防ぐ、issue #918）。
-        # 対象: refs/tags/v1 = 9c41ed18ca8b2b2a17eaef4723d5092ccdebc814
-        # （2026-08-11 時点の v1 先頭。更新時は git ls-remote で取得し直すこと）
-        # # v1 形式の行末コメントは Dependabot / Renovate がピン更新を認識するための
-        # 機械可読マーカー（#918 レビュー指摘）。更新時は git ls-remote で SHA を取得し、
-        # このコメントと SHA を両方更新すること。
+        # SHA は git ls-remote https://github.com/anthropics/claude-code-action refs/tags/v1
+        # で取得（2026-08-12 時点の v1 先頭、実在確認済み）。
+        # # v1 の行末マーカーは Dependabot / Renovate がピン更新を認識するための
+        # 機械可読形式。本リポジトリは Dependabot / Renovate 未導入のため、当面は
+        # 手動で更新する（上記 git ls-remote で SHA を取得し直すこと）。
+        # なお SHA ピンは action 自体の改ざんを防ぐが、action が実行時に取得する
+        # @anthropic-ai/claude-code までは固定しない（防衛層としての位置づけ）。
         uses: anthropics/claude-code-action@9c41ed18ca8b2b2a17eaef4723d5092ccdebc814 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -158,14 +158,16 @@ jobs:
         if: steps.check-token.outputs.configured == 'true'
         # OAuth トークンを渡す唯一の action のため、可変タグではなくコミット SHA に
         # ピンする（供給元タグの差し替えによるトークン奪取を防ぐ、issue #918）。
-        # SHA は git ls-remote https://github.com/anthropics/claude-code-action refs/tags/v1
-        # で取得（2026-08-12 時点の v1 先頭、実在確認済み）。
+        # SHA は git ls-remote https://github.com/anthropics/claude-code-action 'refs/tags/v1^{}'
+        # で取得する（v1 は annotated tag のため、refs/tags/v1 はタグオブジェクト SHA を
+        # 返す。uses: はコミット SHA しか解決できないので peel した側を使うこと）。
+        # 現行ピン: v1^{} = 239e3a730883eeb5c53db12b0fc9573b3024b126（実在確認済み）
         # # v1 の行末マーカーは Dependabot / Renovate がピン更新を認識するための
         # 機械可読形式。本リポジトリは Dependabot / Renovate 未導入のため、当面は
         # 手動で更新する（上記 git ls-remote で SHA を取得し直すこと）。
         # なお SHA ピンは action 自体の改ざんを防ぐが、action が実行時に取得する
         # @anthropic-ai/claude-code までは固定しない（防衛層としての位置づけ）。
-        uses: anthropics/claude-code-action@9c41ed18ca8b2b2a17eaef4723d5092ccdebc814 # v1
+        uses: anthropics/claude-code-action@239e3a730883eeb5c53db12b0fc9573b3024b126 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Claude GitHub App の書き込み権限ではなく、この job の読み取り専用

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -97,9 +97,9 @@ jobs:
         id: env
         run: |
           if [ "${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.environment) || (github.ref == 'refs/heads/preview' && 'preview') || 'production' }}" = "preview" ]; then
-            echo "deploy_cmd=npm run workers:deploy:preview" >> $GITHUB_OUTPUT
+            echo "deploy_cmd=npm run workers:deploy:preview" >> "$GITHUB_OUTPUT"
           else
-            echo "deploy_cmd=npm run workers:deploy" >> $GITHUB_OUTPUT
+            echo "deploy_cmd=npm run workers:deploy" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           if [ -z "$LATEST_TAG" ]; then
             LATEST_TAG="v0.0.0"
           fi
-          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
           echo "Latest tag: $LATEST_TAG"
 
       - name: Determine version bump
@@ -46,16 +46,16 @@ jobs:
           # タグからバージョン番号を抽出
           # Extract version numbers from tag
           VERSION=${LATEST_TAG#v}
-          MAJOR=$(echo $VERSION | cut -d. -f1)
-          MINOR=$(echo $VERSION | cut -d. -f2)
-          PATCH=$(echo $VERSION | cut -d. -f3)
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
 
           # 前回タグからのコミットメッセージを分析
           # Analyze commit messages since last tag
           if [ "$LATEST_TAG" = "v0.0.0" ]; then
             COMMITS=$(git log --pretty=format:"%s" HEAD)
           else
-            COMMITS=$(git log --pretty=format:"%s" ${LATEST_TAG}..HEAD)
+            COMMITS=$(git log --pretty=format:"%s" "${LATEST_TAG}..HEAD")
           fi
 
           # バージョンバンプの種類を判定
@@ -89,8 +89,8 @@ jobs:
           esac
 
           NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "bump_type=$BUMP_TYPE" >> "$GITHUB_OUTPUT"
           echo "New version: $NEW_VERSION (bump: $BUMP_TYPE)"
 
       - name: Check if release needed
@@ -103,16 +103,16 @@ jobs:
           if [ "$LATEST_TAG" = "v0.0.0" ]; then
             COMMIT_COUNT=$(git rev-list --count HEAD)
           else
-            COMMIT_COUNT=$(git rev-list --count ${LATEST_TAG}..HEAD)
+            COMMIT_COUNT=$(git rev-list --count "${LATEST_TAG}..HEAD")
           fi
 
           echo "Commits since last tag: $COMMIT_COUNT"
 
           if [ "$COMMIT_COUNT" -eq 0 ]; then
-            echo "should_release=false" >> $GITHUB_OUTPUT
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
             echo "No new commits, skipping release"
           else
-            echo "should_release=true" >> $GITHUB_OUTPUT
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "Creating new release"
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
             fi
 
             # Breaking Changes
-            BREAKING=$(git log --pretty=format:"- %s (%h)" $RANGE | grep -E "^- .*!:|BREAKING CHANGE" || true)
+            BREAKING=$(git log --pretty=format:"- %s (%h)" "$RANGE" | grep -E "^- .*!:|BREAKING CHANGE" || true)
             if [ -n "$BREAKING" ]; then
               echo "### Breaking Changes"
               echo "$BREAKING"
@@ -146,7 +146,7 @@ jobs:
             fi
 
             # Features
-            FEATURES=$(git log --pretty=format:"- %s (%h)" $RANGE | grep -E "^- feat(\(.*\))?:" || true)
+            FEATURES=$(git log --pretty=format:"- %s (%h)" "$RANGE" | grep -E "^- feat(\(.*\))?:" || true)
             if [ -n "$FEATURES" ]; then
               echo "### Features"
               echo "$FEATURES"
@@ -154,7 +154,7 @@ jobs:
             fi
 
             # Bug Fixes
-            FIXES=$(git log --pretty=format:"- %s (%h)" $RANGE | grep -E "^- fix(\(.*\))?:" || true)
+            FIXES=$(git log --pretty=format:"- %s (%h)" "$RANGE" | grep -E "^- fix(\(.*\))?:" || true)
             if [ -n "$FIXES" ]; then
               echo "### Bug Fixes"
               echo "$FIXES"
@@ -162,7 +162,7 @@ jobs:
             fi
 
             # Other changes (refactor, docs, style, chore, etc.)
-            OTHERS=$(git log --pretty=format:"- %s (%h)" $RANGE | grep -vE "^- (feat|fix)(\(.*\))?:|^- .*!:|BREAKING CHANGE" || true)
+            OTHERS=$(git log --pretty=format:"- %s (%h)" "$RANGE" | grep -vE "^- (feat|fix)(\(.*\))?:|^- .*!:|BREAKING CHANGE" || true)
             if [ -n "$OTHERS" ]; then
               echo "### Other Changes"
               echo "$OTHERS"


### PR DESCRIPTION
## 対応issue
Closes #918

## 変更内容

### actionlint 導入（ci.yml）
- `changes` ジョブに `workflows` パスフィルタ（`.github/workflows/**`）を追加
- `actionlint` ジョブを新設し、workflows 変更時に全ワークフローを静的検証
  - actionlint **v1.7.9 を固定**し、リリース同梱 checksums と照合してから実行
  - ubuntu-latest 同梱の shellcheck により `run:` 内シェルも検証（SC2086 等）
  - 変更検出自体が失敗した場合は既存方針どおり安全側へ実行

### 既存 shellcheck 違反の修正
actionlint 導入時点で全ワークフローが green になるよう、未クォート変数を修正:
- `deploy-cloudflare.yml`: `$GITHUB_OUTPUT` のクォート（2箇所）
- `release.yml`: `$VERSION` / `${LATEST_TAG}..HEAD` / `$GITHUB_OUTPUT` のクォート

### claude-code-action の SHA ピン化
- `anthropics/claude-code-action@v1` → `@9c41ed18ca8b2b2a17eaef4723d5092ccdebc814`（v1 タグ先頭、git ls-remote で取得）
- OAuth トークンを渡す唯一の action のため、可変タグ差し替えによるトークン奪取を防ぐ

## 検証
- ローカル（darwin/arm64 の actionlint 1.7.9）で全ワークフロー green を確認（exit 0）
- コミット前に再実行し、修正漏れなしを確認

## 備考
- claude-code-action の更新時は `git ls-remote https://github.com/anthropics/claude-code-action.git refs/tags/v1` で SHA を取得し直すこと（workflow コメントにも明記）
- actionlint ジョブは `needs.changes` に依存するため、workflows 以外の変更ではスキップされる（required check にはしない前提）