### PR TITLE
release: promote preview to main after PR #988

### DIFF
--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -152,12 +152,16 @@ async function s3Delete(bucket: string, key: string, clientType: 'images' | 'sou
  * 決まり、最大試行回数は maxRetries+1 回、最大累計待機時間は指数バックオフの合計
  * （デフォルト値なら 1s+2s+4s=7秒）に明示的に収まる。
  */
-const TRANSIENT_R2_ERROR_PATTERNS = [
+const TRANSIENT_R2_ERROR_PATTERNS: Array<string | RegExp> = [
   'ECONNRESET',
   'ETIMEDOUT',
   'ENOTFOUND',
   'service unavailable',
-  '503',
+  // 【Issue #984】裸の'503'部分文字列は、キー名やリクエストIDにたまたま'503'という
+  // 数字列が含まれる場合（例: 'photo-503.png' 等）に恒久エラーを一時障害と誤判定し、
+  // 無駄なリトライ（最大 maxRetries+1 回・最大約7秒）を発生させるリスクがあった。
+  // 'http'/'status'という文脈語が近傍にある場合のみHTTP 503相当として扱うよう限定する。
+  /\b(?:http|status)\D{0,10}503\b/i,
   'NetworkingError',
   'Unspecified error',
   ...CLOUDFLARE_R2_TRANSIENT_MARKERS,
@@ -166,7 +170,9 @@ const TRANSIENT_R2_ERROR_PATTERNS = [
 // テストから直接検証できるようexport
 export function isTransientR2Error(errorMessage: string): boolean {
   return TRANSIENT_R2_ERROR_PATTERNS.some(pattern =>
-    errorMessage.toLowerCase().includes(pattern.toLowerCase())
+    typeof pattern === 'string'
+      ? errorMessage.toLowerCase().includes(pattern.toLowerCase())
+      : pattern.test(errorMessage)
   );
 }
 

--- a/tests/unit/r2-client-transient-error.test.ts
+++ b/tests/unit/r2-client-transient-error.test.ts
@@ -24,6 +24,25 @@ describe('isTransientR2Error', () => {
     expect(isTransientR2Error('AccessDenied: invalid credentials')).toBe(false)
   })
 
+  it('service unavailableという文言を一時障害として扱う', () => {
+    expect(isTransientR2Error('put: service unavailable, please retry')).toBe(true)
+  })
+
+  it('HTTPステータス表記の503（"HTTP 503"）を一時障害として扱う', () => {
+    expect(isTransientR2Error('Request failed with HTTP 503')).toBe(true)
+  })
+
+  it('HTTPステータス表記の503（"status: 503"）を一時障害として扱う', () => {
+    expect(isTransientR2Error('put: status: 503, please retry later')).toBe(true)
+  })
+
+  // 【Issue #984】裸の'503'部分文字列マッチは、キー名やリクエストIDに偶然'503'を含む
+  // 恒久エラーを誤って一時障害と判定するリスクがあった。'http'/'status'という文脈語が
+  // 近傍に無い'503'は一時障害として扱わないことを確認する回帰テスト。
+  it('キー名にたまたま503を含む恒久エラーは一時障害として扱わない (Issue #984)', () => {
+    expect(isTransientR2Error("AccessDenied: key 'photo-503.png' is not permitted")).toBe(false)
+  })
+
   // r2-retry-policy.tsのCLOUDFLARE_R2_TRANSIENT_MARKERSをここから直接importして
   // 全要素をループ検証する。ハードコピーした文字列リテラルではなく実際にimportした
   // 配列を使うことで、「単一の情報源をimportして使っている」こと自体を検証する


### PR DESCRIPTION
## 対象 preview HEAD

- preview HEAD: `3e553c3e33e2c9c46bac99718823bb7e82a339fe`
- 含まれる preview PR: #988 (`fix(r2): 一時障害判定の裸の503文字列マッチを文脈限定に修正`)
- 直前 main: `42c3a3bacd98ba274025d296f1ab0b736472572b`

## レビュー

- PR #988 は draft ではなく、未解決 review thread なし。
- Claude Auto Review は HEAD `70b784280043faafd462d7068ae76421ad09309e` に対して必須指摘なし、任意指摘のみ。
- 任意指摘は #989 へ切り出し済み。
- 自己レビューでは、構造化エラー判定への移行は改善推奨だが、この PR の必須ブロッカーではないと判定。

## CI / preview deploy

- PR #988 head checks: `test` success、`Lint i18n` success、`Application build without Supabase variables` success、`Workers Builds: twica-preview` success。
- ローカル検証: `git diff --check origin/preview...70b784280043faafd462d7068ae76421ad09309e` success。
- ローカル検証: regex sanity check success。
- ローカル検証: `npx vitest run tests/unit/r2-client-transient-error.test.ts` success（11 tests）。
- preview merge commit `3e553c3e33e2c9c46bac99718823bb7e82a339fe`: CI `test` success、`Lint i18n` success、`Application build without Supabase variables` success、Cloudflare Deploy Support `overlay-realtime` success、`Workers Builds: twica-preview` success。
- preview safe GET: `https://twica-preview.tsubasa-azumagakito.workers.dev/` returned HTTP 200.

## 実経路 / ブラウザー確認

- 実引き換え: 未実施。理由: PR #988 は R2 upload retry 判定のエラーハンドリング変更で、EventSub / gacha / overlay / Twitch chat の実引き換え経路を変更していない。
- ブラウザー確認: 未実施。理由: UI変更なし。

## production 確認予定

main へのマージ後、main SHA、Auto Release のタグ/本文、production Workers/補助ワーカーの deploy 状態、production endpoint の安全な GET を確認する。

---
Generated by Codex automation `twica-maker`.