### PR TITLE
test(r2): アップロードリトライのE2Eテストを追加

### DIFF
--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -12,17 +12,31 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // （同一モジュール内呼び出しはexportされたbindingを経由しないため）。
 //
 // そこで2種類のテストで公開関数を実際に実行し、内部の結線を検証する:
-// 1. R2バインディング・環境変数がどちらも無い状態（テスト環境のデフォルト）で呼び出し、
+// 1. R2バインディング・環境変数がどちらも無い状態（下記の明示的なモックで再現）で呼び出し、
 //    実際のuploadToR2/uploadSoundToR2が投げる「環境変数が無い」という恒久エラーが
 //    1回の試行だけでそのまま返ることを確認する（バックオフ待機が発生しないため高速）。
 // 2. @aws-sdk/client-s3をモックし、Issue #976/#977で問題になった「(10001)」エラーを
 //    2回返した後に成功するシナリオで、uploadToR2WithRetryが実際にリトライして
 //    最終的に成功を返すことを確認する（実際のsetTimeoutを使うため数秒かかる）。
-const sendMock = vi.fn()
+//
+// @opennextjs/cloudflareはgetR2Bindingが動的importする（src/lib/r2-client.ts）。
+// モックしないと、Node.js実行環境（Vitest）でgetCloudflareContext({async:true})が
+// wranglerのgetPlatformProxy()へフォールバックしてworkerdを起動しうる（バージョンや
+// 実行環境によって挙動が変わり得る、暗黙の外部依存）。他のgetCloudflareContext到達
+// テスト全て（tests/unit/db-client.test.ts等）と同じ規約に合わせ、常にバインディング
+// 不在（空のenv）を明示的にモックすることで、このテストの前提を固定する。
+const mocks = vi.hoisted(() => ({
+  sendMock: vi.fn(),
+  getCloudflareContext: vi.fn(async () => ({ env: {} })),
+}))
+vi.mock('@opennextjs/cloudflare', () => ({
+  getCloudflareContext: mocks.getCloudflareContext,
+}))
 vi.mock('@aws-sdk/client-s3', () => ({
-  S3Client: vi.fn().mockImplementation(() => ({ send: sendMock })),
+  S3Client: vi.fn().mockImplementation(() => ({ send: mocks.sendMock })),
   PutObjectCommand: vi.fn().mockImplementation((input: unknown) => ({ input })),
 }))
+const sendMock = mocks.sendMock
 
 describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
   const ORIGINAL_ENV = { ...process.env }

