### PR TITLE
security: CSP 強化と #944 レビュー任意指摘の整理（#836 follow-up）

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -353,11 +353,9 @@ export const SECURITY_HEADERS = {
   // media-src: R2バケットからの効果音再生を許可
   // Cloudflare Insights (static.cloudflareinsights.com) のビーコンスクリプトを許可
   // Allow Cloudflare Insights beacon script from static.cloudflareinsights.com
-  // buildCsp()（security-headers.ts）の共通テーブルと一致させること（乖離防止テストあり）
-  CSP_DEVELOPMENT: "default-src 'self'; base-uri 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; media-src 'self' https:; connect-src 'self' https: localhost:* wss:; font-src 'self' data:; worker-src 'self' blob:;",
-  // production の CSP は buildCsp()（src/lib/security-headers.ts）が nonce 付きで
-  // 組み立てるため、ここには定数を持たない（#836: nonce 化に伴い unsafe-inline を
-  // 除去。定数を残すと buildCsp と乖離するため廃止）。
+  // CSP 文字列は buildCsp()（src/lib/security-headers.ts）の共通テーブルからのみ
+  // 組み立てる。ここに定数を置くと buildCsp と乖離し、テストが自己参照になるため
+  // 定数は持たない（#944 レビュー指摘: 乖離防止は directive 単位のテストで担保）。
   HSTS: 'max-age=31536000; includeSubDomains; preload',
 } as const
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -348,11 +348,6 @@ export const SECURITY_HEADERS = {
   X_CONTENT_TYPE_OPTIONS: 'nosniff',
   X_FRAME_OPTIONS: 'DENY',
   X_XSS_PROTECTION: '1; mode=block',
-  // Development CSP includes 'unsafe-eval' for Next.js fast refresh and dev tools
-  // 開発用CSPにはNext.jsのfast refreshと開発ツールのため'unsafe-eval'を含む
-  // media-src: R2バケットからの効果音再生を許可
-  // Cloudflare Insights (static.cloudflareinsights.com) のビーコンスクリプトを許可
-  // Allow Cloudflare Insights beacon script from static.cloudflareinsights.com
   // CSP 文字列は buildCsp()（src/lib/security-headers.ts）の共通テーブルからのみ
   // 組み立てる。ここに定数を置くと buildCsp と乖離し、テストが自己参照になるため
   // 定数は持たない（#944 レビュー指摘: 乖離防止は directive 単位のテストで担保）。

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -49,6 +49,9 @@ export function buildCsp(nonce?: string): string {
   }
   // 開発環境でも nonce 経路を再現できるよう、nonce があれば script-src へ含める
   // （Next.js fast refresh 用の unsafe-eval / インライン用の unsafe-inline は維持）。
+  // 注記: CSP 仕様上 nonce-source があると script-src の 'unsafe-inline' は無視される
+  // ため、dev の nonce あり経路は実質 nonce ベースになる（Next.js が nonce を
+  // 伝播するため実害はない。コメントは誤解を避けるための補足、#949 レビュー任意指摘）。
   const scriptSrc = nonce
     ? `'self' 'nonce-${nonce}' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com`
     : `'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com`

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -6,10 +6,6 @@ import { SECURITY_HEADERS } from './constants'
  * （#944 レビュー指摘: 文字列の三重複による乖離を防ぐ）。
  */
 function composeCsp(scriptSrc: string, connectSrc: string): string {
-  // strict-dynamic 非対応ブラウザ（旧 Safari 等）ではトークンが無視され
-  // `'self' 'nonce-…'` として評価されるため、static.cloudflareinsights.com の
-  // beacon だけが読めなくなる。影響はアナリティクス欠損のみで許容する
-  // （#944 レビュー任意指摘。判断根拠としてコメントに残す）。
   return [
     "default-src 'self'",
     "base-uri 'self'",
@@ -42,6 +38,10 @@ function composeCsp(scriptSrc: string, connectSrc: string): string {
 export function buildCsp(nonce?: string): string {
   const isProduction = process.env.NODE_ENV === 'production'
   if (isProduction) {
+    // strict-dynamic 非対応ブラウザ（旧 Safari 等）ではトークンが無視され
+    // `'self' 'nonce-…'` として評価されるため、static.cloudflareinsights.com の
+    // beacon だけが読めなくなる。影響はアナリティクス欠損のみで許容する
+    // （#944 レビュー任意指摘。判断根拠として nonce 分岐の直近に残す）。
     const scriptSrc = nonce
       ? `'self' 'nonce-${nonce}' 'strict-dynamic'`
       : `'self' https://static.cloudflareinsights.com`
@@ -65,7 +65,8 @@ export function buildCsp(nonce?: string): string {
 export function setSecurityHeaders(
   response: NextResponse,
   pathname?: string,
-  nonce?: string
+  nonce?: string,
+  csp?: string
 ): NextResponse {
   response.headers.set('X-Content-Type-Options', SECURITY_HEADERS.X_CONTENT_TYPE_OPTIONS)
 
@@ -79,7 +80,7 @@ export function setSecurityHeaders(
 
   response.headers.set('X-XSS-Protection', SECURITY_HEADERS.X_XSS_PROTECTION)
 
-  response.headers.set('Content-Security-Policy', buildCsp(nonce))
+  response.headers.set('Content-Security-Policy', csp ?? buildCsp(nonce))
 
   if (process.env.NODE_ENV === 'production') {
     response.headers.set('Strict-Transport-Security', SECURITY_HEADERS.HSTS)

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -38,10 +38,10 @@ function composeCsp(scriptSrc: string, connectSrc: string): string {
 export function buildCsp(nonce?: string): string {
   const isProduction = process.env.NODE_ENV === 'production'
   if (isProduction) {
-    // strict-dynamic 非対応ブラウザ（旧 Safari 等）ではトークンが無視され
-    // `'self' 'nonce-…'` として評価されるため、static.cloudflareinsights.com の
-    // beacon だけが読めなくなる。影響はアナリティクス欠損のみで許容する
-    // （#944 レビュー任意指摘。判断根拠として nonce 分岐の直近に残す）。
+    // CSP Level 2 対応ブラウザは nonce を外部スクリプトにも適用するため、beacon に
+    // nonce を渡している以上（layout.tsx）読み込める。beacon だけが落ちるのは
+    // nonce 自体を解さない CSP Level 1 のみ。影響はアナリティクス欠損のみで許容する
+    // （#949 レビュー任意指摘。判断根拠として nonce 分岐の直近に残す）。
     const scriptSrc = nonce
       ? `'self' 'nonce-${nonce}' 'strict-dynamic'`
       : `'self' https://static.cloudflareinsights.com`
@@ -60,12 +60,14 @@ export function buildCsp(nonce?: string): string {
  * レスポンスにセキュリティヘッダーを設定
  * @param response - NextResponse object to modify
  * @param pathname - Request pathname (optional, used for route-specific headers)
- * @param nonce - CSP nonce (optional, issued by middleware per request, #836)
+ * @param csp - 生成済み CSP 文字列（省略時は buildCsp() で nonce なしを組み立てる）。
+ *   middleware はリクエストごとに 1 回だけ buildCsp(nonce) を呼び、request ヘッダーと
+ *   response ヘッダーの両方へ同じ csp を渡す（nonce 契約、#836）。呼び出し側で
+ *   buildCsp を再実行しないことで nonce と CSP の二重真実源を避ける（#949 レビュー）。
  */
 export function setSecurityHeaders(
   response: NextResponse,
   pathname?: string,
-  nonce?: string,
   csp?: string
 ): NextResponse {
   response.headers.set('X-Content-Type-Options', SECURITY_HEADERS.X_CONTENT_TYPE_OPTIONS)
@@ -80,7 +82,7 @@ export function setSecurityHeaders(
 
   response.headers.set('X-XSS-Protection', SECURITY_HEADERS.X_XSS_PROTECTION)
 
-  response.headers.set('Content-Security-Policy', csp ?? buildCsp(nonce))
+  response.headers.set('Content-Security-Policy', csp ?? buildCsp())
 
   if (process.env.NODE_ENV === 'production') {
     response.headers.set('Strict-Transport-Security', SECURITY_HEADERS.HSTS)

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -6,6 +6,10 @@ import { SECURITY_HEADERS } from './constants'
  * （#944 レビュー指摘: 文字列の三重複による乖離を防ぐ）。
  */
 function composeCsp(scriptSrc: string, connectSrc: string): string {
+  // strict-dynamic 非対応ブラウザ（旧 Safari 等）ではトークンが無視され
+  // `'self' 'nonce-…'` として評価されるため、static.cloudflareinsights.com の
+  // beacon だけが読めなくなる。影響はアナリティクス欠損のみで許容する
+  // （#944 レビュー任意指摘。判断根拠としてコメントに残す）。
   return [
     "default-src 'self'",
     "base-uri 'self'",
@@ -16,6 +20,8 @@ function composeCsp(scriptSrc: string, connectSrc: string): string {
     `connect-src ${connectSrc}`,
     "font-src 'self' data:",
     "worker-src 'self' blob:",
+    "object-src 'none'",
+    "form-action 'self'",
   ].join('; ') + ';'
 }
 

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -85,7 +85,9 @@ export function setSecurityHeaders(
 
   response.headers.set('X-XSS-Protection', SECURITY_HEADERS.X_XSS_PROTECTION)
 
-  response.headers.set('Content-Security-Policy', csp ?? buildCsp())
+  // 空文字列の csp は「無制限 CSP」と同義になるため || でフォールバックする
+  // （?? だと空文字が素通しになり fail-open、#949 レビュー任意指摘3）。
+  response.headers.set('Content-Security-Policy', csp || buildCsp())
 
   if (process.env.NODE_ENV === 'production') {
     response.headers.set('Strict-Transport-Security', SECURITY_HEADERS.HSTS)

--- a/src/lib/session-middleware.ts
+++ b/src/lib/session-middleware.ts
@@ -11,14 +11,12 @@ import { parseSession, verifySession } from '@/lib/session-cookie'
  * cookie is removed when the session expires, while malformed/tampered session
  * cookies are removed immediately.
  */
-export async function updateSession(request: NextRequest, requestHeaders?: Headers) {
+export async function updateSession(request: NextRequest, requestHeaders: Headers) {
   // 追加ヘッダー（CSP nonce 等）は request を再構築せず NextResponse.next の
   // request.headers 経由で渡す（#836: body を持つ Request を new NextRequest で
   // 複製すると Fetch 仕様上 body が tee され、未消費ブランチのバッファリングが
   // 発生しうるため）。
-  const response = NextResponse.next(
-    requestHeaders ? { request: { headers: requestHeaders } } : { request }
-  )
+  const response = NextResponse.next({ request: { headers: requestHeaders } })
 
   const sessionCookie = request.cookies.get(COOKIE_NAMES.SESSION)?.value
   if (sessionCookie) {

--- a/src/lib/url-utils.ts
+++ b/src/lib/url-utils.ts
@@ -32,11 +32,23 @@ const LOCAL_DEV_ORIGINS = new Set([
 
 const WORKERS_DEV_ACCOUNT_SUBDOMAIN = '.tsubasa-azumagakito.workers.dev'
 
-/** workers.dev の host がこのアカウントの twica 系 Worker に属するか判定する。 */
+/**
+ * workers.dev の host がこのアカウントの twica 系 Worker に属するか判定する。
+ * アカウント専有サブドメインであるため第三者は偽装できないが、不正な Host
+ * （空白・記号入り）が誤って通ると呼び出し側の `new URL()` が 500 になる。
+ * 文字種を検証して fail-closed にする（#944 レビュー任意指摘）。
+ */
 function isTwicaWorkersDevHost(normalizedHost: string): boolean {
+  if (!/^[a-z0-9-]+(\.[a-z0-9-]+)+$/.test(normalizedHost)) {
+    return false
+  }
   return (
     normalizedHost.endsWith(WORKERS_DEV_ACCOUNT_SUBDOMAIN) &&
-    normalizedHost.includes('twica')
+    // worker 名（先頭 label）に twica を含む。Workers Builds は
+    // `<version>-twica-preview` / `<branch>-twica-preview` の形でサブドメインを
+    // 生成するため、先頭 label のみ確認すれば十分（アカウント専有のため部分一致でも
+    // 実害はなく、逆に将来のプレフィックス形式を壊さない）。
+    normalizedHost.split('.')[0].includes('twica')
   )
 }
 
@@ -75,7 +87,10 @@ export function resolveAllowedOrigin(host: string | null): string {
 
   const normalizedHost = host.toLowerCase()
   // ローカル開発は host ヘッダーのみで判定（wrangler dev は http://localhost:8787）。
-  // production ビルドでは localhost を許可しない（Host ヘッダ注入の抜け穴を塞ぐ）。
+  // 注意: `npm run dev`（wrangler dev）は next build 済みバンドルを実行するため
+  // NODE_ENV === 'production' が畳み込まれ、この分岐は通らない。LOCAL_DEV_ORIGINS は
+  // `dev:next`（next dev）専用。production ビルドでは localhost を許可しない
+  // （Host ヘッダ注入の抜け穴を塞ぐ）。
   if (process.env.NODE_ENV !== 'production') {
     const localOrigin = `http://${normalizedHost}`
     if (LOCAL_DEV_ORIGINS.has(localOrigin)) return localOrigin

--- a/src/lib/url-utils.ts
+++ b/src/lib/url-utils.ts
@@ -86,10 +86,11 @@ export function resolveAllowedOrigin(host: string | null): string {
   if (!host) return resolveFallbackOrigin()
 
   const normalizedHost = host.toLowerCase()
-  // ローカル開発は host ヘッダーのみで判定（wrangler dev は http://localhost:8787）。
-  // 注意: `npm run dev`（wrangler dev）は next build 済みバンドルを実行するため
-  // NODE_ENV === 'production' が畳み込まれ、この分岐は通らない。LOCAL_DEV_ORIGINS は
-  // `dev:next`（next dev）専用。production ビルドでは localhost を許可しない
+  // ローカル開発は host ヘッダーのみで判定。この分岐は `dev:next`（next dev）で
+  // NODE_ENV=development のときにだけ通り、`npm run dev`（wrangler dev）は next build
+  // 済みバンドルを実行するため production 相当になり通らない。:8787 は wrangler dev
+  // のポートだが、この分岐が通るのは next dev の既定 3000 のみ（-p 8787 等の指定を
+  // 含めて両ポートを残す）。production ビルドでは localhost を許可しない
   // （Host ヘッダ注入の抜け穴を塞ぐ）。
   if (process.env.NODE_ENV !== 'production') {
     const localOrigin = `http://${normalizedHost}`

--- a/src/lib/url-utils.ts
+++ b/src/lib/url-utils.ts
@@ -39,17 +39,25 @@ const WORKERS_DEV_ACCOUNT_SUBDOMAIN = '.tsubasa-azumagakito.workers.dev'
  * 文字種を検証して fail-closed にする（#944 レビュー任意指摘）。
  */
 function isTwicaWorkersDevHost(normalizedHost: string): boolean {
+  // ホスト全体がドット区切りの label（[a-z0-9-]+）で構成されることを確認する。
+  // endsWith だけだと `twica.preview@evil.tsubasa-...` のような userinfo 混入が
+  // 末尾一致で通過し、呼び出し側の `new URL()` が 500 になる（#949 レビューで
+  // 先頭 label 限定を試したが、@ が末尾より前に置けるため全体検証が必須と判明）。
   if (!/^[a-z0-9-]+(\.[a-z0-9-]+)+$/.test(normalizedHost)) {
     return false
   }
-  return (
-    normalizedHost.endsWith(WORKERS_DEV_ACCOUNT_SUBDOMAIN) &&
-    // worker 名（先頭 label）に twica を含む。Workers Builds は
-    // `<version>-twica-preview` / `<branch>-twica-preview` の形でサブドメインを
-    // 生成するため、先頭 label のみ確認すれば十分（アカウント専有のため部分一致でも
-    // 実害はなく、逆に将来のプレフィックス形式を壊さない）。
-    normalizedHost.split('.')[0].includes('twica')
-  )
+  if (!normalizedHost.endsWith(WORKERS_DEV_ACCOUNT_SUBDOMAIN)) {
+    return false
+  }
+  const workerLabel = normalizedHost.split('.')[0]
+  if (!/^[a-z0-9-]+$/.test(workerLabel)) {
+    return false
+  }
+  // worker 名（先頭 label）に twica を含む。Workers Builds は
+  // `<version>-twica-preview` / `<branch>-twica-preview` の形でサブドメインを
+  // 生成するため、先頭 label のみ確認すれば十分（アカウント専有のため部分一致でも
+  // 実害はなく、逆に将来のプレフィックス形式を壊さない）。
+  return workerLabel.includes('twica')
 }
 
 /** フォールバック先の origin を解決する。production で未設定/不正なら fail-loud。 */

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -185,7 +185,7 @@ export async function middleware(request: NextRequest) {
   const response = await updateSession(request, requestHeaders)
   // パスに基づいて適切なセキュリティヘッダーを設定
   // Set appropriate security headers based on the path
-  setSecurityHeaders(response, pathname, nonce, csp)
+  setSecurityHeaders(response, pathname, csp)
 
   // Detect and set locale for server components
   // サーバーコンポーネント用にロケールを検出・設定
@@ -256,7 +256,7 @@ export async function middleware(request: NextRequest) {
           }
         )
 
-        return setSecurityHeaders(errorResponse, pathname, nonce)
+        return setSecurityHeaders(errorResponse, pathname, csp)
       }
     }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -176,13 +176,16 @@ export async function middleware(request: NextRequest) {
   // ヘッダー経由でレンダラへ渡す（body 複製リスクを避ける公式パターン、#836）。
   const nonce = crypto.randomUUID()
   const requestHeaders = new Headers(request.headers)
+  // CPU 課金抑制のため CSP 文字列はリクエストごとに 1 回だけ生成し、
+  // request ヘッダーとレスポンスヘッダーの両方へ渡す（#949 レビュー任意指摘）。
+  const csp = buildCsp(nonce)
   requestHeaders.set('x-nonce', nonce)
-  requestHeaders.set('Content-Security-Policy', buildCsp(nonce))
+  requestHeaders.set('Content-Security-Policy', csp)
 
   const response = await updateSession(request, requestHeaders)
   // パスに基づいて適切なセキュリティヘッダーを設定
   // Set appropriate security headers based on the path
-  setSecurityHeaders(response, pathname, nonce)
+  setSecurityHeaders(response, pathname, nonce, csp)
 
   // Detect and set locale for server components
   // サーバーコンポーネント用にロケールを検出・設定
@@ -204,6 +207,8 @@ export async function middleware(request: NextRequest) {
   // （200 → 2時間）でキャッシュされ、ガチャ結果の表示が最大2時間止まる。
   // realtime-config はルート側で `public, max-age=15, stale-while-revalidate=15` を
   // 明示する意図的な短 TTL キャッシュ対象（オーバーレイのバージョン確認）。
+  // 警告: ここも HTML を返すパスを追加してはならない（CACHEABLE_PUBLIC_PATHS と
+  // 同じ理由で nonce がエッジキャッシュに焼き付く、#949 レビュー任意指摘）。
   const isCacheablePublicPath =
     CACHEABLE_PUBLIC_PATHS.some((path) => pathname.startsWith(path)) ||
     (pathname.startsWith('/api/overlay/') &&

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -98,6 +98,9 @@ const RATE_LIMIT_EXCLUDED_PATHS = [
 // つまり、ここに無いパスでもルートが public を設定すればキャッシュされるため、
 // ルート側の public 設定とこの判定は常に同期させること。
 // 機密情報を返さない・セッション非依存のエンドポイントのみを許可する。
+// 警告: ここへ HTML を返すパスを追加してはならない。エッジキャッシュに nonce 付き
+// CSP が焼き付き、キャッシュ HIT 中の全スクリプトが nonce 不一致でブロックされる
+// （#944 レビュー任意指摘。現状の対象は JSON のみで無害）。
 const CACHEABLE_PUBLIC_PATHS = ['/api/maintenance-status']
 
 /**

--- a/tests/unit/middleware-cache-control.test.ts
+++ b/tests/unit/middleware-cache-control.test.ts
@@ -85,8 +85,7 @@ describe('middleware fail-closed Cache-Control (issue #906)', () => {
 
   it('request ヘッダーに x-nonce と CSP を積む（layout との nonce 契約、#836）', async () => {
     await middleware(makeRequest('/guide'))
-    const [, requestHeaders] = updateSessionMock.mock.calls[0] as unknown as [unknown, Headers | undefined]
-    if (!requestHeaders) throw new Error('middleware must pass request headers to updateSession')
+    const [, requestHeaders] = updateSessionMock.mock.calls[0] as unknown as [unknown, Headers]
     const nonce = requestHeaders.get('x-nonce')
     expect(nonce).toBeTruthy()
     // buildCsp モックは nonce を CSP へ埋め込むため、同じ nonce が CSP に含まれること

--- a/tests/unit/security-headers.test.ts
+++ b/tests/unit/security-headers.test.ts
@@ -74,6 +74,19 @@ describe('setSecurityHeaders', () => {
       )
     })
 
+    it('production nonce 経路は nonce 埋め込み・strict-dynamic・unsafe-inline 不在・host-source 不記載を満たす (#836)', () => {
+      vi.stubEnv('NODE_ENV', 'production')
+      const csp = buildCsp('abc123')
+      const scriptSrc = csp.split(';').find((d) => d.trim().startsWith('script-src'))
+      expect(scriptSrc).toContain("'nonce-abc123'")
+      expect(scriptSrc).toContain("'strict-dynamic'")
+      expect(scriptSrc).not.toContain('unsafe-inline')
+      // strict-dynamic 下では host-source は無効のため記述しない（#944 レビュー）
+      expect(scriptSrc).not.toContain('static.cloudflareinsights.com')
+      // style-src の unsafe-inline は Next.js のインラインスタイル用に維持する
+      expect(csp).toContain("style-src 'self' 'unsafe-inline'")
+    })
+
     it('csp 未指定時は buildCsp() の nonce なし production CSP を使う', () => {
       vi.stubEnv('NODE_ENV', 'production')
       const response = NextResponse.json({ test: 'data' })
@@ -122,16 +135,15 @@ describe('setSecurityHeaders', () => {
       ['development nonce あり', () => { vi.stubEnv('NODE_ENV', 'development'); return buildCsp('nonce1') }],
     ])('%s で全 directive が固定されている（乖離防止）', (_label, build) => {
       const csp = build()
-      // directive 名集合を完全一致で比較する。toContain のみだと directive の追加・
-      // 緩和を見逃すため、乖離防止の意図に沿う検証にする（#949 レビュー任意指摘）。
-      const actualDirectives = new Set(
-        csp
-          .split(';')
-          .map((d) => d.trim())
-          .filter(Boolean)
-          .map((d) => d.split(/\s+/)[0])
-      )
-      expect([...actualDirectives].sort()).toEqual([...EXPECTED_DIRECTIVE_NAMES].sort())
+      // directive 名を出現順の配列で完全一致比較する。Set 化すると同名 directive の
+      // 二重出力（後勝ちで事故る典型）を検出できないため、配列のままで順序・重複・
+      // 欠落を同時に固定する（#949 レビュー任意指摘）。
+      const actualDirectives = csp
+        .split(';')
+        .map((d) => d.trim())
+        .filter(Boolean)
+        .map((d) => d.split(/\s+/)[0])
+      expect(actualDirectives).toEqual(EXPECTED_DIRECTIVE_NAMES)
     })
   })
 

--- a/tests/unit/security-headers.test.ts
+++ b/tests/unit/security-headers.test.ts
@@ -66,18 +66,21 @@ describe('setSecurityHeaders', () => {
       expect(csp).toContain("style-src 'self' 'unsafe-inline'")
     })
 
-    it('本番環境で nonce を渡すと script-src が nonce ベースになり unsafe-inline を含まない (#836)', () => {
+    it('生成済み CSP 文字列を渡すとそれを採用する（middleware との nonce 契約）', () => {
+      const response = NextResponse.json({ test: 'data' })
+      const result = setSecurityHeaders(response, undefined, "default-src 'self'; script-src 'self' 'nonce-abc123' 'strict-dynamic';")
+      expect(result.headers.get('Content-Security-Policy')).toBe(
+        "default-src 'self'; script-src 'self' 'nonce-abc123' 'strict-dynamic';"
+      )
+    })
+
+    it('csp 未指定時は buildCsp() の nonce なし production CSP を使う', () => {
       vi.stubEnv('NODE_ENV', 'production')
       const response = NextResponse.json({ test: 'data' })
-      const result = setSecurityHeaders(response, undefined, 'abc123')
+      const result = setSecurityHeaders(response)
       const csp = result.headers.get('Content-Security-Policy')
       const scriptSrc = csp?.split(';').find((d) => d.trim().startsWith('script-src'))
-      expect(scriptSrc).toContain("'nonce-abc123'")
-      expect(scriptSrc).toContain("'strict-dynamic'")
       expect(scriptSrc).not.toContain('unsafe-inline')
-      // strict-dynamic 下では host-source は無効のため記述しない
-      expect(scriptSrc).not.toContain('static.cloudflareinsights.com')
-      // style-src の unsafe-inline は Next.js のインラインスタイル用に維持する
       expect(csp).toContain("style-src 'self' 'unsafe-inline'")
     })
 
@@ -98,16 +101,18 @@ describe('setSecurityHeaders', () => {
       expect(csp).toContain('unsafe-eval')
     })
 
-    const COMMON_DIRECTIVES = [
-      "default-src 'self'",
-      "base-uri 'self'",
-      "style-src 'self' 'unsafe-inline'",
-      "img-src 'self' data: https: blob:",
-      "media-src 'self' https:",
-      "font-src 'self' data:",
-      "worker-src 'self' blob:",
-      "object-src 'none'",
-      "form-action 'self'",
+    const EXPECTED_DIRECTIVE_NAMES = [
+      'default-src',
+      'base-uri',
+      'script-src',
+      'style-src',
+      'img-src',
+      'media-src',
+      'connect-src',
+      'font-src',
+      'worker-src',
+      'object-src',
+      'form-action',
     ]
 
     it.each([
@@ -117,9 +122,16 @@ describe('setSecurityHeaders', () => {
       ['development nonce あり', () => { vi.stubEnv('NODE_ENV', 'development'); return buildCsp('nonce1') }],
     ])('%s で全 directive が固定されている（乖離防止）', (_label, build) => {
       const csp = build()
-      for (const directive of COMMON_DIRECTIVES) {
-        expect(csp).toContain(`${directive};`)
-      }
+      // directive 名集合を完全一致で比較する。toContain のみだと directive の追加・
+      // 緩和を見逃すため、乖離防止の意図に沿う検証にする（#949 レビュー任意指摘）。
+      const actualDirectives = new Set(
+        csp
+          .split(';')
+          .map((d) => d.trim())
+          .filter(Boolean)
+          .map((d) => d.split(/\s+/)[0])
+      )
+      expect([...actualDirectives].sort()).toEqual([...EXPECTED_DIRECTIVE_NAMES].sort())
     })
   })
 

--- a/tests/unit/security-headers.test.ts
+++ b/tests/unit/security-headers.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { NextResponse } from 'next/server'
 import { setSecurityHeaders, buildCsp } from '@/lib/security-headers'
-import { SECURITY_HEADERS } from '@/lib/constants'
 
 afterEach(() => {
   vi.unstubAllEnvs()
@@ -60,9 +59,11 @@ describe('setSecurityHeaders', () => {
       expect(csp).toContain('connect-src \'self\' https: wss:;')
       expect(csp).not.toContain('localhost')
       expect(csp).not.toContain('unsafe-eval')
-      // Note: unsafe-inline is currently allowed for script-src and style-src in production
-      // This is a known limitation for Next.js inline styles/scripts
-      expect(csp).toContain('unsafe-inline')
+      // production の script-src に unsafe-inline は含まれない（nonce ベース、
+      // #836）。style-src の unsafe-inline は Next.js のインラインスタイル用に維持。
+      const scriptSrc = csp?.split(';').find((d) => d.trim().startsWith('script-src'))
+      expect(scriptSrc).not.toContain('unsafe-inline')
+      expect(csp).toContain("style-src 'self' 'unsafe-inline'")
     })
 
     it('本番環境で nonce を渡すと script-src が nonce ベースになり unsafe-inline を含まない (#836)', () => {
@@ -97,9 +98,18 @@ describe('setSecurityHeaders', () => {
       expect(csp).toContain('unsafe-eval')
     })
 
-    it('開発環境の nonce なし CSP は constants の CSP_DEVELOPMENT と一致する（乖離防止）', () => {
+    it('全 variant で base-uri / object-src / form-action を固定する（乖離防止）', () => {
+      vi.stubEnv('NODE_ENV', 'production')
+      expect(buildCsp()).toContain("base-uri 'self';")
+      expect(buildCsp()).toContain("object-src 'none';")
+      expect(buildCsp()).toContain("form-action 'self';")
+      expect(buildCsp('nonce1')).toContain("base-uri 'self';")
+      expect(buildCsp('nonce1')).toContain("object-src 'none';")
+      expect(buildCsp('nonce1')).toContain("form-action 'self';")
       vi.stubEnv('NODE_ENV', 'development')
-      expect(buildCsp()).toBe(SECURITY_HEADERS.CSP_DEVELOPMENT)
+      expect(buildCsp()).toContain("base-uri 'self';")
+      expect(buildCsp()).toContain("object-src 'none';")
+      expect(buildCsp()).toContain("form-action 'self';")
     })
   })
 

--- a/tests/unit/security-headers.test.ts
+++ b/tests/unit/security-headers.test.ts
@@ -98,18 +98,28 @@ describe('setSecurityHeaders', () => {
       expect(csp).toContain('unsafe-eval')
     })
 
-    it('全 variant で base-uri / object-src / form-action を固定する（乖離防止）', () => {
-      vi.stubEnv('NODE_ENV', 'production')
-      expect(buildCsp()).toContain("base-uri 'self';")
-      expect(buildCsp()).toContain("object-src 'none';")
-      expect(buildCsp()).toContain("form-action 'self';")
-      expect(buildCsp('nonce1')).toContain("base-uri 'self';")
-      expect(buildCsp('nonce1')).toContain("object-src 'none';")
-      expect(buildCsp('nonce1')).toContain("form-action 'self';")
-      vi.stubEnv('NODE_ENV', 'development')
-      expect(buildCsp()).toContain("base-uri 'self';")
-      expect(buildCsp()).toContain("object-src 'none';")
-      expect(buildCsp()).toContain("form-action 'self';")
+    const COMMON_DIRECTIVES = [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: https: blob:",
+      "media-src 'self' https:",
+      "font-src 'self' data:",
+      "worker-src 'self' blob:",
+      "object-src 'none'",
+      "form-action 'self'",
+    ]
+
+    it.each([
+      ['production nonce なし', () => { vi.stubEnv('NODE_ENV', 'production'); return buildCsp() }],
+      ['production nonce あり', () => { vi.stubEnv('NODE_ENV', 'production'); return buildCsp('nonce1') }],
+      ['development nonce なし', () => { vi.stubEnv('NODE_ENV', 'development'); return buildCsp() }],
+      ['development nonce あり', () => { vi.stubEnv('NODE_ENV', 'development'); return buildCsp('nonce1') }],
+    ])('%s で全 directive が固定されている（乖離防止）', (_label, build) => {
+      const csp = build()
+      for (const directive of COMMON_DIRECTIVES) {
+        expect(csp).toContain(`${directive};`)
+      }
     })
   })
 

--- a/tests/unit/session-middleware.test.ts
+++ b/tests/unit/session-middleware.test.ts
@@ -52,7 +52,7 @@ describe('updateSession middleware', () => {
 
   it('should pass through request when no session cookie exists', async () => {
     const request = createRequest()
-    const response = await updateSession(request)
+    const response = await updateSession(request, new Headers())
 
     // No Set-Cookie headers should be added
     const setCookieHeader = response.headers.get('set-cookie')
@@ -63,7 +63,7 @@ describe('updateSession middleware', () => {
     const request = createRequest({
       [COOKIE_NAMES.SESSION]: JSON.stringify(validSession),
     })
-    const response = await updateSession(request)
+    const response = await updateSession(request, new Headers())
 
     // No Set-Cookie headers should be added for valid sessions
     const setCookieHeader = response.headers.get('set-cookie')
@@ -80,7 +80,7 @@ describe('updateSession middleware', () => {
       [COOKIE_NAMES.SESSION]: JSON.stringify(expiredSession),
       [COOKIE_NAMES.CSRF_TOKEN]: 'existing-csrf-token',
     })
-    const response = await updateSession(request)
+    const response = await updateSession(request, new Headers())
 
     // セッションCookieは保持（スコープ保持のため）
     const sessionCookie = response.cookies.get(COOKIE_NAMES.SESSION)
@@ -100,7 +100,7 @@ describe('updateSession middleware', () => {
     const request = createRequest({
       [COOKIE_NAMES.SESSION]: JSON.stringify(expiredSession),
     })
-    const response = await updateSession(request)
+    const response = await updateSession(request, new Headers())
 
     // Set-Cookieヘッダが一切出ないことを確認
     const setCookieHeader = response.headers.get('set-cookie')
@@ -112,7 +112,7 @@ describe('updateSession middleware', () => {
       [COOKIE_NAMES.SESSION]: 'invalid-json-value',
       [COOKIE_NAMES.CSRF_TOKEN]: 'some-csrf-token',
     })
-    const response = await updateSession(request)
+    const response = await updateSession(request, new Headers())
 
     // Verify both cookies are cleared for unparseable values
     const sessionCookie = response.cookies.get(COOKIE_NAMES.SESSION)
@@ -129,7 +129,7 @@ describe('updateSession middleware', () => {
     const request = createRequest({
       [COOKIE_NAMES.SESSION]: JSON.stringify(sessionWithoutExpiry),
     })
-    const response = await updateSession(request)
+    const response = await updateSession(request, new Headers())
 
     const sessionCookie = response.cookies.get(COOKIE_NAMES.SESSION)
     expect(sessionCookie?.value).toBe('')
@@ -145,7 +145,7 @@ describe('updateSession middleware', () => {
       [COOKIE_NAMES.SESSION]: JSON.stringify(longExpiredSession),
       [COOKIE_NAMES.CSRF_TOKEN]: 'old-csrf-token',
     })
-    const response = await updateSession(request)
+    const response = await updateSession(request, new Headers())
 
     // セッションCookieは保持
     const sessionCookie = response.cookies.get(COOKIE_NAMES.SESSION)
@@ -161,7 +161,7 @@ describe('updateSession middleware', () => {
     const request = createRequest({
       [COOKIE_NAMES.SESSION]: 'invalid-json-value',
     })
-    const response = await updateSession(request)
+    const response = await updateSession(request, new Headers())
 
     // セッションCookieは削除される
     const sessionCookie = response.cookies.get(COOKIE_NAMES.SESSION)
@@ -179,7 +179,7 @@ describe('updateSession middleware', () => {
     const request = createRequest({
       [COOKIE_NAMES.SESSION]: signedSession,
     })
-    const response = await updateSession(request)
+    const response = await updateSession(request, new Headers())
 
     expect(response.headers.get('set-cookie')).toBeNull()
   })
@@ -190,7 +190,7 @@ describe('updateSession middleware', () => {
     const request = createRequest({
       [COOKIE_NAMES.SESSION]: JSON.stringify(validSession),
     })
-    const response = await updateSession(request)
+    const response = await updateSession(request, new Headers())
 
     expect(response.headers.get('set-cookie')).toBeNull()
   })
@@ -202,7 +202,7 @@ describe('updateSession middleware', () => {
       [COOKIE_NAMES.SESSION]: `${JSON.stringify(validSession)}.${'a'.repeat(64)}`,
       [COOKIE_NAMES.CSRF_TOKEN]: 'some-csrf-token',
     })
-    const response = await updateSession(request)
+    const response = await updateSession(request, new Headers())
 
     expect(response.cookies.get(COOKIE_NAMES.SESSION)?.value).toBe('')
     expect(response.cookies.get(COOKIE_NAMES.CSRF_TOKEN)?.value).toBe('')
@@ -217,7 +217,7 @@ describe('updateSession middleware', () => {
       [COOKIE_NAMES.SESSION]: tamperedSession,
       [COOKIE_NAMES.CSRF_TOKEN]: 'some-csrf-token',
     })
-    const response = await updateSession(request)
+    const response = await updateSession(request, new Headers())
 
     expect(response.cookies.get(COOKIE_NAMES.SESSION)?.value).toBe('')
     expect(response.cookies.get(COOKIE_NAMES.CSRF_TOKEN)?.value).toBe('')

--- a/tests/unit/session-middleware.test.ts
+++ b/tests/unit/session-middleware.test.ts
@@ -52,7 +52,7 @@ describe('updateSession middleware', () => {
 
   it('should pass through request when no session cookie exists', async () => {
     const request = createRequest()
-    const response = await updateSession(request, new Headers())
+    const response = await updateSession(request, new Headers(request.headers))
 
     // No Set-Cookie headers should be added
     const setCookieHeader = response.headers.get('set-cookie')
@@ -63,7 +63,7 @@ describe('updateSession middleware', () => {
     const request = createRequest({
       [COOKIE_NAMES.SESSION]: JSON.stringify(validSession),
     })
-    const response = await updateSession(request, new Headers())
+    const response = await updateSession(request, new Headers(request.headers))
 
     // No Set-Cookie headers should be added for valid sessions
     const setCookieHeader = response.headers.get('set-cookie')
@@ -80,7 +80,7 @@ describe('updateSession middleware', () => {
       [COOKIE_NAMES.SESSION]: JSON.stringify(expiredSession),
       [COOKIE_NAMES.CSRF_TOKEN]: 'existing-csrf-token',
     })
-    const response = await updateSession(request, new Headers())
+    const response = await updateSession(request, new Headers(request.headers))
 
     // セッションCookieは保持（スコープ保持のため）
     const sessionCookie = response.cookies.get(COOKIE_NAMES.SESSION)
@@ -100,7 +100,7 @@ describe('updateSession middleware', () => {
     const request = createRequest({
       [COOKIE_NAMES.SESSION]: JSON.stringify(expiredSession),
     })
-    const response = await updateSession(request, new Headers())
+    const response = await updateSession(request, new Headers(request.headers))
 
     // Set-Cookieヘッダが一切出ないことを確認
     const setCookieHeader = response.headers.get('set-cookie')
@@ -112,7 +112,7 @@ describe('updateSession middleware', () => {
       [COOKIE_NAMES.SESSION]: 'invalid-json-value',
       [COOKIE_NAMES.CSRF_TOKEN]: 'some-csrf-token',
     })
-    const response = await updateSession(request, new Headers())
+    const response = await updateSession(request, new Headers(request.headers))
 
     // Verify both cookies are cleared for unparseable values
     const sessionCookie = response.cookies.get(COOKIE_NAMES.SESSION)
@@ -129,7 +129,7 @@ describe('updateSession middleware', () => {
     const request = createRequest({
       [COOKIE_NAMES.SESSION]: JSON.stringify(sessionWithoutExpiry),
     })
-    const response = await updateSession(request, new Headers())
+    const response = await updateSession(request, new Headers(request.headers))
 
     const sessionCookie = response.cookies.get(COOKIE_NAMES.SESSION)
     expect(sessionCookie?.value).toBe('')
@@ -145,7 +145,7 @@ describe('updateSession middleware', () => {
       [COOKIE_NAMES.SESSION]: JSON.stringify(longExpiredSession),
       [COOKIE_NAMES.CSRF_TOKEN]: 'old-csrf-token',
     })
-    const response = await updateSession(request, new Headers())
+    const response = await updateSession(request, new Headers(request.headers))
 
     // セッションCookieは保持
     const sessionCookie = response.cookies.get(COOKIE_NAMES.SESSION)
@@ -161,7 +161,7 @@ describe('updateSession middleware', () => {
     const request = createRequest({
       [COOKIE_NAMES.SESSION]: 'invalid-json-value',
     })
-    const response = await updateSession(request, new Headers())
+    const response = await updateSession(request, new Headers(request.headers))
 
     // セッションCookieは削除される
     const sessionCookie = response.cookies.get(COOKIE_NAMES.SESSION)
@@ -179,7 +179,7 @@ describe('updateSession middleware', () => {
     const request = createRequest({
       [COOKIE_NAMES.SESSION]: signedSession,
     })
-    const response = await updateSession(request, new Headers())
+    const response = await updateSession(request, new Headers(request.headers))
 
     expect(response.headers.get('set-cookie')).toBeNull()
   })
@@ -190,7 +190,7 @@ describe('updateSession middleware', () => {
     const request = createRequest({
       [COOKIE_NAMES.SESSION]: JSON.stringify(validSession),
     })
-    const response = await updateSession(request, new Headers())
+    const response = await updateSession(request, new Headers(request.headers))
 
     expect(response.headers.get('set-cookie')).toBeNull()
   })
@@ -202,7 +202,7 @@ describe('updateSession middleware', () => {
       [COOKIE_NAMES.SESSION]: `${JSON.stringify(validSession)}.${'a'.repeat(64)}`,
       [COOKIE_NAMES.CSRF_TOKEN]: 'some-csrf-token',
     })
-    const response = await updateSession(request, new Headers())
+    const response = await updateSession(request, new Headers(request.headers))
 
     expect(response.cookies.get(COOKIE_NAMES.SESSION)?.value).toBe('')
     expect(response.cookies.get(COOKIE_NAMES.CSRF_TOKEN)?.value).toBe('')
@@ -217,7 +217,7 @@ describe('updateSession middleware', () => {
       [COOKIE_NAMES.SESSION]: tamperedSession,
       [COOKIE_NAMES.CSRF_TOKEN]: 'some-csrf-token',
     })
-    const response = await updateSession(request, new Headers())
+    const response = await updateSession(request, new Headers(request.headers))
 
     expect(response.cookies.get(COOKIE_NAMES.SESSION)?.value).toBe('')
     expect(response.cookies.get(COOKIE_NAMES.CSRF_TOKEN)?.value).toBe('')

--- a/tests/unit/url-utils.test.ts
+++ b/tests/unit/url-utils.test.ts
@@ -99,6 +99,19 @@ describe('resolveAllowedOrigin (issue #836)', () => {
       .toBe('https://twica-preview.tsubasa-azumagakito.workers.dev')
   })
 
+  it('twica が先頭 label にない workers.dev サブドメインは拒否する（締め付け）', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      // 従来の includes('twica') では通っていたが、先頭 label（worker 名）限定に
+      // 変更したため拒否される（#949 レビュー任意指摘の意図した締め付け）
+      expect(resolveAllowedOrigin('evil.twica.tsubasa-azumagakito.workers.dev'))
+        .toBe('https://twica.bluemoon.works')
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
   it('非許可ホストは warn を1回だけ出力してフォールバックする', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/tests/unit/url-utils.test.ts
+++ b/tests/unit/url-utils.test.ts
@@ -81,11 +81,20 @@ describe('resolveAllowedOrigin (issue #836)', () => {
 
   it('workers.dev サブドメインの文字種が不正な host は拒否する（500 化を防ぐ）', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
-    // 空白・記号入りはアカウント専有ドメインに該当しないため fail-closed
-    expect(resolveAllowedOrigin('twica preview.tsubasa-azumagakito.workers.dev'))
-      .toBe('https://twica.bluemoon.works')
-    expect(resolveAllowedOrigin('twica.preview@evil.tsubasa-azumagakito.workers.dev'))
-      .toBe('https://twica.bluemoon.works')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      // 空白・記号入りはアカウント専有ドメインに該当しないため fail-closed
+      expect(resolveAllowedOrigin('twica preview.tsubasa-azumagakito.workers.dev'))
+        .toBe('https://twica.bluemoon.works')
+      expect(resolveAllowedOrigin('twica.preview@evil.tsubasa-azumagakito.workers.dev'))
+        .toBe('https://twica.bluemoon.works')
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('大文字の workers.dev ホストは小文字化して許可する', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
     expect(resolveAllowedOrigin('TWICA-preview.tsubasa-azumagakito.workers.dev'))
       .toBe('https://twica-preview.tsubasa-azumagakito.workers.dev')
   })

--- a/tests/unit/url-utils.test.ts
+++ b/tests/unit/url-utils.test.ts
@@ -79,6 +79,17 @@ describe('resolveAllowedOrigin (issue #836)', () => {
     expect(resolveAllowedOrigin('')).toBe('https://twica.bluemoon.works')
   })
 
+  it('workers.dev サブドメインの文字種が不正な host は拒否する（500 化を防ぐ）', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
+    // 空白・記号入りはアカウント専有ドメインに該当しないため fail-closed
+    expect(resolveAllowedOrigin('twica preview.tsubasa-azumagakito.workers.dev'))
+      .toBe('https://twica.bluemoon.works')
+    expect(resolveAllowedOrigin('twica.preview@evil.tsubasa-azumagakito.workers.dev'))
+      .toBe('https://twica.bluemoon.works')
+    expect(resolveAllowedOrigin('TWICA-preview.tsubasa-azumagakito.workers.dev'))
+      .toBe('https://twica-preview.tsubasa-azumagakito.workers.dev')
+  })
+
   it('非許可ホストは warn を1回だけ出力してフォールバックする', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})


### PR DESCRIPTION
## 対応issue
#836（#944 マージ後の Claude Auto Review 任意指摘のうち、低リスクで完了できるもの）

## 変更内容

### CSP 強化（security-headers.ts）
- `object-src 'none'` / `form-action 'self'` を全 variant の共通ディレクティブ表へ追加（既存ページに object/embed なし、form は全て同一オリジン onSubmit）
- strict-dynamic 非対応ブラウザのコメントを正確化（beacon のみ落ちるのは CSP Level 1 のみ。Level 2 は nonce が外部スクリプトにも適用されるため）
- `setSecurityHeaders` を `csp` 引数に一本化し、middleware がリクエストごとに 1 回だけ `buildCsp(nonce)` を呼んで request / response 両ヘッダーへ同じ CSP を渡す（二重真実源を排除、#949 再レビュー対応）

### 定数整理（constants.ts / security-headers.test.ts）
- テスト専用だった `CSP_DEVELOPMENT` 定数と迷子コメントを削除
- テストを directive 名集合の完全一致検証へ変更（production / development × nonce 有無の 4 variant、追加・緩和も検出）
- `csp` 引数採用と、`csp` 未指定時フォールバックのテストを追加

### Host allowlist の fail-closed 強化（url-utils.ts）
- workers.dev サブドメイン判定に文字種検証を追加（不正 Host の 500 化を防止）
- 先頭 label（worker 名）限定への締め付けをテストで固定（`evil.twica...` は拒否）
- ローカル開発分岐のコメントを自己矛盾なく修正（`dev:next` のみ通る点、:8787 の意図を明記）

### session-middleware の到達不能分岐削除（YAGNI）
- `requestHeaders` を必須化し、テストを本番経路に忠実な `new Headers(request.headers)` に更新

### 運用コメント（middleware.ts）
- キャッシュ許可パスの両経路（CACHEABLE_PUBLIC_PATHS / realtime-config）に「HTML を追加してはならない（nonce 焼き付き）」警告を追加

## 検証
- 全体テスト **3463 passed** / typecheck / eslint（src, tests）/ lint:i18n クリーン
- production build 成功
- CSP 文字列の変更は preview 実経路の描画・ハイドレーションに影響しない（#944 で実測済みの nonce 伝播経路と同一）

## 備考
- 設計判断・構造変更を伴う残りの任意指摘は #950 で追跡（CSRF allowlist 統合 / layout nonce テスト / ログコスト / frame-ancestors 対応 / X-XSS-Protection 見直し）