### PR TITLE
fix(r2): 一時障害判定の裸の'503'文字列マッチを文脈限定に修正

### DIFF
--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -152,12 +152,16 @@ async function s3Delete(bucket: string, key: string, clientType: 'images' | 'sou
  * 決まり、最大試行回数は maxRetries+1 回、最大累計待機時間は指数バックオフの合計
  * （デフォルト値なら 1s+2s+4s=7秒）に明示的に収まる。
  */
-const TRANSIENT_R2_ERROR_PATTERNS = [
+const TRANSIENT_R2_ERROR_PATTERNS: Array<string | RegExp> = [
   'ECONNRESET',
   'ETIMEDOUT',
   'ENOTFOUND',
   'service unavailable',
-  '503',
+  // 【Issue #984】裸の'503'部分文字列は、キー名やリクエストIDにたまたま'503'という
+  // 数字列が含まれる場合（例: 'photo-503.png' 等）に恒久エラーを一時障害と誤判定し、
+  // 無駄なリトライ（最大 maxRetries+1 回・最大約7秒）を発生させるリスクがあった。
+  // 'http'/'status'という文脈語が近傍にある場合のみHTTP 503相当として扱うよう限定する。
+  /\b(?:http|status)\D{0,10}503\b/i,
   'NetworkingError',
   'Unspecified error',
   ...CLOUDFLARE_R2_TRANSIENT_MARKERS,
@@ -166,7 +170,9 @@ const TRANSIENT_R2_ERROR_PATTERNS = [
 // テストから直接検証できるようexport
 export function isTransientR2Error(errorMessage: string): boolean {
   return TRANSIENT_R2_ERROR_PATTERNS.some(pattern =>
-    errorMessage.toLowerCase().includes(pattern.toLowerCase())
+    typeof pattern === 'string'
+      ? errorMessage.toLowerCase().includes(pattern.toLowerCase())
+      : pattern.test(errorMessage)
   );
 }
 

--- a/tests/unit/r2-client-transient-error.test.ts
+++ b/tests/unit/r2-client-transient-error.test.ts
@@ -24,6 +24,25 @@ describe('isTransientR2Error', () => {
     expect(isTransientR2Error('AccessDenied: invalid credentials')).toBe(false)
   })
 
+  it('service unavailableという文言を一時障害として扱う', () => {
+    expect(isTransientR2Error('put: service unavailable, please retry')).toBe(true)
+  })
+
+  it('HTTPステータス表記の503（"HTTP 503"）を一時障害として扱う', () => {
+    expect(isTransientR2Error('Request failed with HTTP 503')).toBe(true)
+  })
+
+  it('HTTPステータス表記の503（"status: 503"）を一時障害として扱う', () => {
+    expect(isTransientR2Error('put: status: 503, please retry later')).toBe(true)
+  })
+
+  // 【Issue #984】裸の'503'部分文字列マッチは、キー名やリクエストIDに偶然'503'を含む
+  // 恒久エラーを誤って一時障害と判定するリスクがあった。'http'/'status'という文脈語が
+  // 近傍に無い'503'は一時障害として扱わないことを確認する回帰テスト。
+  it('キー名にたまたま503を含む恒久エラーは一時障害として扱わない (Issue #984)', () => {
+    expect(isTransientR2Error("AccessDenied: key 'photo-503.png' is not permitted")).toBe(false)
+  })
+
   // r2-retry-policy.tsのCLOUDFLARE_R2_TRANSIENT_MARKERSをここから直接importして
   // 全要素をループ検証する。ハードコピーした文字列リテラルではなく実際にimportした
   // 配列を使うことで、「単一の情報源をimportして使っている」こと自体を検証する


### PR DESCRIPTION
## 背景 / Issue

#980（PR #983）のレビューで、`TRANSIENT_R2_ERROR_PATTERNS`（`src/lib/r2-client.ts`）の`'503'`が裸の部分文字列マッチだったため、エラーメッセージにファイル名・キー名・リクエストIDとして偶然`'503'`を含む恒久エラー（例: `'photo-503.png'`）を一時障害と誤判定し、無駄なリトライ（最大`maxRetries+1`回・最大約7秒）を発生させるリスクが指摘され、#984として切り出された。

Closes #984

## 変更内容

- `'http'`/`'status'`という文脈語が近傍（10文字以内）にある場合のみHTTP 503相当として扱うよう正規表現 `/\b(?:http|status)\D{0,10}503\b/i` で限定
- `TRANSIENT_R2_ERROR_PATTERNS` / `isTransientR2Error` を `string | RegExp` の混在配列に対応させる最小限の変更
- 回帰テストを追加（誤検知しないケース、正しくHTTP 503表記を検出するケース）

## 検証済みの非退行

`'service unavailable'`という既存の文字列パターンは変更していないため、文脈語を伴わない `"503 Service Unavailable"` のような複合フレーズも引き続き一時障害として判定される。また実際のAWS SDKエラー（`@smithy/smithy-client`のソース確認済み）では、HTTPステータスコードは`error.name`/`Code`に入り`error.message`には混入しない構造のため、想定される現実のエラーメッセージで新たに拾えなくなるケースは無い。

## 検証

- `npx tsc --noEmit` — エラーなし
- `npx eslint`（変更ファイル） — エラーなし
- `npx vitest run`（r2-client-transient-error, r2-client-retry-loop, r2-retry-policy, upload） — 計38テストすべて成功
- 自動レビュー（subagent、`node -e`による正規表現の実測検証含む）を実施し、必須指摘は0件

## リスク

- 判定ロジックのみの変更で、リトライの上限・アップロードAPIの他の挙動には影響しない
- ガチャ引き換え/オーバーレイ表示/Twitchチャット送信には影響しない変更（アップロードAPIのエラーハンドリングのみ）

---

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013TuXYkkRV5eJweD4e8gWQc)_