--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// uploadToR2WithRetry / uploadSoundToR2WithRetry（公開関数）のエンドツーエンドテスト。
+//
+// 【Issue #982】tests/unit/r2-client-retry-loop.test.ts は共通リトライループ本体
+// （withR2UploadRetry）を upload/sleep を注入して直接テストしているが、公開関数
+// uploadToR2WithRetry / uploadSoundToR2WithRetry が実際に withR2UploadRetry へ
+// 正しく結線されている（fileName/buffer/contentTypeを正しく渡す）ことは、それ単体
+// では検証できない（maxRetriesの境界値そのものはr2-client-retry-loop.test.ts側で
+// 検証済みなのでここでは繰り返さない）。r2-client.tsは内部でuploadToR2/uploadSoundToR2を
+// 同一モジュール内の関数として直接呼ぶため、vi.spyOn等でのモック差し替えは効かない
+// （同一モジュール内呼び出しはexportされたbindingを経由しないため）。
+//
+// そこで2種類のテストで公開関数を実際に実行し、内部の結線を検証する:
+// 1. R2バインディング・環境変数がどちらも無い状態（テスト環境のデフォルト）で呼び出し、
+//    実際のuploadToR2/uploadSoundToR2が投げる「環境変数が無い」という恒久エラーが
+//    1回の試行だけでそのまま返ることを確認する（バックオフ待機が発生しないため高速）。
+// 2. @aws-sdk/client-s3をモックし、Issue #976/#977で問題になった「(10001)」エラーを
+//    2回返した後に成功するシナリオで、uploadToR2WithRetryが実際にリトライして
+//    最終的に成功を返すことを確認する（実際のsetTimeoutを使うため数秒かかる）。
+const sendMock = vi.fn()
+vi.mock('@aws-sdk/client-s3', () => ({
+  S3Client: vi.fn().mockImplementation(() => ({ send: sendMock })),
+  PutObjectCommand: vi.fn().mockImplementation((input: unknown) => ({ input })),
+}))
+
+describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
+  const ORIGINAL_ENV = { ...process.env }
+
+  beforeEach(() => {
+    sendMock.mockReset()
+  })
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  it('R2バインディング・環境変数がどちらも無い場合、実際のuploadToR2が投げる恒久エラーを1回の試行で返す', async () => {
+    delete process.env.R2_BUCKET_NAME
+    process.env.R2_PUBLIC_URL = 'https://example.test'
+
+    const { uploadToR2WithRetry } = await import('@/lib/r2-client')
+    const result = await uploadToR2WithRetry('f.png', Buffer.from('x'), 'image/png', 3)
+
+    expect(result).toEqual({ error: 'Missing R2_BUCKET_NAME environment variable' })
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('R2バインディング・環境変数がどちらも無い場合、実際のuploadSoundToR2が投げる恒久エラーを1回の試行で返す', async () => {
+    delete process.env.R2_SOUND_BUCKET_NAME
+    process.env.R2_SOUND_PUBLIC_URL = 'https://example.test'
+
+    const { uploadSoundToR2WithRetry } = await import('@/lib/r2-client')
+    const result = await uploadSoundToR2WithRetry('f.mp3', Buffer.from('x'), 'audio/mpeg', 3)
+
+    expect(result).toEqual({ error: 'Missing R2_SOUND_BUCKET_NAME environment variable' })
+    expect(sendMock).not.toHaveBeenCalled()
+  })
+
+  it('R2固有のInternalError(10001)が2回続いた後に成功すれば、uploadToR2WithRetryは実際にリトライして成功を返す (Issue #976/#977/#980の回帰防止)', async () => {
+    process.env.R2_PUBLIC_URL = 'https://example.test'
+    process.env.R2_BUCKET_NAME = 'test-bucket'
+    process.env.R2_ENDPOINT = 'https://example.r2.test'
+    process.env.R2_ACCESS_KEY_ID = 'fake-key'
+    process.env.R2_SECRET_ACCESS_KEY = 'fake-secret'
+    sendMock
+      .mockRejectedValueOnce(new Error('put: We encountered an internal error. Please try again. (10001)'))
+      .mockRejectedValueOnce(new Error('put: We encountered an internal error. Please try again. (10001)'))
+      .mockResolvedValueOnce({})
+
+    const { uploadToR2WithRetry } = await import('@/lib/r2-client')
+    const result = await uploadToR2WithRetry('f.png', Buffer.from('x'), 'image/png', 3)
+
+    expect(result).toEqual({ url: 'https://example.test/f.png' })
+    expect(sendMock).toHaveBeenCalledTimes(3)
+    // fileName/contentTypeが最後まで正しく引き継がれてPutObjectCommandへ渡っていることを確認する
+    // （リトライのたびに引数を取り違えていないことの検証）
+    const lastCallInput = sendMock.mock.calls[2][0].input
+    expect(lastCallInput).toMatchObject({ Bucket: 'test-bucket', Key: 'f.png', ContentType: 'image/png' })
+  }, 15000)
+
+  it('恒久エラー（AccessDenied）はS3 SDK経由でも1回の試行で打ち切り、リトライしない', async () => {
+    process.env.R2_PUBLIC_URL = 'https://example.test'
+    process.env.R2_BUCKET_NAME = 'test-bucket'
+    process.env.R2_ENDPOINT = 'https://example.r2.test'
+    process.env.R2_ACCESS_KEY_ID = 'fake-key'
+    process.env.R2_SECRET_ACCESS_KEY = 'fake-secret'
+    sendMock.mockRejectedValue(new Error('AccessDenied: invalid credentials'))
+
+    const { uploadToR2WithRetry } = await import('@/lib/r2-client')
+    const result = await uploadToR2WithRetry('f.png', Buffer.from('x'), 'image/png', 3)
+
+    expect(result).toEqual({ error: 'AccessDenied: invalid credentials' })
+    expect(sendMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## 背景 / Issue

#980（PR #983）で、画像アップロードの二重リトライラッパーを撤去し、`uploadToR2WithRetry` / `uploadSoundToR2WithRetry` を唯一のリトライ機構に統一した。この際、リトライループ本体（`withR2UploadRetry`）と一時障害判定関数（`isTransientR2Error`）はそれぞれ個別にテストしたが、公開関数 `uploadToR2WithRetry` / `uploadSoundToR2WithRetry` が実際にこの2つへ正しく結線されている（`fileName`/`buffer`/`contentType`を正しく渡し、実際にリトライして成功する）ことをエンドツーエンドで検証するテストが無かった。

Closes #982

## 変更内容

`tests/unit/r2-client-upload-retry-wiring.test.ts` を新規追加。`r2-client.ts` は内部で `uploadToR2` / `uploadSoundToR2` を同一モジュール内の関数として直接呼ぶため、`vi.spyOn` によるモック差し替えは効かない（実測で確認済み）。そこで以下の2アプローチで公開関数を実際に実行し、結線を検証する。

1. R2バインディング・環境変数が無い状態で呼び出し、実際の `uploadToR2` / `uploadSoundToR2` が投げる恒久エラーが1回の試行でそのまま返ることを確認（高速・env依存のみ）
2. `@aws-sdk/client-s3` をモックし、Issue #976/#977 の `InternalError(10001)` を2回返した後に成功するシナリオで、`uploadToR2WithRetry` が実際にリトライして最終的に成功を返すことを確認（実際の `setTimeout` を使うため約3秒かかる。`PutObjectCommand` に渡された `Bucket`/`Key`/`ContentType` も検証し、リトライ中に引数を取り違えていないことを確認）

## 検証

- `npx tsc --noEmit` — エラーなし
- `npx eslint`（変更ファイル） — エラーなし
- `npx vitest run tests/unit` — 273 files / 3508 tests すべて成功
- 自動レビュー（subagent）を実施し、S3モックが実際にリトライパスを経由していること（ネイティブR2バインディング経由でモックが素通りされていないこと）を、リトライ成功テストの実測所要時間（約3秒 = 1000ms+2000msの指数バックオフと一致）で裏取り。必須（マージブロッカー）指摘は0件

## リスク

- テストファイルの追加のみで、本番コード（`src/lib/r2-client.ts`）は変更していない
- 新規テストのうち1件は実際の `setTimeout` バックオフ（約3秒）を使うため、テストスイート全体の実行時間がわずかに増加する

---

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013TuXYkkRV5eJweD4e8gWQc)_