### PR TITLE
release: preview を main へ昇格（PR #979: R2 InternalError(10001) リトライ対応）

### DIFF
--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -131,18 +131,10 @@ async function s3Delete(bucket: string, key: string, clientType: 'images' | 'sou
 // ============================================================================
 
 /**
- * リトライ対象とする一時的なR2/ネットワークエラーのパターン。
- * uploadToR2WithRetry / uploadSoundToR2WithRetry で共通利用する（重複防止のため一元化）。
- *
- * '(10001)' は Cloudflare R2 の InternalError（HTTP 500）で、公式ドキュメントが
- * リトライを推奨している一時障害:
- * https://developers.cloudflare.com/r2/api/error-codes/
- * これが未登録だったため、本番で本来リトライ可能なアップロード失敗が即座にエラー化していた
- * (Issue #976, #977)。
- * '(10043)' は同じくR2のServiceUnavailable（HTTP 503）で、R2ネイティブバインディング用の
- * リトライ判定（r2-retry-policy.ts）にも同種のマーカーを保持している。
+ * リトライ対象とする一時的なネットワーク/S3 SDKエラーのパターン（画像・効果音共通）。
+ * "Unspecified error" はR2ネイティブバインディングの一時障害 (Issue #349/#348)。
  */
-const TRANSIENT_R2_ERROR_PATTERNS = [
+const BASE_TRANSIENT_R2_ERROR_PATTERNS = [
   'ECONNRESET',
   'ETIMEDOUT',
   'ENOTFOUND',
@@ -150,15 +142,40 @@ const TRANSIENT_R2_ERROR_PATTERNS = [
   '503',
   'NetworkingError',
   'Unspecified error',
+];
+
+/**
+ * Cloudflare R2固有のエラーコードのうち、公式にリトライ推奨とされている一時障害:
+ * https://developers.cloudflare.com/r2/api/error-codes/
+ * '(10001)' InternalError（HTTP 500）/ '(10043)' ServiceUnavailable（HTTP 503）
+ *
+ * 画像アップロード（uploadToR2WithRetry）は呼び出し元（src/app/api/upload/route.ts）で
+ * さらに retryCloudflareR2Upload（r2-retry-policy.ts）に包まれ、そちらが同じコードを
+ * 別途リトライする。ここにも同じコードを含めると「内側リトライ×外側リトライ」で
+ * 待ち時間が数倍に肥大化するため、画像側の一時障害判定にはこのR2固有コードを含めない。
+ * 効果音アップロード（uploadSoundToR2WithRetry）は外側のラップが無く、このリトライが
+ * 唯一の再試行機構なので、R2固有コードもここで判定する（Issue #976, #977 と同種の
+ * 未リトライ失敗を防ぐ）。
+ */
+const SOUND_TRANSIENT_R2_ERROR_PATTERNS = [
+  ...BASE_TRANSIENT_R2_ERROR_PATTERNS,
   '(10001)',
   '(10043)',
 ];
 
-// テストから直接検証できるようexport（r2-retry-policy.tsのisTransientCloudflareR2Errorと同じ方針）
-export function isTransientR2Error(errorMessage: string): boolean {
-  return TRANSIENT_R2_ERROR_PATTERNS.some(pattern =>
+function matchesTransientPattern(errorMessage: string, patterns: readonly string[]): boolean {
+  return patterns.some(pattern =>
     errorMessage.toLowerCase().includes(pattern.toLowerCase())
   );
+}
+
+// テストから直接検証できるようexport（r2-retry-policy.tsのisTransientCloudflareR2Errorと同じ方針）
+export function isTransientR2UploadError(errorMessage: string): boolean {
+  return matchesTransientPattern(errorMessage, BASE_TRANSIENT_R2_ERROR_PATTERNS);
+}
+
+export function isTransientR2SoundUploadError(errorMessage: string): boolean {
+  return matchesTransientPattern(errorMessage, SOUND_TRANSIENT_R2_ERROR_PATTERNS);
 }
 
 /**
@@ -307,9 +324,10 @@ export async function uploadToR2WithRetry(
       const errorMessage = error instanceof Error ? error.message : String(error);
 
       // 一時的なエラーかどうかを判定
-      // "Unspecified error" はR2ネイティブバインディングの一時障害 (Issue #349/#348)
-      // "(10001)" はR2のInternalError (Issue #976/#977)
-      const isTransient = isTransientR2Error(errorMessage);
+      // R2固有のエラーコード（10001/10043等）は呼び出し元のretryCloudflareR2Upload
+      // （r2-retry-policy.ts）側でリトライするため、ここでは含めない（二重リトライによる
+      // 待ち時間の肥大化を防ぐため。詳細はSOUND_TRANSIENT_R2_ERROR_PATTERNSのコメント参照）
+      const isTransient = isTransientR2UploadError(errorMessage);
 
       if (!isTransient || attempt === maxRetries) {
         return { error: errorMessage };
@@ -349,9 +367,9 @@ export async function uploadSoundToR2WithRetry(
       const errorMessage = error instanceof Error ? error.message : String(error);
 
       // 一時的なエラーかどうかを判定
-      // "Unspecified error" はR2ネイティブバインディングの一時障害 (Issue #349/#348)
-      // "(10001)" はR2のInternalError (Issue #976/#977)
-      const isTransient = isTransientR2Error(errorMessage);
+      // 効果音アップロードは呼び出し元に外側のリトライラッパーが無いため、
+      // R2固有のエラーコード（10001/10043等）もここで一時障害として扱う
+      const isTransient = isTransientR2SoundUploadError(errorMessage);
 
       if (!isTransient || attempt === maxRetries) {
         return { error: errorMessage };

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -17,6 +17,7 @@
 // 実行時に判定するが、このモジュール自体を Edge middleware から import してよいことを
 // 意味しないため、middleware 到達コードとの境界は静的テストで固定している。
 import { logger } from './logger.server';
+import { CLOUDFLARE_R2_TRANSIENT_MARKERS } from './r2-retry-policy';
 
 /**
  * Minimal R2Bucket interface matching Cloudflare Workers R2 API.
@@ -145,9 +146,8 @@ const BASE_TRANSIENT_R2_ERROR_PATTERNS = [
 ];
 
 /**
- * Cloudflare R2固有のエラーコードのうち、公式にリトライ推奨とされている一時障害:
- * https://developers.cloudflare.com/r2/api/error-codes/
- * '(10001)' InternalError（HTTP 500）/ '(10043)' ServiceUnavailable（HTTP 503）
+ * Cloudflare R2固有のエラーコード（'(10001)' InternalError / '(10043)' ServiceUnavailable等、
+ * 詳細は r2-retry-policy.ts の CLOUDFLARE_R2_TRANSIENT_MARKERS を参照）を含む一時障害パターン。
  *
  * 画像アップロード（uploadToR2WithRetry）は呼び出し元（src/app/api/upload/route.ts）で
  * さらに retryCloudflareR2Upload（r2-retry-policy.ts）に包まれ、そちらが同じコードを
@@ -156,11 +156,12 @@ const BASE_TRANSIENT_R2_ERROR_PATTERNS = [
  * 効果音アップロード（uploadSoundToR2WithRetry）は外側のラップが無く、このリトライが
  * 唯一の再試行機構なので、R2固有コードもここで判定する（Issue #976, #977 と同種の
  * 未リトライ失敗を防ぐ）。
+ *
+ * マーカー文字列自体はr2-retry-policy.tsからimportし、二重管理（今回のバグの原因）を避ける。
  */
 const SOUND_TRANSIENT_R2_ERROR_PATTERNS = [
   ...BASE_TRANSIENT_R2_ERROR_PATTERNS,
-  '(10001)',
-  '(10043)',
+  ...CLOUDFLARE_R2_TRANSIENT_MARKERS,
 ];
 
 function matchesTransientPattern(errorMessage: string, patterns: readonly string[]): boolean {

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -131,6 +131,37 @@ async function s3Delete(bucket: string, key: string, clientType: 'images' | 'sou
 // ============================================================================
 
 /**
+ * リトライ対象とする一時的なR2/ネットワークエラーのパターン。
+ * uploadToR2WithRetry / uploadSoundToR2WithRetry で共通利用する（重複防止のため一元化）。
+ *
+ * '(10001)' は Cloudflare R2 の InternalError（HTTP 500）で、公式ドキュメントが
+ * リトライを推奨している一時障害:
+ * https://developers.cloudflare.com/r2/api/error-codes/
+ * これが未登録だったため、本番で本来リトライ可能なアップロード失敗が即座にエラー化していた
+ * (Issue #976, #977)。
+ * '(10043)' は同じくR2のServiceUnavailable（HTTP 503）で、R2ネイティブバインディング用の
+ * リトライ判定（r2-retry-policy.ts）にも同種のマーカーを保持している。
+ */
+const TRANSIENT_R2_ERROR_PATTERNS = [
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'service unavailable',
+  '503',
+  'NetworkingError',
+  'Unspecified error',
+  '(10001)',
+  '(10043)',
+];
+
+// テストから直接検証できるようexport（r2-retry-policy.tsのisTransientCloudflareR2Errorと同じ方針）
+export function isTransientR2Error(errorMessage: string): boolean {
+  return TRANSIENT_R2_ERROR_PATTERNS.some(pattern =>
+    errorMessage.toLowerCase().includes(pattern.toLowerCase())
+  );
+}
+
+/**
  * R2にファイルをアップロード（画像用）
  * Workers環境ではネイティブバインディング、ローカルではS3 SDKを使用
  * @param fileName - ファイル名（キー）
@@ -277,10 +308,8 @@ export async function uploadToR2WithRetry(
 
       // 一時的なエラーかどうかを判定
       // "Unspecified error" はR2ネイティブバインディングの一時障害 (Issue #349/#348)
-      const transientErrors = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'service unavailable', '503', 'NetworkingError', 'Unspecified error'];
-      const isTransient = transientErrors.some(err =>
-        errorMessage.toLowerCase().includes(err.toLowerCase())
-      );
+      // "(10001)" はR2のInternalError (Issue #976/#977)
+      const isTransient = isTransientR2Error(errorMessage);
 
       if (!isTransient || attempt === maxRetries) {
         return { error: errorMessage };
@@ -321,10 +350,8 @@ export async function uploadSoundToR2WithRetry(
 
       // 一時的なエラーかどうかを判定
       // "Unspecified error" はR2ネイティブバインディングの一時障害 (Issue #349/#348)
-      const transientErrors = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'service unavailable', '503', 'NetworkingError', 'Unspecified error'];
-      const isTransient = transientErrors.some(err =>
-        errorMessage.toLowerCase().includes(err.toLowerCase())
-      );
+      // "(10001)" はR2のInternalError (Issue #976/#977)
+      const isTransient = isTransientR2Error(errorMessage);
 
       if (!isTransient || attempt === maxRetries) {
         return { error: errorMessage };

--- a/src/lib/r2-retry-policy.ts
+++ b/src/lib/r2-retry-policy.ts
@@ -3,9 +3,13 @@ export interface R2UploadResult {
   error?: string
 }
 
-const CLOUDFLARE_R2_TRANSIENT_MARKERS = [
-  // 10001: InternalError (HTTP 500)。公式にリトライ推奨の一時障害
-  // (https://developers.cloudflare.com/r2/api/error-codes/)。
+// Cloudflare R2固有のエラーシグネチャのうち、公式にリトライ推奨とされている一時障害:
+// https://developers.cloudflare.com/r2/api/error-codes/
+// r2-client.ts（効果音アップロードの一時障害判定）とここで別々に同じ文字列を持つと、
+// 一方だけ更新漏れが起きて今回のバグ（10001が片方のリストにしか無かった）が再発するため、
+// このマーカー一覧を単一の情報源としてexportし、r2-client.ts側からimportして使う。
+export const CLOUDFLARE_R2_TRANSIENT_MARKERS = [
+  // 10001: InternalError (HTTP 500)。
   // 未登録だったため本番のR2アップロード失敗が即座にエラー化していた (Issue #976, #977)。
   '(10001)',
   // 10043: ServiceUnavailable (HTTP 503)。

--- a/src/lib/r2-retry-policy.ts
+++ b/src/lib/r2-retry-policy.ts
@@ -4,6 +4,11 @@ export interface R2UploadResult {
 }
 
 const CLOUDFLARE_R2_TRANSIENT_MARKERS = [
+  // 10001: InternalError (HTTP 500)。公式にリトライ推奨の一時障害
+  // (https://developers.cloudflare.com/r2/api/error-codes/)。
+  // 未登録だったため本番のR2アップロード失敗が即座にエラー化していた (Issue #976, #977)。
+  '(10001)',
+  // 10043: ServiceUnavailable (HTTP 503)。
   '(10043)',
   'cloudflarestatus.com',
   'contact customer support',

--- a/tests/unit/r2-client-transient-error.test.ts
+++ b/tests/unit/r2-client-transient-error.test.ts
@@ -1,27 +1,46 @@
 import { describe, expect, it } from 'vitest'
-import { isTransientR2Error } from '@/lib/r2-client'
+import { isTransientR2UploadError, isTransientR2SoundUploadError } from '@/lib/r2-client'
 
 // uploadToR2WithRetry / uploadSoundToR2WithRetry の一時障害判定ロジック。
 // Issue #976/#977: R2のInternalError(10001)が未登録だったため、本番で
 // リトライ可能なはずのアップロード失敗が即座にエラー化していた。
-describe('isTransientR2Error', () => {
-  it('R2のInternalError (10001) を一時障害として扱う (Issue #976/#977)', () => {
-    expect(isTransientR2Error('put: We encountered an internal error. Please try again. (10001)')).toBe(true)
-  })
-
-  it('R2のServiceUnavailable (10043) を一時障害として扱う', () => {
-    expect(isTransientR2Error('put: Please look at https://www.cloudflarestatus.com (10043)')).toBe(true)
+//
+// 画像用（isTransientR2UploadError）はretryCloudflareR2Upload（r2-retry-policy.ts）で
+// 二重にラップされるため、R2固有のエラーコードはそちら側のみで判定し、ここには含めない
+// （二重リトライによる待ち時間の肥大化を防ぐ）。効果音用（isTransientR2SoundUploadError）は
+// 外側のラップが無い唯一のリトライ層なので、R2固有のエラーコードもここで判定する。
+describe('isTransientR2UploadError（画像アップロード用）', () => {
+  it('ネットワーク系エラーを一時障害として扱う', () => {
+    expect(isTransientR2UploadError('connect ECONNRESET')).toBe(true)
   })
 
   it('R2ネイティブバインディングのUnspecified errorを一時障害として扱う (Issue #349/#348)', () => {
-    expect(isTransientR2Error('Unspecified error')).toBe(true)
+    expect(isTransientR2UploadError('Unspecified error')).toBe(true)
   })
 
-  it('ネットワーク系エラーを一時障害として扱う', () => {
-    expect(isTransientR2Error('connect ECONNRESET')).toBe(true)
+  it('R2固有のエラーコード(10001)はここでは一時障害として扱わない（外側のretryCloudflareR2Uploadが担当、二重リトライ防止）', () => {
+    expect(isTransientR2UploadError('put: We encountered an internal error. Please try again. (10001)')).toBe(false)
   })
 
   it('認証エラーなど恒久障害は一時障害として扱わない', () => {
-    expect(isTransientR2Error('AccessDenied: invalid credentials')).toBe(false)
+    expect(isTransientR2UploadError('AccessDenied: invalid credentials')).toBe(false)
+  })
+})
+
+describe('isTransientR2SoundUploadError（効果音アップロード用）', () => {
+  it('R2のInternalError (10001) を一時障害として扱う (Issue #976/#977と同種)', () => {
+    expect(isTransientR2SoundUploadError('put: We encountered an internal error. Please try again. (10001)')).toBe(true)
+  })
+
+  it('R2のServiceUnavailable (10043) を一時障害として扱う', () => {
+    expect(isTransientR2SoundUploadError('put: Please look at https://www.cloudflarestatus.com (10043)')).toBe(true)
+  })
+
+  it('ネットワーク系エラーを一時障害として扱う', () => {
+    expect(isTransientR2SoundUploadError('connect ECONNRESET')).toBe(true)
+  })
+
+  it('認証エラーなど恒久障害は一時障害として扱わない', () => {
+    expect(isTransientR2SoundUploadError('AccessDenied: invalid credentials')).toBe(false)
   })
 })

--- a/tests/unit/r2-client-transient-error.test.ts
+++ b/tests/unit/r2-client-transient-error.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { isTransientR2Error } from '@/lib/r2-client'
+
+// uploadToR2WithRetry / uploadSoundToR2WithRetry の一時障害判定ロジック。
+// Issue #976/#977: R2のInternalError(10001)が未登録だったため、本番で
+// リトライ可能なはずのアップロード失敗が即座にエラー化していた。
+describe('isTransientR2Error', () => {
+  it('R2のInternalError (10001) を一時障害として扱う (Issue #976/#977)', () => {
+    expect(isTransientR2Error('put: We encountered an internal error. Please try again. (10001)')).toBe(true)
+  })
+
+  it('R2のServiceUnavailable (10043) を一時障害として扱う', () => {
+    expect(isTransientR2Error('put: Please look at https://www.cloudflarestatus.com (10043)')).toBe(true)
+  })
+
+  it('R2ネイティブバインディングのUnspecified errorを一時障害として扱う (Issue #349/#348)', () => {
+    expect(isTransientR2Error('Unspecified error')).toBe(true)
+  })
+
+  it('ネットワーク系エラーを一時障害として扱う', () => {
+    expect(isTransientR2Error('connect ECONNRESET')).toBe(true)
+  })
+
+  it('認証エラーなど恒久障害は一時障害として扱わない', () => {
+    expect(isTransientR2Error('AccessDenied: invalid credentials')).toBe(false)
+  })
+})

--- a/tests/unit/r2-retry-policy.test.ts
+++ b/tests/unit/r2-retry-policy.test.ts
@@ -6,6 +6,10 @@ describe('R2 retry policy', () => {
     expect(isTransientCloudflareR2Error('put: Please look at https://www.cloudflarestatus.com for issues or contact customer support. (10043)')).toBe(true)
   })
 
+  it('Cloudflare R2 error 10001（InternalError）を一時障害として扱う (Issue #976/#977)', () => {
+    expect(isTransientCloudflareR2Error('put: We encountered an internal error. Please try again. (10001)')).toBe(true)
+  })
+
   it('認証エラーなど恒久障害は再試行対象にしない', () => {
     expect(isTransientCloudflareR2Error('AccessDenied: invalid credentials')).toBe(false)
   })


### PR DESCRIPTION
## 内容

PR #979（`fix(r2): InternalError(10001)を一時障害として再試行対象にする`）をpreviewでレビュー・検証済み。本番（main）へ昇格する。

- Closes #976
- Closes #977

## preview検証結果

- `npx tsc --noEmit` — エラーなし
- `npx eslint` — エラーなし（既存の無関係な警告のみ）
- `npx vitest run tests/unit` — 271 files / 3504 tests すべて成功
- 自動レビュー（Claude Auto Review）: 指摘2件（二重リトライによる待ち時間肥大化、R2エラーコードマーカーの二重管理）を修正・解消済み。再レビューで指摘なしを確認

## リスク

- アップロードAPI（画像/効果音）のエラーハンドリングのみの変更で、UIや他の機能への影響はない
- ガチャ引き換え/オーバーレイ表示/Twitchチャット送信に影響する変更ではないため、preview実チャネル引き換えテストは対象外

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MF74mrAdWmYJnmgEc3ZNrj)_