### PR TITLE
security: CSRF と OAuth の trusted-origin 統合・frame-ancestors 追加（#950）

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -347,10 +347,9 @@ export const ERROR_MESSAGES = {
 export const SECURITY_HEADERS = {
   X_CONTENT_TYPE_OPTIONS: 'nosniff',
   X_FRAME_OPTIONS: 'DENY',
-  X_XSS_PROTECTION: '1; mode=block',
   // CSP 文字列は buildCsp()（src/lib/security-headers.ts）の共通テーブルからのみ
   // 組み立てる。ここに定数を置くと buildCsp と乖離し、テストが自己参照になるため
-  // 定数は持たない（#944 レビュー指摘: 乖離防止は directive 単位のテストで担保）。
+  // 定数は持たない（乖離防止は directive 単位のテストで担保）。
   HSTS: 'max-age=31536000; includeSubDomains; preload',
 } as const
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -348,6 +348,9 @@ export const ERROR_MESSAGES = {
 export const SECURITY_HEADERS = {
   X_CONTENT_TYPE_OPTIONS: 'nosniff',
   X_FRAME_OPTIONS: 'DENY',
+  // 旧 UA の XSS auditor を明示的に無効化（auditor 自体を悪用する既知手法への対策。
+  // 現行ブラウザは auditor 自体が廃止済みで、XSS 対策は CSP が担う）。
+  X_XSS_PROTECTION: '0',
   // CSP 文字列は buildCsp()（src/lib/security-headers.ts）の共通テーブルからのみ
   // 組み立てる。ここに定数を置くと buildCsp と乖離し、テストが自己参照になるため
   // 定数は持たない（乖離防止は directive 単位のテストで担保）。

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -248,6 +248,7 @@ export const ERROR_MESSAGES = {
   FORBIDDEN: 'Forbidden',
   CSRF_TOKEN_INVALID: 'Invalid or missing CSRF token',
   CSRF_TOKEN_MISSING: 'CSRF token is required for this request',
+  CSRF_ORIGIN_NOT_TRUSTED: 'Request origin is not trusted',
 
   // Request validation errors
   MISSING_REQUIRED_FIELDS: 'Missing required fields',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -248,7 +248,7 @@ export const ERROR_MESSAGES = {
   FORBIDDEN: 'Forbidden',
   CSRF_TOKEN_INVALID: 'Invalid or missing CSRF token',
   CSRF_TOKEN_MISSING: 'CSRF token is required for this request',
-  CSRF_ORIGIN_NOT_TRUSTED: 'Request origin is not trusted',
+  CSRF_ORIGIN_NOT_TRUSTED: 'リクエストのオリジンが許可されていません',
 
   // Request validation errors
   MISSING_REQUIRED_FIELDS: 'Missing required fields',

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -213,6 +213,26 @@ export async function validateCSRFToken(
     return { valid: false, error: 'セッションの有効期限が切れました。再度ログインしてください。' }
   }
 
+  // リクエスト URL 自体が非許可 authority なら fail-closed にする
+  // （expectedOrigin は request.url 由来で攻撃者指定になり得るため、getBaseUrl と
+  // 同じ trusted-origin 判定を通す。workers.dev はここで許可される。Origin/Referer
+  // の有無に関わらず常時判定し、不要なトークン生成・Cookie 書き込み・HMAC 計算を
+  // 避けるために session 取得直後に置く）。
+  const requestUrl = new URL(request.url)
+  const expectedOrigin = `${requestUrl.protocol}//${requestUrl.host}`
+  // ALLOWED_ORIGINS は本来「Origin ヘッダーの許可リスト」（Vercel 系も含む）だが、
+  // この OR が実効するのはローカル wrangler dev（NODE_ENV=production 相当で
+  // localhost:8787）の救済のみ。本番では isTrustedOrigin が NEXT_PUBLIC_APP_URL /
+  // workers.dev を許可するため、Vercel 系が信頼 authority へ昇格することはない。
+  if (!isTrustedOrigin(expectedOrigin) && !CSRF_CONFIG.ALLOWED_ORIGINS.includes(expectedOrigin)) {
+    logger.warn('CSRF validation failed: request URL origin not trusted', {
+      userId: session.twitchUserId,
+      expectedOrigin,
+      endpoint: sanitizeURL(request.url),
+    })
+    return { valid: false, error: ERROR_MESSAGES.CSRF_ORIGIN_NOT_TRUSTED }
+  }
+
   let sessionTokenHash = session.csrfTokenHash
   let generatedToken: string | null = null
 
@@ -258,8 +278,6 @@ export async function validateCSRFToken(
   // Originヘッダーの検証（多層防御として）
   const origin = request.headers.get('origin')
   const referer = request.headers.get('referer')
-  const requestUrl = new URL(request.url)
-  const expectedOrigin = `${requestUrl.protocol}//${requestUrl.host}`
 
   function isLocalOrigin(origin: string): boolean {
     try {
@@ -280,19 +298,6 @@ export async function validateCSRFToken(
     } catch {
       return false
     }
-  }
-
-  // リクエスト URL 自体が非許可 authority なら fail-closed にする
-  // （expectedOrigin は request.url 由来で攻撃者指定になり得るため、getBaseUrl と
-  // 同じ trusted-origin 判定を通す。workers.dev はここで許可される。Origin/Referer
-  // の有無に関わらず常時判定する）。
-  if (!isTrustedOrigin(expectedOrigin) && !CSRF_CONFIG.ALLOWED_ORIGINS.includes(expectedOrigin)) {
-    logger.warn('CSRF validation failed: request URL origin not trusted', {
-      userId: session.twitchUserId,
-      expectedOrigin,
-      endpoint: sanitizeURL(request.url),
-    })
-    return { valid: false, error: ERROR_MESSAGES.CSRF_ORIGIN_NOT_TRUSTED }
   }
 
   // リクエストURL自体のoriginと一致する場合は同一オリジンリクエストなので許可する

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -55,6 +55,34 @@ export function sanitizeURL(url: string): string {
 }
 
 /**
+ * ローカル開発・実機確認で使う origin（ループバック + RFC1918 プライベートレンジ）を
+ * 判定する。CSRF_ALLOW_ALL_LOCAL が有効な開発環境（ALLOW_LOCAL_ORIGINS）でのみ
+ * 許可される。事前ゲートと Origin ヘッダー検査の両方で同じ関数を使い、ゲートを
+ * 通過しても後段で拒否される経路（デッドコード）を作らない（#952 レビュー必須指摘）。
+ */
+function isLocalOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin)
+    // URL.hostname は IPv6 を [::1] の形式で返すため、比較前に角括弧を除去する
+    const hostname = url.hostname.replace(/^\[|\]$/g, '')
+
+    if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') {
+      return true
+    }
+
+    const localNetworkPatterns = [
+      /^192\.168\.\d+\.\d+$/,
+      /^10\.\d+\.\d+\.\d+$/,
+      /^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/,
+    ]
+
+    return localNetworkPatterns.some(pattern => pattern.test(hostname))
+  } catch {
+    return false
+  }
+}
+
+/**
  * CSRFトークンを生成 (Web Crypto API)
  */
 function generateCSRFToken(): string {
@@ -224,16 +252,24 @@ export async function validateCSRFToken(
   // host ヘッダーは Workers/OpenNext では必ず存在する。テスト環境（undici の
   // Request）では forbidden header のため取得できないので、その場合のみ
   // request.url の host へフォールバックする（本番のズレ対策は host 優先で成立）。
-  // スキームは request.url に依存せず、localhost / 127.0.0.1 のみ http、それ以外は
-  // https とする（request.url が http に再構成される環境でも全 API が fail-closed
-  // にならないようにする）。
-  const authority = (request.headers.get('host') ?? requestUrl.host).toLowerCase()
-  const isLoopback =
-    /^localhost(:\d+)?$/.test(authority) || /^127\.0\.0\.1(:\d+)?$/.test(authority)
-  const expectedOrigin = `${isLoopback ? 'http:' : 'https:'}//${authority}`
-  // ALLOWED_ORIGINS は単体テスト（example.com モック）との互換のため残す。
-  // 本番では isTrustedOrigin が NEXT_PUBLIC_APP_URL / workers.dev / ローカルを許可する。
-  if (!isTrustedOrigin(expectedOrigin) && !CSRF_CONFIG.ALLOWED_ORIGINS.includes(expectedOrigin)) {
+  // 空文字は fail-open になるので ?? ではなく || でフォールバックする。
+  // スキームは request.url に依存せず、ローカル origin（localhost / 127.0.0.1 /
+  // ::1 / プライベートレンジ）のみ http、それ以外は https とする（request.url が
+  // http に再構成される環境でも全 API が fail-closed にならないようにする）。
+  const authority = (request.headers.get('host') || requestUrl.host).toLowerCase()
+  const isLocal = isLocalOrigin(`http://${authority}`)
+  const expectedOrigin = `${isLocal ? 'http:' : 'https:'}//${authority}`
+  // 許可集合は後段の Origin ヘッダー検査と同一にする（#952 レビュー必須指摘）。
+  // isTrustedOrigin（workers.dev / カスタムドメイン / ローカル開発）と
+  // ALLOWED_ORIGINS（NEXT_PUBLIC_APP_URL / Vercel / 開発 localhost）に加え、
+  // ALLOW_LOCAL_ORIGINS が有効な環境では ::1 やプライベートレンジも許可する。
+  // これにより next dev -p 4000 や LAN IP 実機確認が事前ゲートで 403 になる退行を防ぐ。
+  const localAllowed = CSRF_CONFIG.ALLOW_LOCAL_ORIGINS && isLocal
+  if (
+    !isTrustedOrigin(expectedOrigin) &&
+    !CSRF_CONFIG.ALLOWED_ORIGINS.includes(expectedOrigin) &&
+    !localAllowed
+  ) {
     // expectedOrigin は外部入力（host ヘッダー）を含むため、制御文字除去・長さ制限を
     // してからログへ出す（url-utils と同じサニタイズ方針）。
     const sanitizedOrigin = expectedOrigin.replace(/[\u0000-\u001f\u007f]/g, '').slice(0, 128)
@@ -290,27 +326,6 @@ export async function validateCSRFToken(
   // Originヘッダーの検証（多層防御として）
   const origin = request.headers.get('origin')
   const referer = request.headers.get('referer')
-
-  function isLocalOrigin(origin: string): boolean {
-    try {
-      const url = new URL(origin)
-      const hostname = url.hostname
-      
-      if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') {
-        return true
-      }
-      
-      const localNetworkPatterns = [
-        /^192\.168\.\d+\.\d+$/,
-        /^10\.\d+\.\d+\.\d+$/,
-        /^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/,
-      ]
-      
-      return localNetworkPatterns.some(pattern => pattern.test(hostname))
-    } catch {
-      return false
-    }
-  }
 
   // リクエストURL自体のoriginと一致する場合は同一オリジンリクエストなので許可する
   // （例: workers.dev URLからのリクエストでNEXT_PUBLIC_APP_URLがカスタムドメインの場合）

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -282,21 +282,22 @@ export async function validateCSRFToken(
     }
   }
 
-  // Origin ヘッダーがある場合、リクエスト URL 自体が非許可 authority なら
-  // fail-closed にする（expectedOrigin は request.url 由来で攻撃者指定になり得るため、
-  // getBaseUrl と同じ trusted-origin 判定を通す。workers.dev はここで許可される）。
-  if (origin && !isTrustedOrigin(expectedOrigin) && !CSRF_CONFIG.ALLOWED_ORIGINS.includes(expectedOrigin)) {
+  // リクエスト URL 自体が非許可 authority なら fail-closed にする
+  // （expectedOrigin は request.url 由来で攻撃者指定になり得るため、getBaseUrl と
+  // 同じ trusted-origin 判定を通す。workers.dev はここで許可される。Origin/Referer
+  // の有無に関わらず常時判定する）。
+  if (!isTrustedOrigin(expectedOrigin) && !CSRF_CONFIG.ALLOWED_ORIGINS.includes(expectedOrigin)) {
     logger.warn('CSRF validation failed: request URL origin not trusted', {
       userId: session.twitchUserId,
       expectedOrigin,
       endpoint: sanitizeURL(request.url),
     })
-    return { valid: false, error: 'リクエストのオリジンが許可されていません' }
+    return { valid: false, error: ERROR_MESSAGES.CSRF_ORIGIN_NOT_TRUSTED }
   }
 
   // リクエストURL自体のoriginと一致する場合は同一オリジンリクエストなので許可する
   // （例: workers.dev URLからのリクエストでNEXT_PUBLIC_APP_URLがカスタムドメインの場合）
-  if (origin && origin !== expectedOrigin && !CSRF_CONFIG.ALLOWED_ORIGINS.includes(origin) && !isTrustedOrigin(origin)) {
+  if (origin && origin !== expectedOrigin && !CSRF_CONFIG.ALLOWED_ORIGINS.includes(origin)) {
     const isLocal = CSRF_CONFIG.ALLOW_LOCAL_ORIGINS && isLocalOrigin(origin)
 
     if (!isLocal) {

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -213,17 +213,21 @@ export async function validateCSRFToken(
     return { valid: false, error: 'セッションの有効期限が切れました。再度ログインしてください。' }
   }
 
-  // リクエスト URL 自体が非許可 authority なら fail-closed にする
-  // （expectedOrigin は request.url 由来で攻撃者指定になり得るため、getBaseUrl と
-  // 同じ trusted-origin 判定を通す。workers.dev はここで許可される。Origin/Referer
-  // の有無に関わらず常時判定し、不要なトークン生成・Cookie 書き込み・HMAC 計算を
-  // 避けるために session 取得直後に置く）。
+  // expectedOrigin は request.url ではなく host ヘッダーから解決する。
+  // request.url は OpenNext が再構成するため実機で公開 origin と一致する保証が無く、
+  // ズレると全 CSRF 保護 API が fail-closed で全滅する（#952 レビュー必須指摘）。
+  // host ヘッダーは getBaseUrl と同じ入力で本番実績があり、workers.dev /
+  // カスタムドメイン / ローカルを許可する。非許可 authority は fail-closed にする。
+  // Origin/Referer の有無に関わらず常時判定し、不要なトークン生成・Cookie 書き込み・
+  // HMAC 計算を避けるために session 取得直後に置く。
   const requestUrl = new URL(request.url)
-  const expectedOrigin = `${requestUrl.protocol}//${requestUrl.host}`
-  // ALLOWED_ORIGINS は本来「Origin ヘッダーの許可リスト」（Vercel 系も含む）だが、
-  // この OR が実効するのはローカル wrangler dev（NODE_ENV=production 相当で
-  // localhost:8787）の救済のみ。本番では isTrustedOrigin が NEXT_PUBLIC_APP_URL /
-  // workers.dev を許可するため、Vercel 系が信頼 authority へ昇格することはない。
+  // host ヘッダーは Workers/OpenNext では必ず存在する。テスト環境（undici の
+  // Request）では forbidden header のため取得できないので、その場合のみ
+  // request.url の host へフォールバックする（本番のズレ対策は host 優先で成立）。
+  const authority = request.headers.get('host') ?? requestUrl.host
+  const expectedOrigin = `${requestUrl.protocol}//${authority}`
+  // ALLOWED_ORIGINS は単体テスト（example.com モック）との互換のため残す。
+  // 本番では isTrustedOrigin が NEXT_PUBLIC_APP_URL / workers.dev / ローカルを許可する。
   if (!isTrustedOrigin(expectedOrigin) && !CSRF_CONFIG.ALLOWED_ORIGINS.includes(expectedOrigin)) {
     logger.warn('CSRF validation failed: request URL origin not trusted', {
       userId: session.twitchUserId,

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -33,6 +33,7 @@ import { logger } from './logger.server'
 import { reportSecurityError } from './sentry/error-handler'
 import { COOKIE_NAMES, CSRF_CONFIG, ERROR_MESSAGES, getSessionCookieOptions, getDeleteCookieOptions } from './constants'
 import { parseSession, signSession, type Session, verifySession } from './session'
+import { isTrustedOrigin } from './url-utils'
 
 export async function hashIP(ip: string | null): Promise<string> {
   if (!ip) return 'unknown'
@@ -281,9 +282,21 @@ export async function validateCSRFToken(
     }
   }
 
+  // Origin ヘッダーがある場合、リクエスト URL 自体が非許可 authority なら
+  // fail-closed にする（expectedOrigin は request.url 由来で攻撃者指定になり得るため、
+  // getBaseUrl と同じ trusted-origin 判定を通す。workers.dev はここで許可される）。
+  if (origin && !isTrustedOrigin(expectedOrigin) && !CSRF_CONFIG.ALLOWED_ORIGINS.includes(expectedOrigin)) {
+    logger.warn('CSRF validation failed: request URL origin not trusted', {
+      userId: session.twitchUserId,
+      expectedOrigin,
+      endpoint: sanitizeURL(request.url),
+    })
+    return { valid: false, error: 'リクエストのオリジンが許可されていません' }
+  }
+
   // リクエストURL自体のoriginと一致する場合は同一オリジンリクエストなので許可する
   // （例: workers.dev URLからのリクエストでNEXT_PUBLIC_APP_URLがカスタムドメインの場合）
-  if (origin && origin !== expectedOrigin && !CSRF_CONFIG.ALLOWED_ORIGINS.includes(origin)) {
+  if (origin && origin !== expectedOrigin && !CSRF_CONFIG.ALLOWED_ORIGINS.includes(origin) && !isTrustedOrigin(origin)) {
     const isLocal = CSRF_CONFIG.ALLOW_LOCAL_ORIGINS && isLocalOrigin(origin)
 
     if (!isLocal) {

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -224,14 +224,22 @@ export async function validateCSRFToken(
   // host ヘッダーは Workers/OpenNext では必ず存在する。テスト環境（undici の
   // Request）では forbidden header のため取得できないので、その場合のみ
   // request.url の host へフォールバックする（本番のズレ対策は host 優先で成立）。
-  const authority = request.headers.get('host') ?? requestUrl.host
-  const expectedOrigin = `${requestUrl.protocol}//${authority}`
+  // スキームは request.url に依存せず、localhost / 127.0.0.1 のみ http、それ以外は
+  // https とする（request.url が http に再構成される環境でも全 API が fail-closed
+  // にならないようにする）。
+  const authority = (request.headers.get('host') ?? requestUrl.host).toLowerCase()
+  const isLoopback =
+    /^localhost(:\d+)?$/.test(authority) || /^127\.0\.0\.1(:\d+)?$/.test(authority)
+  const expectedOrigin = `${isLoopback ? 'http:' : 'https:'}//${authority}`
   // ALLOWED_ORIGINS は単体テスト（example.com モック）との互換のため残す。
   // 本番では isTrustedOrigin が NEXT_PUBLIC_APP_URL / workers.dev / ローカルを許可する。
   if (!isTrustedOrigin(expectedOrigin) && !CSRF_CONFIG.ALLOWED_ORIGINS.includes(expectedOrigin)) {
+    // expectedOrigin は外部入力（host ヘッダー）を含むため、制御文字除去・長さ制限を
+    // してからログへ出す（url-utils と同じサニタイズ方針）。
+    const sanitizedOrigin = expectedOrigin.replace(/[\u0000-\u001f\u007f]/g, '').slice(0, 128)
     logger.warn('CSRF validation failed: request URL origin not trusted', {
       userId: session.twitchUserId,
-      expectedOrigin,
+      expectedOrigin: sanitizedOrigin,
       endpoint: sanitizeURL(request.url),
     })
     return { valid: false, error: ERROR_MESSAGES.CSRF_ORIGIN_NOT_TRUSTED }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -21,11 +21,6 @@ import { sanitizeLogArg } from './log-sanitizer'
  * developer-authored strings and are assumed not to contain secrets.
  */
 export const logger = {
-  debug: (message: string, ...args: unknown[]) => {
-    // Workers Logs のコスト抑制のため、検知シグナルとしては重要だが毎回の出力が
-    // 不要な経路（非許可 Host のフォールバック等）は debug で残す（#950）。
-    console.debug(`[DEBUG] ${message}`, ...args.map(sanitizeLogArg))
-  },
   info: (message: string, ...args: unknown[]) => {
     console.log(`[INFO] ${message}`, ...args.map(sanitizeLogArg))
   },

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -21,6 +21,11 @@ import { sanitizeLogArg } from './log-sanitizer'
  * developer-authored strings and are assumed not to contain secrets.
  */
 export const logger = {
+  debug: (message: string, ...args: unknown[]) => {
+    // Workers Logs のコスト抑制のため、検知シグナルとしては重要だが毎回の出力が
+    // 不要な経路（非許可 Host のフォールバック等）は debug で残す（#950）。
+    console.debug(`[DEBUG] ${message}`, ...args.map(sanitizeLogArg))
+  },
   info: (message: string, ...args: unknown[]) => {
     console.log(`[INFO] ${message}`, ...args.map(sanitizeLogArg))
   },

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -5,7 +5,7 @@ import { SECURITY_HEADERS } from './constants'
  * script-src / connect-src 以外は全 variant 共通のため、1箇所の表から組み立てる
  * （文字列の三重複による乖離を防ぐ）。
  */
-function composeCsp(scriptSrc: string, connectSrc: string): string {
+function composeCsp(scriptSrc: string, connectSrc: string, frameAncestors: string): string {
   return [
     "default-src 'self'",
     "base-uri 'self'",
@@ -18,32 +18,8 @@ function composeCsp(scriptSrc: string, connectSrc: string): string {
     "worker-src 'self' blob:",
     "object-src 'none'",
     "form-action 'self'",
+    `frame-ancestors ${frameAncestors}`,
   ].join('; ') + ';'
-}
-
-/**
- * frame-ancestors は pathname 依存で付与する。frame-ancestors を含むポリシーが
- * 配信されると UA は X-Frame-Options を無視するため、全ルートに 'self' を付けると
- * DENY が実効的に緩和される（#952 レビュー必須指摘）。
- * - overlay ルート: 同一オリジン iframe 埋め込みを許可（X-Frame-Options SAMEORIGIN と同値）
- * - その他: 'none'（X-Frame-Options DENY と同値）
- * X-Frame-Options も併記し続けるのは、CSP Level 2 非対応の旧 UA 向けフォールバック。
- */
-function withFrameAncestors(csp: string, pathname?: string): string {
-  const directive = isOverlayPath(pathname)
-    ? "frame-ancestors 'self'"
-    : "frame-ancestors 'none'"
-  // csp は外部から渡せる引数のため、';' 終端を仮定せず正規化し、既存の
-  // frame-ancestors を除去してから付与する（CSP は重複 directive が先勝ちのため、
-  // 入力に残っていると overlay 用の 'self' が黙って無効化される）。
-  const base = csp
-    .replace(/;\s*$/, '')
-    .split(';')
-    .map((d) => d.trim())
-    // CSP の directive 名は case-insensitive のため、大小を問わず除去する
-    .filter((d) => d && !d.toLowerCase().startsWith('frame-ancestors'))
-    .join('; ')
-  return `${base}; ${directive};`
 }
 
 /** overlay ルート（同一オリジン iframe 埋め込みを許可する）の判定を1箇所に集約。 */
@@ -68,7 +44,13 @@ function isOverlayPath(pathname?: string): boolean {
  *   'unsafe-inline' は付けず、strict-dynamic も無いため host-source は有効
  *   （JSON エラー応答はスクリプトを含まず実害なし）。
  */
-export function buildCsp(nonce?: string): string {
+export function buildCsp(nonce?: string, pathname?: string): string {
+  // frame-ancestors は pathname 依存で付与する。frame-ancestors を含むポリシーが
+  // 配信されると UA は X-Frame-Options を無視するため、全ルートに 'self' を付けると
+  // DENY が実効的に緩和される。overlay は同一オリジン iframe 埋め込みを許可
+  // （X-Frame-Options SAMEORIGIN と同値）、その他は 'none'（DENY と同値）。
+  // X-Frame-Options も併記し続けるのは、CSP Level 2 非対応の旧 UA 向けフォールバック。
+  const frameAncestors = isOverlayPath(pathname) ? "'self'" : "'none'"
   const isProduction = process.env.NODE_ENV === 'production'
   if (isProduction) {
     // CSP Level 2 対応ブラウザは nonce を外部スクリプトにも適用するため、beacon に
@@ -77,7 +59,7 @@ export function buildCsp(nonce?: string): string {
     const scriptSrc = nonce
       ? `'self' 'nonce-${nonce}' 'strict-dynamic'`
       : `'self' https://static.cloudflareinsights.com`
-    return composeCsp(scriptSrc, "'self' https: wss:")
+    return composeCsp(scriptSrc, "'self' https: wss:", frameAncestors)
   }
   // 開発環境でも nonce 経路を再現できるよう、nonce があれば script-src へ含める
   // （Next.js fast refresh 用の unsafe-eval / インライン用の unsafe-inline は維持）。
@@ -87,7 +69,7 @@ export function buildCsp(nonce?: string): string {
   const scriptSrc = nonce
     ? `'self' 'nonce-${nonce}' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com`
     : `'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com`
-  return composeCsp(scriptSrc, "'self' https: localhost:* wss:")
+  return composeCsp(scriptSrc, "'self' https: localhost:* wss:", frameAncestors)
 }
 
 /**
@@ -118,7 +100,7 @@ export function setSecurityHeaders(
 
   // 空文字列の csp は「無制限 CSP」と同義になるため || でフォールバックする
   // （?? だと空文字が素通しになり fail-open）。
-  response.headers.set('Content-Security-Policy', withFrameAncestors(csp || buildCsp(), pathname))
+  response.headers.set('Content-Security-Policy', csp || buildCsp(undefined, pathname))
 
   if (process.env.NODE_ENV === 'production') {
     response.headers.set('Strict-Transport-Security', SECURITY_HEADERS.HSTS)

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -40,7 +40,8 @@ function withFrameAncestors(csp: string, pathname?: string): string {
     .replace(/;\s*$/, '')
     .split(';')
     .map((d) => d.trim())
-    .filter((d) => d && !d.startsWith('frame-ancestors'))
+    // CSP の directive 名は case-insensitive のため、大小を問わず除去する
+    .filter((d) => d && !d.toLowerCase().startsWith('frame-ancestors'))
     .join('; ')
   return `${base}; ${directive};`
 }

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -33,14 +33,24 @@ function withFrameAncestors(csp: string, pathname?: string): string {
   const directive = isOverlayPath(pathname)
     ? "frame-ancestors 'self'"
     : "frame-ancestors 'none'"
-  // csp は外部から渡せる引数のため、';' 終端を仮定せず正規化してから連結する
-  // （終端なしだと直前 directive の値へ融合し frame-ancestors が無効化される）。
-  return `${csp.replace(/;\s*$/, '')}; ${directive};`
+  // csp は外部から渡せる引数のため、';' 終端を仮定せず正規化し、既存の
+  // frame-ancestors を除去してから付与する（CSP は重複 directive が先勝ちのため、
+  // 入力に残っていると overlay 用の 'self' が黙って無効化される）。
+  const base = csp
+    .replace(/;\s*$/, '')
+    .split(';')
+    .map((d) => d.trim())
+    .filter((d) => d && !d.startsWith('frame-ancestors'))
+    .join('; ')
+  return `${base}; ${directive};`
 }
 
 /** overlay ルート（同一オリジン iframe 埋め込みを許可する）の判定を1箇所に集約。 */
 function isOverlayPath(pathname?: string): boolean {
-  return pathname?.startsWith('/overlay') ?? false
+  if (!pathname) return false
+  // フレーム許可は緩和側の判定のため、前方一致ではなくルート境界で判定する
+  // （/overlay-foo や /overlays は対象外）。
+  return pathname === '/overlay' || pathname.startsWith('/overlay/')
 }
 
 /**
@@ -95,6 +105,7 @@ export function setSecurityHeaders(
 ): NextResponse {
   const { pathname, csp } = options ?? {}
   response.headers.set('X-Content-Type-Options', SECURITY_HEADERS.X_CONTENT_TYPE_OPTIONS)
+  response.headers.set('X-XSS-Protection', SECURITY_HEADERS.X_XSS_PROTECTION)
 
   // overlay ルートは同一オリジンからの iframe 埋め込みを許可（プレビュー機能用）
   // Allow same-origin iframe embedding for overlay routes (for preview functionality)

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -27,12 +27,20 @@ function composeCsp(scriptSrc: string, connectSrc: string): string {
  * DENY が実効的に緩和される（#952 レビュー必須指摘）。
  * - overlay ルート: 同一オリジン iframe 埋め込みを許可（X-Frame-Options SAMEORIGIN と同値）
  * - その他: 'none'（X-Frame-Options DENY と同値）
+ * X-Frame-Options も併記し続けるのは、CSP Level 2 非対応の旧 UA 向けフォールバック。
  */
 function withFrameAncestors(csp: string, pathname?: string): string {
-  const directive = pathname?.startsWith('/overlay')
+  const directive = isOverlayPath(pathname)
     ? "frame-ancestors 'self'"
     : "frame-ancestors 'none'"
-  return `${csp}${directive};`
+  // csp は外部から渡せる引数のため、';' 終端を仮定せず正規化してから連結する
+  // （終端なしだと直前 directive の値へ融合し frame-ancestors が無効化される）。
+  return `${csp.replace(/;\s*$/, '')}; ${directive};`
+}
+
+/** overlay ルート（同一オリジン iframe 埋め込みを許可する）の判定を1箇所に集約。 */
+function isOverlayPath(pathname?: string): boolean {
+  return pathname?.startsWith('/overlay') ?? false
 }
 
 /**
@@ -90,7 +98,7 @@ export function setSecurityHeaders(
 
   // overlay ルートは同一オリジンからの iframe 埋め込みを許可（プレビュー機能用）
   // Allow same-origin iframe embedding for overlay routes (for preview functionality)
-  if (pathname?.startsWith('/overlay')) {
+  if (isOverlayPath(pathname)) {
     response.headers.set('X-Frame-Options', 'SAMEORIGIN')
   } else {
     response.headers.set('X-Frame-Options', SECURITY_HEADERS.X_FRAME_OPTIONS)

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -3,7 +3,7 @@ import { SECURITY_HEADERS } from './constants'
 
 /**
  * script-src / connect-src 以外は全 variant 共通のため、1箇所の表から組み立てる
- * （#944 レビュー指摘: 文字列の三重複による乖離を防ぐ）。
+ * （文字列の三重複による乖離を防ぐ）。
  */
 function composeCsp(scriptSrc: string, connectSrc: string): string {
   return [
@@ -18,6 +18,9 @@ function composeCsp(scriptSrc: string, connectSrc: string): string {
     "worker-src 'self' blob:",
     "object-src 'none'",
     "form-action 'self'",
+    // overlay は同一オリジン iframe 埋め込みのみ許可（X-Frame-Options SAMEORIGIN と
+    // 同じ意味。frame-ancestors は CSP ヘッダーのみ有効で meta では無効）。
+    "frame-ancestors 'self'",
   ].join('; ') + ';'
 }
 
@@ -40,8 +43,7 @@ export function buildCsp(nonce?: string): string {
   if (isProduction) {
     // CSP Level 2 対応ブラウザは nonce を外部スクリプトにも適用するため、beacon に
     // nonce を渡している以上（layout.tsx）読み込める。beacon だけが落ちるのは
-    // nonce 自体を解さない CSP Level 1 のみ。影響はアナリティクス欠損のみで許容する
-    // （#949 レビュー任意指摘。判断根拠として nonce 分岐の直近に残す）。
+    // nonce 自体を解さない CSP Level 1 のみ。影響はアナリティクス欠損のみで許容する。
     const scriptSrc = nonce
       ? `'self' 'nonce-${nonce}' 'strict-dynamic'`
       : `'self' https://static.cloudflareinsights.com`
@@ -51,7 +53,7 @@ export function buildCsp(nonce?: string): string {
   // （Next.js fast refresh 用の unsafe-eval / インライン用の unsafe-inline は維持）。
   // 注記: CSP 仕様上 nonce-source があると script-src の 'unsafe-inline' は無視される
   // ため、dev の nonce あり経路は実質 nonce ベースになる（Next.js が nonce を
-  // 伝播するため実害はない。コメントは誤解を避けるための補足、#949 レビュー任意指摘）。
+  // 伝播するため実害はない。コメントは誤解を避けるための補足）。
   const scriptSrc = nonce
     ? `'self' 'nonce-${nonce}' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com`
     : `'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com`
@@ -62,17 +64,17 @@ export function buildCsp(nonce?: string): string {
  * Set security headers on response
  * レスポンスにセキュリティヘッダーを設定
  * @param response - NextResponse object to modify
- * @param pathname - Request pathname (optional, used for route-specific headers)
- * @param csp - 生成済み CSP 文字列（省略時は buildCsp() で nonce なしを組み立てる）。
- *   middleware はリクエストごとに 1 回だけ buildCsp(nonce) を呼び、request ヘッダーと
- *   response ヘッダーの両方へ同じ csp を渡す（nonce 契約、#836）。呼び出し側で
- *   buildCsp を再実行しないことで nonce と CSP の二重真実源を避ける（#949 レビュー）。
+ * @param options - pathname（route 別ヘッダー用）と生成済み CSP 文字列。
+ *   csp 省略時は buildCsp() で nonce なしを組み立てる。middleware はリクエストごとに
+ *   1 回だけ buildCsp(nonce) を呼び、request / response 両ヘッダーへ同じ csp を渡す
+ *   （nonce 契約）。引数をオブジェクトにしたのは、csp の位置に nonce 文字列を渡す
+ *   誤用をコンパイラで弾くため（string のままの第3引数は意味の取り違えが検出不能）。
  */
 export function setSecurityHeaders(
   response: NextResponse,
-  pathname?: string,
-  csp?: string
+  options?: { pathname?: string; csp?: string }
 ): NextResponse {
+  const { pathname, csp } = options ?? {}
   response.headers.set('X-Content-Type-Options', SECURITY_HEADERS.X_CONTENT_TYPE_OPTIONS)
 
   // overlay ルートは同一オリジンからの iframe 埋め込みを許可（プレビュー機能用）
@@ -83,10 +85,8 @@ export function setSecurityHeaders(
     response.headers.set('X-Frame-Options', SECURITY_HEADERS.X_FRAME_OPTIONS)
   }
 
-  response.headers.set('X-XSS-Protection', SECURITY_HEADERS.X_XSS_PROTECTION)
-
   // 空文字列の csp は「無制限 CSP」と同義になるため || でフォールバックする
-  // （?? だと空文字が素通しになり fail-open、#949 レビュー任意指摘3）。
+  // （?? だと空文字が素通しになり fail-open）。
   response.headers.set('Content-Security-Policy', csp || buildCsp())
 
   if (process.env.NODE_ENV === 'production') {

--- a/src/lib/security-headers.ts
+++ b/src/lib/security-headers.ts
@@ -18,10 +18,21 @@ function composeCsp(scriptSrc: string, connectSrc: string): string {
     "worker-src 'self' blob:",
     "object-src 'none'",
     "form-action 'self'",
-    // overlay は同一オリジン iframe 埋め込みのみ許可（X-Frame-Options SAMEORIGIN と
-    // 同じ意味。frame-ancestors は CSP ヘッダーのみ有効で meta では無効）。
-    "frame-ancestors 'self'",
   ].join('; ') + ';'
+}
+
+/**
+ * frame-ancestors は pathname 依存で付与する。frame-ancestors を含むポリシーが
+ * 配信されると UA は X-Frame-Options を無視するため、全ルートに 'self' を付けると
+ * DENY が実効的に緩和される（#952 レビュー必須指摘）。
+ * - overlay ルート: 同一オリジン iframe 埋め込みを許可（X-Frame-Options SAMEORIGIN と同値）
+ * - その他: 'none'（X-Frame-Options DENY と同値）
+ */
+function withFrameAncestors(csp: string, pathname?: string): string {
+  const directive = pathname?.startsWith('/overlay')
+    ? "frame-ancestors 'self'"
+    : "frame-ancestors 'none'"
+  return `${csp}${directive};`
 }
 
 /**
@@ -87,7 +98,7 @@ export function setSecurityHeaders(
 
   // 空文字列の csp は「無制限 CSP」と同義になるため || でフォールバックする
   // （?? だと空文字が素通しになり fail-open）。
-  response.headers.set('Content-Security-Policy', csp || buildCsp())
+  response.headers.set('Content-Security-Policy', withFrameAncestors(csp || buildCsp(), pathname))
 
   if (process.env.NODE_ENV === 'production') {
     response.headers.set('Strict-Transport-Security', SECURITY_HEADERS.HSTS)

--- a/src/lib/url-utils.ts
+++ b/src/lib/url-utils.ts
@@ -86,6 +86,10 @@ export function isTrustedOrigin(origin: string): boolean {
   } catch {
     return false
   }
+  // origin 文字列（scheme+host+port）だけを受理する（path や userinfo 付きは拒否）
+  if (url.origin !== origin) {
+    return false
+  }
   const normalizedHost = url.host.toLowerCase()
 
   // ローカル開発は host ヘッダーのみで判定。この分岐は NODE_ENV !== 'production'
@@ -142,11 +146,10 @@ export function resolveAllowedOrigin(host: string | null): string {
   }
 
   // 許可外ホストを無言でフォールバックすると、NEXT_PUBLIC_APP_URL と実配信ホストの
-  // ズレに気付けず OAuth が全滅する。Cloudflare は Host でルーティングするため大量
-  // 発生はしにくいが、Workers Logs のコストを抑えるため debug で手掛かりを残す。
+  // ズレに気付けず OAuth が全滅する。warn ログで手掛かりを残す。
   // host は外部入力のため、制御文字を除去し長さを制限してから出力する（ログ汚染対策）。
   const sanitizedHost = host.replace(/[\u0000-\u001f\u007f]/g, '').slice(0, 128)
-  logger.debug(`[url-utils] Disallowed host detected, falling back to NEXT_PUBLIC_APP_URL: ${sanitizedHost}`)
+  logger.warn(`[url-utils] Disallowed host detected, falling back to NEXT_PUBLIC_APP_URL: ${sanitizedHost}`)
   return fallbackOrigin
 }
 

--- a/src/lib/url-utils.ts
+++ b/src/lib/url-utils.ts
@@ -35,29 +35,22 @@ const WORKERS_DEV_ACCOUNT_SUBDOMAIN = '.tsubasa-azumagakito.workers.dev'
 /**
  * workers.dev の host がこのアカウントの twica 系 Worker に属するか判定する。
  * アカウント専有サブドメインであるため第三者は偽装できないが、不正な Host
- * （空白・記号入り）が誤って通ると呼び出し側の `new URL()` が 500 になる。
- * 文字種を検証して fail-closed にする（#944 レビュー任意指摘）。
+ * （空白・記号・userinfo 混入）が誤って通ると、呼び出し側の `new URL()` が
+ * 500 になるか origin が別ホストへすり替わる。文字種を検証して fail-closed にする。
  */
 function isTwicaWorkersDevHost(normalizedHost: string): boolean {
-  // ホスト全体がドット区切りの label（[a-z0-9-]+）で構成されることを確認する。
   // endsWith だけだと `twica.preview@evil.tsubasa-...` のような userinfo 混入が
-  // 末尾一致で通過し、呼び出し側の `new URL()` が 500 になる（#949 レビューで
-  // 先頭 label 限定を試したが、@ が末尾より前に置けるため全体検証が必須と判明）。
+  // 末尾一致で通過するため、ホスト全体がドット区切り label であることを確認する。
   if (!/^[a-z0-9-]+(\.[a-z0-9-]+)+$/.test(normalizedHost)) {
     return false
   }
   if (!normalizedHost.endsWith(WORKERS_DEV_ACCOUNT_SUBDOMAIN)) {
     return false
   }
-  const workerLabel = normalizedHost.split('.')[0]
-  if (!/^[a-z0-9-]+$/.test(workerLabel)) {
-    return false
-  }
   // worker 名（先頭 label）に twica を含む。Workers Builds は
-  // `<version>-twica-preview` / `<branch>-twica-preview` の形でサブドメインを
-  // 生成するため、先頭 label のみ確認すれば十分（アカウント専有のため部分一致でも
-  // 実害はなく、逆に将来のプレフィックス形式を壊さない）。
-  return workerLabel.includes('twica')
+  // `<version>-twica-preview` / `<branch>-twica-preview` の形でサブドメインを生成する。
+  // 全体の文字種検証が済んでいるため先頭 label の再検証は不要。
+  return normalizedHost.split('.')[0].includes('twica')
 }
 
 /** フォールバック先の origin を解決する。production で未設定/不正なら fail-loud。 */
@@ -82,10 +75,45 @@ function resolveFallbackOrigin(): string {
 }
 
 /**
+ * origin 文字列（scheme+host+port）がこのアプリの正規 origin か判定する。
+ * getBaseUrl と同じ allowlist 判定を CSRF 検証（src/lib/csrf.ts）と共有し、
+ * 非許可 authority からの状態変更リクエストを fail-closed にする（#950）。
+ */
+export function isTrustedOrigin(origin: string): boolean {
+  let url: URL
+  try {
+    url = new URL(origin)
+  } catch {
+    return false
+  }
+  const normalizedHost = url.host.toLowerCase()
+
+  // ローカル開発は host ヘッダーのみで判定。この分岐は NODE_ENV !== 'production'
+  // （next dev / vitest）でだけ通り、npm run dev（wrangler dev）は production 相当。
+  if (process.env.NODE_ENV !== 'production' && LOCAL_DEV_ORIGINS.has(url.origin)) {
+    return true
+  }
+  // workers.dev は常に https
+  if (url.protocol === 'https:' && isTwicaWorkersDevHost(normalizedHost)) {
+    return true
+  }
+  // カスタムドメイン（NEXT_PUBLIC_APP_URL）
+  const fallback = process.env.NEXT_PUBLIC_APP_URL
+  if (fallback) {
+    try {
+      if (url.origin === new URL(fallback).origin) return true
+    } catch {
+      // NEXT_PUBLIC_APP_URL が不正な場合は workers.dev 判定のみで fail-closed
+    }
+  }
+  return false
+}
+
+/**
  * リクエストから正規化された許可 origin を解決する。
  * 許可 origin（ローカル開発 / カスタムドメイン / workers.dev）に一致する host のみ採用し、
  * それ以外は NEXT_PUBLIC_APP_URL の origin を返す（fail-closed）。port を含む完全一致で
- * 検証するため、許可ホストに任意ポートを付けた偽装を拒否する（#836 レビュー指摘）。
+ * 検証するため、許可ホストに任意ポートを付けた偽装を拒否する。
  *
  * NEXT_PUBLIC_APP_URL の解決は allowlist 判定後の遅延評価。production で設定漏れが
  * あっても workers.dev からの正規アクセスは維持される（ビルド設定漏れに備えた二重防御）。
@@ -94,12 +122,8 @@ export function resolveAllowedOrigin(host: string | null): string {
   if (!host) return resolveFallbackOrigin()
 
   const normalizedHost = host.toLowerCase()
-  // ローカル開発は host ヘッダーのみで判定。この分岐は `dev:next`（next dev）で
-  // NODE_ENV=development のときにだけ通り、`npm run dev`（wrangler dev）は next build
-  // 済みバンドルを実行するため production 相当になり通らない。:8787 は wrangler dev
-  // のポートだが、この分岐が通るのは next dev の既定 3000 のみ（-p 8787 等の指定を
-  // 含めて両ポートを残す）。production ビルドでは localhost を許可しない
-  // （Host ヘッダ注入の抜け穴を塞ぐ）。
+  // ローカル開発は host ヘッダーのみで判定（LOCAL_DEV_ORIGINS 完全一致のみ許可）。
+  // production ビルドでは localhost を許可しない（Host ヘッダ注入の抜け穴を塞ぐ）。
   if (process.env.NODE_ENV !== 'production') {
     const localOrigin = `http://${normalizedHost}`
     if (LOCAL_DEV_ORIGINS.has(localOrigin)) return localOrigin
@@ -118,10 +142,11 @@ export function resolveAllowedOrigin(host: string | null): string {
   }
 
   // 許可外ホストを無言でフォールバックすると、NEXT_PUBLIC_APP_URL と実配信ホストの
-  // ズレに気付けず OAuth が全滅する（#836 レビュー指摘）。warn ログで手掛かりを残す。
+  // ズレに気付けず OAuth が全滅する。Cloudflare は Host でルーティングするため大量
+  // 発生はしにくいが、Workers Logs のコストを抑えるため debug で手掛かりを残す。
   // host は外部入力のため、制御文字を除去し長さを制限してから出力する（ログ汚染対策）。
   const sanitizedHost = host.replace(/[\u0000-\u001f\u007f]/g, '').slice(0, 128)
-  logger.warn(`[url-utils] Disallowed host detected, falling back to NEXT_PUBLIC_APP_URL: ${sanitizedHost}`)
+  logger.debug(`[url-utils] Disallowed host detected, falling back to NEXT_PUBLIC_APP_URL: ${sanitizedHost}`)
   return fallbackOrigin
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -178,7 +178,7 @@ export async function middleware(request: NextRequest) {
   const requestHeaders = new Headers(request.headers)
   // CPU 課金抑制のため CSP 文字列はリクエストごとに 1 回だけ生成し、
   // request ヘッダーとレスポンスヘッダーの両方へ渡す（nonce 契約）。
-  const csp = buildCsp(nonce)
+  const csp = buildCsp(nonce, pathname)
   requestHeaders.set('x-nonce', nonce)
   requestHeaders.set('Content-Security-Policy', csp)
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -100,7 +100,7 @@ const RATE_LIMIT_EXCLUDED_PATHS = [
 // 機密情報を返さない・セッション非依存のエンドポイントのみを許可する。
 // 警告: ここへ HTML を返すパスを追加してはならない。エッジキャッシュに nonce 付き
 // CSP が焼き付き、キャッシュ HIT 中の全スクリプトが nonce 不一致でブロックされる
-// （#944 レビュー任意指摘。現状の対象は JSON のみで無害）。
+// （現状の対象は JSON のみで無害）。
 const CACHEABLE_PUBLIC_PATHS = ['/api/maintenance-status']
 
 /**
@@ -152,7 +152,7 @@ export async function middleware(request: NextRequest) {
   // updateSession 等の余分な I/O を一切発生させないため。
   const maintenanceBlockResponse = checkMaintenanceWriteBlock(request)
   if (maintenanceBlockResponse) {
-    return setSecurityHeaders(maintenanceBlockResponse, pathname)
+    return setSecurityHeaders(maintenanceBlockResponse, { pathname })
   }
 
   // Issue #657: 不正な streamerId をDBクエリへ渡す前に拒否する。
@@ -163,7 +163,7 @@ export async function middleware(request: NextRequest) {
       { error: 'Invalid streamer ID' },
       { status: 400 }
     )
-    return setSecurityHeaders(errorResponse, pathname)
+    return setSecurityHeaders(errorResponse, { pathname })
   }
 
   // #836 項目5: リクエストごとに CSP nonce を発行する。
@@ -177,7 +177,7 @@ export async function middleware(request: NextRequest) {
   const nonce = crypto.randomUUID()
   const requestHeaders = new Headers(request.headers)
   // CPU 課金抑制のため CSP 文字列はリクエストごとに 1 回だけ生成し、
-  // request ヘッダーとレスポンスヘッダーの両方へ渡す（#949 レビュー任意指摘）。
+  // request ヘッダーとレスポンスヘッダーの両方へ渡す（nonce 契約）。
   const csp = buildCsp(nonce)
   requestHeaders.set('x-nonce', nonce)
   requestHeaders.set('Content-Security-Policy', csp)
@@ -185,7 +185,7 @@ export async function middleware(request: NextRequest) {
   const response = await updateSession(request, requestHeaders)
   // パスに基づいて適切なセキュリティヘッダーを設定
   // Set appropriate security headers based on the path
-  setSecurityHeaders(response, pathname, csp)
+  setSecurityHeaders(response, { pathname, csp })
 
   // Detect and set locale for server components
   // サーバーコンポーネント用にロケールを検出・設定
@@ -208,7 +208,7 @@ export async function middleware(request: NextRequest) {
   // realtime-config はルート側で `public, max-age=15, stale-while-revalidate=15` を
   // 明示する意図的な短 TTL キャッシュ対象（オーバーレイのバージョン確認）。
   // 警告: ここも HTML を返すパスを追加してはならない（CACHEABLE_PUBLIC_PATHS と
-  // 同じ理由で nonce がエッジキャッシュに焼き付く、#949 レビュー任意指摘）。
+  // 同じ理由で nonce がエッジキャッシュに焼き付く）。
   const isCacheablePublicPath =
     CACHEABLE_PUBLIC_PATHS.some((path) => pathname.startsWith(path)) ||
     (pathname.startsWith('/api/overlay/') &&
@@ -256,7 +256,7 @@ export async function middleware(request: NextRequest) {
           }
         )
 
-        return setSecurityHeaders(errorResponse, pathname, csp)
+        return setSecurityHeaders(errorResponse, { pathname, csp })
       }
     }
 

--- a/tests/unit/csrf.test.ts
+++ b/tests/unit/csrf.test.ts
@@ -460,6 +460,89 @@ describe('CSRF Protection', () => {
       expect(result.valid).toBe(true)
     })
 
+    it('should accept request from trusted workers.dev origin (#950)', async () => {
+      const token = 'a'.repeat(64)
+      const tokenHash = await hashToken(token)
+      const sessionData = {
+        twitchUserId: 'user123',
+        twitchUsername: 'testuser',
+        twitchDisplayName: 'Test User',
+        twitchProfileImageUrl: 'https://example.com/image.png',
+        broadcasterType: 'affiliate',
+        expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+        csrfTokenHash: tokenHash,
+        version: 1
+      }
+      const mockCookieStore = createMockCookieStore({
+        get: vi.fn((name) => {
+          if (name === COOKIE_NAMES.SESSION) {
+            return { value: JSON.stringify(sessionData) }
+          }
+          if (name === COOKIE_NAMES.CSRF_TOKEN) {
+            return { value: token }
+          }
+          return undefined
+        }),
+        set: vi.fn(),
+      })
+      mockCookies.mockResolvedValue(mockCookieStore as any)
+
+      // Origin は forbidden header のため headers.get をスパイして注入する
+      const request = new Request('https://twica-preview.tsubasa-azumagakito.workers.dev')
+      const getSpy = vi.spyOn(request.headers, 'get').mockImplementation((name) => {
+        if (name === 'origin') return 'https://twica-preview.tsubasa-azumagakito.workers.dev'
+        if (name === 'referer') return null
+        return null
+      })
+
+      const result = await validateCSRFToken(request)
+
+      expect(result.valid).toBe(true)
+      getSpy.mockRestore()
+    })
+
+    it('should reject request URL from untrusted authority even with matching origin header (#950)', async () => {
+      const token = 'a'.repeat(64)
+      const tokenHash = await hashToken(token)
+      const sessionData = {
+        twitchUserId: 'user123',
+        twitchUsername: 'testuser',
+        twitchDisplayName: 'Test User',
+        twitchProfileImageUrl: 'https://example.com/image.png',
+        broadcasterType: 'affiliate',
+        expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+        csrfTokenHash: tokenHash,
+        version: 1
+      }
+      const mockCookieStore = createMockCookieStore({
+        get: vi.fn((name) => {
+          if (name === COOKIE_NAMES.SESSION) {
+            return { value: JSON.stringify(sessionData) }
+          }
+          if (name === COOKIE_NAMES.CSRF_TOKEN) {
+            return { value: token }
+          }
+          return undefined
+        }),
+        set: vi.fn(),
+      })
+      mockCookies.mockResolvedValue(mockCookieStore as any)
+
+      // Origin は forbidden header のため headers.get をスパイして注入する
+      const request = new Request('https://evil.example.com')
+      const getSpy = vi.spyOn(request.headers, 'get').mockImplementation((name) => {
+        if (name === 'origin') return 'https://evil.example.com'
+        if (name === 'referer') return null
+        return null
+      })
+
+      const result = await validateCSRFToken(request)
+
+      expect(result.valid).toBe(false)
+      expect(result.error).toBe('リクエストのオリジンが許可されていません')
+      getSpy.mockRestore()
+    })
+
     it('should reject invalid origin header', async () => {
       const token = 'a'.repeat(64)
       const tokenHash = await hashToken(token)

--- a/tests/unit/csrf.test.ts
+++ b/tests/unit/csrf.test.ts
@@ -487,18 +487,11 @@ describe('CSRF Protection', () => {
       })
       mockCookies.mockResolvedValue(mockCookieStore as any)
 
-      // Origin は forbidden header のため headers.get をスパイして注入する
       const request = new Request('https://twica-preview.tsubasa-azumagakito.workers.dev')
-      const getSpy = vi.spyOn(request.headers, 'get').mockImplementation((name) => {
-        if (name === 'origin') return 'https://twica-preview.tsubasa-azumagakito.workers.dev'
-        if (name === 'referer') return null
-        return null
-      })
 
       const result = await validateCSRFToken(request)
 
       expect(result.valid).toBe(true)
-      getSpy.mockRestore()
     })
 
     it('should reject request URL from untrusted authority even with matching origin header (#950)', async () => {
@@ -528,19 +521,12 @@ describe('CSRF Protection', () => {
       })
       mockCookies.mockResolvedValue(mockCookieStore as any)
 
-      // Origin は forbidden header のため headers.get をスパイして注入する
       const request = new Request('https://evil.example.com')
-      const getSpy = vi.spyOn(request.headers, 'get').mockImplementation((name) => {
-        if (name === 'origin') return 'https://evil.example.com'
-        if (name === 'referer') return null
-        return null
-      })
 
       const result = await validateCSRFToken(request)
 
       expect(result.valid).toBe(false)
-      expect(result.error).toBe('リクエストのオリジンが許可されていません')
-      getSpy.mockRestore()
+      expect(result.error).toBe(ERROR_MESSAGES.CSRF_ORIGIN_NOT_TRUSTED)
     })
 
     it('should reject invalid origin header', async () => {

--- a/tests/unit/csrf.test.ts
+++ b/tests/unit/csrf.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { cookies } from 'next/headers'
 import { logger } from '@/lib/logger.server'
 
-import { COOKIE_NAMES, ERROR_MESSAGES } from '@/lib/constants'
+import { COOKIE_NAMES, CSRF_CONFIG, ERROR_MESSAGES } from '@/lib/constants'
 import { setCSRFToken, validateCSRFToken, hashToken, clearCSRFToken, hashIP, sanitizeURL } from '@/lib/csrf'
 import { signSession, verifySession } from '@/lib/session'
 
@@ -531,6 +531,138 @@ describe('CSRF Protection', () => {
       const result = await validateCSRFToken(request)
 
       expect(result.valid).toBe(true)
+      getSpy.mockRestore()
+    })
+
+    it('ALLOW_LOCAL_ORIGINS 有効時は LAN IP のホストを許可する（#952 レビュー必須指摘）', async () => {
+      const config = CSRF_CONFIG as unknown as { ALLOW_LOCAL_ORIGINS: boolean }
+      config.ALLOW_LOCAL_ORIGINS = true
+      try {
+        const token = 'a'.repeat(64)
+        const tokenHash = await hashToken(token)
+        const sessionData = {
+          twitchUserId: 'user123',
+          twitchUsername: 'testuser',
+          twitchDisplayName: 'Test User',
+          twitchProfileImageUrl: 'https://example.com/image.png',
+          broadcasterType: 'affiliate',
+          expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+          csrfTokenHash: tokenHash,
+          version: 1
+        }
+        const mockCookieStore = createMockCookieStore({
+          get: vi.fn((name) => {
+            if (name === COOKIE_NAMES.SESSION) {
+              return { value: JSON.stringify(sessionData) }
+            }
+            if (name === COOKIE_NAMES.CSRF_TOKEN) {
+              return { value: token }
+            }
+            return undefined
+          }),
+          set: vi.fn(),
+        })
+        mockCookies.mockResolvedValue(mockCookieStore as any)
+
+        const request = new Request('https://evil.example.com')
+        const getSpy = vi.spyOn(request.headers, 'get').mockImplementation((name) => {
+          if (name === 'host') return '192.168.1.5:3000'
+          return null
+        })
+
+        const result = await validateCSRFToken(request)
+
+        expect(result.valid).toBe(true)
+        getSpy.mockRestore()
+      } finally {
+        config.ALLOW_LOCAL_ORIGINS = false
+      }
+    })
+
+    it('ALLOW_LOCAL_ORIGINS 有効時は ::1 と任意ポートの localhost も許可する（#952 レビュー必須指摘）', async () => {
+      const config = CSRF_CONFIG as unknown as { ALLOW_LOCAL_ORIGINS: boolean }
+      config.ALLOW_LOCAL_ORIGINS = true
+      try {
+        const token = 'a'.repeat(64)
+        const tokenHash = await hashToken(token)
+        const sessionData = {
+          twitchUserId: 'user123',
+          twitchUsername: 'testuser',
+          twitchDisplayName: 'Test User',
+          twitchProfileImageUrl: 'https://example.com/image.png',
+          broadcasterType: 'affiliate',
+          expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+          csrfTokenHash: tokenHash,
+          version: 1
+        }
+        const mockCookieStore = createMockCookieStore({
+          get: vi.fn((name) => {
+            if (name === COOKIE_NAMES.SESSION) {
+              return { value: JSON.stringify(sessionData) }
+            }
+            if (name === COOKIE_NAMES.CSRF_TOKEN) {
+              return { value: token }
+            }
+            return undefined
+          }),
+          set: vi.fn(),
+        })
+        mockCookies.mockResolvedValue(mockCookieStore as any)
+
+        for (const host of ['[::1]:3000', 'localhost:4000']) {
+          const request = new Request('https://evil.example.com')
+          const getSpy = vi.spyOn(request.headers, 'get').mockImplementation((name) => {
+            if (name === 'host') return host
+            return null
+          })
+
+          const result = await validateCSRFToken(request)
+
+          expect(result.valid).toBe(true)
+          getSpy.mockRestore()
+        }
+      } finally {
+        config.ALLOW_LOCAL_ORIGINS = false
+      }
+    })
+
+    it('ALLOW_LOCAL_ORIGINS 無効時は LAN IP のホストを拒否する（fail-closed）', async () => {
+      const token = 'a'.repeat(64)
+      const tokenHash = await hashToken(token)
+      const sessionData = {
+        twitchUserId: 'user123',
+        twitchUsername: 'testuser',
+        twitchDisplayName: 'Test User',
+        twitchProfileImageUrl: 'https://example.com/image.png',
+        broadcasterType: 'affiliate',
+        expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+        csrfTokenHash: tokenHash,
+        version: 1
+      }
+      const mockCookieStore = createMockCookieStore({
+        get: vi.fn((name) => {
+          if (name === COOKIE_NAMES.SESSION) {
+            return { value: JSON.stringify(sessionData) }
+          }
+          if (name === COOKIE_NAMES.CSRF_TOKEN) {
+            return { value: token }
+          }
+          return undefined
+        }),
+        set: vi.fn(),
+      })
+      mockCookies.mockResolvedValue(mockCookieStore as any)
+
+      const request = new Request('https://evil.example.com')
+      const getSpy = vi.spyOn(request.headers, 'get').mockImplementation((name) => {
+        if (name === 'host') return '192.168.1.5:3000'
+        return null
+      })
+
+      const result = await validateCSRFToken(request)
+
+      expect(result.valid).toBe(false)
+      expect(result.error).toBe(ERROR_MESSAGES.CSRF_ORIGIN_NOT_TRUSTED)
       getSpy.mockRestore()
     })
 

--- a/tests/unit/csrf.test.ts
+++ b/tests/unit/csrf.test.ts
@@ -494,6 +494,46 @@ describe('CSRF Protection', () => {
       expect(result.valid).toBe(true)
     })
 
+    it('host ヘッダーが正規ドメインなら request.url が別ホストでも許可する（#952 レビュー）', async () => {
+      const token = 'a'.repeat(64)
+      const tokenHash = await hashToken(token)
+      const sessionData = {
+        twitchUserId: 'user123',
+        twitchUsername: 'testuser',
+        twitchDisplayName: 'Test User',
+        twitchProfileImageUrl: 'https://example.com/image.png',
+        broadcasterType: 'affiliate',
+        expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+        csrfTokenHash: tokenHash,
+        version: 1
+      }
+      const mockCookieStore = createMockCookieStore({
+        get: vi.fn((name) => {
+          if (name === COOKIE_NAMES.SESSION) {
+            return { value: JSON.stringify(sessionData) }
+          }
+          if (name === COOKIE_NAMES.CSRF_TOKEN) {
+            return { value: token }
+          }
+          return undefined
+        }),
+        set: vi.fn(),
+      })
+      mockCookies.mockResolvedValue(mockCookieStore as any)
+
+      // undici の Request では host が forbidden のため headers.get をスパイして注入する
+      const request = new Request('https://evil.example.com')
+      const getSpy = vi.spyOn(request.headers, 'get').mockImplementation((name) => {
+        if (name === 'host') return 'TWICA-PREVIEW.tsubasa-azumagakito.workers.dev'
+        return null
+      })
+
+      const result = await validateCSRFToken(request)
+
+      expect(result.valid).toBe(true)
+      getSpy.mockRestore()
+    })
+
     it('should reject request URL from untrusted authority even with matching origin header (#950)', async () => {
       const token = 'a'.repeat(64)
       const tokenHash = await hashToken(token)

--- a/tests/unit/layout-nonce.test.tsx
+++ b/tests/unit/layout-nonce.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import RootLayout from '@/app/layout'
+
+/**
+ * #950: layout.tsx が middleware 発行の x-nonce を Cloudflare Insights Script へ
+ * 渡すこと（CSP nonce 契約の単体テスト）。next/script をスタブして props を捕捉する。
+ */
+const mocks = vi.hoisted(() => ({
+  scriptProps: [] as Record<string, unknown>[],
+  headersMock: vi.fn(),
+}))
+
+vi.mock('next/script', () => ({
+  default: (props: Record<string, unknown>) => {
+    mocks.scriptProps.push(props)
+    return null
+  },
+}))
+
+vi.mock('next/headers', () => ({
+  headers: mocks.headersMock,
+}))
+
+vi.mock('next-intl', () => ({
+  NextIntlClientProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('next-intl/server', () => ({
+  getLocale: async () => 'ja',
+  getMessages: async () => ({}),
+}))
+
+const BEACON_SRC = 'https://static.cloudflareinsights.com/beacon.min.js'
+
+describe('RootLayout nonce propagation (issue #950)', () => {
+  beforeEach(() => {
+    mocks.scriptProps.length = 0
+    mocks.headersMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('TOKEN 設定時は Script へ x-nonce を渡す', async () => {
+    vi.stubEnv('NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN', 'token123')
+    mocks.headersMock.mockResolvedValue(new Headers({ 'x-nonce': 'nonce-abc' }))
+
+    render(await RootLayout({ children: <div>children</div> }))
+
+    const script = mocks.scriptProps.find((p) => p.src === BEACON_SRC)
+    expect(script).toBeDefined()
+    expect(script?.nonce).toBe('nonce-abc')
+  })
+
+  it('x-nonce が無い場合は Script の nonce が undefined', async () => {
+    vi.stubEnv('NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN', 'token123')
+    mocks.headersMock.mockResolvedValue(new Headers())
+
+    render(await RootLayout({ children: <div>children</div> }))
+
+    const script = mocks.scriptProps.find((p) => p.src === BEACON_SRC)
+    expect(script?.nonce).toBeUndefined()
+  })
+
+  it('TOKEN 未設定時は Script を描画しない', async () => {
+    vi.stubEnv('NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN', '')
+    mocks.headersMock.mockResolvedValue(new Headers({ 'x-nonce': 'nonce-abc' }))
+
+    render(await RootLayout({ children: <div>children</div> }))
+
+    expect(mocks.scriptProps.length).toBe(0)
+  })
+})

--- a/tests/unit/security-headers.test.ts
+++ b/tests/unit/security-headers.test.ts
@@ -182,6 +182,18 @@ describe('setSecurityHeaders', () => {
       const csp = result.headers.get('Content-Security-Policy')
       expect(csp).toContain("frame-ancestors 'self';")
     })
+
+    it('配信されるヘッダー値（setSecurityHeaders 経由）でも directive が重複しない', () => {
+      const response = NextResponse.json({ test: 'data' })
+      const result = setSecurityHeaders(response, { pathname: '/dashboard' })
+      const csp = result.headers.get('Content-Security-Policy')
+      const names = csp
+        ?.split(';')
+        .map((d) => d.trim())
+        .filter(Boolean)
+        .map((d) => d.split(/\s+/)[0])
+      expect(names).toEqual([...EXPECTED_DIRECTIVE_NAMES, 'frame-ancestors'])
+    })
   })
 
   describe('Strict-Transport-Security', () => {

--- a/tests/unit/security-headers.test.ts
+++ b/tests/unit/security-headers.test.ts
@@ -66,12 +66,11 @@ describe('setSecurityHeaders', () => {
       expect(csp).toContain("style-src 'self' 'unsafe-inline'")
     })
 
-    it('生成済み CSP 文字列を渡すとそれを採用し frame-ancestors を付与する（middleware との nonce 契約）', () => {
+    it('生成済み CSP 文字列を渡すとそれをそのまま採用する（middleware は buildCsp で生成済み）', () => {
       const response = NextResponse.json({ test: 'data' })
       const result = setSecurityHeaders(response, { csp: "default-src 'self'; script-src 'self' 'nonce-abc123' 'strict-dynamic';" })
       const csp = result.headers.get('Content-Security-Policy')
       expect(csp).toContain("default-src 'self'; script-src 'self' 'nonce-abc123' 'strict-dynamic';")
-      expect(csp).toContain("frame-ancestors 'none';")
     })
 
     it('csp が空文字列の場合は buildCsp() へフォールバックする（fail-closed）', () => {
@@ -82,33 +81,6 @@ describe('setSecurityHeaders', () => {
       const scriptSrc = csp?.split(';').find((d) => d.trim().startsWith('script-src'))
       expect(scriptSrc).not.toContain('unsafe-inline')
       expect(csp).toContain("default-src 'self'")
-    })
-
-    it('終端 ; なしの csp を渡しても frame-ancestors が正しく連結される', () => {
-      const response = NextResponse.json({ test: 'data' })
-      const result = setSecurityHeaders(response, { csp: "default-src 'self'; script-src 'self'" })
-      const csp = result.headers.get('Content-Security-Policy')
-      expect(csp).toContain("script-src 'self'; frame-ancestors 'none';")
-    })
-
-    it('入力 csp に frame-ancestors が含まれていても上書きされる（重複先勝ち対策）', () => {
-      const response = NextResponse.json({ test: 'data' })
-      const result = setSecurityHeaders(response, {
-        pathname: '/overlay/123',
-        csp: "default-src 'self'; frame-ancestors 'none';",
-      })
-      const csp = result.headers.get('Content-Security-Policy')
-      expect(csp).toContain("frame-ancestors 'self';")
-      expect(csp?.split('frame-ancestors').length).toBe(2)
-    })
-
-    it('pathname と csp を同時に渡すと pathname に応じた frame-ancestors が付与される', () => {
-      const response = NextResponse.json({ test: 'data' })
-      const overlay = setSecurityHeaders(response, {
-        pathname: '/overlay/123',
-        csp: "default-src 'self';",
-      })
-      expect(overlay.headers.get('Content-Security-Policy')).toContain("frame-ancestors 'self';")
     })
 
     it('production nonce 経路は nonce 埋め込み・strict-dynamic・unsafe-inline 不在・host-source 不記載を満たす', () => {
@@ -163,6 +135,7 @@ describe('setSecurityHeaders', () => {
       'worker-src',
       'object-src',
       'form-action',
+      'frame-ancestors',
     ]
 
     // variant 非依存の directive は値込みで固定する。名前のみだと
@@ -233,7 +206,7 @@ describe('setSecurityHeaders', () => {
         .map((d) => d.trim())
         .filter(Boolean)
         .map((d) => d.split(/\s+/)[0])
-      expect(names).toEqual([...EXPECTED_DIRECTIVE_NAMES, 'frame-ancestors'])
+      expect(names).toEqual(EXPECTED_DIRECTIVE_NAMES)
     })
   })
 

--- a/tests/unit/security-headers.test.ts
+++ b/tests/unit/security-headers.test.ts
@@ -60,12 +60,12 @@ describe('setSecurityHeaders', () => {
       expect(csp).toContain("style-src 'self' 'unsafe-inline'")
     })
 
-    it('生成済み CSP 文字列を渡すとそれを採用する（middleware との nonce 契約）', () => {
+    it('生成済み CSP 文字列を渡すとそれを採用し frame-ancestors を付与する（middleware との nonce 契約）', () => {
       const response = NextResponse.json({ test: 'data' })
       const result = setSecurityHeaders(response, { csp: "default-src 'self'; script-src 'self' 'nonce-abc123' 'strict-dynamic';" })
-      expect(result.headers.get('Content-Security-Policy')).toBe(
-        "default-src 'self'; script-src 'self' 'nonce-abc123' 'strict-dynamic';"
-      )
+      const csp = result.headers.get('Content-Security-Policy')
+      expect(csp).toContain("default-src 'self'; script-src 'self' 'nonce-abc123' 'strict-dynamic';")
+      expect(csp).toContain("frame-ancestors 'none';")
     })
 
     it('csp が空文字列の場合は buildCsp() へフォールバックする（fail-closed）', () => {
@@ -130,7 +130,6 @@ describe('setSecurityHeaders', () => {
       'worker-src',
       'object-src',
       'form-action',
-      'frame-ancestors',
     ]
 
     // variant 非依存の directive は値込みで固定する。名前のみだと
@@ -145,7 +144,6 @@ describe('setSecurityHeaders', () => {
       "worker-src 'self' blob:",
       "object-src 'none'",
       "form-action 'self'",
-      "frame-ancestors 'self'",
     ]
 
     it.each([
@@ -168,6 +166,21 @@ describe('setSecurityHeaders', () => {
       for (const directive of COMMON_DIRECTIVE_VALUES) {
         expect(csp).toContain(`${directive};`)
       }
+    })
+
+    it('非 overlay ルートは frame-ancestors none を付与する（DENY と同値）', () => {
+      const response = NextResponse.json({ test: 'data' })
+      const result = setSecurityHeaders(response, { pathname: '/dashboard/settings' })
+      const csp = result.headers.get('Content-Security-Policy')
+      expect(csp).toContain("frame-ancestors 'none';")
+      expect(csp).not.toContain("frame-ancestors 'self'")
+    })
+
+    it('overlay ルートは frame-ancestors self を付与する（SAMEORIGIN と同値）', () => {
+      const response = NextResponse.json({ test: 'data' })
+      const result = setSecurityHeaders(response, { pathname: '/overlay/123' })
+      const csp = result.headers.get('Content-Security-Policy')
+      expect(csp).toContain("frame-ancestors 'self';")
     })
   })
 

--- a/tests/unit/security-headers.test.ts
+++ b/tests/unit/security-headers.test.ts
@@ -13,6 +13,12 @@ describe('setSecurityHeaders', () => {
     expect(result.headers.get('X-Content-Type-Options')).toBe('nosniff')
   })
 
+  it('X-XSS-Protectionヘッダーを 0 で設定する（旧 UA の auditor 無効化）', () => {
+    const response = NextResponse.json({ test: 'data' })
+    const result = setSecurityHeaders(response)
+    expect(result.headers.get('X-XSS-Protection')).toBe('0')
+  })
+
   it('X-Frame-Optionsヘッダーを設定する（デフォルトはDENY）', () => {
     const response = NextResponse.json({ test: 'data' })
     const result = setSecurityHeaders(response)
@@ -76,6 +82,33 @@ describe('setSecurityHeaders', () => {
       const scriptSrc = csp?.split(';').find((d) => d.trim().startsWith('script-src'))
       expect(scriptSrc).not.toContain('unsafe-inline')
       expect(csp).toContain("default-src 'self'")
+    })
+
+    it('終端 ; なしの csp を渡しても frame-ancestors が正しく連結される', () => {
+      const response = NextResponse.json({ test: 'data' })
+      const result = setSecurityHeaders(response, { csp: "default-src 'self'; script-src 'self'" })
+      const csp = result.headers.get('Content-Security-Policy')
+      expect(csp).toContain("script-src 'self'; frame-ancestors 'none';")
+    })
+
+    it('入力 csp に frame-ancestors が含まれていても上書きされる（重複先勝ち対策）', () => {
+      const response = NextResponse.json({ test: 'data' })
+      const result = setSecurityHeaders(response, {
+        pathname: '/overlay/123',
+        csp: "default-src 'self'; frame-ancestors 'none';",
+      })
+      const csp = result.headers.get('Content-Security-Policy')
+      expect(csp).toContain("frame-ancestors 'self';")
+      expect(csp?.split('frame-ancestors').length).toBe(2)
+    })
+
+    it('pathname と csp を同時に渡すと pathname に応じた frame-ancestors が付与される', () => {
+      const response = NextResponse.json({ test: 'data' })
+      const overlay = setSecurityHeaders(response, {
+        pathname: '/overlay/123',
+        csp: "default-src 'self';",
+      })
+      expect(overlay.headers.get('Content-Security-Policy')).toContain("frame-ancestors 'self';")
     })
 
     it('production nonce 経路は nonce 埋め込み・strict-dynamic・unsafe-inline 不在・host-source 不記載を満たす', () => {
@@ -181,6 +214,14 @@ describe('setSecurityHeaders', () => {
       const result = setSecurityHeaders(response, { pathname: '/overlay/123' })
       const csp = result.headers.get('Content-Security-Policy')
       expect(csp).toContain("frame-ancestors 'self';")
+    })
+
+    it('/overlay-foo のような前方一致は overlay として扱わない', () => {
+      const response = NextResponse.json({ test: 'data' })
+      const result = setSecurityHeaders(response, { pathname: '/overlay-foo' })
+      const csp = result.headers.get('Content-Security-Policy')
+      expect(csp).toContain("frame-ancestors 'none';")
+      expect(result.headers.get('X-Frame-Options')).toBe('DENY')
     })
 
     it('配信されるヘッダー値（setSecurityHeaders 経由）でも directive が重複しない', () => {

--- a/tests/unit/security-headers.test.ts
+++ b/tests/unit/security-headers.test.ts
@@ -22,20 +22,14 @@ describe('setSecurityHeaders', () => {
   it('overlayルートではX-Frame-OptionsがSAMEORIGINになる', () => {
     // overlay ルートは同一オリジンからの iframe 埋め込みを許可（プレビュー機能用）
     const response = NextResponse.json({ test: 'data' })
-    const result = setSecurityHeaders(response, '/overlay/123')
+    const result = setSecurityHeaders(response, { pathname: '/overlay/123' })
     expect(result.headers.get('X-Frame-Options')).toBe('SAMEORIGIN')
   })
 
   it('overlay以外のルートではX-Frame-OptionsがDENYのまま', () => {
     const response = NextResponse.json({ test: 'data' })
-    const result = setSecurityHeaders(response, '/dashboard/settings')
+    const result = setSecurityHeaders(response, { pathname: '/dashboard/settings' })
     expect(result.headers.get('X-Frame-Options')).toBe('DENY')
-  })
-
-  it('X-XSS-Protectionヘッダーを設定する', () => {
-    const response = NextResponse.json({ test: 'data' })
-    const result = setSecurityHeaders(response)
-    expect(result.headers.get('X-XSS-Protection')).toBe('1; mode=block')
   })
 
   describe('Content-Security-Policy', () => {
@@ -59,8 +53,8 @@ describe('setSecurityHeaders', () => {
       expect(csp).toContain('connect-src \'self\' https: wss:;')
       expect(csp).not.toContain('localhost')
       expect(csp).not.toContain('unsafe-eval')
-      // production の script-src に unsafe-inline は含まれない（nonce ベース、
-      // #836）。style-src の unsafe-inline は Next.js のインラインスタイル用に維持。
+      // production の script-src に unsafe-inline は含まれない（nonce ベース）。
+      // style-src の unsafe-inline は Next.js のインラインスタイル用に維持。
       const scriptSrc = csp?.split(';').find((d) => d.trim().startsWith('script-src'))
       expect(scriptSrc).not.toContain('unsafe-inline')
       expect(csp).toContain("style-src 'self' 'unsafe-inline'")
@@ -68,20 +62,30 @@ describe('setSecurityHeaders', () => {
 
     it('生成済み CSP 文字列を渡すとそれを採用する（middleware との nonce 契約）', () => {
       const response = NextResponse.json({ test: 'data' })
-      const result = setSecurityHeaders(response, undefined, "default-src 'self'; script-src 'self' 'nonce-abc123' 'strict-dynamic';")
+      const result = setSecurityHeaders(response, { csp: "default-src 'self'; script-src 'self' 'nonce-abc123' 'strict-dynamic';" })
       expect(result.headers.get('Content-Security-Policy')).toBe(
         "default-src 'self'; script-src 'self' 'nonce-abc123' 'strict-dynamic';"
       )
     })
 
-    it('production nonce 経路は nonce 埋め込み・strict-dynamic・unsafe-inline 不在・host-source 不記載を満たす (#836)', () => {
+    it('csp が空文字列の場合は buildCsp() へフォールバックする（fail-closed）', () => {
+      vi.stubEnv('NODE_ENV', 'production')
+      const response = NextResponse.json({ test: 'data' })
+      const result = setSecurityHeaders(response, { csp: '' })
+      const csp = result.headers.get('Content-Security-Policy')
+      const scriptSrc = csp?.split(';').find((d) => d.trim().startsWith('script-src'))
+      expect(scriptSrc).not.toContain('unsafe-inline')
+      expect(csp).toContain("default-src 'self'")
+    })
+
+    it('production nonce 経路は nonce 埋め込み・strict-dynamic・unsafe-inline 不在・host-source 不記載を満たす', () => {
       vi.stubEnv('NODE_ENV', 'production')
       const csp = buildCsp('abc123')
       const scriptSrc = csp.split(';').find((d) => d.trim().startsWith('script-src'))
       expect(scriptSrc).toContain("'nonce-abc123'")
       expect(scriptSrc).toContain("'strict-dynamic'")
       expect(scriptSrc).not.toContain('unsafe-inline')
-      // strict-dynamic 下では host-source は無効のため記述しない（#944 レビュー）
+      // strict-dynamic 下では host-source は無効のため記述しない
       expect(scriptSrc).not.toContain('static.cloudflareinsights.com')
       // style-src の unsafe-inline は Next.js のインラインスタイル用に維持する
       expect(csp).toContain("style-src 'self' 'unsafe-inline'")
@@ -126,6 +130,22 @@ describe('setSecurityHeaders', () => {
       'worker-src',
       'object-src',
       'form-action',
+      'frame-ancestors',
+    ]
+
+    // variant 非依存の directive は値込みで固定する。名前のみだと
+    // `object-src 'self'` への緩和などを検出できない。
+    const COMMON_DIRECTIVE_VALUES = [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: https: blob:",
+      "media-src 'self' https:",
+      "font-src 'self' data:",
+      "worker-src 'self' blob:",
+      "object-src 'none'",
+      "form-action 'self'",
+      "frame-ancestors 'self'",
     ]
 
     it.each([
@@ -137,13 +157,17 @@ describe('setSecurityHeaders', () => {
       const csp = build()
       // directive 名を出現順の配列で完全一致比較する。Set 化すると同名 directive の
       // 二重出力（後勝ちで事故る典型）を検出できないため、配列のままで順序・重複・
-      // 欠落を同時に固定する（#949 レビュー任意指摘）。
+      // 欠落を同時に固定する。
       const actualDirectives = csp
         .split(';')
         .map((d) => d.trim())
         .filter(Boolean)
         .map((d) => d.split(/\s+/)[0])
       expect(actualDirectives).toEqual(EXPECTED_DIRECTIVE_NAMES)
+      // variant 非依存 directive は値込みで検証
+      for (const directive of COMMON_DIRECTIVE_VALUES) {
+        expect(csp).toContain(`${directive};`)
+      }
     })
   })
 

--- a/tests/unit/url-utils.test.ts
+++ b/tests/unit/url-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { getBaseUrl, resolveAllowedOrigin } from '@/lib/url-utils'
+import { getBaseUrl, isTrustedOrigin, resolveAllowedOrigin } from '@/lib/url-utils'
 
 /**
  * #836 項目6: getBaseUrl の host ヘッダー allowlist 検証。
@@ -81,7 +81,7 @@ describe('resolveAllowedOrigin (issue #836)', () => {
 
   it('workers.dev サブドメインの文字種が不正な host は拒否する（500 化を防ぐ）', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
     try {
       // 空白・記号入りはアカウント専有ドメインに該当しないため fail-closed
       expect(resolveAllowedOrigin('twica preview.tsubasa-azumagakito.workers.dev'))
@@ -89,7 +89,7 @@ describe('resolveAllowedOrigin (issue #836)', () => {
       expect(resolveAllowedOrigin('twica.preview@evil.tsubasa-azumagakito.workers.dev'))
         .toBe('https://twica.bluemoon.works')
     } finally {
-      warnSpy.mockRestore()
+      debugSpy.mockRestore()
     }
   })
 
@@ -101,25 +101,36 @@ describe('resolveAllowedOrigin (issue #836)', () => {
 
   it('twica が先頭 label にない workers.dev サブドメインは拒否する（締め付け）', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
     try {
       // 従来の includes('twica') では通っていたが、先頭 label（worker 名）限定に
-      // 変更したため拒否される（#949 レビュー任意指摘の意図した締め付け）
+      // 変更したため拒否される
       expect(resolveAllowedOrigin('evil.twica.tsubasa-azumagakito.workers.dev'))
         .toBe('https://twica.bluemoon.works')
     } finally {
-      warnSpy.mockRestore()
+      debugSpy.mockRestore()
     }
   })
 
-  it('非許可ホストは warn を1回だけ出力してフォールバックする', () => {
+  it('workers.dev ホストの非許可 port は拒否する', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    try {
+      expect(resolveAllowedOrigin('twica.tsubasa-azumagakito.workers.dev:8443'))
+        .toBe('https://twica.bluemoon.works')
+    } finally {
+      debugSpy.mockRestore()
+    }
+  })
+
+  it('非許可ホストは debug を1回だけ出力してフォールバックする', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
+    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
     try {
       expect(resolveAllowedOrigin('evil.example.com')).toBe('https://twica.bluemoon.works')
-      expect(warnSpy).toHaveBeenCalledTimes(1)
+      expect(debugSpy).toHaveBeenCalledTimes(1)
     } finally {
-      warnSpy.mockRestore()
+      debugSpy.mockRestore()
     }
   })
 
@@ -135,6 +146,38 @@ describe('resolveAllowedOrigin (issue #836)', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_URL', 'not-a-url')
     expect(() => resolveAllowedOrigin('evil.example.com')).toThrow('invalid in production')
     vi.unstubAllEnvs()
+  })
+})
+
+describe('isTrustedOrigin (issue #950)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('カスタムドメインの origin を許可する', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
+    expect(isTrustedOrigin('https://twica.bluemoon.works')).toBe(true)
+  })
+
+  it('workers.dev（twica 系）の origin を許可する', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
+    expect(isTrustedOrigin('https://twica.tsubasa-azumagakito.workers.dev')).toBe(true)
+    expect(isTrustedOrigin('https://twica-preview.tsubasa-azumagakito.workers.dev')).toBe(true)
+    expect(isTrustedOrigin('https://codex-issue-836-twica-preview.tsubasa-azumagakito.workers.dev')).toBe(true)
+  })
+
+  it('非許可 origin を拒否する', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
+    expect(isTrustedOrigin('https://evil.example.com')).toBe(false)
+    expect(isTrustedOrigin('https://twica.bluemoon.works.evil.com')).toBe(false)
+    expect(isTrustedOrigin('https://twica.tsubasa-azumagakito.workers.dev.evil.com')).toBe(false)
+    expect(isTrustedOrigin('not-a-url')).toBe(false)
+  })
+
+  it('開発環境では localhost origin を許可する', () => {
+    vi.stubEnv('NODE_ENV', 'development')
+    expect(isTrustedOrigin('http://localhost:3000')).toBe(true)
+    expect(isTrustedOrigin('http://localhost:8787')).toBe(true)
   })
 })
 

--- a/tests/unit/url-utils.test.ts
+++ b/tests/unit/url-utils.test.ts
@@ -180,6 +180,23 @@ describe('isTrustedOrigin (issue #950)', () => {
     expect(isTrustedOrigin('https://twica-preview.tsubasa-azumagakito.workers.dev/evil')).toBe(false)
   })
 
+  it('workers.dev は https のみ許可する（http は拒否）', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
+    expect(isTrustedOrigin('http://twica.tsubasa-azumagakito.workers.dev')).toBe(false)
+  })
+
+  it('production では localhost origin を拒否する', () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
+    expect(isTrustedOrigin('http://localhost:3000')).toBe(false)
+    expect(isTrustedOrigin('http://localhost:8787')).toBe(false)
+  })
+
+  it('port 付き workers.dev origin を拒否する', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
+    expect(isTrustedOrigin('https://twica.tsubasa-azumagakito.workers.dev:8443')).toBe(false)
+  })
+
   it('開発環境では localhost origin を許可する', () => {
     vi.stubEnv('NODE_ENV', 'development')
     expect(isTrustedOrigin('http://localhost:3000')).toBe(true)

--- a/tests/unit/url-utils.test.ts
+++ b/tests/unit/url-utils.test.ts
@@ -178,6 +178,8 @@ describe('isTrustedOrigin (issue #950)', () => {
     expect(isTrustedOrigin('https://twica.bluemoon.works/evil')).toBe(false)
     expect(isTrustedOrigin('https://user@twica.bluemoon.works')).toBe(false)
     expect(isTrustedOrigin('https://twica-preview.tsubasa-azumagakito.workers.dev/evil')).toBe(false)
+    expect(isTrustedOrigin('')).toBe(false)
+    expect(isTrustedOrigin('http://localhost:3000/')).toBe(false)
   })
 
   it('workers.dev は https のみ許可する（http は拒否）', () => {

--- a/tests/unit/url-utils.test.ts
+++ b/tests/unit/url-utils.test.ts
@@ -81,7 +81,7 @@ describe('resolveAllowedOrigin (issue #836)', () => {
 
   it('workers.dev サブドメインの文字種が不正な host は拒否する（500 化を防ぐ）', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
-    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     try {
       // 空白・記号入りはアカウント専有ドメインに該当しないため fail-closed
       expect(resolveAllowedOrigin('twica preview.tsubasa-azumagakito.workers.dev'))
@@ -89,7 +89,7 @@ describe('resolveAllowedOrigin (issue #836)', () => {
       expect(resolveAllowedOrigin('twica.preview@evil.tsubasa-azumagakito.workers.dev'))
         .toBe('https://twica.bluemoon.works')
     } finally {
-      debugSpy.mockRestore()
+      warnSpy.mockRestore()
     }
   })
 
@@ -101,36 +101,35 @@ describe('resolveAllowedOrigin (issue #836)', () => {
 
   it('twica が先頭 label にない workers.dev サブドメインは拒否する（締め付け）', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
-    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     try {
-      // 従来の includes('twica') では通っていたが、先頭 label（worker 名）限定に
-      // 変更したため拒否される
+      // worker 名（先頭 label）に twica を含まないサブドメインは拒否する
       expect(resolveAllowedOrigin('evil.twica.tsubasa-azumagakito.workers.dev'))
         .toBe('https://twica.bluemoon.works')
     } finally {
-      debugSpy.mockRestore()
+      warnSpy.mockRestore()
     }
   })
 
   it('workers.dev ホストの非許可 port は拒否する', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
-    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     try {
       expect(resolveAllowedOrigin('twica.tsubasa-azumagakito.workers.dev:8443'))
         .toBe('https://twica.bluemoon.works')
     } finally {
-      debugSpy.mockRestore()
+      warnSpy.mockRestore()
     }
   })
 
-  it('非許可ホストは debug を1回だけ出力してフォールバックする', () => {
+  it('非許可ホストは warn を1回だけ出力してフォールバックする', () => {
     vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
-    const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     try {
       expect(resolveAllowedOrigin('evil.example.com')).toBe('https://twica.bluemoon.works')
-      expect(debugSpy).toHaveBeenCalledTimes(1)
+      expect(warnSpy).toHaveBeenCalledTimes(1)
     } finally {
-      debugSpy.mockRestore()
+      warnSpy.mockRestore()
     }
   })
 
@@ -172,6 +171,13 @@ describe('isTrustedOrigin (issue #950)', () => {
     expect(isTrustedOrigin('https://twica.bluemoon.works.evil.com')).toBe(false)
     expect(isTrustedOrigin('https://twica.tsubasa-azumagakito.workers.dev.evil.com')).toBe(false)
     expect(isTrustedOrigin('not-a-url')).toBe(false)
+  })
+
+  it('path や userinfo 付きの URL は origin 文字列ではないため拒否する', () => {
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.bluemoon.works')
+    expect(isTrustedOrigin('https://twica.bluemoon.works/evil')).toBe(false)
+    expect(isTrustedOrigin('https://user@twica.bluemoon.works')).toBe(false)
+    expect(isTrustedOrigin('https://twica-preview.tsubasa-azumagakito.workers.dev/evil')).toBe(false)
   })
 
   it('開発環境では localhost origin を許可する', () => {


### PR DESCRIPTION
## 対応issue
#950（#944 / #949 レビュー任意指摘の追跡。優先度順に実装可能な項目を対応）

## 変更内容

### 1. CSRF と OAuth の trusted-origin 統合（優先度1）
- `src/lib/url-utils.ts` に `isTrustedOrigin(origin)` を追加（origin 文字列のみ受理: ローカル / workers.dev / NEXT_PUBLIC_APP_URL）
- `src/lib/csrf.ts` の expectedOrigin を **host ヘッダー + スキーム自動決定**で解決（#952 レビュー必須指摘対応）:
  - request.url は OpenNext の再構成に依存するため使用せず、host ヘッダー（getBaseUrl と同じ入力）を優先
  - スキームはローカル origin（localhost / 127.0.0.1 / ::1 / プライベートレンジ）のみ http、それ以外は https（request.url が http に再構成されても全 API が fail-closed しない）
  - 非許可 authority は Origin/Referer の有無に関わらず session 取得直後に fail-closed
  - **事前ゲートの許可集合を後段の Origin ヘッダー検査と同一化**（#952 レビュー必須指摘対応）: `isTrustedOrigin || ALLOWED_ORIGINS || (ALLOW_LOCAL_ORIGINS && isLocalOrigin)`。`next dev -p 4000` や LAN IP 実機確認、`[::1]` が事前ゲートで 403 になる退行を解消。`isLocalOrigin` を共通関数化して事前ゲートと Origin 検査で共有
  - host は小文字化し、ログは制御文字除去・長さ制限
- テスト: 非許可 authority の拒否、workers.dev origin の許可、host ヘッダー優先（request.url が別ホストでも正規 host なら許可）、ALLOW_LOCAL_ORIGINS 有効時の LAN IP / ::1 / 任意ポート localhost 許可、無効時の fail-closed（#952 レビュー必須指摘対応）

### 2. frame-ancestors を buildCsp に統合（#952 レビュー必須/任意指摘対応）
- `buildCsp(nonce, pathname)` で frame-ancestors を1箇所で組み立て（overlay='self' / その他='none'）
- 文字列の post-processing（split/filter/join）を廃止し、単一真実源・CPU 削減
- `setSecurityHeaders` の csp 未指定フォールバックも `buildCsp(undefined, pathname)` で統一
- `/overlay-foo` 等の前方一致は overlay として扱わない（ルート境界判定）

### 3. その他のレビュー対応
- `X-XSS-Protection: 0`（旧 UA の auditor 無効化、OWASP 推奨）
- `setSecurityHeaders` をオプションオブジェクト化（`{ pathname, csp }`）
- `isTwicaWorkersDevHost` の冗長な先頭 label 再検証を削除、ホスト全体の文字種検証で userinfo 混入を拒否
- `CSP_DEVELOPMENT` 定数廃止、directive 名 + variant 非依存 directive の値込み検証
- layout の nonce 受け渡し単体テスト（`tests/unit/layout-nonce.test.tsx`）
- レビュー経緯のメタ情報コメントを判断根拠コメントへ整理

## 検証
- 全体テスト **3487 passed** / integration 13 passed / typecheck / eslint / lint:i18n クリーン
- production build 成功
- preview 実経路（ヘッドレス・未ログインで実施可能な範囲）:
  - `GET /` → 200・CSP に `frame-ancestors 'none'`・`X-Frame-Options: DENY`・`X-XSS-Protection: 0`・HSTS を確認
  - `GET /overlay` → CSP に `frame-ancestors 'self'`・`X-Frame-Options: SAMEORIGIN` を確認（overlay 埋め込みは維持）
  - トップ 200・CSP violation 0・ログイン導線の OAuth `redirect_uri` が preview origin で生成されることを確認
  - `POST /api/gacha`（未ログイン JSON）→ 403 `Forbidden`（認証段階で停止。preview host では CSRF 事前ゲートを通過していることは単体テストの host ヘッダー経路で担保）
  - 不正 `Host` ヘッダーは Cloudflare エッジが 403 で遮断（Worker 到達前に拒否）

## 備考
- **残る必須ゲート**: AGENTS.md「Preview 実経路テスト」の実引き換え（ガチャ→オーバーレイ→チャット）は Twitch 認証と実配信が必要。preview で実チャネルポイント引き換えを複数回行い、403 が出ないこと・オーバーレイ表示とチャット送信が成立することを確認したら結果をここに追記してマージする（ユーザー操作待ち）
- 残る任意指摘（isTrustedOrigin / resolveAllowedOrigin の二重実装の統合、ERROR_MESSAGES 言語統一、withFrameAncestors 相当の設計）は #950 で追跡
- #834 は別途 Claude へハンドオフ（`docs/issue-834-claude-handoff.md`）