### PR TITLE
ci: claude-review の post_review を base.sha checkout に切り替え（#917）

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -40,9 +40,12 @@
 #
 # Claude 実行 job と投稿 job を分離し、投稿用の pull-requests: write は Claude の
 # 実行終了後にのみ使う。post_review は base（preview）由来の .github/scripts/
-# format-review.mjs を実行する（issue #917）。write 権限 job で head 由来コードを
-# 実行しない多層防御として、checkout は base.sha を明示する。fork では secrets が
-# 渡らず起動条件も満たされない。
+# format-review.mjs を実行する（issue #917）。checkout を base.sha にすることで
+# write 権限 job で実行する「外部モジュール」を head 由来にしない多層防御。
+# ただし actions/github-script のインラインスクリプトは workflow YAML 由来＝head
+# 由来のまま（workflow 定義自体が head 由来のため実効的な権限拡大はなく、旧
+# コメントの但し書きは引き続き有効）。fork では secrets が渡らず起動条件も
+# 満たされない。
 # なおコメントは初回のみ createComment（通知あり）、以降は updateComment で
 # 上書きする（単一コメント維持方針）ため、2回目以降の通知は発生しない。
 # PR ページと Step summary で確認する運用。
@@ -305,11 +308,17 @@ jobs:
           # job の checkout は別ランナーで共有されない。cone モード既定の
           # sparse-checkout で .github/scripts を対象にする（ルート直下の
           # ファイルは常に展開される）。base.sha（preview）を明示するのは、
-          # write 権限 job で head 由来コード（PR 作成者が変更可能な
-          # format-review.mjs）を実行しないため（issue #917）。
+          # write 権限 job で実行する外部モジュール（PR 作成者が変更可能な
+          # format-review.mjs）を head 由来にしないため（issue #917）。
+          # インライン github-script は head 由来のままなので、防御は「外部
+          # モジュールのみ base 化」に限定される点に注意。
           # format-review.mjs は preview にマージ済みのため base.sha で取得できる。
           # コンフリクト中の PR では merge ref が無いため、base.sha / head.sha の
           # どちらも checkout 可能な SHA を明示する方式を維持する。
+          # 注意: format-review.mjs を変更する PR では、自 PR の post_review は
+          # base 側の旧版で動く（自 PR では検証されない）。export 名・
+          # REVIEW_MARKER を変える場合は TypeError / コメント重複が起こり得るため、
+          # マージ後に追い PR で実経路を確認すること。
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: .github/scripts

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -39,9 +39,10 @@
 #   paths が無視されて常に実行される（コスト受容の前提）。
 #
 # Claude 実行 job と投稿 job を分離し、投稿用の pull-requests: write は Claude の
-# 実行終了後にのみ使う。post_review も PR head 由来の .github/scripts/
-# format-review.mjs を実行するが、workflow 定義自体が head 由来である以上
-# 実効的な権限拡大はなく、fork では secrets が渡らず起動条件も満たされない。
+# 実行終了後にのみ使う。post_review は base（preview）由来の .github/scripts/
+# format-review.mjs を実行する（issue #917）。write 権限 job で head 由来コードを
+# 実行しない多層防御として、checkout は base.sha を明示する。fork では secrets が
+# 渡らず起動条件も満たされない。
 # なおコメントは初回のみ createComment（通知あり）、以降は updateComment で
 # 上書きする（単一コメント維持方針）ため、2回目以降の通知は発生しない。
 # PR ページと Step summary で確認する運用。
@@ -303,14 +304,14 @@ jobs:
           # 整形ロジック（format-review.mjs）を読み込むために必要。claude_review
           # job の checkout は別ランナーで共有されない。cone モード既定の
           # sparse-checkout で .github/scripts を対象にする（ルート直下の
-          # ファイルは常に展開される）。head SHA を明示するのはコンフリクト中の
-          # PR で merge ref が無いため。初回導入時は base 側にこのファイルが
-          # 存在しないため head を使うが、preview へマージ後は base.sha に
-          # 切り替え、write 権限 job で head 由来コードを実行しないようにする
-          # （追跡: issue #917。workflow 定義自体も head 由来のため権限拡大は
-          # ないが、多層防御の選択肢として追跡している）。
+          # ファイルは常に展開される）。base.sha（preview）を明示するのは、
+          # write 権限 job で head 由来コード（PR 作成者が変更可能な
+          # format-review.mjs）を実行しないため（issue #917）。
+          # format-review.mjs は preview にマージ済みのため base.sha で取得できる。
+          # コンフリクト中の PR では merge ref が無いため、base.sha / head.sha の
+          # どちらも checkout 可能な SHA を明示する方式を維持する。
           persist-credentials: false
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
           sparse-checkout: .github/scripts
 
       # checkout の clean: true がワークスペースを空にするため、artifact は


### PR DESCRIPTION
## 対応issue
Closes #917

## 変更内容
- `post_review` job の checkout を `${{ github.event.pull_request.head.sha }}` → `${{ github.event.pull_request.base.sha }}` に変更
- 前提（base=preview に `.github/scripts/format-review.mjs` が存在）は PR #916 マージ済みで満たされている
- 関連コメント（リスク受容ブロック・sparse-checkout の説明）を実態に合わせて更新

## 目的
write 権限（pull-requests: write）を持つ post_review job で、PR 作成者が変更可能な head 由来コードを実行しない多層防御。

## 検証
- actionlint は本ブランチ対象ファイル（claude-review.yml）で違反なし（deploy/release の既存 shellcheck 違反は #918 で解消予定）
- workflow 自体のテストはなし（format-review.mjs の純関数テストは既存のまま）