### PR TITLE
fix(chat): チャット通知の {packName} をカード自身のパックから解決 (#948)

### DIFF
--- a/db/planetscale/migrations/20260813120000_chat_pack_name_card_collection.sql
+++ b/db/planetscale/migrations/20260813120000_chat_pack_name_card_collection.sql
@@ -1,0 +1,371 @@
+-- migration-transaction: required
+-- migration-providers: planetscale
+
+-- Issue #948: チャット通知 {packName} を「抽選スコープ」でなく「獲得カード自身の
+-- パック」から解決するため、outbox のカード payload に collection_name を加算する。
+--
+-- 従来は送信側が抽選の collectionName（パック指定抽選のときだけ非NULL）で解決して
+-- おり、メイン報酬＝全カード抽選では名前付きパックのカードを引いても {packName} が
+-- 常に空文字になっていた。カード payload へ collection_name を追加し、送信側が
+-- カードのパックを優先して解決できるようにする。
+--
+-- CREATE OR REPLACE は既適用migrationを変更せず、同一シグネチャのRPC実装だけを
+-- 差し替える。payload v1 への additive field のため、旧 worker は未知 key を無視し、
+-- 新 worker は field 欠落の旧 outbox 行を従来どおり抽選スコープへフォールバックする。
+CREATE OR REPLACE FUNCTION public.execute_gacha_transaction_with_chat_outbox(
+  p_event_id text,
+  p_user_twitch_id text,
+  p_user_twitch_username text,
+  p_card_id uuid,
+  p_streamer_id uuid,
+  p_reward_cost integer,
+  p_reward_id text,
+  p_chat_batch_id text,
+  p_draw_index integer,
+  p_draw_count integer,
+  p_collection_name text
+) RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_history_id uuid;
+  v_max_issuance_count integer;
+  v_issued_count integer;
+  v_cards_payload jsonb;
+  v_outbox_count integer;
+  v_card_count integer;
+  v_unique_count integer;
+  v_all_count integer;
+  v_new_card_names jsonb;
+  v_new_card_names_resolved boolean;
+  v_is_duplicate boolean := false;
+BEGIN
+  IF p_event_id IS NULL THEN
+    RAISE EXCEPTION 'event_id must not be null';
+  END IF;
+  -- PostgreSQLの比較演算はNULLをfalseではなくunknownにするため、範囲比較だけでは
+  -- NULLを拒否できない。履歴だけ作ってoutboxを組み立てない半端な成功を防ぐ。
+  IF p_draw_index IS NULL OR p_draw_count IS NULL
+     OR p_draw_index < 1 OR p_draw_count < 1 OR p_draw_count > 15
+     OR p_draw_index > p_draw_count THEN
+    RAISE EXCEPTION 'invalid draw position: %/%', p_draw_index, p_draw_count;
+  END IF;
+  IF p_chat_batch_id IS NOT NULL
+     AND p_event_id <> (CASE
+       WHEN p_draw_index = 1 THEN p_chat_batch_id
+       ELSE p_chat_batch_id || ':' || p_draw_index::text
+     END) THEN
+    RAISE EXCEPTION 'event_id does not match chat batch draw position';
+  END IF;
+
+  -- Twitch再送・live/Cron replayが同じeventを別transactionで同時実行し得る。
+  -- card行だけをlockすると、別cardを抽選した再送は直列化されず、同じcardでも
+  -- 先行COMMIT後の発行上限をduplicate判定より先に見て誤返金し得る。event_idの
+  -- 64bit hashをtransaction advisory lockにし、同一eventのduplicate確認から
+  -- outbox再構成までを直列化する。hash衝突は無関係な2件を一時直列化するだけで、
+  -- correctnessや権限境界を壊さない。
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_event_id, 803));
+
+  -- duplicate final drawでも下の全履歴再構成を実行する。歯抜けbatchで不足drawを
+  -- 埋めた後、既存の最終eventへ到達した場合にoutboxを作り損ねないため。
+  SELECT id INTO v_history_id
+  FROM gacha_history
+  WHERE event_id = p_event_id;
+  v_is_duplicate := FOUND;
+
+  IF NOT v_is_duplicate THEN
+    SELECT max_issuance_count
+      INTO v_max_issuance_count
+      FROM cards
+      WHERE id = p_card_id
+        AND streamer_id = p_streamer_id
+        AND is_active = true
+      FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object('is_duplicate', false, 'limit_reached', true);
+    END IF;
+
+    IF v_max_issuance_count IS NOT NULL THEN
+      SELECT COUNT(*) INTO v_issued_count
+        FROM user_cards
+        WHERE card_id = p_card_id;
+
+      IF v_issued_count >= v_max_issuance_count THEN
+        RETURN jsonb_build_object('is_duplicate', false, 'limit_reached', true);
+      END IF;
+    END IF;
+
+    INSERT INTO gacha_history (
+      event_id, user_twitch_id, user_twitch_username, card_id, streamer_id,
+      reward_cost, reward_id
+    )
+    VALUES (
+      p_event_id, p_user_twitch_id, p_user_twitch_username, p_card_id,
+      p_streamer_id, p_reward_cost, p_reward_id
+    )
+    ON CONFLICT (event_id) DO NOTHING
+    RETURNING id INTO v_history_id;
+
+    IF v_history_id IS NULL THEN
+      -- pre-check後に同じeventを別transactionがcommitした競合。カード付与はせず、
+      -- duplicate finalなら下のoutbox再構成だけを安全に試みる。
+      v_is_duplicate := true;
+    ELSE
+      INSERT INTO users (twitch_user_id, twitch_username, twitch_display_name)
+      VALUES (p_user_twitch_id, p_user_twitch_username, p_user_twitch_username)
+      ON CONFLICT (twitch_user_id) DO NOTHING;
+
+      SELECT id INTO v_user_id FROM users WHERE twitch_user_id = p_user_twitch_id;
+
+      IF v_user_id IS NOT NULL THEN
+        INSERT INTO user_cards (user_id, card_id, obtained_at)
+        VALUES (v_user_id, p_card_id, now());
+      END IF;
+    END IF;
+  END IF;
+
+  IF p_chat_batch_id IS NOT NULL AND p_draw_index = p_draw_count THEN
+    -- N連途中にbuilding行を残すと、webhookが2xxを返した後の部分失敗で永久孤児に
+    -- なる。最終drawのtransaction内で、確定済みgacha_historyをevent_id順に
+    -- 再構成し、全件揃った場合だけ完成済みpendingを1件作る。
+    WITH expected_events AS (
+      SELECT
+        draw_index,
+        CASE
+          WHEN draw_index = 1 THEN p_chat_batch_id
+          ELSE p_chat_batch_id || ':' || draw_index::text
+        END AS event_id
+      FROM generate_series(1, p_draw_count) AS draw(draw_index)
+    ),
+    ordered_cards AS (
+      SELECT
+        expected_events.draw_index,
+        jsonb_build_object(
+          'id', c.id,
+          'name', c.name,
+          'description', c.description,
+          'image_url', c.image_url,
+          'rarity', c.rarity,
+          'drop_rate', c.drop_rate,
+          'max_issuance_count', c.max_issuance_count,
+          'collection_name', c.collection_name
+        ) AS card_payload
+      FROM expected_events
+      JOIN gacha_history gh ON gh.event_id = expected_events.event_id
+      JOIN cards c ON c.id = gh.card_id
+      WHERE gh.streamer_id = p_streamer_id
+        AND gh.user_twitch_id = p_user_twitch_id
+    )
+    SELECT jsonb_agg(card_payload ORDER BY draw_index), count(*)::integer
+      INTO v_cards_payload, v_outbox_count
+      FROM ordered_cards;
+
+    IF v_outbox_count <> p_draw_count THEN
+      RAISE EXCEPTION 'chat outbox history incomplete for batch %: expected %, found %',
+        p_chat_batch_id, p_draw_count, v_outbox_count;
+    END IF;
+
+    -- chat無効時は所有数集約もoutbox INSERTも実行しない。enabled streamerの1行
+    -- 存在確認だけに絞り、通知を使わない配信者のガチャコストを増やさない。
+    IF EXISTS (
+      SELECT 1
+      FROM streamers
+      WHERE id = p_streamer_id
+        AND chat_announcement_enabled = true
+    ) THEN
+      -- 所有数系placeholderをrelay時に再問合せすると、retry待ちの別ガチャやカード
+      -- 設定変更で元の通知本文が変わる。ユーザー所持を1回だけ集約し、{num}、
+      -- {unique}、{all}、{newCards}をこのtransactionの同一statement snapshotで
+      -- 固定する。relayはこのversioned値だけを使い、外部送信リトライを決定的にする。
+      WITH user_card_counts AS (
+      SELECT
+        uc.card_id,
+        count(*)::integer AS final_count,
+        bool_or(c.is_active = true) AS is_active
+      FROM users u
+      JOIN user_cards uc ON uc.user_id = u.id
+      JOIN cards c
+        ON c.id = uc.card_id
+       AND c.streamer_id = p_streamer_id
+      WHERE u.twitch_user_id = p_user_twitch_id
+      GROUP BY uc.card_id
+    ),
+    expected_events AS (
+      -- CTEはstatementをまたいで共有できない。上のstatementは全historyの完成を
+      -- 先にfail-closed検証し、ここではchat有効時だけ所有数を集約するため、同じ
+      -- event列を意図的に再定義する。単一statement化するとchat無効配信者にも
+      -- placeholder集約コストが発生するため、この重複を保つ。
+      SELECT
+        draw_index,
+        CASE
+          WHEN draw_index = 1 THEN p_chat_batch_id
+          ELSE p_chat_batch_id || ':' || draw_index::text
+        END AS event_id
+      FROM generate_series(1, p_draw_count) AS draw(draw_index)
+    ),
+    drawn_card_counts AS (
+      SELECT
+        gh.card_id,
+        min(expected_events.draw_index) AS first_draw_index,
+        count(*)::integer AS drawn_count,
+        min(c.name) AS card_name
+      FROM expected_events
+      JOIN gacha_history gh ON gh.event_id = expected_events.event_id
+      JOIN cards c ON c.id = gh.card_id
+      -- event_idは一意で上のordered_cardsも完成を検証済みだが、この集約だけを
+      -- 読んでも別配信者・別ユーザーの履歴を混入させない防御境界を明示する。
+      WHERE gh.streamer_id = p_streamer_id
+        AND gh.user_twitch_id = p_user_twitch_id
+      GROUP BY gh.card_id
+    ),
+    expected_history_timestamp_counts AS (
+      SELECT
+        gh.card_id,
+        gh.redeemed_at,
+        count(*)::integer AS expected_count
+      FROM expected_events
+      JOIN gacha_history gh ON gh.event_id = expected_events.event_id
+      WHERE gh.streamer_id = p_streamer_id
+        AND gh.user_twitch_id = p_user_twitch_id
+      GROUP BY gh.card_id, gh.redeemed_at
+    ),
+    obtained_card_timestamp_counts AS (
+      SELECT
+        uc.card_id,
+        uc.obtained_at,
+        count(*)::integer AS obtained_count
+      FROM users u
+      JOIN user_cards uc ON uc.user_id = u.id
+      JOIN cards c
+        ON c.id = uc.card_id
+       AND c.streamer_id = p_streamer_id
+      WHERE u.twitch_user_id = p_user_twitch_id
+      GROUP BY uc.card_id, uc.obtained_at
+    )
+    SELECT
+      coalesce((
+        SELECT final_count
+        FROM user_card_counts
+        WHERE card_id = (v_cards_payload -> 0 ->> 'id')::uuid
+      ), 0),
+      (SELECT count(*)::integer FROM user_card_counts WHERE is_active),
+      (
+        SELECT count(*)::integer
+        FROM cards
+        WHERE streamer_id = p_streamer_id
+          AND is_active = true
+      ),
+      coalesce((
+        SELECT jsonb_agg(drawn.card_name ORDER BY drawn.first_draw_index)
+        FROM drawn_card_counts drawn
+        JOIN user_card_counts owned ON owned.card_id = drawn.card_id
+        WHERE owned.final_count > 0
+          AND owned.final_count - drawn.drawn_count <= 0
+      ), '[]'::jsonb),
+      NOT EXISTS (
+        -- 歯抜け復旧では過去historyが存在してもuser_cardsが無い場合がある。
+        -- 各distinct drawについて所持行と最終所持数を確認し、どちらかが欠けるなら
+        -- 配列の空/非空を「初入手0件」の根拠にしてはいけない。
+        SELECT 1
+        FROM drawn_card_counts drawn
+        LEFT JOIN user_card_counts owned ON owned.card_id = drawn.card_id
+        WHERE owned.card_id IS NULL OR owned.final_count < drawn.drawn_count
+      )
+      AND NOT EXISTS (
+        -- 歯抜け復旧で過去の所持カードが残っているだけでは、そのカードが今回の
+        -- historyで実際に付与された証拠にならない。各eventのredeemed_atと同じ
+        -- obtained_atをcardごとにgroup化し、同一timestamp groupの件数まで照合する。
+        -- 同じカードを同一transaction内で複数drawした場合も、1枚の所持行を複数の
+        -- historyへ使い回せないため、初入手0件と判定不能を安全に区別できる。
+        SELECT 1
+        FROM expected_history_timestamp_counts expected
+        LEFT JOIN obtained_card_timestamp_counts confirmed
+          ON confirmed.card_id = expected.card_id
+         AND confirmed.obtained_at = expected.redeemed_at
+        WHERE expected.redeemed_at IS NULL
+           OR confirmed.obtained_count IS NULL
+           OR confirmed.obtained_count < expected.expected_count
+      )
+      INTO v_card_count, v_unique_count, v_all_count, v_new_card_names,
+        v_new_card_names_resolved;
+
+      -- `newCardNames` はv1の配列契約を維持する。追加fieldは任意で、旧workerは
+      -- 未知keyを無視できる。新workerはfield欠落の旧payloadを判定不能として扱い、
+      -- 過去のsnapshotを再問合せして配送内容を変えない。
+      INSERT INTO public.chat_notification_outbox (
+      batch_id, payload_version, payload, expected_draw_count,
+      assembled_draw_count, status
+    )
+    SELECT
+      p_chat_batch_id,
+      1,
+      jsonb_build_object(
+        'batchId', p_chat_batch_id,
+        'broadcasterTwitchUserId', s.twitch_user_id,
+        'userId', p_user_twitch_id,
+        'streamer', jsonb_build_object(
+          'id', s.id,
+          'chat_announcement_enabled', s.chat_announcement_enabled,
+          'chat_announcement_template', s.chat_announcement_template,
+          'chat_announcement_multi_template', s.chat_announcement_multi_template,
+          'chat_announcement_multi_show_cards', s.chat_announcement_multi_show_cards,
+          'default_card_pack_name', s.default_card_pack_name
+        ),
+        'gachaResult', jsonb_build_object(
+          'type', 'gacha',
+          'card', v_cards_payload -> 0,
+          'cards', v_cards_payload,
+          'userTwitchUsername', p_user_twitch_username,
+          'rewardId', p_reward_id,
+          'collectionName', p_collection_name
+        ),
+        'chatSnapshot', jsonb_build_object(
+          'cardCount', v_card_count,
+          'uniqueCount', v_unique_count,
+          'allCount', v_all_count,
+          'newCardNames', v_new_card_names,
+          'newCardNamesResolved', v_new_card_names_resolved
+        )
+      ),
+      p_draw_count,
+      p_draw_count,
+      'pending'
+    FROM streamers s
+    WHERE s.id = p_streamer_id
+      AND s.chat_announcement_enabled = true
+      ON CONFLICT (batch_id) DO NOTHING;
+    END IF;
+  END IF;
+
+  IF v_is_duplicate THEN
+    RETURN jsonb_build_object(
+      'is_duplicate', true,
+      -- final duplicateは歯抜け/応答消失回復で再構成した完全なカード列を返す。
+      -- アプリは残drawだけの配列をoverlay batchとして誤採番せずに済む。
+      'cards', CASE
+        WHEN p_chat_batch_id IS NOT NULL AND p_draw_index = p_draw_count
+          THEN v_cards_payload
+        ELSE NULL
+      END
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'is_duplicate', false,
+    'limit_reached', false,
+    'history_id', v_history_id,
+    'cards', CASE
+      WHEN p_chat_batch_id IS NOT NULL AND p_draw_index = p_draw_count
+        THEN v_cards_payload
+      ELSE NULL
+    END
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.execute_gacha_transaction_with_chat_outbox(
+  text, text, text, uuid, uuid, integer, text, text, integer, integer, text
+) IS
+  'ガチャ確定とchat outbox組立を同一transactionで実行するversioned RPC。カードpayloadのcollection_nameは{packName}解決用のadditive field（Issue #948）。';

--- a/messages/en.json
+++ b/messages/en.json
@@ -521,7 +521,7 @@
       "multiTemplate": "Multi-draw Template (optional)",
       "multiTemplatePlaceholder": "@'{'user'}' got '{'rarityCounts'}' from a '{'draws'}'-draw gacha! '{'cards'}'",
       "multiShowCards": "Include card-name list in multi-draw announcements",
-      "placeholderHelp": "Available placeholders: '{'user'}'=username, '{'card'}'=first card name, '{'rarity'}'=rarity, '{'num'}'=owned count, '{'unique'}'=unique types owned, '{'all'}'=total types, '{'detail'}'=card description, '{'url'}'=collection URL, '{'packName'}'=name of the pack the obtained card belongs to (empty string when the draw wasn't restricted to a pack)",
+      "placeholderHelp": "Available placeholders: '{'user'}'=username, '{'card'}'=first card name, '{'rarity'}'=rarity, '{'num'}'=owned count, '{'unique'}'=unique types owned, '{'all'}'=total types, '{'detail'}'=card description, '{'url'}'=collection URL, '{'packName'}'=name of the pack the obtained card belongs to (empty string for unclassified cards)",
       "multiPlaceholderHelp": "Multi-draw only: '{'draws'}'=draw count, '{'rarityCounts'}'=rarity counts (e.g. Rare x3, Common x3), '{'cards'}'=card-name list, '{'newCards'}'=newly obtained card names this draw, '{'newCardsOrNone'}'=newly obtained card names this draw (or \"なし\" when zero new cards were resolved), '{'newCardCount'}'=count of newly obtained card types this draw ('{'newCards'}'/'{'newCardsOrNone'}'/'{'newCardCount'}' only have content when \"Include card-name list in multi-draw announcements\" is enabled; otherwise, or when new-card information cannot be resolved, they are replaced with an empty string)",
       "previewLength": "Preview length: {current} / {max} characters"
     },

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -521,7 +521,7 @@
       "multiTemplate": "N連ガチャ用テンプレート（任意）",
       "multiTemplatePlaceholder": "@'{'user'}' が'{'draws'}'連ガチャで '{'rarityCounts'}' を獲得しました！'{'cards'}'",
       "multiShowCards": "N連通知にカード名一覧を含める",
