### PR TITLE
release: preview を main へ昇格（PR #969）

### DIFF
--- a/src/components/LiveDirectory.tsx
+++ b/src/components/LiveDirectory.tsx
@@ -51,9 +51,8 @@ const RANKING_PERIODS: ReadonlyArray<{
   { id: "allTime", labelKey: "period.allTime" },
 ];
 
-// RANKING_PERIODSはラジオボタンの表示順を決めるための配列であり、既定選択の
-// 正本ではない。表示順の並べ替えが既定値まで無言で変えてしまわないよう、
-// 独立した定数として明示する。
+// 既定の集計期間は表示順（RANKING_PERIODS）とは独立した製品判断のため、
+// 定数として明示する。
 const DEFAULT_RANKING_PERIOD: LiveDirectoryRankingPeriod = "last7Days";
 
 function compareFallback(a: LiveDirectoryEntry, b: LiveDirectoryEntry): number {

--- a/src/components/LiveDirectory.tsx
+++ b/src/components/LiveDirectory.tsx
@@ -133,12 +133,12 @@ export default function LiveDirectory({
 }: LiveDirectoryProps) {
   const t = useTranslations("livePage");
   const [view, setView] = useState<LiveDirectoryView>("recentlyStarted");
-  // 当初は「ランキング公開直後に順位が急変する退行を避ける」ため全期間を初期値に
-  // していたが、公開から日数が経ち初期表示が急変する懸念は解消したため、直近の
-  // 活動を反映した順位のほうが「今アクティブなチャネル」を探す利用者の意図に
-  // 合う直近7日間へ切り替える。全期間は引き続き選択可能。
-  const [rankingPeriod, setRankingPeriod] =
-    useState<LiveDirectoryRankingPeriod>("last7Days");
+  // 「今アクティブなチャネル」を探す利用者の意図に合わせ、既定は直近7日間。
+  // 全期間も引き続き選択可能。RANKING_PERIODSの並びと初期選択がずれないよう、
+  // 個別のリテラルではなく配列の先頭要素から導出する。
+  const [rankingPeriod, setRankingPeriod] = useState<LiveDirectoryRankingPeriod>(
+    RANKING_PERIODS[0].id,
+  );
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const sortedEntries = useMemo(() => sortLiveDirectoryEntries(entries), [entries]);
   // 種類数は「現在有効なカード種類数」というスナップショット指標であり、

--- a/src/components/LiveDirectory.tsx
+++ b/src/components/LiveDirectory.tsx
@@ -51,8 +51,9 @@ const RANKING_PERIODS: ReadonlyArray<{
   { id: "allTime", labelKey: "period.allTime" },
 ];
 
-// 既定の集計期間は表示順（RANKING_PERIODS）とは独立した製品判断のため、
-// 定数として明示する。
+// 「今アクティブなチャネル」を探す利用者の意図に合わせ、既定は直近7日間
+// （全期間も引き続き選択可能）。表示順（RANKING_PERIODS）とは独立した
+// 製品判断のため、定数として明示する。
 const DEFAULT_RANKING_PERIOD: LiveDirectoryRankingPeriod = "last7Days";
 
 function compareFallback(a: LiveDirectoryEntry, b: LiveDirectoryEntry): number {
@@ -137,8 +138,6 @@ export default function LiveDirectory({
 }: LiveDirectoryProps) {
   const t = useTranslations("livePage");
   const [view, setView] = useState<LiveDirectoryView>("recentlyStarted");
-  // 「今アクティブなチャネル」を探す利用者の意図に合わせ、既定は直近7日間。
-  // 全期間も引き続き選択可能。
   const [rankingPeriod, setRankingPeriod] =
     useState<LiveDirectoryRankingPeriod>(DEFAULT_RANKING_PERIOD);
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);

--- a/src/components/LiveDirectory.tsx
+++ b/src/components/LiveDirectory.tsx
@@ -51,6 +51,11 @@ const RANKING_PERIODS: ReadonlyArray<{
   { id: "allTime", labelKey: "period.allTime" },
 ];
 
+// RANKING_PERIODSはラジオボタンの表示順を決めるための配列であり、既定選択の
+// 正本ではない。表示順の並べ替えが既定値まで無言で変えてしまわないよう、
+// 独立した定数として明示する。
+const DEFAULT_RANKING_PERIOD: LiveDirectoryRankingPeriod = "last7Days";
+
 function compareFallback(a: LiveDirectoryEntry, b: LiveDirectoryEntry): number {
   // 視聴者数は変動が大きく、利用者が選択していない順位付けを同率時だけ
   // 暗黙に行うと表示順の意図が分かりにくい。安定した識別情報だけを使い、
@@ -134,11 +139,9 @@ export default function LiveDirectory({
   const t = useTranslations("livePage");
   const [view, setView] = useState<LiveDirectoryView>("recentlyStarted");
   // 「今アクティブなチャネル」を探す利用者の意図に合わせ、既定は直近7日間。
-  // 全期間も引き続き選択可能。RANKING_PERIODSの並びと初期選択がずれないよう、
-  // 個別のリテラルではなく配列の先頭要素から導出する。
-  const [rankingPeriod, setRankingPeriod] = useState<LiveDirectoryRankingPeriod>(
-    RANKING_PERIODS[0].id,
-  );
+  // 全期間も引き続き選択可能。
+  const [rankingPeriod, setRankingPeriod] =
+    useState<LiveDirectoryRankingPeriod>(DEFAULT_RANKING_PERIOD);
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const sortedEntries = useMemo(() => sortLiveDirectoryEntries(entries), [entries]);
   // 種類数は「現在有効なカード種類数」というスナップショット指標であり、

--- a/src/components/LiveDirectory.tsx
+++ b/src/components/LiveDirectory.tsx
@@ -133,8 +133,10 @@ export default function LiveDirectory({
 }: LiveDirectoryProps) {
   const t = useTranslations("livePage");
   const [view, setView] = useState<LiveDirectoryView>("recentlyStarted");
-  // 直近の活動を反映した順位のほうが「今アクティブなチャネル」を探す利用者の
-  // 意図に合うため、初期表示は直近7日間にする。全期間は引き続き選択可能。
+  // 当初は「ランキング公開直後に順位が急変する退行を避ける」ため全期間を初期値に
+  // していたが、公開から日数が経ち初期表示が急変する懸念は解消したため、直近の
+  // 活動を反映した順位のほうが「今アクティブなチャネル」を探す利用者の意図に
+  // 合う直近7日間へ切り替える。全期間は引き続き選択可能。
   const [rankingPeriod, setRankingPeriod] =
     useState<LiveDirectoryRankingPeriod>("last7Days");
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);

--- a/src/components/LiveDirectory.tsx
+++ b/src/components/LiveDirectory.tsx
@@ -133,10 +133,10 @@ export default function LiveDirectory({
 }: LiveDirectoryProps) {
   const t = useTranslations("livePage");
   const [view, setView] = useState<LiveDirectoryView>("recentlyStarted");
-  // 既存ランキングは全期間だったため初期値を維持する。期間を明示して選べるように
-  // しつつ、リリース直後に順位の見え方が突然変わる退行を避ける。
+  // 直近の活動を反映した順位のほうが「今アクティブなチャネル」を探す利用者の
+  // 意図に合うため、初期表示は直近7日間にする。全期間は引き続き選択可能。
   const [rankingPeriod, setRankingPeriod] =
-    useState<LiveDirectoryRankingPeriod>("allTime");
+    useState<LiveDirectoryRankingPeriod>("last7Days");
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const sortedEntries = useMemo(() => sortLiveDirectoryEntries(entries), [entries]);
   // 種類数は「現在有効なカード種類数」というスナップショット指標であり、

--- a/tests/unit/components/live-directory.test.tsx
+++ b/tests/unit/components/live-directory.test.tsx
@@ -95,10 +95,8 @@ const recentRankings: LiveDirectoryRankingEntry[] = [
 ];
 
 // recentRankingItemsの既定値はrankingItemsと同一（=last7DaysとallTimeが同じ
-// 内容）にしている。期間ごとの表示差を検証したいテストは、専用の recentRankings
-// フィクスチャを明示的に渡すこと（例: "defaults the usage ranking period..." /
-// "switches usage ranking periods..."）。それ以外のテストは期間非依存の検証に
-// 限定する前提で、この既定値のままにしている。
+// 内容）。期間ごとの表示差を検証したいテストは、専用の recentRankings
+// フィクスチャを明示的に渡すこと。
 function renderDirectory(
   streamItems: LiveDirectoryEntry[] = entries,
   rankingItems: LiveDirectoryRankingEntry[] = rankings,
@@ -225,7 +223,9 @@ describe("LiveDirectory", () => {
     expect(alphaLink.querySelector("img")).toHaveAttribute("alt", "");
   });
 
-  it("defaults the usage ranking period to last7Days when the usage ranking tab is first opened", () => {
+  // rankingPeriod は利用量タブ間で共有される単一state（本ファイル上部の
+  // LiveDirectory実装参照）なので、1タブでの検証で全タブ分の既定値を保証する。
+  it("defaults the shared ranking period state to last7Days, verified via the channel points tab", () => {
     renderDirectory(entries, rankings, recentRankings);
     fireEvent.click(screen.getByRole("tab", { name: "チャネルポイントランキング" }));
 

--- a/tests/unit/components/live-directory.test.tsx
+++ b/tests/unit/components/live-directory.test.tsx
@@ -83,6 +83,17 @@ const rankings: LiveDirectoryRankingEntry[] = [
   },
 ];
 
+/** allTime（rankings）とは別の値を持つ、直近7日間ランキング用フィクスチャ。 */
+const recentRankings: LiveDirectoryRankingEntry[] = [
+  {
+    identity: rankings[0].identity,
+    cardCount: 1,
+    redemptionCount: 2,
+    totalPoints: 345,
+    rankedMetrics: ["cardCount", "redemptionCount", "totalPoints"],
+  },
+];
+
 function renderDirectory(
   streamItems: LiveDirectoryEntry[] = entries,
   rankingItems: LiveDirectoryRankingEntry[] = rankings,
@@ -209,16 +220,7 @@ describe("LiveDirectory", () => {
     expect(alphaLink.querySelector("img")).toHaveAttribute("alt", "");
   });
 
-  it("defaults the usage ranking period to last7Days on first render", () => {
-    const recentRankings: LiveDirectoryRankingEntry[] = [
-      {
-        identity: rankings[0].identity,
-        cardCount: 1,
-        redemptionCount: 2,
-        totalPoints: 345,
-        rankedMetrics: ["cardCount", "redemptionCount", "totalPoints"],
-      },
-    ];
+  it("defaults the usage ranking period to last7Days when the usage ranking tab is first opened", () => {
     renderDirectory(entries, rankings, recentRankings);
     fireEvent.click(screen.getByRole("tab", { name: "チャネルポイントランキング" }));
 
@@ -232,15 +234,6 @@ describe("LiveDirectory", () => {
   });
 
   it("switches usage ranking periods while card count always uses current values", () => {
-    const recentRankings: LiveDirectoryRankingEntry[] = [
-      {
-        identity: rankings[0].identity,
-        cardCount: 1,
-        redemptionCount: 2,
-        totalPoints: 345,
-        rankedMetrics: ["cardCount", "redemptionCount", "totalPoints"],
-      },
-    ];
     renderDirectory(entries, rankings, recentRankings);
     fireEvent.click(screen.getByRole("tab", { name: "チャネルポイントランキング" }));
 
@@ -260,6 +253,11 @@ describe("LiveDirectory", () => {
     expect(screen.getByRole("group", { name: "集計期間" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "全期間" })).toBeChecked();
     expect(screen.getByText("30,000ポイント")).toBeInTheDocument();
+
+    // 全期間 → 直近7日間へ戻す経路も検証する（切り替えは双方向）。
+    fireEvent.click(screen.getByRole("radio", { name: "直近7日間" }));
+    expect(screen.getByRole("radio", { name: "直近7日間" })).toBeChecked();
+    expect(screen.getByText("345ポイント")).toBeInTheDocument();
   });
 
   it("excludes rows outside each metric candidate set before calculating ranks", () => {

--- a/tests/unit/components/live-directory.test.tsx
+++ b/tests/unit/components/live-directory.test.tsx
@@ -223,16 +223,16 @@ describe("LiveDirectory", () => {
     fireEvent.click(screen.getByRole("tab", { name: "チャネルポイントランキング" }));
 
     expect(screen.getByRole("group", { name: "集計期間" })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "全期間" })).toBeChecked();
-    expect(screen.getByText("30,000ポイント")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("radio", { name: "直近7日間" }));
-
     expect(screen.getByRole("radio", { name: "直近7日間" })).toBeChecked();
     expect(screen.getByText("345ポイント")).toBeInTheDocument();
     expect(
       screen.getByText("直近7日間に記録されたカード引き換えを集計しています。"),
     ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: "全期間" }));
+
+    expect(screen.getByRole("radio", { name: "全期間" })).toBeChecked();
+    expect(screen.getByText("30,000ポイント")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("tab", { name: "種類数ランキング" }));
     expect(screen.queryByRole("group", { name: "集計期間" })).not.toBeInTheDocument();
@@ -243,8 +243,8 @@ describe("LiveDirectory", () => {
     // 種類数は期間設定の対象外だが、利用量タブへ戻ったときの選択状態は保持する。
     fireEvent.click(screen.getByRole("tab", { name: "チャネルポイントランキング" }));
     expect(screen.getByRole("group", { name: "集計期間" })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "直近7日間" })).toBeChecked();
-    expect(screen.getByText("345ポイント")).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "全期間" })).toBeChecked();
+    expect(screen.getByText("30,000ポイント")).toBeInTheDocument();
   });
 
   it("excludes rows outside each metric candidate set before calculating ranks", () => {

--- a/tests/unit/components/live-directory.test.tsx
+++ b/tests/unit/components/live-directory.test.tsx
@@ -223,8 +223,9 @@ describe("LiveDirectory", () => {
     expect(alphaLink.querySelector("img")).toHaveAttribute("alt", "");
   });
 
-  // rankingPeriod は利用量タブ間で共有される単一state（本ファイル上部の
-  // LiveDirectory実装参照）なので、1タブでの検証で全タブ分の既定値を保証する。
+  // rankingPeriod は利用量タブ間で共有される単一state
+  // （src/components/LiveDirectory.tsx の useState 1本）なので、
+  // 1タブでの検証で全タブ分の既定値を保証する。
   it("defaults the shared ranking period state to last7Days, verified via the channel points tab", () => {
     renderDirectory(entries, rankings, recentRankings);
     fireEvent.click(screen.getByRole("tab", { name: "チャネルポイントランキング" }));
@@ -242,11 +243,11 @@ describe("LiveDirectory", () => {
     renderDirectory(entries, rankings, recentRankings);
     fireEvent.click(screen.getByRole("tab", { name: "チャネルポイントランキング" }));
 
-    fireEvent.click(screen.getByRole("radio", { name: "全期間" }));
-
-    expect(screen.getByRole("radio", { name: "全期間" })).toBeChecked();
-    expect(screen.getByText("30,000ポイント")).toBeInTheDocument();
-
+    // 種類数タブは既定値変更後もrankingPeriod（ここではlast7Days）を無視して
+    // allTimeだけを参照することを検証する。rankingPeriodがallTimeへ切り替わった
+    // 後にこの分岐を確認すると、rankings[rankingPeriod]とrankings.allTimeが
+    // 一致してしまい、誤って分岐を削っても検知できない回帰ガードになるため、
+    // last7Days選択中に確認する。
     fireEvent.click(screen.getByRole("tab", { name: "種類数ランキング" }));
     expect(screen.queryByRole("group", { name: "集計期間" })).not.toBeInTheDocument();
     expect(screen.getByText("現在有効なカード種類数です。")).toBeInTheDocument();
@@ -254,6 +255,24 @@ describe("LiveDirectory", () => {
     expect(screen.queryByText("1種類")).not.toBeInTheDocument();
 
     // 種類数は期間設定の対象外だが、利用量タブへ戻ったときの選択状態は保持する。
+    fireEvent.click(screen.getByRole("tab", { name: "チャネルポイントランキング" }));
+    expect(screen.getByRole("group", { name: "集計期間" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "直近7日間" })).toBeChecked();
+    expect(screen.getByText("345ポイント")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("radio", { name: "全期間" }));
+
+    expect(screen.getByRole("radio", { name: "全期間" })).toBeChecked();
+    expect(screen.getByText("30,000ポイント")).toBeInTheDocument();
+    expect(
+      screen.getByText("TwiCaに記録されている全期間のカード引き換えを集計しています。"),
+    ).toBeInTheDocument();
+
+    // 全期間へ切り替えた後も、種類数タブは同じallTimeを参照し続ける
+    // （タブ往復による二重フェッチや不整合がないことの確認）。
+    fireEvent.click(screen.getByRole("tab", { name: "種類数ランキング" }));
+    expect(screen.getAllByText("12種類")).toHaveLength(2);
+
     fireEvent.click(screen.getByRole("tab", { name: "チャネルポイントランキング" }));
     expect(screen.getByRole("group", { name: "集計期間" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "全期間" })).toBeChecked();

--- a/tests/unit/components/live-directory.test.tsx
+++ b/tests/unit/components/live-directory.test.tsx
@@ -94,6 +94,11 @@ const recentRankings: LiveDirectoryRankingEntry[] = [
   },
 ];
 
+// recentRankingItemsの既定値はrankingItemsと同一（=last7DaysとallTimeが同じ
+// 内容）にしている。期間ごとの表示差を検証したいテストは、専用の recentRankings
+// フィクスチャを明示的に渡すこと（例: "defaults the usage ranking period..." /
+// "switches usage ranking periods..."）。それ以外のテストは期間非依存の検証に
+// 限定する前提で、この既定値のままにしている。
 function renderDirectory(
   streamItems: LiveDirectoryEntry[] = entries,
   rankingItems: LiveDirectoryRankingEntry[] = rankings,

--- a/tests/unit/components/live-directory.test.tsx
+++ b/tests/unit/components/live-directory.test.tsx
@@ -209,7 +209,7 @@ describe("LiveDirectory", () => {
     expect(alphaLink.querySelector("img")).toHaveAttribute("alt", "");
   });
 
-  it("switches usage ranking periods while card count always uses current values", () => {
+  it("defaults the usage ranking period to last7Days on first render", () => {
     const recentRankings: LiveDirectoryRankingEntry[] = [
       {
         identity: rankings[0].identity,
@@ -222,12 +222,27 @@ describe("LiveDirectory", () => {
     renderDirectory(entries, rankings, recentRankings);
     fireEvent.click(screen.getByRole("tab", { name: "チャネルポイントランキング" }));
 
+    // 初期選択は直近7日間。全期間へは明示的な操作でのみ切り替わる（regression guard）。
     expect(screen.getByRole("group", { name: "集計期間" })).toBeInTheDocument();
     expect(screen.getByRole("radio", { name: "直近7日間" })).toBeChecked();
     expect(screen.getByText("345ポイント")).toBeInTheDocument();
     expect(
       screen.getByText("直近7日間に記録されたカード引き換えを集計しています。"),
     ).toBeInTheDocument();
+  });
+
+  it("switches usage ranking periods while card count always uses current values", () => {
+    const recentRankings: LiveDirectoryRankingEntry[] = [
+      {
+        identity: rankings[0].identity,
+        cardCount: 1,
+        redemptionCount: 2,
+        totalPoints: 345,
+        rankedMetrics: ["cardCount", "redemptionCount", "totalPoints"],
+      },
+    ];
+    renderDirectory(entries, rankings, recentRankings);
+    fireEvent.click(screen.getByRole("tab", { name: "チャネルポイントランキング" }));
 
     fireEvent.click(screen.getByRole("radio", { name: "全期間" }));
 


### PR DESCRIPTION
## 概要

PR #969 を取り込んだ検証済み `preview` を `main` へ昇格します。

- 対象 preview SHA: `376e2b8030aa8598ca65844147dacb0cb36cbf3c`
- 対象変更: PR #969「チャネル・ランキングページの集計期間デフォルトを直近7日間にする」
- `main...preview` の差分: `src/components/LiveDirectory.tsx` と `tests/unit/components/live-directory.test.tsx` の2ファイルのみ

## レビュー

- PR #969 の自動レビュー: 必須指摘なし
- 独立した厳格レビュー: 必須指摘なし
- 未解決review thread: 0件
- 空表示時のフォールバック導線は任意改善として Issue #970 で追跡

## Preview検証

### CI・デプロイ

- [CI #31802850700](https://github.com/azumag/twica/actions/runs/31802850700): 成功
  - typecheck、unit、integration、i18n lint、OpenNext/auxiliary Worker build、Supabase非依存検査
- [Cloudflare Deploy Support #31802850606](https://github.com/azumag/twica/actions/runs/31802850606): 成功
  - preview overlay-realtime Worker のbuild・deploy成功
- [Workers Builds: twica-preview](https://dash.cloudflare.com/b9ab93f1f71640b6965a60c646b2392b/workers/services/view/twica-preview/production/builds/a68b54b4-4b01-4c56-8ea5-89d0cf972022): preview SHA `376e2b8` で成功
- migration/package変更なし。migration系job、通常lint、analysisのskipはpreview pushのworkflow条件どおり

### 実画面

分類は「preview機能テスト」です。読み取り専用ランキングUIの初期state変更であり、EventSub、ガチャ状態更新、overlay、Twitchチャット経路へ到達しないため、実チャネルポイント引き換えは不要です。

PR head `67187f465445efb24490320143d87a7e5089ffc4` のbranch previewで以下を確認しました。

- `/live` HTTP 200、正常描画
- チャネルポイントランキング初回表示は「直近7日間」が選択済み
- 直近7日間は290ポイント、説明文も直近7日間用
- 「全期間」へ切替でき、9,930ポイントと全期間用説明へ追随
- 種類数ランキングは期間UIなし、4種類、現在値用説明
- console error/warn 0件、観測したHTTP応答にnon-2xxなし
- ログイン、設定、Twitch報酬には未接触

PR headとpreview merge commitのtree SHAはともに `47632372def35bc2813c5d2441a057642c32a274` で完全一致します。マージ後canonical previewも同一treeのWorkers Build完了後にHTTP 200を確認済みです。canonical URLのブラウザ再確認は、アプリ内ブラウザの管理ポリシー確認が一時利用不可となり実施できなかったため、上記の同一tree証跡とbranch preview実画面結果で補完しています。

## mainマージ後

- main SHAに対する CI、Cloudflare Deploy Support、Workers Builds: twica、Auto Releaseを個別に確認
- 新しいRelease/tagがexact main SHAを指すことを確認
- `https://twica.bluemoon.works/live` でHTTP 200とランキング期間UIを確認
- 本番でも実引き換えは行わない
