### PR TITLE
fix(overlay): クールダウン記録のsessionStorageキーをバージョニングし新旧コードの衝突を解消

### DIFF
--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -37,7 +37,7 @@ import {
   serializePollState,
   parsePollState,
   parseReloadCooldownRecords,
-  appendReloadCooldownRecord,
+  upsertReloadCooldownRecord,
   RELOAD_COOLDOWN_MS,
   POLLSTATE_TTL_MS,
 } from "@/lib/overlay-version";
@@ -163,7 +163,15 @@ const SOUND_DURATION_FALLBACK_MS = 15 * 1000;
 const IMAGE_METADATA_TIMEOUT_MS = 1_500;
 
 // sessionStorage キー。リロード前後で状態を引き継ぐために使う
-const RELOAD_COOLDOWN_STORAGE_KEY = "twica-overlay-reload";
+// Issue #634: クールダウン記録の保存形式を単一オブジェクトから配列へ変更した際、
+// キー名も"-v2"へ変更した(自動レビュー指摘: 同じキーのままだと、ローリング
+// デプロイの混在ウィンドウ中に同一タブが旧コードのビルドへ着地するたびに、
+// 旧コードの単一オブジェクト専用パーサ/ライターがクールダウン記録を巻き戻して
+// しまう恐れがあった)。新旧コードが別々のキーだけを読み書きすることで、
+// この干渉を構造的に無くしている。旧キーに残るデータは新コードから一切
+// 参照されず、次回リロードが1回クールダウンなしで発生する以外の影響はない
+// (詳細はoverlay-version.tsのparseReloadCooldownRecords doc参照)。
+const RELOAD_COOLDOWN_STORAGE_KEY = "twica-overlay-reload-v2";
 const POLLSTATE_STORAGE_KEY = "twica-overlay-pollstate";
 const pollStateStorageKey = (streamerId: string) =>
   `${POLLSTATE_STORAGE_KEY}:${streamerId}`;