-      "placeholderHelp": "使用可能なプレースホルダー: '{'user'}'=ユーザー名, '{'card'}'=先頭カード名, '{'rarity'}'=レアリティ, '{'num'}'=所持枚数, '{'unique'}'=所持種類数, '{'all'}'=全種類数, '{'detail'}'=カード説明, '{'url'}'=コレクションURL, '{'packName'}'=獲得カードが属するパック名（パック未指定の抽選では空文字）",
+      "placeholderHelp": "使用可能なプレースホルダー: '{'user'}'=ユーザー名, '{'card'}'=先頭カード名, '{'rarity'}'=レアリティ, '{'num'}'=所持枚数, '{'unique'}'=所持種類数, '{'all'}'=全種類数, '{'detail'}'=カード説明, '{'url'}'=コレクションURL, '{'packName'}'=獲得カードが属するパック名（未分類カードでは空文字）",
       "multiPlaceholderHelp": "N連用: '{'draws'}'=抽選回数, '{'rarityCounts'}'=レアリティ別枚数（例: レアx3、コモンx3）, '{'cards'}'=カード名一覧, '{'newCards'}'=今回初めて獲得したカード名一覧, '{'newCardsOrNone'}'=今回初めて獲得したカード名一覧（初入手がないと正常に判定できた場合は「なし」）, '{'newCardCount'}'=今回初めて獲得したカード種類数（'{'newCards'}'・'{'newCardsOrNone'}'・'{'newCardCount'}'は「N連通知にカード名一覧を含める」を有効にしている場合のみ値が入ります。無効または初入手情報を取得できない場合は空文字に置き換わります）",
       "previewLength": "プレビュー文字数: {current} / {max}文字"
     },

