### PR TITLE
release: preview を main へ昇格

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -8,7 +8,6 @@ import { getFileTypeFromBuffer, getFileExtension, isValidExtension } from '@/lib
 import { logger } from '@/lib/logger.server';
 import { validateCSRFToken } from '@/lib/csrf';
 import { uploadToR2WithRetry } from '@/lib/r2-client';
-import { retryCloudflareR2Upload } from '@/lib/r2-retry-policy';
 import { recordBlobFile } from '@/lib/storage-db';
 import { getStorageUsage } from '@/lib/storage-usage';
 import { sha256Prefix, randomUUID } from '@/lib/crypto-utils';
@@ -182,9 +181,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     fileName = `${userPrefixForFile}_${uniqueSuffix}.${ext}`;
 
     // R2にアップロード（Vercel Blobの代わり）
-    const uploadResult = await retryCloudflareR2Upload(
-      () => uploadToR2WithRetry(fileName!, buffer!, actualType)
-    );
+    // uploadToR2WithRetry自体がR2固有エラーコード込みでリトライする単一のリトライループ
+    // なので、ここで別のリトライラッパーに包まない（二重リトライで待ち時間が肥大化する
+    // 問題があったため撤去した。Issue #980）
+    const uploadResult = await uploadToR2WithRetry(fileName!, buffer!, actualType);
 
     if ('error' in uploadResult) {
       return handleBlobError(

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -132,10 +132,24 @@ async function s3Delete(bucket: string, key: string, clientType: 'images' | 'sou
 // ============================================================================
 
 /**
- * リトライ対象とする一時的なネットワーク/S3 SDKエラーのパターン（画像・効果音共通）。
+ * リトライ対象とする一時的なR2/ネットワーク/S3 SDKエラーのパターン（画像・効果音アップロード共通）。
  * "Unspecified error" はR2ネイティブバインディングの一時障害 (Issue #349/#348)。
+ * Cloudflare R2固有のエラーコード（'(10001)' InternalError / '(10043)' ServiceUnavailable等）は
+ * r2-retry-policy.ts の CLOUDFLARE_R2_TRANSIENT_MARKERS を単一の情報源としてimportする
+ * （ここに直接書くと今回のバグ=片方のリストにしか登録されない、が再発するため）。
+ *
+ * 【Issue #980】以前は画像アップロード（uploadToR2WithRetry）だけ、呼び出し元
+ * （src/app/api/upload/route.ts）で r2-retry-policy.ts の retryCloudflareR2Upload に
+ * さらに二重ラップされており、CLOUDFLARE_R2_TRANSIENT_MARKERS 該当エラーを
+ * 内側・外側の両方でリトライすると最大試行回数・待ち時間が最悪ケースで約4倍
+ * （12回・合計約22秒）に肥大化する上限のないリスクがあった。その二重ラップ自体を撤去し、
+ * 画像・効果音とも「このモジュールの1本のリトライループだけがリトライを担う」構成に
+ * 統一したため、二重リトライは構造的に発生し得ない。リトライの上限は
+ * uploadToR2WithRetry/uploadSoundToR2WithRetry の maxRetries（デフォルト3）1箇所だけで
+ * 決まり、最大試行回数は maxRetries+1 回、最大累計待機時間は指数バックオフの合計
+ * （デフォルト値なら 1s+2s+4s=7秒）に明示的に収まる。
  */
-const BASE_TRANSIENT_R2_ERROR_PATTERNS = [
+const TRANSIENT_R2_ERROR_PATTERNS = [
   'ECONNRESET',
   'ETIMEDOUT',
   'ENOTFOUND',
@@ -143,40 +157,14 @@ const BASE_TRANSIENT_R2_ERROR_PATTERNS = [
   '503',
   'NetworkingError',
   'Unspecified error',
-];
-
-/**
- * Cloudflare R2固有のエラーコード（'(10001)' InternalError / '(10043)' ServiceUnavailable等、
- * 詳細は r2-retry-policy.ts の CLOUDFLARE_R2_TRANSIENT_MARKERS を参照）を含む一時障害パターン。
- *
- * 画像アップロード（uploadToR2WithRetry）は呼び出し元（src/app/api/upload/route.ts）で
- * さらに retryCloudflareR2Upload（r2-retry-policy.ts）に包まれ、そちらが同じコードを
- * 別途リトライする。ここにも同じコードを含めると「内側リトライ×外側リトライ」で
- * 待ち時間が数倍に肥大化するため、画像側の一時障害判定にはこのR2固有コードを含めない。
- * 効果音アップロード（uploadSoundToR2WithRetry）は外側のラップが無く、このリトライが
- * 唯一の再試行機構なので、R2固有コードもここで判定する（Issue #976, #977 と同種の
- * 未リトライ失敗を防ぐ）。
- *
- * マーカー文字列自体はr2-retry-policy.tsからimportし、二重管理（今回のバグの原因）を避ける。
- */
-const SOUND_TRANSIENT_R2_ERROR_PATTERNS = [
-  ...BASE_TRANSIENT_R2_ERROR_PATTERNS,
   ...CLOUDFLARE_R2_TRANSIENT_MARKERS,
 ];
 
-function matchesTransientPattern(errorMessage: string, patterns: readonly string[]): boolean {
-  return patterns.some(pattern =>
+// テストから直接検証できるようexport（r2-retry-policy.tsのisTransientCloudflareR2Errorと同じ方針）
+export function isTransientR2Error(errorMessage: string): boolean {
+  return TRANSIENT_R2_ERROR_PATTERNS.some(pattern =>
     errorMessage.toLowerCase().includes(pattern.toLowerCase())
   );
-}
-
-// テストから直接検証できるようexport（r2-retry-policy.tsのisTransientCloudflareR2Errorと同じ方針）
-export function isTransientR2UploadError(errorMessage: string): boolean {
-  return matchesTransientPattern(errorMessage, BASE_TRANSIENT_R2_ERROR_PATTERNS);
-}
-
-export function isTransientR2SoundUploadError(errorMessage: string): boolean {
-  return matchesTransientPattern(errorMessage, SOUND_TRANSIENT_R2_ERROR_PATTERNS);
 }
 
 /**
@@ -324,11 +312,8 @@ export async function uploadToR2WithRetry(
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
 
-      // 一時的なエラーかどうかを判定
-      // R2固有のエラーコード（10001/10043等）は呼び出し元のretryCloudflareR2Upload
-      // （r2-retry-policy.ts）側でリトライするため、ここでは含めない（二重リトライによる
-      // 待ち時間の肥大化を防ぐため。詳細はSOUND_TRANSIENT_R2_ERROR_PATTERNSのコメント参照）
-      const isTransient = isTransientR2UploadError(errorMessage);
+      // 一時的なエラーかどうかを判定（R2固有コード・ネットワークエラーとも、ここが唯一のリトライ層）
+      const isTransient = isTransientR2Error(errorMessage);
 
       if (!isTransient || attempt === maxRetries) {
         return { error: errorMessage };
@@ -367,10 +352,8 @@ export async function uploadSoundToR2WithRetry(
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
 
-      // 一時的なエラーかどうかを判定
-      // 効果音アップロードは呼び出し元に外側のリトライラッパーが無いため、
-      // R2固有のエラーコード（10001/10043等）もここで一時障害として扱う
-      const isTransient = isTransientR2SoundUploadError(errorMessage);
+      // 一時的なエラーかどうかを判定（R2固有コード・ネットワークエラーとも、ここが唯一のリトライ層）
+      const isTransient = isTransientR2Error(errorMessage);
 
       if (!isTransient || attempt === maxRetries) {
         return { error: errorMessage };

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -333,20 +333,21 @@ export async function uploadSoundToR2WithRetry(
 /**
  * uploadToR2WithRetry / uploadSoundToR2WithRetry の共通リトライループ本体。
  * ログの接頭辞（'[R2]' / '[R2 Sound]'）とアップロード呼び出し以外は完全に同一だった
- * 2つのループを1本化した（自動レビュー(PR #983)の指摘を反映）。
+ * 2つのループの重複を解消するために1本化した。
  *
  * sleepを引数として注入可能にしているのは、テストから実際の待機（最大7秒）なしに
  * リトライ回数・バックオフ時間・打ち切り条件を検証できるようにするため
  * （r2-retry-policy.tsの旧retryCloudflareR2Uploadと同じ設計。テストは
  * tests/unit/r2-client-retry-loop.test.ts を参照）。本番呼び出し元（上記2関数）は
- * 常にデフォルトの実setTimeoutを使う。
+ * 常にデフォルトの実setTimeoutを使う。テスト専用のexportなので、本番からは
+ * 上記2関数を経由してのみ呼ぶこと。
  *
  * @param logPrefix - ログメッセージの接頭辞
  * @param upload - 実際のアップロード処理（1回分）。R2の公開URLを返すかthrowする
  * @param maxRetries - 最大リトライ回数
  * @param sleep - バックオフ待機の実装（テスト用に差し替え可能。デフォルトは実setTimeout）
  */
-async function withR2UploadRetry(
+export async function withR2UploadRetry(
   logPrefix: string,
   upload: () => Promise<string>,
   maxRetries: number,
@@ -375,6 +376,3 @@ async function withR2UploadRetry(
 
   return { error: 'Max retries exceeded' };
 }
-
-// テストから直接検証できるようexport（本番呼び出し元は上記2関数経由でのみ使う）
-export { withR2UploadRetry };

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -141,8 +141,8 @@ async function s3Delete(bucket: string, key: string, clientType: 'images' | 'sou
  * 【Issue #980】以前は画像アップロード（uploadToR2WithRetry）だけ、呼び出し元
  * （src/app/api/upload/route.ts）で r2-retry-policy.ts の retryCloudflareR2Upload に
  * さらに二重ラップされており、CLOUDFLARE_R2_TRANSIENT_MARKERS 該当エラーを
- * 内側・外側の両方でリトライすると最大試行回数・待ち時間が最悪ケースで約4倍
- * （12回・合計約22秒）に肥大化する上限のないリスクがあった。その二重ラップ自体を撤去し、
+ * 内側・外側の両方でリトライすると最大試行回数・待ち時間が最悪ケースで約3倍
+ * （4回→12回・7秒→約22秒）に肥大化する上限のないリスクがあった。その二重ラップ自体を撤去し、
  * 画像・効果音とも「このモジュールの1本のリトライループだけがリトライを担う」構成に
  * 統一したため、二重リトライは構造的に発生し得ない。リトライの上限は
  * uploadToR2WithRetry/uploadSoundToR2WithRetry の maxRetries（デフォルト3）1箇所だけで

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -140,11 +140,14 @@ async function s3Delete(bucket: string, key: string, clientType: 'images' | 'sou
  *
  * 【Issue #980】以前は画像アップロード（uploadToR2WithRetry）だけ、呼び出し元
  * （src/app/api/upload/route.ts）で r2-retry-policy.ts の retryCloudflareR2Upload に
- * さらに二重ラップされており、CLOUDFLARE_R2_TRANSIENT_MARKERS 該当エラーを
- * 内側・外側の両方でリトライすると最大試行回数・待ち時間が最悪ケースで約3倍
- * （4回→12回・7秒→約22秒）に肥大化する上限のないリスクがあった。その二重ラップ自体を撤去し、
- * 画像・効果音とも「このモジュールの1本のリトライループだけがリトライを担う」構成に
- * 統一したため、二重リトライは構造的に発生し得ない。リトライの上限は
+ * さらに二重ラップされていた。旧・画像用の内側リストはCLOUDFLARE_R2_TRANSIENT_MARKERSを
+ * 意図的に除外していたため、単発のR2固有エラーコードだけでは二重にリトライされなかったが、
+ * 「内側が判定するネットワーク系エラーが複数回続いた末に、内側の最大試行到達で返した
+ * 最終エラーがたまたまCLOUDFLARE_R2_TRANSIENT_MARKERSにも該当する」という系列が起きると、
+ * 外側もそれを一時障害と判定して再試行し、理論上の最悪ケースで試行回数・待ち時間が
+ * 約3倍（4回→12回・7秒→約22秒）に肥大化しうる、上限が明示されていないリトライ構成だった。
+ * その二重ラップ自体を撤去し、画像・効果音とも「このモジュールの1本のリトライループだけが
+ * リトライを担う」構成に統一したため、二重リトライは構造的に発生し得ない。リトライの上限は
  * uploadToR2WithRetry/uploadSoundToR2WithRetry の maxRetries（デフォルト3）1箇所だけで
  * 決まり、最大試行回数は maxRetries+1 回、最大累計待機時間は指数バックオフの合計
  * （デフォルト値なら 1s+2s+4s=7秒）に明示的に収まる。
@@ -305,28 +308,7 @@ export async function uploadToR2WithRetry(
   contentType: string,
   maxRetries: number = 3
 ): Promise<{ url: string } | { error: string }> {
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    try {
-      const url = await uploadToR2(fileName, buffer, contentType);
-      return { url };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-
-      // 一時的なエラーかどうかを判定（R2固有コード・ネットワークエラーとも、ここが唯一のリトライ層）
-      const isTransient = isTransientR2Error(errorMessage);
-
-      if (!isTransient || attempt === maxRetries) {
-        return { error: errorMessage };
-      }
-
-      // 指数バックオフでリトライ
-      const delay = Math.pow(2, attempt) * 1000;
-      logger.warn(`[R2] Upload failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms:`, errorMessage);
-      await new Promise(resolve => setTimeout(resolve, delay));
-    }
-  }
-
-  return { error: 'Max retries exceeded' };
+  return withR2UploadRetry('[R2]', () => uploadToR2(fileName, buffer, contentType), maxRetries);
 }
 
 /**
@@ -345,9 +327,34 @@ export async function uploadSoundToR2WithRetry(
   contentType: string,
   maxRetries: number = 3
 ): Promise<{ url: string } | { error: string }> {
+  return withR2UploadRetry('[R2 Sound]', () => uploadSoundToR2(fileName, buffer, contentType), maxRetries);
+}
+
+/**
+ * uploadToR2WithRetry / uploadSoundToR2WithRetry の共通リトライループ本体。
+ * ログの接頭辞（'[R2]' / '[R2 Sound]'）とアップロード呼び出し以外は完全に同一だった
+ * 2つのループを1本化した（自動レビュー(PR #983)の指摘を反映）。
+ *
+ * sleepを引数として注入可能にしているのは、テストから実際の待機（最大7秒）なしに
+ * リトライ回数・バックオフ時間・打ち切り条件を検証できるようにするため
+ * （r2-retry-policy.tsの旧retryCloudflareR2Uploadと同じ設計。テストは
+ * tests/unit/r2-client-retry-loop.test.ts を参照）。本番呼び出し元（上記2関数）は
+ * 常にデフォルトの実setTimeoutを使う。
+ *
+ * @param logPrefix - ログメッセージの接頭辞
+ * @param upload - 実際のアップロード処理（1回分）。R2の公開URLを返すかthrowする
+ * @param maxRetries - 最大リトライ回数
+ * @param sleep - バックオフ待機の実装（テスト用に差し替え可能。デフォルトは実setTimeout）
+ */
+async function withR2UploadRetry(
+  logPrefix: string,
+  upload: () => Promise<string>,
+  maxRetries: number,
+  sleep: (ms: number) => Promise<void> = (ms) => new Promise(resolve => setTimeout(resolve, ms))
+): Promise<{ url: string } | { error: string }> {
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     try {
-      const url = await uploadSoundToR2(fileName, buffer, contentType);
+      const url = await upload();
       return { url };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
@@ -361,10 +368,13 @@ export async function uploadSoundToR2WithRetry(
 
       // 指数バックオフでリトライ
       const delay = Math.pow(2, attempt) * 1000;
-      logger.warn(`[R2 Sound] Upload failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms:`, errorMessage);
-      await new Promise(resolve => setTimeout(resolve, delay));
+      logger.warn(`${logPrefix} Upload failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms:`, errorMessage);
+      await sleep(delay);
     }
   }
 
   return { error: 'Max retries exceeded' };
 }
+
+// テストから直接検証できるようexport（本番呼び出し元は上記2関数経由でのみ使う）
+export { withR2UploadRetry };

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -160,7 +160,7 @@ const TRANSIENT_R2_ERROR_PATTERNS = [
   ...CLOUDFLARE_R2_TRANSIENT_MARKERS,
 ];
 
-// テストから直接検証できるようexport（r2-retry-policy.tsのisTransientCloudflareR2Errorと同じ方針）
+// テストから直接検証できるようexport
 export function isTransientR2Error(errorMessage: string): boolean {
   return TRANSIENT_R2_ERROR_PATTERNS.some(pattern =>
     errorMessage.toLowerCase().includes(pattern.toLowerCase())

--- a/src/lib/r2-retry-policy.ts
+++ b/src/lib/r2-retry-policy.ts
@@ -22,7 +22,7 @@ export function isTransientCloudflareR2Error(message: string): boolean {
 // ラップして再試行する汎用ヘルパー）も提供しており、src/app/api/upload/route.ts が
 // r2-client.ts の uploadToR2WithRetry（それ自体が独立したリトライループを持つ）をさらに
 // これで二重に包んでいた。CLOUDFLARE_R2_TRANSIENT_MARKERS 該当エラーは両方の層が
-// リトライ対象と判定するため、最悪ケースで試行回数・待ち時間が約4倍（12回・約22秒）に
+// リトライ対象と判定するため、最悪ケースで試行回数・待ち時間が約3倍（4回→12回・約22秒）に
 // 肥大化しうる、明示的な上限のないリトライ構成になっていた。
 // 再試行はr2-client.ts側の1ループに一本化し、ここは「何が一時障害か」の判定
 // （CLOUDFLARE_R2_TRANSIENT_MARKERS / isTransientCloudflareR2Error）だけを提供する

--- a/src/lib/r2-retry-policy.ts
+++ b/src/lib/r2-retry-policy.ts
@@ -1,11 +1,6 @@
-export interface R2UploadResult {
-  url?: string
-  error?: string
-}
-
 // Cloudflare R2固有のエラーシグネチャのうち、公式にリトライ推奨とされている一時障害:
 // https://developers.cloudflare.com/r2/api/error-codes/
-// r2-client.ts（効果音アップロードの一時障害判定）とここで別々に同じ文字列を持つと、
+// r2-client.ts（画像・効果音共通のアップロードリトライ）とここで別々に同じ文字列を持つと、
 // 一方だけ更新漏れが起きて今回のバグ（10001が片方のリストにしか無かった）が再発するため、
 // このマーカー一覧を単一の情報源としてexportし、r2-client.ts側からimportして使う。
 export const CLOUDFLARE_R2_TRANSIENT_MARKERS = [
@@ -23,21 +18,12 @@ export function isTransientCloudflareR2Error(message: string): boolean {
   return CLOUDFLARE_R2_TRANSIENT_MARKERS.some((marker) => normalized.includes(marker))
 }
 
-export async function retryCloudflareR2Upload<T extends R2UploadResult>(
-  upload: () => Promise<T>,
-  maxRetries = 2,
-  sleep: (ms: number) => Promise<void> = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
-): Promise<T> {
-  let result = await upload()
-
-  for (let attempt = 0; attempt < maxRetries; attempt++) {
-    if (!result.error || !isTransientCloudflareR2Error(result.error)) {
-      return result
-    }
-
-    await sleep(2 ** attempt * 500)
-    result = await upload()
-  }
-
-  return result
-}
+// 【Issue #980】このモジュールは以前 retryCloudflareR2Upload（R2UploadResultを返す関数を
+// ラップして再試行する汎用ヘルパー）も提供しており、src/app/api/upload/route.ts が
+// r2-client.ts の uploadToR2WithRetry（それ自体が独立したリトライループを持つ）をさらに
+// これで二重に包んでいた。CLOUDFLARE_R2_TRANSIENT_MARKERS 該当エラーは両方の層が
+// リトライ対象と判定するため、最悪ケースで試行回数・待ち時間が約4倍（12回・約22秒）に
+// 肥大化しうる、明示的な上限のないリトライ構成になっていた。
+// 再試行はr2-client.ts側の1ループに一本化し、ここは「何が一時障害か」の判定
+// （CLOUDFLARE_R2_TRANSIENT_MARKERS / isTransientCloudflareR2Error）だけを提供する
+// single source of truthとして残す。retryCloudflareR2Uploadは撤去済み。

--- a/src/lib/r2-retry-policy.ts
+++ b/src/lib/r2-retry-policy.ts
@@ -13,17 +13,14 @@ export const CLOUDFLARE_R2_TRANSIENT_MARKERS = [
   'contact customer support',
 ]
 
-export function isTransientCloudflareR2Error(message: string): boolean {
-  const normalized = message.toLowerCase()
-  return CLOUDFLARE_R2_TRANSIENT_MARKERS.some((marker) => normalized.includes(marker))
-}
-
-// 【Issue #980】このモジュールは以前 retryCloudflareR2Upload（R2UploadResultを返す関数を
-// ラップして再試行する汎用ヘルパー）も提供しており、src/app/api/upload/route.ts が
-// r2-client.ts の uploadToR2WithRetry（それ自体が独立したリトライループを持つ）をさらに
-// これで二重に包んでいた。CLOUDFLARE_R2_TRANSIENT_MARKERS 該当エラーは両方の層が
-// リトライ対象と判定するため、最悪ケースで試行回数・待ち時間が約3倍（4回→12回・約22秒）に
-// 肥大化しうる、明示的な上限のないリトライ構成になっていた。
-// 再試行はr2-client.ts側の1ループに一本化し、ここは「何が一時障害か」の判定
-// （CLOUDFLARE_R2_TRANSIENT_MARKERS / isTransientCloudflareR2Error）だけを提供する
-// single source of truthとして残す。retryCloudflareR2Uploadは撤去済み。
+// 【Issue #980】このモジュールは以前 isTransientCloudflareR2Error（一時障害判定の関数版）と
+// retryCloudflareR2Upload（それを使うリトライラッパー）も提供しており、
+// src/app/api/upload/route.ts が r2-client.ts の uploadToR2WithRetry
+// （それ自体が独立したリトライループを持つ）をさらにこれで二重に包んでいた。
+// CLOUDFLARE_R2_TRANSIENT_MARKERS 該当エラーは両方の層がリトライ対象と判定するため、
+// 最悪ケースで試行回数・待ち時間が約3倍（4回→12回・約22秒）に肥大化しうる、
+// 明示的な上限のないリトライ構成になっていた。
+// 再試行はr2-client.ts側の1ループに一本化し、判定関数もr2-client.tsのisTransientR2Errorに
+// 統合した（この2つを別々に持つと、この一覧を判定に使うロジックが2箇所に分裂し、
+// 今回の教訓に反する）。ここは CLOUDFLARE_R2_TRANSIENT_MARKERS という
+// 「何が一時障害か」のデータだけを提供するsingle source of truthとして残す。

--- a/src/lib/r2-retry-policy.ts
+++ b/src/lib/r2-retry-policy.ts
@@ -13,14 +13,10 @@ export const CLOUDFLARE_R2_TRANSIENT_MARKERS = [
   'contact customer support',
 ]
 
-// 【Issue #980】このモジュールは以前 isTransientCloudflareR2Error（一時障害判定の関数版）と
-// retryCloudflareR2Upload（それを使うリトライラッパー）も提供しており、
-// src/app/api/upload/route.ts が r2-client.ts の uploadToR2WithRetry
-// （それ自体が独立したリトライループを持つ）をさらにこれで二重に包んでいた。
-// CLOUDFLARE_R2_TRANSIENT_MARKERS 該当エラーは両方の層がリトライ対象と判定するため、
-// 最悪ケースで試行回数・待ち時間が約3倍（4回→12回・約22秒）に肥大化しうる、
-// 明示的な上限のないリトライ構成になっていた。
-// 再試行はr2-client.ts側の1ループに一本化し、判定関数もr2-client.tsのisTransientR2Errorに
-// 統合した（この2つを別々に持つと、この一覧を判定に使うロジックが2箇所に分裂し、
-// 今回の教訓に反する）。ここは CLOUDFLARE_R2_TRANSIENT_MARKERS という
-// 「何が一時障害か」のデータだけを提供するsingle source of truthとして残す。
+// 【Issue #980】以前このファイルは isTransientCloudflareR2Error（判定関数）と
+// retryCloudflareR2Upload（二重リトライの原因になった外側リトライラッパー）も
+// 提供していたが撤去済み。判定ロジック・リトライループはr2-client.tsの
+// isTransientR2Error / withR2UploadRetry に一本化した。経緯・撤去理由の詳細は
+// src/lib/r2-client.ts の TRANSIENT_R2_ERROR_PATTERNS のコメントとIssue #980を参照
+// （同じ説明をファイル間で重複させない）。ここは CLOUDFLARE_R2_TRANSIENT_MARKERS
+// という「何が一時障害か」のデータだけを提供するsingle source of truthとして残す。

--- a/tests/unit/r2-client-retry-loop.test.ts
+++ b/tests/unit/r2-client-retry-loop.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+import { withR2UploadRetry } from '@/lib/r2-client'
+
+// uploadToR2WithRetry / uploadSoundToR2WithRetry が共通で使うリトライループ本体
+// （withR2UploadRetry）の動作テスト。
+//
+// 【Issue #980】以前はuploadToR2WithRetryのループ相当の動作は、r2-retry-policy.tsの
+// retryCloudflareR2Upload（upload/sleepを引数として注入できる設計だった）が
+// tests/unit/r2-retry-policy.test.ts でテストされていたが、二重リトライ撤去に伴い
+// retryCloudflareR2Uploadごと削除された。isTransientR2Error（一時障害かどうかの
+// 判定関数）が真を返すことのテスト（r2-client-transient-error.test.ts）だけでは
+// 「実際にリトライされて成功する／恒久障害では再試行しない／上限で打ち切る」という
+// ループそのものの挙動は検証できないため、withR2UploadRetryをexportしてここで
+// 直接テストする（sleepを注入し、実際の待機なしで検証する）。
+describe('withR2UploadRetry', () => {
+  it('一時障害（R2固有エラーコード）が続いた後に成功すれば、最終的に成功を返す', async () => {
+    const upload = vi.fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error('put: internal error (10001)'))
+      .mockRejectedValueOnce(new Error('put: internal error (10001)'))
+      .mockResolvedValueOnce('https://example.test/image.png')
+    const sleep = vi.fn().mockResolvedValue(undefined)
+
+    await expect(withR2UploadRetry('[R2]', upload, 3, sleep)).resolves.toEqual({
+      url: 'https://example.test/image.png',
+    })
+    expect(upload).toHaveBeenCalledTimes(3)
+    // 指数バックオフ: 1回目のリトライ前に1000ms、2回目のリトライ前に2000ms
+    expect(sleep).toHaveBeenNthCalledWith(1, 1000)
+    expect(sleep).toHaveBeenNthCalledWith(2, 2000)
+  })
+
+  it('恒久的なエラー（認証エラー等）は再試行せず即座にエラーを返す', async () => {
+    const upload = vi.fn<() => Promise<string>>().mockRejectedValue(new Error('AccessDenied: invalid credentials'))
+    const sleep = vi.fn().mockResolvedValue(undefined)
+
+    await expect(withR2UploadRetry('[R2]', upload, 3, sleep)).resolves.toEqual({
+      error: 'AccessDenied: invalid credentials',
+    })
+    expect(upload).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  it('一時障害がmaxRetries回を超えて続く場合は、最大試行回数(maxRetries+1回)で打ち切りエラーを返す', async () => {
+    const upload = vi.fn<() => Promise<string>>().mockRejectedValue(new Error('connect ECONNRESET'))
+    const sleep = vi.fn().mockResolvedValue(undefined)
+
+    await expect(withR2UploadRetry('[R2]', upload, 2, sleep)).resolves.toEqual({
+      error: 'connect ECONNRESET',
+    })
+    // maxRetries=2 なら初回+2リトライ=最大3回試行
+    expect(upload).toHaveBeenCalledTimes(3)
+    expect(sleep).toHaveBeenCalledTimes(2)
+  })
+
+  it('maxRetries=0（リトライ無効）なら、一時障害でも1回で打ち切る', async () => {
+    const upload = vi.fn<() => Promise<string>>().mockRejectedValue(new Error('connect ECONNRESET'))
+    const sleep = vi.fn().mockResolvedValue(undefined)
+
+    await expect(withR2UploadRetry('[R2]', upload, 0, sleep)).resolves.toEqual({
+      error: 'connect ECONNRESET',
+    })
+    expect(upload).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/r2-client-transient-error.test.ts
+++ b/tests/unit/r2-client-transient-error.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { isTransientR2Error } from '@/lib/r2-client'
+import { CLOUDFLARE_R2_TRANSIENT_MARKERS } from '@/lib/r2-retry-policy'
 
 // uploadToR2WithRetry / uploadSoundToR2WithRetry の一時障害判定ロジック。
 // Issue #976/#977: R2のInternalError(10001)が未登録だったため、本番で
@@ -19,15 +20,15 @@ describe('isTransientR2Error', () => {
     expect(isTransientR2Error('Unspecified error')).toBe(true)
   })
 
-  it('R2のInternalError (10001) を一時障害として扱う (Issue #976/#977)', () => {
-    expect(isTransientR2Error('put: We encountered an internal error. Please try again. (10001)')).toBe(true)
-  })
-
-  it('R2のServiceUnavailable (10043) を一時障害として扱う', () => {
-    expect(isTransientR2Error('put: Please look at https://www.cloudflarestatus.com (10043)')).toBe(true)
-  })
-
   it('認証エラーなど恒久障害は一時障害として扱わない', () => {
     expect(isTransientR2Error('AccessDenied: invalid credentials')).toBe(false)
+  })
+
+  // r2-retry-policy.tsのCLOUDFLARE_R2_TRANSIENT_MARKERSをここから直接importして
+  // 全要素をループ検証する。ハードコピーした文字列リテラルではなく実際にimportした
+  // 配列を使うことで、「単一の情報源をimportして使っている」こと自体を検証する
+  // （マーカーを追加してもここを更新し忘れない、二重管理の再発防止）。
+  it.each(CLOUDFLARE_R2_TRANSIENT_MARKERS)('Cloudflare R2固有のマーカー%sを一時障害として扱う (Issue #976/#977)', (marker) => {
+    expect(isTransientR2Error(`put: error ${marker}`)).toBe(true)
   })
 })

--- a/tests/unit/r2-client-transient-error.test.ts
+++ b/tests/unit/r2-client-transient-error.test.ts
@@ -1,46 +1,33 @@
 import { describe, expect, it } from 'vitest'
-import { isTransientR2UploadError, isTransientR2SoundUploadError } from '@/lib/r2-client'
+import { isTransientR2Error } from '@/lib/r2-client'
 
 // uploadToR2WithRetry / uploadSoundToR2WithRetry の一時障害判定ロジック。
 // Issue #976/#977: R2のInternalError(10001)が未登録だったため、本番で
 // リトライ可能なはずのアップロード失敗が即座にエラー化していた。
 //
-// 画像用（isTransientR2UploadError）はretryCloudflareR2Upload（r2-retry-policy.ts）で
-// 二重にラップされるため、R2固有のエラーコードはそちら側のみで判定し、ここには含めない
-// （二重リトライによる待ち時間の肥大化を防ぐ）。効果音用（isTransientR2SoundUploadError）は
-// 外側のラップが無い唯一のリトライ層なので、R2固有のエラーコードもここで判定する。
-describe('isTransientR2UploadError（画像アップロード用）', () => {
+// 【Issue #980】以前は画像用・効果音用で別々のパターンリストを持っていた
+// （画像アップロードは呼び出し元でさらに二重にリトライラップされていたため、
+// R2固有のエラーコードを画像側の判定からわざと除外していた）。その二重ラップ
+// （src/app/api/upload/route.ts の retryCloudflareR2Upload）自体を撤去したので、
+// 画像・効果音とも isTransientR2Error 1本で判定する（差異なし）。
+describe('isTransientR2Error', () => {
   it('ネットワーク系エラーを一時障害として扱う', () => {
-    expect(isTransientR2UploadError('connect ECONNRESET')).toBe(true)
+    expect(isTransientR2Error('connect ECONNRESET')).toBe(true)
   })
 
   it('R2ネイティブバインディングのUnspecified errorを一時障害として扱う (Issue #349/#348)', () => {
-    expect(isTransientR2UploadError('Unspecified error')).toBe(true)
+    expect(isTransientR2Error('Unspecified error')).toBe(true)
   })
 
-  it('R2固有のエラーコード(10001)はここでは一時障害として扱わない（外側のretryCloudflareR2Uploadが担当、二重リトライ防止）', () => {
-    expect(isTransientR2UploadError('put: We encountered an internal error. Please try again. (10001)')).toBe(false)
-  })
-
-  it('認証エラーなど恒久障害は一時障害として扱わない', () => {
-    expect(isTransientR2UploadError('AccessDenied: invalid credentials')).toBe(false)
-  })
-})
-
-describe('isTransientR2SoundUploadError（効果音アップロード用）', () => {
-  it('R2のInternalError (10001) を一時障害として扱う (Issue #976/#977と同種)', () => {
-    expect(isTransientR2SoundUploadError('put: We encountered an internal error. Please try again. (10001)')).toBe(true)
+  it('R2のInternalError (10001) を一時障害として扱う (Issue #976/#977)', () => {
+    expect(isTransientR2Error('put: We encountered an internal error. Please try again. (10001)')).toBe(true)
   })
 
   it('R2のServiceUnavailable (10043) を一時障害として扱う', () => {
-    expect(isTransientR2SoundUploadError('put: Please look at https://www.cloudflarestatus.com (10043)')).toBe(true)
-  })
-
-  it('ネットワーク系エラーを一時障害として扱う', () => {
-    expect(isTransientR2SoundUploadError('connect ECONNRESET')).toBe(true)
+    expect(isTransientR2Error('put: Please look at https://www.cloudflarestatus.com (10043)')).toBe(true)
   })
 
   it('認証エラーなど恒久障害は一時障害として扱わない', () => {
-    expect(isTransientR2SoundUploadError('AccessDenied: invalid credentials')).toBe(false)
+    expect(isTransientR2Error('AccessDenied: invalid credentials')).toBe(false)
   })
 })

--- a/tests/unit/r2-retry-policy.test.ts
+++ b/tests/unit/r2-retry-policy.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { CLOUDFLARE_R2_TRANSIENT_MARKERS } from '@/lib/r2-retry-policy'
-import { isTransientR2Error } from '@/lib/r2-client'
 
 // CLOUDFLARE_R2_TRANSIENT_MARKERS は、Cloudflare R2固有のエラーコードのうち
 // 「一時障害としてリトライすべきもの」の単一の情報源(single source of truth)。
-// 実際のリトライループと判定関数（isTransientR2Error）はr2-client.ts側に一本化されている
+// 実際の判定ロジック（isTransientR2Error）はr2-client.ts側に一本化されている
 // （Issue #980でこのファイルにあった isTransientCloudflareR2Error / retryCloudflareR2Upload
-// は撤去済み）。ここでは「マーカー一覧に想定するコードが登録されているか」というデータの
-// 内容だけを検証し、判定ロジック自体のテストはr2-client-transient-error.test.tsに委ねる
-// （同じ判定ロジックを2箇所でテストする重複を避ける）。
+// は撤去済み）。ここではマーカー一覧という「データ」自体の内容だけを検証する。
+// このマーカーを使った判定の実際の挙動（isTransientR2Errorが真を返すか）は
+// tests/unit/r2-client-transient-error.test.ts に委ね、同じ判定ロジックを
+// 2箇所でテストする重複を避ける。
 describe('CLOUDFLARE_R2_TRANSIENT_MARKERS', () => {
   it('Cloudflare R2のInternalError (10001) を含む (Issue #976/#977)', () => {
     expect(CLOUDFLARE_R2_TRANSIENT_MARKERS).toContain('(10001)')
@@ -16,15 +16,5 @@ describe('CLOUDFLARE_R2_TRANSIENT_MARKERS', () => {
 
   it('Cloudflare R2のServiceUnavailable (10043) を含む', () => {
     expect(CLOUDFLARE_R2_TRANSIENT_MARKERS).toContain('(10043)')
-  })
-
-  it('r2-client.tsのisTransientR2Errorがこのマーカー一覧をimportして使っている（単一の情報源であることの回帰確認）', () => {
-    // マーカー一覧に無い架空のコードは一時障害と判定されないはずだが、
-    // 一覧のどの要素を追加してもisTransientR2Error側の判定に反映される必要がある
-    // （二重管理の再発防止。先頭要素だけでなく全要素を検証する）
-    expect(isTransientR2Error('put: unrecognized error (99999)')).toBe(false)
-    for (const marker of CLOUDFLARE_R2_TRANSIENT_MARKERS) {
-      expect(isTransientR2Error(`put: error ${marker}`)).toBe(true)
-    }
   })
 })

--- a/tests/unit/r2-retry-policy.test.ts
+++ b/tests/unit/r2-retry-policy.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it, vi } from 'vitest'
-import { isTransientCloudflareR2Error, retryCloudflareR2Upload } from '@/lib/r2-retry-policy'
+import { describe, expect, it } from 'vitest'
+import { isTransientCloudflareR2Error } from '@/lib/r2-retry-policy'
 
-describe('R2 retry policy', () => {
+// CLOUDFLARE_R2_TRANSIENT_MARKERS / isTransientCloudflareR2Error は、Cloudflare R2固有の
+// エラーコードのうち「一時障害としてリトライすべきもの」の単一の情報源(single source of
+// truth)。実際のリトライループはr2-client.tsのuploadToR2WithRetry/uploadSoundToR2WithRetry
+// 側にあり（Issue #980でこのファイルにあった二重ラップretryCloudflareR2Uploadは撤去済み）、
+// そちらから本モジュールのマーカー一覧をimportして使う。
+describe('isTransientCloudflareR2Error', () => {
   it('Cloudflare R2 error 10043を一時障害として扱う', () => {
     expect(isTransientCloudflareR2Error('put: Please look at https://www.cloudflarestatus.com for issues or contact customer support. (10043)')).toBe(true)
   })
@@ -12,25 +17,5 @@ describe('R2 retry policy', () => {
 
   it('認証エラーなど恒久障害は再試行対象にしない', () => {
     expect(isTransientCloudflareR2Error('AccessDenied: invalid credentials')).toBe(false)
-  })
-
-  it('10043の後に成功した場合は再実行する', async () => {
-    const upload = vi.fn<() => Promise<{ url?: string; error?: string }>>()
-      .mockResolvedValueOnce({ error: 'put failed (10043)' })
-      .mockResolvedValueOnce({ url: 'https://example.test/image.png' })
-    const sleep = vi.fn().mockResolvedValue(undefined)
-
-    await expect(retryCloudflareR2Upload(upload, 2, sleep)).resolves.toEqual({ url: 'https://example.test/image.png' })
-    expect(upload).toHaveBeenCalledTimes(2)
-    expect(sleep).toHaveBeenCalledWith(500)
-  })
-
-  it('非一時エラーは再試行しない', async () => {
-    const upload = vi.fn().mockResolvedValue({ error: 'AccessDenied' })
-    const sleep = vi.fn().mockResolvedValue(undefined)
-
-    await expect(retryCloudflareR2Upload(upload, 2, sleep)).resolves.toEqual({ error: 'AccessDenied' })
-    expect(upload).toHaveBeenCalledTimes(1)
-    expect(sleep).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/r2-retry-policy.test.ts
+++ b/tests/unit/r2-retry-policy.test.ts
@@ -20,8 +20,11 @@ describe('CLOUDFLARE_R2_TRANSIENT_MARKERS', () => {
 
   it('r2-client.tsのisTransientR2Errorがこのマーカー一覧をimportして使っている（単一の情報源であることの回帰確認）', () => {
     // マーカー一覧に無い架空のコードは一時障害と判定されないはずだが、
-    // 一覧に追加すればisTransientR2Error側の判定にも反映される（二重管理の再発防止）
+    // 一覧のどの要素を追加してもisTransientR2Error側の判定に反映される必要がある
+    // （二重管理の再発防止。先頭要素だけでなく全要素を検証する）
     expect(isTransientR2Error('put: unrecognized error (99999)')).toBe(false)
-    expect(isTransientR2Error(`put: internal error ${CLOUDFLARE_R2_TRANSIENT_MARKERS[0]}`)).toBe(true)
+    for (const marker of CLOUDFLARE_R2_TRANSIENT_MARKERS) {
+      expect(isTransientR2Error(`put: error ${marker}`)).toBe(true)
+    }
   })
 })

--- a/tests/unit/r2-retry-policy.test.ts
+++ b/tests/unit/r2-retry-policy.test.ts
@@ -1,21 +1,27 @@
 import { describe, expect, it } from 'vitest'
-import { isTransientCloudflareR2Error } from '@/lib/r2-retry-policy'
+import { CLOUDFLARE_R2_TRANSIENT_MARKERS } from '@/lib/r2-retry-policy'
+import { isTransientR2Error } from '@/lib/r2-client'
 
-// CLOUDFLARE_R2_TRANSIENT_MARKERS / isTransientCloudflareR2Error は、Cloudflare R2固有の
-// エラーコードのうち「一時障害としてリトライすべきもの」の単一の情報源(single source of
-// truth)。実際のリトライループはr2-client.tsのuploadToR2WithRetry/uploadSoundToR2WithRetry
-// 側にあり（Issue #980でこのファイルにあった二重ラップretryCloudflareR2Uploadは撤去済み）、
-// そちらから本モジュールのマーカー一覧をimportして使う。
-describe('isTransientCloudflareR2Error', () => {
-  it('Cloudflare R2 error 10043を一時障害として扱う', () => {
-    expect(isTransientCloudflareR2Error('put: Please look at https://www.cloudflarestatus.com for issues or contact customer support. (10043)')).toBe(true)
+// CLOUDFLARE_R2_TRANSIENT_MARKERS は、Cloudflare R2固有のエラーコードのうち
+// 「一時障害としてリトライすべきもの」の単一の情報源(single source of truth)。
+// 実際のリトライループと判定関数（isTransientR2Error）はr2-client.ts側に一本化されている
+// （Issue #980でこのファイルにあった isTransientCloudflareR2Error / retryCloudflareR2Upload
+// は撤去済み）。ここでは「マーカー一覧に想定するコードが登録されているか」というデータの
+// 内容だけを検証し、判定ロジック自体のテストはr2-client-transient-error.test.tsに委ねる
+// （同じ判定ロジックを2箇所でテストする重複を避ける）。
+describe('CLOUDFLARE_R2_TRANSIENT_MARKERS', () => {
+  it('Cloudflare R2のInternalError (10001) を含む (Issue #976/#977)', () => {
+    expect(CLOUDFLARE_R2_TRANSIENT_MARKERS).toContain('(10001)')
   })
 
-  it('Cloudflare R2 error 10001（InternalError）を一時障害として扱う (Issue #976/#977)', () => {
-    expect(isTransientCloudflareR2Error('put: We encountered an internal error. Please try again. (10001)')).toBe(true)
+  it('Cloudflare R2のServiceUnavailable (10043) を含む', () => {
+    expect(CLOUDFLARE_R2_TRANSIENT_MARKERS).toContain('(10043)')
   })
 
-  it('認証エラーなど恒久障害は再試行対象にしない', () => {
-    expect(isTransientCloudflareR2Error('AccessDenied: invalid credentials')).toBe(false)
+  it('r2-client.tsのisTransientR2Errorがこのマーカー一覧をimportして使っている（単一の情報源であることの回帰確認）', () => {
+    // マーカー一覧に無い架空のコードは一時障害と判定されないはずだが、
+    // 一覧に追加すればisTransientR2Error側の判定にも反映される（二重管理の再発防止）
+    expect(isTransientR2Error('put: unrecognized error (99999)')).toBe(false)
+    expect(isTransientR2Error(`put: internal error ${CLOUDFLARE_R2_TRANSIENT_MARKERS[0]}`)).toBe(true)
   })
 })


### PR DESCRIPTION
## 概要

Preview で検証済みの PR #983（R2 アップロードの二重リトライ撤去・一時障害判定の一本化）を `main` へ昇格します。

## Preview 検証

- preview head: `f811edf7460b345f9e9778268b8597fa5b463910`（PR #983 merge commit）
- Preview CI: 成功（typecheck、unit/integration tests、i18n lint、Supabase-independent application build）
- Cloudflare Deploy Support: 成功（preview overlay-realtime Worker）
- Preview 本体 URL: https://twica-preview.tsubasa-azumagakito.workers.dev/ （HTTP 200）
- 変更影響: R2 upload retry 層のみ。EventSub、ガチャ引換、overlay 公開、Twitch chat caller は変更なし
- Twitch 実引換: 対象外（チャネルポイント経路に接続しない変更）
- 画像/効果音の Preview upload smoke: 未確認（既存の認証済み Preview セッションがなく、redirect_mismatch で Dashboard に到達できなかったため。認証突破・設定変更・ファイル送信は行っていない）

## 既知の任意事項

- `503` 等の部分一致マーカーによる最大7秒の誤待機リスクは #984
- 高位 upload 結線のリトライ統合テストは #982 で追跡

## レビュー

PR #983 の自動レビューで必須指摘 0 件。