### PR TITLE
release: preview を main へ昇格（PR #956 / #947）

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -141,7 +141,8 @@
       "imageUrlValidating": "Validating image...",
       "heicConverting": "Converting HEIC image...",
       "heicConvertFailed": "Could not read the HEIC image. Please choose another image or convert it to JPEG and try again.",
-      "heicTooLarge": "The HEIC image is too large. Please choose an image under {mb}MB."
+      "heicTooLarge": "The HEIC image is too large. Please choose an image under {mb}MB.",
+      "imageDecodeFailed": "Could not read the image. Please choose a different image."
     },
     "cardNumberEditor": {
       "title": "Edit Card Numbers",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -141,7 +141,8 @@
       "imageUrlValidating": "画像を検証中...",
       "heicConverting": "HEIC画像を変換中…",
       "heicConvertFailed": "HEIC画像を読み込めませんでした。別の画像を選択するか、JPEGへ変換してから再度お試しください。",
-      "heicTooLarge": "HEIC画像のサイズが大きすぎます。{mb}MB以下の画像を選択してください。"
+      "heicTooLarge": "HEIC画像のサイズが大きすぎます。{mb}MB以下の画像を選択してください。",
+      "imageDecodeFailed": "画像を読み込めませんでした。別の画像を選択してください。"
     },
     "cardNumberEditor": {
       "title": "カード番号をまとめて編集",

--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -1230,6 +1230,15 @@ export default function CardManager({
       // Ignore stale callback from cancelled/re-selected file
       if (requestId !== imageDimensionRequestId.current) return;
       const imgWidth = img.naturalWidth;
+      const imgHeight = img.naturalHeight;
+      // 実ブラウザでは Blob URL のデコードに失敗しても onload が発火し、
+      // naturalWidth/naturalHeight が 0 になることがある。0 寸法を読み込み失敗
+      // として扱い、ファイル名・MIME・サイズを含まない安全なエラーだけを表示して
+      // トリミングモーダルへ進めない（issue #947）。
+      if (imgWidth === 0 || imgHeight === 0) {
+        setUploadError(t("messages.imageDecodeFailed"));
+        return;
+      }
       setSourceImageWidth(imgWidth);
       // 画像幅以下の解像度のうち最大のものをデフォルトに設定
       // Default to the largest resolution that doesn't exceed image width
@@ -1244,11 +1253,9 @@ export default function CardManager({
     img.onerror = () => {
       URL.revokeObjectURL(objectUrl);
       if (requestId !== imageDimensionRequestId.current) return;
-      // 読み取り失敗時はフォールバック：従来通り全選択肢を表示
-      setSourceImageWidth(null);
-      setSelectedWidth(maxImageWidth);
-      setSelectedFileForCrop(file);
-      setCropModeModalOpen(true);
+      // 読み取り失敗時は従来のフォールバック（全選択肢を出してモーダルを開く）を
+      // やめ、トリミングへ進まず安全なエラーを表示する（issue #947）。
+      setUploadError(t("messages.imageDecodeFailed"));
     };
     img.src = objectUrl;
   };

--- a/tests/unit/components/card-manager-fit.test.tsx
+++ b/tests/unit/components/card-manager-fit.test.tsx
@@ -8,7 +8,11 @@ vi.mock('@/lib/logger')
 
 // happy-dom は blob URL に対する img の読み込みイベントを発火しないため、
 // src 設定時に onload を呼び出すスタブで、クロップモード選択モーダルまでのフローを再現する。
+// issue #947 以降は naturalWidth/naturalHeight が 0 だとデコード失敗として扱われるため、
+// 正常系のスタブでは非0寸法を返す。
 function stubImageLoad() {
+  vi.spyOn(HTMLImageElement.prototype, 'naturalWidth', 'get').mockReturnValue(800)
+  vi.spyOn(HTMLImageElement.prototype, 'naturalHeight', 'get').mockReturnValue(800)
   vi.spyOn(HTMLImageElement.prototype, 'src', 'set').mockImplementation(function (
     this: HTMLImageElement
   ) {

--- a/tests/unit/components/card-manager-heic.test.tsx
+++ b/tests/unit/components/card-manager-heic.test.tsx
@@ -23,8 +23,11 @@ vi.mock('@/lib/logger')
 
 // happy-dom は blob URL に対する img の読み込みイベント（onload/onerror）を発火しないため、
 // src が設定されたら onload を呼び出すスタブで、クロップモーダルが開くまでの既存フローを
-// テストで再現する。
+// テストで再現する。issue #947 以降は naturalWidth/naturalHeight が 0 だとデコード失敗
+// として扱われるため、正常系のスタブでは非0寸法を返す。
 function stubImageLoad() {
+  vi.spyOn(HTMLImageElement.prototype, 'naturalWidth', 'get').mockReturnValue(800)
+  vi.spyOn(HTMLImageElement.prototype, 'naturalHeight', 'get').mockReturnValue(800)
   vi.spyOn(HTMLImageElement.prototype, 'src', 'set').mockImplementation(function (
     this: HTMLImageElement
   ) {

--- a/tests/unit/components/card-manager-image-decode.test.tsx
+++ b/tests/unit/components/card-manager-image-decode.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import CardManager from '@/components/CardManager'
+import jaMessages from '../../../messages/ja.json'
+
+vi.mock('@/lib/logger')
+
+const DECODE_ERROR_MESSAGE = '画像を読み込めませんでした。別の画像を選択してください。'
+
+// happy-dom は blob URL に対する img の読み込みイベントを発火しないため、
+// src 設定時に onload/onerror を手動発火するスタブでデコード結果を再現する。
+// naturalWidth/naturalHeight は issue #947 の 0 寸法判定を検証できるよう
+// テストごとに差し替える。
+function stubImageLoad({
+  width = 800,
+  height = 800,
+}: { width?: number; height?: number } = {}) {
+  vi.spyOn(HTMLImageElement.prototype, 'naturalWidth', 'get').mockReturnValue(width)
+  vi.spyOn(HTMLImageElement.prototype, 'naturalHeight', 'get').mockReturnValue(height)
+  vi.spyOn(HTMLImageElement.prototype, 'src', 'set').mockImplementation(function (
+    this: HTMLImageElement
+  ) {
+    setTimeout(() => this.onload?.(new Event('load')), 0)
+  })
+}
+
+function stubImageError() {
+  vi.spyOn(HTMLImageElement.prototype, 'src', 'set').mockImplementation(function (
+    this: HTMLImageElement
+  ) {
+    setTimeout(() => this.onerror?.(new Event('error')), 0)
+  })
+}
+
+function renderCardManager() {
+  return render(
+    <NextIntlClientProvider locale="ja" messages={jaMessages}>
+      <CardManager
+        streamerId="streamer-1"
+        initialCards={[]}
+        initialRarityWeights={{}}
+      />
+    </NextIntlClientProvider>
+  )
+}
+
+function selectBrokenFile(container: HTMLElement, name = 'broken.png') {
+  fireEvent.click(screen.getByText('新規カード追加'))
+  const input = container.querySelector('input[type="file"]') as HTMLInputElement
+  fireEvent.change(input, {
+    target: {
+      files: [new File(['this is not an image'], name, { type: 'image/png' })],
+    },
+  })
+}
+
+describe('CardManager image decode failure (issue #947)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('onerror 時に安全なエラーを表示し、トリミングモーダルを開かない', async () => {
+    stubImageError()
+    const { container } = renderCardManager()
+    selectBrokenFile(container)
+
+    expect(await screen.findByText(DECODE_ERROR_MESSAGE)).toBeInTheDocument()
+    expect(screen.queryByText('トリミングサイズを選択')).not.toBeInTheDocument()
+  })
+
+  it('エラー文にファイル名・MIME・サイズを含めない', async () => {
+    stubImageError()
+    const { container } = renderCardManager()
+    selectBrokenFile(container, 'secret-name.png')
+
+    await screen.findByText(DECODE_ERROR_MESSAGE)
+    expect(screen.queryByText(/secret-name/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/image\/png/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/21/)).not.toBeInTheDocument()
+  })
+
+  it('naturalWidth が 0 の onload は読み込み失敗として扱う', async () => {
+    stubImageLoad({ width: 0, height: 800 })
+    const { container } = renderCardManager()
+    selectBrokenFile(container)
+
+    expect(await screen.findByText(DECODE_ERROR_MESSAGE)).toBeInTheDocument()
+    expect(screen.queryByText('トリミングサイズを選択')).not.toBeInTheDocument()
+  })
+
+  it('naturalHeight が 0 の onload は読み込み失敗として扱う', async () => {
+    stubImageLoad({ width: 800, height: 0 })
+    const { container } = renderCardManager()
+    selectBrokenFile(container)
+
+    expect(await screen.findByText(DECODE_ERROR_MESSAGE)).toBeInTheDocument()
+    expect(screen.queryByText('トリミングサイズを選択')).not.toBeInTheDocument()
+  })
+
+  it('正常な寸法の画像は従来どおりトリミングモーダルが開く', async () => {
+    stubImageLoad()
+    const { container } = renderCardManager()
+    selectBrokenFile(container)
+
+    expect(await screen.findByText('トリミングサイズを選択')).toBeInTheDocument()
+    expect(screen.queryByText(DECODE_ERROR_MESSAGE)).not.toBeInTheDocument()
+  })
+
+  it('フォームをキャンセルした後は古い onerror がエラーを出さない', async () => {
+    const createdImages: HTMLImageElement[] = []
+    const originalCreateElement = document.createElement.bind(document)
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const element = originalCreateElement(tag)
+      if (tag === 'img') {
+        createdImages.push(element as HTMLImageElement)
+      }
+      return element
+    })
+    const { container } = renderCardManager()
+    selectBrokenFile(container)
+
+    // フォームのキャンセルで世代IDが進む（resetForm）
+    fireEvent.click(screen.getByText('キャンセル'))
+    createdImages[0]?.onerror?.(new Event('error'))
+
+    expect(screen.queryByText(DECODE_ERROR_MESSAGE)).not.toBeInTheDocument()
+    expect(screen.queryByText('トリミングサイズを選択')).not.toBeInTheDocument()
+  })
+})

--- a/tests/unit/components/card-manager-image-decode.test.tsx
+++ b/tests/unit/components/card-manager-image-decode.test.tsx
@@ -33,6 +33,23 @@ function stubImageError() {
   })
 }
 
+/**
+ * 発火を後から制御できる onerror スタブ。
+ * フォームのキャンセル（世代ID前進）後に古い onerror を明示的に呼び出して、
+ * エラーが表示されないことを検証するためのヘルパー。
+ */
+function createDeferredImageError() {
+  let fireError: (() => void) | null = null
+  vi.spyOn(HTMLImageElement.prototype, 'src', 'set').mockImplementation(function (
+    this: HTMLImageElement
+  ) {
+    fireError = () => {
+      this.onerror?.(new Event('error'))
+    }
+  })
+  return () => fireError?.()
+}
+
 function renderCardManager() {
   return render(
     <NextIntlClientProvider locale="ja" messages={jaMessages}>
@@ -77,7 +94,6 @@ describe('CardManager image decode failure (issue #947)', () => {
     await screen.findByText(DECODE_ERROR_MESSAGE)
     expect(screen.queryByText(/secret-name/)).not.toBeInTheDocument()
     expect(screen.queryByText(/image\/png/)).not.toBeInTheDocument()
-    expect(screen.queryByText(/21/)).not.toBeInTheDocument()
   })
 
   it('naturalWidth が 0 の onload は読み込み失敗として扱う', async () => {
@@ -108,21 +124,13 @@ describe('CardManager image decode failure (issue #947)', () => {
   })
 
   it('フォームをキャンセルした後は古い onerror がエラーを出さない', async () => {
-    const createdImages: HTMLImageElement[] = []
-    const originalCreateElement = document.createElement.bind(document)
-    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
-      const element = originalCreateElement(tag)
-      if (tag === 'img') {
-        createdImages.push(element as HTMLImageElement)
-      }
-      return element
-    })
+    const fireError = createDeferredImageError()
     const { container } = renderCardManager()
     selectBrokenFile(container)
 
     // フォームのキャンセルで世代IDが進む（resetForm）
     fireEvent.click(screen.getByText('キャンセル'))
-    createdImages[0]?.onerror?.(new Event('error'))
+    fireError()
 
     expect(screen.queryByText(DECODE_ERROR_MESSAGE)).not.toBeInTheDocument()
     expect(screen.queryByText('トリミングサイズを選択')).not.toBeInTheDocument()


### PR DESCRIPTION
## 概要
#947（カード画像デコード失敗時の安全なエラー表示）を preview で検証済みの状態で main へ昇格します。

## 内容
- `src/components/CardManager.tsx`: `naturalWidth/naturalHeight === 0` を読み込み失敗として扱い、`onerror` 時のフォールバック（トリミングモーダルを開く）を廃止して安全なエラー表示へ
- `messages/ja.json` / `messages/en.json`: `cardManager.messages.imageDecodeFailed` を追加（ファイル名・MIME・サイズを含まない文言）
- 新規テスト6件 + 既存テスト stub 修正

## 検証
- PR #956 で CI 全 pass（test 3484件 / build / lint / i18n / Workers Builds preview）
- preview 実ブラウザ E2E（アプリ内ブラウザ・gpt-5.6-luna）: 合格
  - 壊れた PNG → トリミングモーダル非表示・安全なエラー表示・ファイル情報非表示
  - 有効な PNG → トリミングモーダル表示（回帰なし）
- 内部レビュー（deepseek v4 pro）: 必須指摘なし（任意2件は対応済み）