### PR TITLE
chore(live): 匿名配信者数カウントをオプトアウト可能にして無効化 (#951)

### DIFF
--- a/src/lib/live-directory.ts
+++ b/src/lib/live-directory.ts
@@ -461,11 +461,32 @@ export async function getLiveDirectory(): Promise<LiveDirectoryEntry[]> {
 }
 
 /**
+ * 匿名配信者数カウント（#951）のオプトアウト判定。
+ *
+ * 未設定（または "true"/"1"）なら現行挙動のまま有効、明示的な "false"/"0" のみ
+ * 無効化する。未知の値は有効として扱う（明示的に無効化した環境だけが対象のため、
+ * タイポで機能が消える事故を防ぐ）。判定は関数内で毎回 process.env を読むため、
+ * テストでは vi.stubEnv で切り替えられる。
+ */
+function isLiveDirectoryCountEnabled(): boolean {
+  const raw = process.env.LIVE_DIRECTORY_COUNT_ENABLED?.trim();
+  if (raw === undefined || raw === "") return true;
+  const normalized = raw.toLowerCase();
+  return normalized !== "false" && normalized !== "0";
+}
+
+/**
  * 現在ライブ中の active 配信者数を返す。KVキャッシュ(60s) → メモリ → 実取得。
  *
  * オプトイン（publish_live_status）の有無に関わらず全 active 配信者を母集団にし、
  * Helix でライブ判定した人数だけを返す（#951）。identity はこの関数から返さず、
  * RSC payload を通過するのは整数のみ。
+ *
+ * Helix GET /streams は active 配信者100人ごとに1リクエスト飛ぶため、登録者数の
+ * 増加に比例してキャッシュミス時のページ表示1回あたりのリクエスト数が増える。
+ * 費用・レートリミット対策として環境変数 LIVE_DIRECTORY_COUNT_ENABLED による
+ * コード変更を伴わないオプトアウト（kill switch）を用意する。無効時は後述の通り
+ * null を返し、RPC/Helix/KV を一切呼ばない。
  *
  * 障害時は null を返して人数行自体を非表示にする。「0人」は「誰も配信していない」
  * という正常値を意味し、RPC/Helix 障害と区別する。障害による空結果はキャッシュへ
@@ -473,6 +494,12 @@ export async function getLiveDirectory(): Promise<LiveDirectoryEntry[]> {
  * しない方針は既存 getLiveDirectory() と同じ。
  */
 export async function getLiveDirectoryCount(): Promise<number | null> {
+  // オプトアウト中は人数行ごと非表示にする。ページ側は liveCount !== null で
+  // ガードしており、null は「表示しない」、0 は「正常な0人」と区別される。
+  if (!isLiveDirectoryCountEnabled()) {
+    return null;
+  }
+
   try {
     const kv = await getKvBinding();
     if (kv) {

--- a/tests/unit/live-directory.test.ts
+++ b/tests/unit/live-directory.test.ts
@@ -465,6 +465,31 @@ describe("getLiveDirectoryCount (#951)", () => {
     vi.unstubAllGlobals();
   });
 
+  it("returns null without RPC/Helix when opted out via env flag", async () => {
+    vi.stubEnv("LIVE_DIRECTORY_COUNT_ENABLED", "false");
+
+    await expect(getLiveDirectoryCount()).resolves.toBeNull();
+    expect(getDb).not.toHaveBeenCalled();
+    expect(fetchTwitchApi).not.toHaveBeenCalled();
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it("treats 0 as an opt-out and an unset env as enabled", async () => {
+    vi.stubEnv("LIVE_DIRECTORY_COUNT_ENABLED", "0");
+
+    await expect(getLiveDirectoryCount()).resolves.toBeNull();
+    expect(fetchTwitchApi).not.toHaveBeenCalled();
+
+    // 未設定（デフォルト）に戻すと通常どおり Helix 判定が走る。
+    vi.unstubAllEnvs();
+    vi.mocked(fetchTwitchApi).mockResolvedValue(
+      new Response(JSON.stringify(streamResponse(["u1"])), { status: 200 }) as never,
+    );
+
+    await expect(getLiveDirectoryCount()).resolves.toBe(1);
+    expect(fetchTwitchApi).toHaveBeenCalledTimes(1);
+  });
+
   it("returns the number of live active streamers regardless of opt-in", async () => {
     vi.mocked(fetchTwitchApi).mockResolvedValue(
       new Response(JSON.stringify(streamResponse(["u1"])), { status: 200 }) as never,

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -76,6 +76,10 @@ service = "twica-overlay-realtime"
 # Public value that must survive dashboard-only configuration overwrites.
 [vars]
 NEXT_PUBLIC_TWITCH_CLIENT_ID = "okxjgv064gr80kcijf1b0e182x394o"
+# #951 匿名配信者数カウントは active 配信者100人ごとに Helix GET /streams が
+# 飛ぶため、登録者数の増加に伴う費用・レートリミット対策として一旦無効化する。
+# 再開時は "true" に戻してデプロイする（コード変更不要の kill switch）。
+LIVE_DIRECTORY_COUNT_ENABLED = "false"
 
 # Server secrets are configured with `wrangler secret put` or in the
 # Cloudflare dashboard. NEXT_PUBLIC_* build-time values are supplied by Workers
@@ -95,6 +99,8 @@ enabled = true
 
 [env.preview.vars]
 NEXT_PUBLIC_TWITCH_CLIENT_ID = "k40qdqew0buz3cjshwp6fbr5pmuayw"
+# 本番と同じくオプトアウトを適用し、preview でも Helix 呼び出しを抑える。
+LIVE_DIRECTORY_COUNT_ENABLED = "false"
 
 [[env.preview.kv_namespaces]]
 binding = "RATE_LIMIT_KV"


### PR DESCRIPTION
## 概要
Closes #951（実装済みのためクローズ済みですが、匿名配信者数カウントの費用・レートリミット対策として一旦無効化します）

/live の「現在 N 人が配信中です」は active 配信者100人ごとに Helix GET /streams を1リクエスト飛ばすため、登録者数の増加に比例してページ表示ごとの API コストが増えます。今回は EventSub 増減収集案を検討しましたが、取りこぼし・重複・offline 遅延・初期状態取得・購読ライフサイクル管理が必要で過剰なため不採用です。

## 変更内容
- `src/lib/live-directory.ts`
  - `LIVE_DIRECTORY_COUNT_ENABLED` 環境変数による kill switch を追加
  - 無効時は RPC / Helix / KV を一切呼ばず `null` を返し、既存の `liveCount !== null` ガードで人数行ごと非表示
  - 未設定（デフォルト）は従来どおり有効、明示的な false/0 のみ無効
- `wrangler.toml`: 本番 `[vars]` と `[env.preview.vars]` の両方に `LIVE_DIRECTORY_COUNT_ENABLED = "false"` を設定
- テスト: オプトアウト時 RPC/Helix/KV 非呼び出し、0 も無効扱い、未設定なら有効、を追加（計2件）

## 検証
- 単体テスト 3484件パス（全269ファイル）
- tsc --noEmit / eslint（変更2ファイル）パス

## 再開方法
`LIVE_DIRECTORY_COUNT_ENABLED` を "true" に戻してデプロイするだけで再開できます（コード変更不要）。