@@ -803,7 +811,7 @@ export default function OverlayPage() {
     try {
       sessionStorage.setItem(
         RELOAD_COOLDOWN_STORAGE_KEY,
-        JSON.stringify(appendReloadCooldownRecord(cooldownRecords, targetVersion, Date.now())),
+        JSON.stringify(upsertReloadCooldownRecord(cooldownRecords, targetVersion, Date.now())),
       );
       sessionStorage.setItem(
         pollStateStorageKey(streamerId),

--- a/src/lib/overlay-version.ts
+++ b/src/lib/overlay-version.ts
@@ -17,7 +17,12 @@
 import { isValidOverlayHistoryId } from "@/lib/overlay-realtime/contract";
 import { normalizeOverlayHistoryTimestamp } from "@/lib/overlay-history-cursor";
 
-/** sessionStorage に保存するクールダウン記録(直前にリロードしたバージョンと時刻)の型 */
+/**
+ * クールダウン記録1件分の型(あるバージョンへ最後にリロードした時刻)。
+ * Issue #634 より、sessionStorage には単体ではなくこの型の配列
+ * (ReloadCooldownRecord[])を保持する。直近見た複数バージョンを保持する
+ * 理由は MAX_RELOAD_COOLDOWN_RECORDS の doc を参照。
+ */
 export interface ReloadCooldownRecord {
   version: string;
   reloadedAt: number;
@@ -63,6 +68,16 @@ export const RELOAD_COOLDOWN_MS = 60 * 60 * 1000; // 60分
  * ローリングデプロイで同時に混在するバージョンは通常2つ(旧/新)だが、
  * 短時間に連続するデプロイも考慮し、多少の余裕を持たせて4件まで保持する
  * (無制限保持によるsessionStorage肥大化・直近判定の希薄化を避ける)。
+ *
+ * トレードオフ(自動レビューで指摘): 保持対象が「直前の1件」から「直近N件」へ
+ * 広がったことで、60分以内に一度リロード先となったバージョンへ戻る正規の
+ * 再デプロイ(ロールバック後のfix-forwardで同一アーティファクトを再配信する等)
+ * も、往復と区別できずクールダウン対象になる。旧設計では直前の1件と一致
+ * しない限り即座に追従できていたため、この点は挙動変更である。往復リロード
+ * 連発(配信画面の破壊)を防ぐ利益の方が明確に大きいため許容するが、運用者は
+ * 「同一バージョンへの再デプロイは直近リロードから最大60分反映が遅れ得る」
+ * ことを認識しておく必要がある(RELOAD_COOLDOWN_MSのdocにある「恒久ガードに
+ * しない」方針により、60分を超えれば自然に追従する)。
  */
 export const MAX_RELOAD_COOLDOWN_RECORDS = 4;
 
@@ -123,7 +138,9 @@ export function isReloadCooldownActive(
 }
 
 /**
- * targetVersion へのリロード実行をクールダウン記録へ追記する純粋関数(Issue #634)。
+ * targetVersion へのリロード実行をクールダウン記録へ反映する純粋関数(Issue #634)。
+ * 同一バージョンの既存エントリを更新するか、無ければ新規追加するupsertであり、
+ * 単純な追記ではない(この関数名はその意図を明示する)。
  *
  * 同一バージョンの既存エントリがあれば取り除いてから追記する(重複を持たず、
  * 常に最新の reloadedAt だけを保持する＝そのバージョンへ再訪した時点で
@@ -131,38 +148,40 @@ export function isReloadCooldownActive(
  * 最も古い(挿入順で先頭側の)エントリから破棄する(往復検出には直近見た
  * バージョンほど有用なため)。
  */
-export function appendReloadCooldownRecord(
+export function upsertReloadCooldownRecord(
   records: ReloadCooldownRecord[] | null,
   version: string,
   reloadedAt: number,
 ): ReloadCooldownRecord[] {
   const withoutSameVersion = (records ?? []).filter((record) => record.version !== version);
-  const appended = [...withoutSameVersion, { version, reloadedAt }];
-  return appended.slice(-MAX_RELOAD_COOLDOWN_RECORDS);
+  const upserted = [...withoutSameVersion, { version, reloadedAt }];
+  return upserted.slice(-MAX_RELOAD_COOLDOWN_RECORDS);
 }
 
 /**
- * sessionStorage に保存されたクールダウン記録(JSON文字列)をパースする。
+ * sessionStorage に保存されたクールダウン記録(JSON文字列の配列)をパースする。
  *
- * Issue #634 より前のクライアントは単一の { version, reloadedAt } オブジェクト
- * を書き込んでいた。ローリングデプロイで新旧コードが混在する間、既に開いている
- * OBS タブが旧形式の値を書き込んだ直後に新コードへ切り替わるウィンドウが
- * あり得るため、旧形式(単一オブジェクト)も 1 件配列として読み込めるようにし、
- * デプロイ境界をまたいでクールダウン記録が失われないようにする。
- *
- * 逆方向(新コードが配列形式で書き込んだ直後に、混在ウィンドウ中の別タブが
- * 旧コードのまま location.reload() し、旧コードの単一オブジェクト専用パーサが
- * 同じキーを読む)も起こり得るが、旧コードの実装は candidate.version が
- * 配列には存在しないため型不一致で null を返す(例外は投げない)。この場合は
- * クールダウン記録なし = そのバージョンへの初回リロードとして扱われるだけで、
- * 本 Issue が元々許容していた「往復1巡目相当」の余分なリロードが最大1回
- * 発生する程度に縮退し、無限リロードや例外には至らない。
+ * Issue #634 より前のクライアントは、同じ目的のsessionStorageキーへ単一の
+ * { version, reloadedAt } オブジェクトを書き込んでいた。ここで新旧の形式を
+ * 両対応させる代わりに、page.tsx側でストレージキー自体を新バージョン用
+ * ("twica-overlay-reload-v2")へ切り替えている(自動レビュー指摘: 同一キーを
+ * 新旧コードで奪い合うと、ローリングデプロイの混在ウィンドウ中に同一タブが
+ * 旧コードのビルドへ着地するたびクールダウン記録が単一オブジェクトへ巻き戻され
+ * 続ける恐れがあった。sessionStorageはタブ単位で独立しているため「別タブが
+ * 読む」ことはないが、「同一タブが旧コードのビルドへ着地する」ことは起こり
+ * 得る)。キーを分けることで新コードは常に自分が書いた配列形式だけを読み、
+ * 旧コードは自分の旧キーだけを読み書きするため、双方が干渉し合わない。
+ * 旧キーへ残る単一オブジェクトのデータは新コードから一切参照されず無害に
+ * 取り残されるだけで、そのユーザーの次回リロードが1回クールダウンなしで
+ * 発生する(＝そのユーザーにとって初回リロードと同じ扱い)以外の影響はない。
  *
  * parsePollState と同様、以下のいずれかに該当する場合は例外を投げず null を
  * 返す(呼び出し側は「クールダウン記録なし」として扱い、安全側に倒れる):
  * - raw が null/undefined/空文字列
  * - JSON として parse できない(壊れたデータ)
- * - 配列でも { version, reloadedAt } 形状のオブジェクト(旧形式)でもない
+ * - トップレベルが配列でない(上記の旧キー使用により、新キーの下に単一
+ *   オブジェクトが書き込まれることは正常経路では起こらないが、汚染された
+ *   sessionStorageに対する防御として配列以外は一律nullにする)
  * - 配列内の個々のエントリが期待する形状(version: string, reloadedAt: number)
  *   を満たさない場合はそのエントリだけを無視する(parsePollState の
  *   seenHistoryIds フィルタと同じ「壊れた要素だけ捨てる」方針)。結果として
@@ -180,13 +199,10 @@ export function parseReloadCooldownRecords(
     return null;
   }
 
-  if (!parsed || typeof parsed !== "object") return null;
-
-  // 旧形式(Issue #634 より前): 単一オブジェクトを 1 件配列として扱う。
-  const rawEntries: unknown[] = Array.isArray(parsed) ? parsed : [parsed];
+  if (!Array.isArray(parsed)) return null;
 
   const validEntries: ReloadCooldownRecord[] = [];
-  for (const entry of rawEntries) {
+  for (const entry of parsed) {
     if (!entry || typeof entry !== "object") continue;
     const candidate = entry as Record<string, unknown>;
     if (typeof candidate.version !== "string") continue;
@@ -196,8 +212,8 @@ export function parseReloadCooldownRecords(
 
   if (validEntries.length === 0) return null;
 
-  // 自前の書き込み(appendReloadCooldownRecord)は常に上限内に収まるが、
-  // 外部からの汚染や将来の互換性崩れに備え読み取り側でも直近側だけへ切り詰める。
+  // 自前の書き込み(upsertReloadCooldownRecord)は常に上限内に収まるが、
+  // 外部からの汚染に備え読み取り側でも直近側だけへ切り詰める。
   return validEntries.slice(-MAX_RELOAD_COOLDOWN_RECORDS);
 }
 

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -767,7 +767,7 @@ describe('OverlayPage', () => {
     // overlay-version.tsの純粋関数群とは異なりpage.tsx内部の実装詳細のため
     // 非exportになっている。ここでは実装と同じリテラル値を直接指定する
     // (page.tsx側でキー名を変更した場合はこのテストも追随して更新が必要)。
-    const RELOAD_COOLDOWN_STORAGE_KEY = 'twica-overlay-reload'
+    const RELOAD_COOLDOWN_STORAGE_KEY = 'twica-overlay-reload-v2'
     const POLLSTATE_STORAGE_KEY = 'twica-overlay-pollstate'
 
     // page.tsx内部のreload時間定数(非export)と同じ値をテスト側でも保持する。
@@ -895,6 +895,53 @@ describe('OverlayPage', () => {
         pollCursor: '2026-06-01T00:00:00.123Z',
         pollHistoryId: HISTORY_ID_BEFORE_RELOAD,
       })
+    })
+
+    it('リロード実行後、sessionStorageへ書き込まれるクールダウン記録に既存エントリと新規エントリが両方含まれる(Issue #634、自動レビュー指摘への対応)', async () => {
+      // upsertReloadCooldownRecord(cooldownRecords, ...)の第1引数に、実際に
+      // sessionStorageから読み取った既存記録を渡し忘れて誤ってnull/[]を渡す
+      // ような結線バグが混入しても、純粋関数単体のテストや「クールダウン中は
+      // スキップされる」ことしか見ないテストでは検知できない。ここでは実際の
+      // リロード実行後にsessionStorageへ書き込まれた内容そのものを検証し、
+      // mount前から存在した別バージョン('v-z')の記録が消えずに残ったまま
+      // 新規バージョン('v-b')が追記されることを直接確認する。
+      vi.useFakeTimers()
+      vi.spyOn(Math, 'random').mockReturnValue(0)
+      const reloadMock = stubLocationReload()
+      stubEventsFetch('v-a')
+
+      const existingReloadedAt = Date.now() - 1000
+      sessionStorage.setItem(
+        RELOAD_COOLDOWN_STORAGE_KEY,
+        JSON.stringify([{ version: 'v-z', reloadedAt: existingReloadedAt }]),
+      )
+
+      let onOverlayVersion: SubscribeOptions['onOverlayVersion']
+      subscribeMock.mockImplementation((_streamerId, _callback, options: SubscribeOptions) => {
+        onOverlayVersion = options.onOverlayVersion
+        options.onSuccess?.()
+        return vi.fn()
+      })
+
+      render(<OverlayPageV />)
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+
+      act(() => {
+        onOverlayVersion?.('v-b')
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      expect(reloadMock).toHaveBeenCalledTimes(1)
+      const written = JSON.parse(sessionStorage.getItem(RELOAD_COOLDOWN_STORAGE_KEY) ?? 'null')
+      expect(written).toEqual([
+        { version: 'v-z', reloadedAt: existingReloadedAt },
+        { version: 'v-b', reloadedAt: expect.any(Number) },
+      ])
     })
 
     it('connected中は旧loopを10分以上進めても/eventsへnetwork requestを出さない', async () => {
@@ -1025,7 +1072,7 @@ describe('OverlayPage', () => {
       // 記録を仕込んでおく(60分クールダウン中なのでスキップされるはず)
       sessionStorage.setItem(
         RELOAD_COOLDOWN_STORAGE_KEY,
-        JSON.stringify({ version: 'v-b', reloadedAt: Date.now() }),
+        JSON.stringify([{ version: 'v-b', reloadedAt: Date.now() }]),
       )
       stubEventsFetch('v-b')
 

--- a/tests/unit/overlay-version.test.ts
+++ b/tests/unit/overlay-version.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   shouldScheduleReload,
   isReloadCooldownActive,
-  appendReloadCooldownRecord,
+  upsertReloadCooldownRecord,
   serializePollState,
   parsePollState,
   parseReloadCooldownRecords,
@@ -107,29 +107,29 @@ describe("isReloadCooldownActive", () => {
   });
 });
 
-describe("appendReloadCooldownRecord (Issue #634)", () => {
+describe("upsertReloadCooldownRecord (Issue #634)", () => {
   it("recordsがnullの場合は新規エントリ1件の配列を返す", () => {
-    expect(appendReloadCooldownRecord(null, "v1", 100)).toEqual([
+    expect(upsertReloadCooldownRecord(null, "v1", 100)).toEqual([
       { version: "v1", reloadedAt: 100 },
     ]);
   });
 
   it("既存の空配列に追記できる", () => {
-    expect(appendReloadCooldownRecord([], "v1", 100)).toEqual([
+    expect(upsertReloadCooldownRecord([], "v1", 100)).toEqual([
       { version: "v1", reloadedAt: 100 },
     ]);
   });
 
   it("同一バージョンの既存エントリは古いものを置き換える(重複を持たない)", () => {
     const records: ReloadCooldownRecord[] = [{ version: "v1", reloadedAt: 100 }];
-    expect(appendReloadCooldownRecord(records, "v1", 200)).toEqual([
+    expect(upsertReloadCooldownRecord(records, "v1", 200)).toEqual([
       { version: "v1", reloadedAt: 200 },
     ]);
   });
 
   it("異なるバージョンは既存エントリを保持したまま追記される", () => {
     const records: ReloadCooldownRecord[] = [{ version: "v1", reloadedAt: 100 }];
-    expect(appendReloadCooldownRecord(records, "v2", 200)).toEqual([
+    expect(upsertReloadCooldownRecord(records, "v2", 200)).toEqual([
       { version: "v1", reloadedAt: 100 },
       { version: "v2", reloadedAt: 200 },
     ]);
@@ -138,7 +138,7 @@ describe("appendReloadCooldownRecord (Issue #634)", () => {
   it(`MAX_RELOAD_COOLDOWN_RECORDS(${MAX_RELOAD_COOLDOWN_RECORDS}件)を超える場合は最も古いエントリから破棄する`, () => {
     let records: ReloadCooldownRecord[] | null = null;
     for (let i = 0; i < MAX_RELOAD_COOLDOWN_RECORDS + 2; i++) {
-      records = appendReloadCooldownRecord(records, `v${i}`, i);
+      records = upsertReloadCooldownRecord(records, `v${i}`, i);
     }
     expect(records).toHaveLength(MAX_RELOAD_COOLDOWN_RECORDS);
     // 直近MAX_RELOAD_COOLDOWN_RECORDS件だけが残る(先頭の古いものが破棄される)
@@ -158,12 +158,12 @@ describe("ローリングデプロイ中のバージョン往復への耐性(Iss
 
     // 初回: current=A, received=B(未記録) → リロード許可、実行して記録
     expect(isReloadCooldownActive(records, "v-b", now, cooldownMs)).toBe(false);
-    records = appendReloadCooldownRecord(records, "v-b", now);
+    records = upsertReloadCooldownRecord(records, "v-b", now);
 
     // ローリングデプロイの混在ウィンドウで別エッジからv-aが返る(未記録)→リロード許可、実行して記録
     now += 1000;
     expect(isReloadCooldownActive(records, "v-a", now, cooldownMs)).toBe(false);
-    records = appendReloadCooldownRecord(records, "v-a", now);
+    records = upsertReloadCooldownRecord(records, "v-a", now);
 
     // 再度v-bが返る → 直前のv-b記録がクールダウン中のため、往復2巡目以降は抑止される
     now += 1000;
@@ -185,12 +185,12 @@ describe("ローリングデプロイ中のバージョン往復への耐性(Iss
   it("往復ではない一度きりのロールバックでは、既存挙動どおり新バージョンへ即座に切り替わる", () => {
     // v-bへ一度だけリロードした後、これまで一度も見ていないv-cへロールバックされた場合、
     // v-cは記録に無いため即座にリロード許可される(#634受け入れ条件3番目: 既存挙動を壊さない)。
-    const records = appendReloadCooldownRecord(null, "v-b", 0);
+    const records = upsertReloadCooldownRecord(null, "v-b", 0);
     expect(isReloadCooldownActive(records, "v-c", 1000, RELOAD_COOLDOWN_MS)).toBe(false);
   });
 
   it("クールダウン明け後は往復した同一バージョンへも再度リロードできる(恒久ガードにしない)", () => {
-    const records = appendReloadCooldownRecord(null, "v-b", 0);
+    const records = upsertReloadCooldownRecord(null, "v-b", 0);
     const now = RELOAD_COOLDOWN_MS; // ちょうどクールダウン明けの境界
     expect(isReloadCooldownActive(records, "v-b", now, RELOAD_COOLDOWN_MS)).toBe(false);
   });
@@ -208,13 +208,6 @@ describe("parseReloadCooldownRecords", () => {
     ]);
   });
 
-  it("旧形式(Issue #634より前の単一オブジェクト)を1件配列として復元する(後方互換)", () => {
-    // ローリングデプロイの混在ウィンドウで、旧コードが書き込んだ値を新コードが
-    // 読む可能性があるため、単一オブジェクトも読めなければならない。
-    const raw = JSON.stringify({ version: "v2", reloadedAt: 12345 });
-    expect(parseReloadCooldownRecords(raw)).toEqual([{ version: "v2", reloadedAt: 12345 }]);
-  });
-
   it("rawがnull/undefined/空文字列ならnullを返す", () => {
     expect(parseReloadCooldownRecords(null)).toBeNull();
     expect(parseReloadCooldownRecords(undefined)).toBeNull();
@@ -226,28 +219,18 @@ describe("parseReloadCooldownRecords", () => {
     expect(parseReloadCooldownRecords("{broken")).toBeNull();
   });
 
-  it("JSONとして正当だがオブジェクトでも配列でもない場合はnullを返す", () => {
+  it("トップレベルが配列でない場合はnullを返す(数値・null・文字列)", () => {
     expect(parseReloadCooldownRecords("42")).toBeNull();
     expect(parseReloadCooldownRecords("null")).toBeNull();
     expect(parseReloadCooldownRecords('"v2"')).toBeNull();
   });
 
+  it("トップレベルが単一オブジェクト(旧形式相当)の場合もnullを返す(Issue #634でキーをv2へ分離したため、新キーの下に単一オブジェクトが書かれる正常経路は無い。汚染データへの防御として配列以外は一律拒否する)", () => {
+    expect(parseReloadCooldownRecords(JSON.stringify({ version: "v2", reloadedAt: 12345 }))).toBeNull();
+  });
+
   it("空配列はnullを返す(有効なエントリなし)", () => {
     expect(parseReloadCooldownRecords("[]")).toBeNull();
-  });
-
-  it("versionが欠けている/文字列でない要素はnullを返す(単一オブジェクト形式)", () => {
-    expect(parseReloadCooldownRecords(JSON.stringify({ reloadedAt: 1 }))).toBeNull();
-    expect(
-      parseReloadCooldownRecords(JSON.stringify({ version: 123, reloadedAt: 1 })),
-    ).toBeNull();
-  });
-
-  it("reloadedAtが欠けている/数値でない要素はnullを返す(単一オブジェクト形式)", () => {
-    expect(parseReloadCooldownRecords(JSON.stringify({ version: "v2" }))).toBeNull();
-    expect(
-      parseReloadCooldownRecords(JSON.stringify({ version: "v2", reloadedAt: "not-a-number" })),
-    ).toBeNull();
   });
 
   it("配列内の不正な要素だけを無視し、有効な要素は復元する(parsePollStateのフィルタ方針と同じ)", () => {
@@ -278,6 +261,26 @@ describe("parseReloadCooldownRecords", () => {
     expect(parsed).toHaveLength(MAX_RELOAD_COOLDOWN_RECORDS);
     expect(parsed?.[0].version).toBe("v3");
     expect(parsed?.at(-1)?.version).toBe(`v${entries.length - 1}`);
+  });
+
+  // page.tsxの実際の書き込み経路(JSON.stringify(upsertReloadCooldownRecord(...)))を
+  // そのまま再現するround-tripテスト。自動レビュー指摘: 純粋関数単体のテストだけでは
+  // 「既存記録を引数に渡し忘れて実質nullのまま追記してしまう」ような呼び出し側の
+  // 結線バグ(Issue #634の本質的な修正対象)を検知できない。upsert→serialize→parseを
+  // 連鎖させることで、page.tsx側の呼び出しパターンに近い形で検証する
+  // (コンポーネントレベルの検証は tests/unit/components/overlay-page.test.tsx 側で
+  // 実際のsessionStorage書き込み結果を直接アサートする形でも行う)。
+  it("upsertした結果をシリアライズしてパースすると、複数バージョンの履歴を保持したまま復元される", () => {
+    let records: ReloadCooldownRecord[] | null = null;
+    records = upsertReloadCooldownRecord(records, "v-b", 1000);
+    records = parseReloadCooldownRecords(JSON.stringify(records));
+    records = upsertReloadCooldownRecord(records, "v-a", 2000);
+    records = parseReloadCooldownRecords(JSON.stringify(records));
+
+    expect(records).toEqual([
+      { version: "v-b", reloadedAt: 1000 },
+      { version: "v-a", reloadedAt: 2000 },
+    ]);
   });
 });
 


### PR DESCRIPTION
## 背景

PR #994（Issue #634、マージ済み）へ、マージ後にClaude Auto Review（自動レビューbot）から複数の任意指摘が届いた。#994自体は必須指摘0件で合格・マージ済みのため巻き戻さないが、指摘のうち特に構造的な設計改善（storageキーの衝突解消）とテストカバレッジのギャップは価値があると判断し、フォローアップPRとして対応する。

## 主な変更: storageキーのバージョニング (`twica-overlay-reload` → `-v2`)

PR #994時点の実装は、クールダウン記録の保存形式を単一オブジェクトから配列へ変更しつつ、**同じsessionStorageキー**の下で新旧形式を後方互換パースしていた。自動レビューで、この設計に2つの問題が指摘された。

1. 「別タブが旧形式を書き込む」という後方互換コメントの前提が誤っていた（sessionStorageはタブ単位で独立しており別タブは読めない。実際に起こり得るのは「同一タブが旧コードのビルドへ着地する」ケース）。
2. 縮退の見積もりが楽観的だった。旧コードは新形式(配列)を読むと型不一致でnullを返すが、その後の書き込みでは単一オブジェクト形式へ巻き戻す。混在ウィンドウ中に同一タブが旧コードのビルドへ着地するたびに、この巻き戻しが繰り返され得る（「最大1回」ではない）。

新旧コードで別々のキー（旧: `twica-overlay-reload`、新: `twica-overlay-reload-v2`）を使うよう変更し、この干渉を構造的に無くした。新コードは常に自分が書いた配列形式だけを読み、旧コードは自分の旧キーだけを読み書きするため、双方が干渉し合わない。この結果、後方互換の単一オブジェクトパースは不要になったため削除し、`parseReloadCooldownRecords`はトップレベルが配列であることを要求する（配列以外は汚染データとしてnullを返す）よう単純化した。

## その他の任意指摘への対応

- `appendReloadCooldownRecord` → `upsertReloadCooldownRecord` へリネーム（実体は追記ではなく同一バージョンのupsertであるため）
- `MAX_RELOAD_COOLDOWN_RECORDS`のdocに「同一バージョンへの再デプロイも60分間は追従しなくなる」というトレードオフを明記
- `ReloadCooldownRecord`の型docを「直前の1件」から「配列の1要素」の説明へ更新
- **テストカバレッジのギャップに対応**: 純粋関数単体のテストと「事前に配列を仕込んでスキップされる」ことしか見ないコンポーネントテストだけでは、page.tsx側で既存記録を渡し忘れて実質nullのまま追記してしまうような結線バグを検知できないという指摘を受け、(1) upsert→serialize→parseのround-tripテスト、(2) 実際のリロード実行後にsessionStorageへ書き込まれた内容に既存エントリと新規エントリが両方含まれることを直接アサートするコンポーネントテストを追加した

## 検証

- `npx tsc --noEmit` / `npx eslint`（変更ファイル） — エラーなし
- `npx vitest run tests/unit/overlay-version.test.ts tests/unit/components/overlay-page.test.tsx` — 89 tests成功
- `npx vitest run tests/unit`（フルスイート） — 273 files / 3528 tests成功（回帰なし）

## リスク

- storageキー変更により、既存の（PR #994以降デプロイ済みの）open中OBSタブが持つ旧キーのクールダウン記録は新コードから参照されなくなる。実害は「そのタブの次回リロードが1回クールダウンなしで発生する」程度で、Issue #634の初回リロード（そもそも常に許可される想定の挙動）と同等であり、データ破損やエラーは発生しない
- overlay表示に影響する変更のため、preview環境での実チャネルポイント引き換えによる確認を別途検討する

Refs #634, PR #994

---

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013TuXYkkRV5eJweD4e8gWQc)_