--- a/src/lib/services/eventsub-redemption.ts
+++ b/src/lib/services/eventsub-redemption.ts
@@ -1261,13 +1261,13 @@ export async function sendChatAnnouncement(
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://twica.live';
   const collectionUrl = `${baseUrl}/collection/${streamer.id}`;
 
-  // Issue #597: {packName} 用に、抽選が絞られたパックの表示名を解決する。
-  // DBクエリ不要（collectionName/default_card_pack_name は既に取得済み）のため
-  // 他プレースホルダーのような needsX ガードは不要。
-  // Resolve the {packName} display name. No extra DB query needed (both inputs
-  // are already fetched), unlike the other placeholders gated behind needsX.
+  // Issue #948: {packName} は「抽選スコープ」でなく「獲得カード自身のパック」を
+  // 優先して解決する。メイン報酬＝全カード抽選では抽選スコープ（collectionName）が
+  // 常に null になり、名前付きパックのカードでも {packName} が空文字になるため。
+  // 旧 outbox 行（カード payload に collection_name が無い）は従来どおり
+  // 抽選スコープへフォールバックして後方互換を保つ。
   const packName = resolvePackDisplayName(
-    collectionName,
+    card.collection_name ?? collectionName ?? null,
     streamer.default_card_pack_name ?? null,
     DEFAULT_PACK_CHAT_FALLBACK_LABEL
   );

--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -41,6 +41,10 @@ export interface GachaCard {
   rarity: string
   drop_rate: number
   max_issuance_count?: number | null
+  // Issue #948: 獲得カード自身が属するパック名（未分類カードは null）。
+  // チャット通知 {packName} を抽選スコープでなくカードの実パックから解決する
+  // ために追加した additive field。旧 outbox payload では undefined。
+  collection_name?: string | null
 }
 
 /**

--- a/tests/unit/chat-pack-name-card-collection-migration.test.ts
+++ b/tests/unit/chat-pack-name-card-collection-migration.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  join(process.cwd(), 'db/planetscale/migrations/20260813120000_chat_pack_name_card_collection.sql'),
+  'utf8',
+)
+
+describe('chat pack name card collection migration (#948)', () => {
+  it('PlanetScale transaction migrationとして宣言し、既存RPCをCREATE OR REPLACEで差し替える', () => {
+    expect(migration).toMatch(/^-- migration-transaction: required\n-- migration-providers: planetscale/)
+    expect(migration).toContain(
+      'CREATE OR REPLACE FUNCTION public.execute_gacha_transaction_with_chat_outbox(',
+    )
+    // 旧7引数RPCを曖昧化しない（既存のversioned 11引数シグネチャを維持）
+    expect(migration).not.toContain('CREATE OR REPLACE FUNCTION public.execute_gacha_transaction(')
+    expect(migration).toContain('p_collection_name text')
+  })
+
+  it('カードpayloadにcollection_nameを追加する', () => {
+    const cardPayload = migration.slice(
+      migration.indexOf("jsonb_build_object(\n          'id', c.id,"),
+      migration.indexOf(') AS card_payload'),
+    )
+    expect(cardPayload).toContain("'max_issuance_count', c.max_issuance_count")
+    expect(cardPayload).toContain("'collection_name', c.collection_name")
+  })
+
+  it('既存のoutbox payloadフィールド（streamer/gachaResult/chatSnapshot）を維持する', () => {
+    for (const fragment of [
+      "'chatSnapshot', jsonb_build_object(",
+      "'newCardNames', v_new_card_names",
+      "'default_card_pack_name', s.default_card_pack_name",
+      "'collectionName', p_collection_name",
+      'ON CONFLICT (batch_id) DO NOTHING',
+    ]) {
+      expect(migration).toContain(fragment)
+    }
+  })
+
+  it('同じシグネチャの差し替えであることをCOMMENTで明示する', () => {
+    expect(migration).toContain(
+      "COMMENT ON FUNCTION public.execute_gacha_transaction_with_chat_outbox(\n  text, text, text, uuid, uuid, integer, text, text, integer, integer, text\n)",
+    )
+    expect(migration).toContain('Issue #948')
+  })
+})

--- a/tests/unit/send-chat-announcement.test.ts
+++ b/tests/unit/send-chat-announcement.test.ts
@@ -430,3 +430,101 @@ describe('sendChatAnnouncement: duplicate分類の写し替え (#842/#843)', () 
     expect(sendSpy).toHaveBeenCalledWith('130871908', 'new=')
   })
 })
+
+describe('sendChatAnnouncement: {packName} はカード自身のパックを優先する (#948)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const packStreamer = {
+    id: 'streamer-1',
+    chat_announcement_enabled: true,
+    chat_announcement_template: 'pack={packName}',
+    chat_announcement_multi_template: null,
+    chat_announcement_multi_show_cards: false,
+    default_card_pack_name: 'デフォルトパック',
+  }
+  const card = {
+    id: 'card-1',
+    name: 'Alpha',
+    description: null,
+    image_url: null,
+    rarity: 'common',
+    drop_rate: 1,
+  }
+  const snapshot = {
+    cardCount: 1,
+    uniqueCount: 1,
+    allCount: 10,
+    newCardNames: [],
+    newCardNamesResolved: true,
+  }
+
+  it('全カード抽選でも、カードが名前付きパックに属していればそのパック名を表示する', async () => {
+    const sendSpy = vi.spyOn(TwitchChatService.prototype, 'sendChatMessageDetailed').mockResolvedValue({
+      outcome: 'sent',
+    })
+    const packedCard = {
+      ...card,
+      collection_name: 'レアパック',
+    }
+
+    // 抽選スコープ（collectionName）は未指定のまま、カードのパックだけが解決される
+    await sendChatAnnouncement(
+      '130871908', packStreamer, packedCard, 'Viewer', 'viewer-1',
+      undefined, undefined, snapshot,
+    )
+
+    expect(sendSpy).toHaveBeenCalledWith('130871908', 'pack=レアパック')
+  })
+
+  it('旧outbox行（カードのcollection_name無し）は抽選スコープへフォールバックする', async () => {
+    const sendSpy = vi.spyOn(TwitchChatService.prototype, 'sendChatMessageDetailed').mockResolvedValue({
+      outcome: 'sent',
+    })
+    const legacyCard = { ...card }
+
+    await sendChatAnnouncement(
+      '130871908', packStreamer, legacyCard, 'Viewer', 'viewer-1',
+      undefined, '抽選パック', snapshot,
+    )
+
+    expect(sendSpy).toHaveBeenCalledWith('130871908', 'pack=抽選パック')
+  })
+
+  it('未分類カードで抽選スコープも未指定なら空文字のまま（従来挙動を維持）', async () => {
+    const sendSpy = vi.spyOn(TwitchChatService.prototype, 'sendChatMessageDetailed').mockResolvedValue({
+      outcome: 'sent',
+    })
+    const unclassifiedCard = {
+      ...card,
+      collection_name: null,
+    }
+
+    await sendChatAnnouncement(
+      '130871908', packStreamer, unclassifiedCard, 'Viewer', 'viewer-1',
+      undefined, undefined, snapshot,
+    )
+
+    expect(sendSpy).toHaveBeenCalledWith('130871908', 'pack=')
+  })
+
+  it('デフォルトパック指定抽選はカードのパックを優先しつつ、未分類ならデフォルト名を表示する', async () => {
+    const sendSpy = vi.spyOn(TwitchChatService.prototype, 'sendChatMessageDetailed').mockResolvedValue({
+      outcome: 'sent',
+    })
+    const unclassifiedCard = {
+      ...card,
+      collection_name: null,
+    }
+
+    await sendChatAnnouncement(
+      '130871908', packStreamer, unclassifiedCard, 'Viewer', 'viewer-1',
+      undefined, '__default__', snapshot,
+    )
+
+    // カードが未分類のため抽選スコープ（デフォルトパック）へ fallback し、
+    // default_card_pack_name が表示される（#597 の従来挙動を壊さない）
+    expect(sendSpy).toHaveBeenCalledWith('130871908', 'pack=デフォルトパック')
+  })
+})


### PR DESCRIPTION
## 概要
Closes #948

チャット通知の `{packName}` が表示されない問題を修正する。従来は「抽選スコープのパック」（パック指定抽選のときだけ非NULL）で解決していたため、メイン報酬＝全カード抽選では名前付きパックのカードを引いても常に空文字になっていた。

## 原因
- `sendChatAnnouncement` が `resolvePackDisplayName(collectionName, ...)` で解決（抽選スコープ基準）
- 全カード抽選では `collectionName` が常に `null` になり、カード自身のパック（`cards.collection_name`）が使われていなかった

## 変更内容
- `db/planetscale/migrations/20260813120000_chat_pack_name_card_collection.sql`（新規）
  - `execute_gacha_transaction_with_chat_outbox` を CREATE OR REPLACE し、カード payload に `collection_name` を追加（additive field）
- `src/lib/services/gacha.ts`: `GachaCard` に `collection_name?` を追加
- `src/lib/services/eventsub-redemption.ts`: `card.collection_name ?? collectionName ?? null` でカード優先に変更（旧 outbox 行は抽選スコープへフォールバック）
- `messages/ja.json` / `messages/en.json`: `{packName}` のヘルプ文言を「未分類カードでは空文字」に更新
- テスト: sendChatAnnouncement 4件（カード優先・旧payloadフォールバック・未分類空文字・デフォルトパック）+ migration テスト4件

## 検証
- 単体テスト: 3495件パス
- typecheck / lint / lint:i18n / next build: パス
- migration order check: 76件 OK
- 内部レビュー（deepseek v4 pro）: 必須指摘なし（任意: 文言更新対応済み）

## ブラウザE2E（previewマージ後に実施予定）
- チャット通知テンプレートに `パック: {packName}` を設定し、全カード抽選で名前付きパックのカードを引いたときパック名が表示されること
- 未分類カードでは空文字のままであること