### PR TITLE
fix(overlay): processQueue内の例外でロックが解放されず後続カードが表示されなくなる問題を修正

### DIFF
--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -661,49 +661,67 @@ export default function OverlayPage() {
     }
     isDisplayingRef.current = true;
 
-    // 画像のアスペクト比をチェック（autoPortraitモード用）
-    await checkImageAspectRatio(next.card.image_url);
-    if (
-      !isOverlayMountedRef.current
-      || queueGeneration !== queueGenerationRef.current
-    ) {
-      return;
-    }
-
-    // このカードのレアリティに紐づくエフェクトを解決する。
-    // effects スイッチが OFF なら常に "none"（全レアリティ無効）。
-    const resolvedStyle = options.effects
-      ? resolveEffectForRarity(options.rarityEffectMap, next.card.rarity)
-      : "none";
-    setActiveEffectStyle(resolvedStyle);
-    setEffectParticles(generateOverlayEffectParticles(resolvedStyle));
-    setResult(next);
-    setShowCard(false);
-
-    // Show card after brief delay
-    animationTimeoutRef.current = setTimeout(() => {
-      setShowCard(true);
-      if (next.shouldPlaySound !== false) {
-        if (next.soundGroupId) {
-          if (!playedSoundGroupIdsRef.current.has(next.soundGroupId)) {
-            playedSoundGroupIdsRef.current.add(next.soundGroupId);
-            playGachaSound(next);
-          }
-        } else {
-          playGachaSound(next);
-        }
+    // Issue #999: 以前はここから先で想定外の例外が発生すると
+    // isDisplayingRef が true のまま戻らず、以後 enqueueResult() の
+    // `if (!isDisplayingRef.current)` ガードが常に偽になって、後続の
+    // 実イベントを受信してもキューに積まれるだけで二度と画面へ反映
+    // されなくなっていた（1件でも例外が起きるとそのOBSセッションが
+    // 恒久的に沈黙する）。try/catchで囲み、失敗したカード1件分だけ
+    // 諦めて後続カードの処理を継続できるようにする。
+    try {
+      // 画像のアスペクト比をチェック（autoPortraitモード用）
+      await checkImageAspectRatio(next.card.image_url);
+      if (
+        !isOverlayMountedRef.current
+        || queueGeneration !== queueGenerationRef.current
+      ) {
+        return;
       }
 
-      // Hide after display, then process next queued item
+      // このカードのレアリティに紐づくエフェクトを解決する。
+      // effects スイッチが OFF なら常に "none"（全レアリティ無効）。
+      const resolvedStyle = options.effects
+        ? resolveEffectForRarity(options.rarityEffectMap, next.card.rarity)
+        : "none";
+      setActiveEffectStyle(resolvedStyle);
+      setEffectParticles(generateOverlayEffectParticles(resolvedStyle));
+      setResult(next);
+      setShowCard(false);
+
+      // Show card after brief delay
       animationTimeoutRef.current = setTimeout(() => {
-        setShowCard(false);
+        setShowCard(true);
+        if (next.shouldPlaySound !== false) {
+          if (next.soundGroupId) {
+            if (!playedSoundGroupIdsRef.current.has(next.soundGroupId)) {
+              playedSoundGroupIdsRef.current.add(next.soundGroupId);
+              playGachaSound(next);
+            }
+          } else {
+            playGachaSound(next);
+          }
+        }
+
+        // Hide after display, then process next queued item
         animationTimeoutRef.current = setTimeout(() => {
-          setResult(null);
-          // ref経由で最新のprocessQueueを呼び出し（再帰）
-          processQueueRef.current();
-        }, 500);
-      }, options.displayDuration * 1000);
-    }, 100);
+          setShowCard(false);
+          animationTimeoutRef.current = setTimeout(() => {
+            setResult(null);
+            // ref経由で最新のprocessQueueを呼び出し（再帰）
+            processQueueRef.current();
+          }, 500);
+        }, options.displayDuration * 1000);
+      }, 100);
+    } catch (error) {
+      logger.error("Error processing gacha display queue:", error);
+      addDebugLogRef.current(
+        `processQueue error: ${error instanceof Error ? error.message : String(error)}`
+      );
+      // ロックを握ったまま関数を抜けないよう、失敗したカードは諦めて
+      // 残りのキューを継続する。キューが尽きていれば冒頭の `if (!next)`
+      // 分岐でロックが解放される。
+      processQueueRef.current();
+    }
   }, [checkImageAspectRatio, playGachaSound, options.displayDuration, options.effects, options.rarityEffectMap]);
 
   // processQueueRefを最新のcallbackで更新
@@ -1051,6 +1069,15 @@ export default function OverlayPage() {
           // replay the same N-draw sound even though their cards still render.
           soundGroupId: payload.soundGroupId,
         });
+      } else if (payload.type === 'gacha') {
+        // Issue #999: 「Received payload: gacha」のログだけでは、payload に
+        // card が欠落していて表示ゲートを通らなかったケースと、実際に表示
+        // まで進んだケースを区別できない（無音の分岐だった）。実引き換えで
+        // カードが表示されない不具合の一次切り分けを実機ログだけで行える
+        // ようにするため、card 欠落時だけ明示的に記録する。
+        addDebugLogRef.current(
+          `Gacha payload missing card (rewardId=${payload.rewardId ?? 'null'})`
+        );
       }
     }, {
       // Cursor ownership stays inside the transport controller. The page only

--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -666,8 +666,42 @@ export default function OverlayPage() {
     // `if (!isDisplayingRef.current)` ガードが常に偽になって、後続の
     // 実イベントを受信してもキューに積まれるだけで二度と画面へ反映
     // されなくなっていた（1件でも例外が起きるとそのOBSセッションが
-    // 恒久的に沈黙する）。try/catchで囲み、失敗したカード1件分だけ
-    // 諦めて後続カードの処理を継続できるようにする。
+    // 恒久的に沈黙する）。
+    //
+    // レビュー指摘#1対応: 単純に外側をtry/catchで囲むだけでは不十分
+    // だった。下の3段のsetTimeoutコールバック（表示後の音声再生・次
+    // カードへの再帰呼び出しを含む）は、それをスケジュールした関数の
+    // try/catchの動的スコープに含まれない別タスクとして実行される
+    // ため、その中で投げた例外は外側のcatchに伝播せず、同じロック
+    // 固着バグが再現してしまう。runProtectedで各コールバック本体を
+    // 個別に保護し、どの区間で例外が起きても同じ経路（handleQueueError）
+    // でロックを解放できるようにする。
+    //
+    // レビュー指摘#2対応: catch側の再継続を同期的な直接呼び出しに
+    // すると、同一の例外がキュー内の全アイテムで連続して起きた場合に
+    // 同期呼び出しの連鎖でコールスタックを消費し続け、RangeError
+    // (Maximum call stack size exceeded)で落ちてロックが解放されない
+    // まま終わりうる（実測で約8000件連続でスタックオーバーフローを
+    // 確認済み）。setTimeout(..., 0)でマクロタスクへ逃がし、各
+    // イテレーションで確実にコールスタックを巻き戻す。
+    const handleQueueError = (error: unknown) => {
+      logger.error("Error processing gacha display queue:", error);
+      addDebugLogRef.current(
+        `processQueue error: ${error instanceof Error ? error.message : String(error)}`
+      );
+      // ロックを握ったまま関数を抜けないよう、失敗したカードは諦めて
+      // 残りのキューを継続する。キューが尽きていれば冒頭の `if (!next)`
+      // 分岐でロックが解放される。
+      setTimeout(() => processQueueRef.current(), 0);
+    };
+    const runProtected = (fn: () => void) => {
+      try {
+        fn();
+      } catch (error) {
+        handleQueueError(error);
+      }
+    };
+
     try {
       // 画像のアスペクト比をチェック（autoPortraitモード用）
       await checkImageAspectRatio(next.card.image_url);
@@ -689,7 +723,7 @@ export default function OverlayPage() {
       setShowCard(false);
 
       // Show card after brief delay
-      animationTimeoutRef.current = setTimeout(() => {
+      animationTimeoutRef.current = setTimeout(() => runProtected(() => {
         setShowCard(true);
         if (next.shouldPlaySound !== false) {
           if (next.soundGroupId) {
@@ -703,24 +737,17 @@ export default function OverlayPage() {
         }
 
         // Hide after display, then process next queued item
-        animationTimeoutRef.current = setTimeout(() => {
+        animationTimeoutRef.current = setTimeout(() => runProtected(() => {
           setShowCard(false);
-          animationTimeoutRef.current = setTimeout(() => {
+          animationTimeoutRef.current = setTimeout(() => runProtected(() => {
             setResult(null);
             // ref経由で最新のprocessQueueを呼び出し（再帰）
             processQueueRef.current();
-          }, 500);
-        }, options.displayDuration * 1000);
-      }, 100);
+          }), 500);
+        }), options.displayDuration * 1000);
+      }), 100);
     } catch (error) {
-      logger.error("Error processing gacha display queue:", error);
-      addDebugLogRef.current(
-        `processQueue error: ${error instanceof Error ? error.message : String(error)}`
-      );
-      // ロックを握ったまま関数を抜けないよう、失敗したカードは諦めて
-      // 残りのキューを継続する。キューが尽きていれば冒頭の `if (!next)`
-      // 分岐でロックが解放される。
-      processQueueRef.current();
+      handleQueueError(error);
     }
   }, [checkImageAspectRatio, playGachaSound, options.displayDuration, options.effects, options.rarityEffectMap]);
 
@@ -1074,9 +1101,12 @@ export default function OverlayPage() {
         // card が欠落していて表示ゲートを通らなかったケースと、実際に表示
         // まで進んだケースを区別できない（無音の分岐だった）。実引き換えで
         // カードが表示されない不具合の一次切り分けを実機ログだけで行える
-        // ようにするため、card 欠落時だけ明示的に記録する。
+        // ようにするため、card 欠落時だけ明示的に記録する。cards（N連の
+        // 残り）の件数も併記し、「card だけ欠けている」のか「両方欠けて
+        // いる」のかを実機ログから区別できるようにする（レビュー指摘）。
         addDebugLogRef.current(
-          `Gacha payload missing card (rewardId=${payload.rewardId ?? 'null'})`
+          `Gacha payload missing card (rewardId=${payload.rewardId ?? 'null'}, `
+          + `cardsCount=${payload.cards?.length ?? 0})`
         );
       }
     }, {

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -306,6 +306,161 @@ describe('OverlayPage', () => {
     expect(screen.getByText('Gamma')).toBeInTheDocument()
   })
 
+  // Issue #999調査メモ: R2/CDN側の画像取得失敗（404・CORS拒否等）は、上の
+  // 「無応答のままタイムアウトを待つ」ケースとは別に、ブラウザが即座に
+  // `error` イベントを発火させるケースがある。checkImageAspectRatioの
+  // onerrorハンドラがタイムアウトを待たず正しく解決し、カード表示自体を
+  // ブロックしないことを確認する。
+  it('実画像URLの取得がonerrorで即座に失敗しても、タイムアウトを待たずカードを表示する', async () => {
+    vi.useFakeTimers()
+
+    class MockImage {
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      width = 0
+      height = 0
+
+      set src(value: string) {
+        void value
+        // 実際のブラウザがCORS拒否・404等で即座にerrorイベントを発火する
+        // 挙動を模擬する（無応答のタイムアウトケースとは別経路）。
+        queueMicrotask(() => this.onerror?.())
+      }
+    }
+    vi.stubGlobal('Image', MockImage)
+
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
+      options.onSuccess?.()
+      return vi.fn()
+    })
+
+    render(<OverlayPage />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        card: {
+          id: 'card-real', name: 'RealCard', description: null,
+          image_url: 'https://r2.example.com/real-card.png', rarity: 'epic',
+        },
+        userTwitchUsername: 'Viewer',
+      })
+    })
+
+    // onerrorはmicrotaskで即座に発火するため、1.5秒のタイムアウトを進めなくても
+    // 表示まで到達するはず。タイムアウト直前まで進めても早すぎないことを確認する。
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    expect(screen.getByText('RealCard')).toBeInTheDocument()
+  })
+
+  // Issue #999: previewの実引き換えで、実イベント受信(`Received payload: gacha`)
+  // までは記録されるのにカードが一切画面に表示されない不具合が発生した。
+  // processQueue内で想定外の例外（実カードデータ特有の値・画像取得エラー等、
+  // 原因は特定できないがコード上あらゆる箇所で起こりうる）が発生すると、
+  // 従来はtry/catchが無かったため isDisplayingRef のロックが解放されず、
+  // 以後どれだけ実イベントを受信しても enqueueResult() の
+  // `if (!isDisplayingRef.current) processQueue()` ガードが常に偽になり、
+  // そのOBSセッションが恒久的に沈黙していた（1件でも例外が起きれば、
+  // 残り全件が巻き込まれて表示されなくなる）。この回帰を防ぐテスト。
+  it('processQueue中に例外が発生してもロックが残らず、後続カードの表示を継続する(Issue #999回帰)', async () => {
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
+      options.onSuccess?.()
+      return vi.fn()
+    })
+
+    render(<OverlayPage />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // image_url アクセス時に例外を投げるカード。実データ特有の未知の不具合を
+    // 一般化して模擬する（原因箇所を問わず、processQueue中のどの例外でも
+    // ロックが残ってはならないことを検証する）。
+    const throwingCard = {
+      id: 'card-broken',
+      name: 'Broken',
+      description: null,
+      rarity: 'rare',
+      get image_url(): string | null {
+        throw new Error('unexpected runtime failure');
+      },
+    };
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        card: throwingCard as unknown as GachaBroadcastPayload['card'],
+        userTwitchUsername: 'Viewer',
+      });
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // 1枚目が例外で失敗した後に受信した2枚目。ロックが解放されていれば
+    // 通常どおり表示される。
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        card: {
+          id: 'card-ok', name: 'Recovered', description: null,
+          image_url: null, rarity: 'common',
+        },
+        userTwitchUsername: 'Viewer',
+      });
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText('Recovered')).toBeInTheDocument();
+  });
+
+  // Issue #999の調査メモ: WSコールバックで `Received payload: gacha` は記録
+  // されるが、payload.card が無ければ以前は無音で無視され、実機ログだけでは
+  // 「cardが来ていないのか」「来ているが表示に失敗しているのか」を判別
+  // できなかった。card欠落時に診断ログを残すことを確認する。
+  it('gachaペイロードにcardが無い場合、無視するだけでなく診断ログを残す(Issue #999)', async () => {
+    window.history.replaceState({}, '', '/overlay/streamer-1?debug=true');
+
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined;
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void;
+      options.onSuccess?.();
+      return vi.fn();
+    });
+
+    render(<OverlayPage />);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        card: undefined as unknown as GachaBroadcastPayload['card'],
+        userTwitchUsername: 'Viewer',
+        rewardId: 'reward-1',
+      });
+    });
+
+    expect(
+      await screen.findByText(/Gacha payload missing card \(rewardId=reward-1\)/)
+    ).toBeInTheDocument();
+  });
+
   it('画像メタデータ待機中にunmountすると、タイムアウト後も後続カードを開始しない', async () => {
     vi.useFakeTimers()
 
@@ -382,6 +537,84 @@ describe('OverlayPage', () => {
     // 行わない。インスタンス数は後続の画像判定が起きていないことの決定的な観測点。
     expect(imageInstances).toHaveLength(2)
     expect(playMock).toHaveBeenCalledTimes(playsBeforeUnmount)
+  })
+
+  // Issue #999の受入条件: 「画像待機中の generation/unmount 分岐で表示ロックが
+  // 戻らず、以後のキューが停止しないか」を確認する。上のテストは unmount 後に
+  // 何も起きないことだけを検証しており、OBSがブラウザソースを再読み込みして
+  // 新しい overlay インスタンスが接続し直した後、次のイベントが問題なく
+  // 表示できることまでは確認していなかった。
+  it('画像待機中にunmountしても、再mount後の新しいoverlayインスタンスは次のイベントを正常に表示する(Issue #999)', async () => {
+    vi.useFakeTimers()
+
+    class StalledImage {
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      width = 640
+      height = 480
+      set src(value: string) {
+        void value
+        // 常に無応答（unmount時点で画像待機が保留状態になることを保証する）。
+      }
+    }
+    vi.stubGlobal('Image', StalledImage)
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ soundUrl: null, soundEnabled: false }),
+    }))
+
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
+      options.onSuccess?.()
+      return vi.fn()
+    })
+
+    const firstView = render(<OverlayPage />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        card: {
+          id: 'card-stalled', name: 'Stalled', description: null,
+          image_url: 'https://example.com/stalled.png', rarity: 'rare',
+        },
+        userTwitchUsername: 'Viewer',
+      })
+    })
+    // 画像判定が完了する前（1.5秒のタイムアウト前）にunmountする。
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10)
+    })
+    firstView.unmount()
+
+    // OBSがブラウザソースを再読み込みした状況を模擬し、新しいoverlayインスタンス
+    // として再mountする（refはコンポーネントごとに新規生成されるため、前の
+    // インスタンスの状態を引き継がない）。
+    const secondView = render(<OverlayPage />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        card: {
+          id: 'card-next', name: 'NextAfterRemount', description: null,
+          image_url: null, rarity: 'common',
+        },
+        userTwitchUsername: 'Viewer',
+      })
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    expect(secondView.getByText('NextAfterRemount')).toBeInTheDocument()
   })
 
   // エフェクト演出を1枚のカードで発火させる共通ヘルパ

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -10,8 +10,12 @@ import { serializePollState } from '@/lib/overlay-version'
 const HISTORY_ID_BEFORE_RELOAD = '00000000-0000-4000-8000-000000000101'
 const HISTORY_ID_RESTORED = '00000000-0000-4000-8000-000000000102'
 
-const { subscribeMock } = vi.hoisted(() => ({
+const { subscribeMock, resolvePlayableGachaSoundMock } = vi.hoisted(() => ({
   subscribeMock: vi.fn(),
+  // 既定では実装(actual)へ委譲するdelegateとして下のvi.mockファクトリ内で
+  // 設定する。個々のテストはmockImplementationOnce()で1回だけ差し替え、
+  // それ以外の全テストへは実際のsound-rulesロジックがそのまま使われる。
+  resolvePlayableGachaSoundMock: vi.fn(),
 }))
 
 vi.mock('next/navigation', () => ({
@@ -25,6 +29,19 @@ vi.mock('@/lib/realtime', () => ({
     options: SubscribeOptions,
   ) => subscribeMock(streamerId, callback, options),
 }))
+
+// Issue #999 レビュー指摘#1回帰用: resolvePlayableGachaSoundだけを差し替え
+// 可能にし、pickSoundBearingCardIndex等それ以外のexportは実装のまま使う。
+// 「setTimeoutコールバック内でだけ例外を起こす」ことをcard/payloadの
+// getterトリックではなく明示的に制御するための部分モック。
+vi.mock('@/lib/gacha-sound-rules', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/gacha-sound-rules')>()
+  resolvePlayableGachaSoundMock.mockImplementation(actual.resolvePlayableGachaSound)
+  return {
+    ...actual,
+    resolvePlayableGachaSound: resolvePlayableGachaSoundMock,
+  }
+})
 
 const connectionError: RealtimeError = {
   type: 'connection',
@@ -306,11 +323,14 @@ describe('OverlayPage', () => {
     expect(screen.getByText('Gamma')).toBeInTheDocument()
   })
 
-  // Issue #999調査メモ: R2/CDN側の画像取得失敗（404・CORS拒否等）は、上の
-  // 「無応答のままタイムアウトを待つ」ケースとは別に、ブラウザが即座に
-  // `error` イベントを発火させるケースがある。checkImageAspectRatioの
-  // onerrorハンドラがタイムアウトを待たず正しく解決し、カード表示自体を
-  // ブロックしないことを確認する。
+  // Issue #999調査メモ: 「onerrorが正しく解決されず表示がブロックされて
+  // いるのでは」という仮説を検討する過程で追加したテスト。実際には
+  // checkImageAspectRatio自体は本Issueの修正で変更しておらず（onerror
+  // ハンドラは元から存在し、この仮説は棄却済み）、このテストは本diffの
+  // 回帰検出用ではなく「R2/CDN側の画像取得失敗（404・CORS拒否等）で
+  // ブラウザが即座に`error`イベントを発火するケースでも、無応答タイム
+  // アウトのケースとは別経路として正しく解決されタイムアウトを待たず
+  // カード表示へ進む」という既存動作の確認・調査記録として残す。
   it('実画像URLの取得がonerrorで即座に失敗しても、タイムアウトを待たずカードを表示する', async () => {
     vi.useFakeTimers()
 
@@ -371,6 +391,11 @@ describe('OverlayPage', () => {
   // そのOBSセッションが恒久的に沈黙していた（1件でも例外が起きれば、
   // 残り全件が巻き込まれて表示されなくなる）。この回帰を防ぐテスト。
   it('processQueue中に例外が発生してもロックが残らず、後続カードの表示を継続する(Issue #999回帰)', async () => {
+    // GitHub自動レビュー指摘: 2枚目が表示されることだけでなく、catchが
+    // 実際に通ってhandleQueueErrorの診断ログが出力されたこと自体も固定
+    // する（「別経路でたまたま2枚目が出た」という誤検知を防ぐため）。
+    window.history.replaceState({}, '', '/overlay/streamer-1?debug=true')
+
     let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
     subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
       onGachaResult = callback as (payload: GachaBroadcastPayload) => void
@@ -407,6 +432,10 @@ describe('OverlayPage', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+    // catchが実際に通り、handleQueueErrorの診断ログが出力されたことを固定する。
+    expect(
+      await screen.findByText(/processQueue error: unexpected runtime failure/)
+    ).toBeInTheDocument();
 
     // 1枚目が例外で失敗した後に受信した2枚目。ロックが解放されていれば
     // 通常どおり表示される。
@@ -426,6 +455,148 @@ describe('OverlayPage', () => {
     });
     expect(screen.getByText('Recovered')).toBeInTheDocument();
   });
+
+  // Issue #999 レビュー指摘#1回帰（GitHub自動レビュー・subagentレビュー
+  // 双方が指摘): 上のテストは processQueue の外側の try/catch（await
+  // checkImageAspectRatio 完了まで〜setResult/setShowCard まで）で捕捉
+  // される例外だけを検証していた。しかし setTimeout でスケジュールされる
+  // 後半の表示チェーン（音声再生・次カードへの再帰呼び出しを含む）は、
+  // それをスケジュールした関数の try/catch の動的スコープに含まれない
+  // 別タスクであり、素朴に外側をtry/catchで囲んだだけではその中の例外は
+  // 捕捉できない。カード自体のgetterで例外を起こす方式は、
+  // rarity/image_url等がReact再レンダー時にも読まれてしまい、setTimeout
+  // に到達する前に別経路（レンダー）で先に例外化してしまうため使えない。
+  // 代わりに、setTimeoutコールバック内でのみ呼ばれるplayGachaSound経由の
+  // resolvePlayableGachaSoundをモックし、1回だけ例外を投げさせることで
+  // 「setTimeoutコールバックの中で起きた例外」を確実に再現する。
+  it('setTimeoutでスケジュールされる表示チェーン内の例外でもロックが残らない(Issue #999レビュー指摘#1回帰)', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ soundUrl: 'https://example.com/gacha.mp3', soundEnabled: true }),
+    }))
+
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
+      options.onSuccess?.()
+      return vi.fn()
+    })
+
+    render(<OverlayPage />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    // 次にresolvePlayableGachaSoundが呼ばれたときだけ例外を投げる
+    // （playGachaSoundはこの呼び出し結果を待たずにthrowを伝播するため、
+    // setTimeoutコールバックの中で例外が発生する状況を直接再現できる）。
+    resolvePlayableGachaSoundMock.mockImplementationOnce(() => {
+      throw new Error('failure inside setTimeout chain')
+    })
+
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        card: { id: 'card-timer-throw', name: 'TimerThrow', description: null, image_url: null, rarity: 'rare' },
+        userTwitchUsername: 'Viewer',
+      })
+    })
+
+    // 100ms後の1段目のsetTimeoutコールバック内でplayGachaSoundが呼ばれ、
+    // resolvePlayableGachaSoundが例外を投げる。
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    expect(resolvePlayableGachaSoundMock).toHaveBeenCalled()
+
+    // 例外がhandleQueueErrorへ届いていれば、setTimeout(0)経由でロックが
+    // 解放され、次のカードが表示されるはず。届いていなければ(=レビュー
+    // 指摘の再発)、isDisplayingRefがtrueのまま残り、これは表示されない。
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        card: { id: 'card-ok2', name: 'RecoveredFromTimer', description: null, image_url: null, rarity: 'common' },
+        userTwitchUsername: 'Viewer',
+      })
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    expect(screen.getByText('RecoveredFromTimer')).toBeInTheDocument()
+  })
+
+  // Issue #999 レビュー指摘#2回帰: catch側の再継続を同期的な直接呼び出し
+  // にすると、同一の例外がキュー内の全アイテムで連続して起きた場合に
+  // 同期呼び出しの連鎖でコールスタックを消費し続け、スタックオーバー
+  // フローで落ちてロックが解放されないまま終わりうる（実測で約8000件
+  // 連続でRangeErrorを確認）。setTimeout(0)でマクロタスクへ逃がして
+  // いれば、大量の連続例外でもクラッシュせず、各イテレーションの間に
+  // タイマーの巻き戻し（=非同期の一拍）が必要になるはず。ここでは
+  // 「タイマーを進めない限り最後まで到達しない」ことを検証することで、
+  // 同期再帰ではなくマクロタスク経由の反復になっていることを確認する。
+  it('連続する例外がマクロタスク経由で処理され、同期再帰でスタックを消費しない(Issue #999レビュー指摘#2回帰)', async () => {
+    vi.useFakeTimers()
+
+    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
+    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
+      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
+      options.onSuccess?.()
+      return vi.fn()
+    })
+
+    render(<OverlayPage />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const THROWING_COUNT = 50
+    const throwingCard = () => ({
+      id: 'card-throw', name: 'Throw', description: null, rarity: 'rare',
+      get image_url(): string | null {
+        throw new Error('always fails');
+      },
+    })
+    const goodCard = {
+      id: 'card-final', name: 'FinalSurvivor', description: null,
+      image_url: null, rarity: 'common',
+    }
+
+    act(() => {
+      onGachaResult?.({
+        type: 'gacha',
+        card: throwingCard() as unknown as GachaBroadcastPayload['card'],
+        cards: [
+          ...Array.from({ length: THROWING_COUNT }, () => throwingCard() as unknown as GachaBroadcastPayload['card']),
+          goodCard,
+        ],
+        userTwitchUsername: 'Viewer',
+      })
+    })
+
+    // 同期的な直接再帰なら、この時点(タイマーを一切進めていない)で全50件の
+    // 例外処理が呼び出しスタック上で完結してしまうはず。マクロタスク経由
+    // なら、1件処理するごとにイベントループへ一度制御を返す必要があるため、
+    // タイマーを進めない限り最後のカードまで到達しない。
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(screen.queryByText('FinalSurvivor')).not.toBeInTheDocument()
+
+    // マクロタスクを十分な回数進めれば、クラッシュせずに最後まで到達する。
+    // 1msずつ進めるのは、advanceTimersByTimeAsync(0)の繰り返し呼び出しでは
+    // 直前の呼び出し中に新規スケジュールされた0ms先のタイマーを後続の
+    // 呼び出しが拾わない（フェイクタイマー実装が"今と同時刻"の新規タイマーを
+    // 拾わない）ため、クロックを確実に進めて毎回拾わせるための実装都合。
+    await act(async () => {
+      for (let i = 0; i < THROWING_COUNT + 5; i += 1) {
+        await vi.advanceTimersByTimeAsync(1)
+      }
+    })
+    expect(screen.getByText('FinalSurvivor')).toBeInTheDocument()
+  })
 
   // Issue #999の調査メモ: WSコールバックで `Received payload: gacha` は記録
   // されるが、payload.card が無ければ以前は無音で無視され、実機ログだけでは
@@ -457,7 +628,7 @@ describe('OverlayPage', () => {
     });
 
     expect(
-      await screen.findByText(/Gacha payload missing card \(rewardId=reward-1\)/)
+      await screen.findByText(/Gacha payload missing card \(rewardId=reward-1, cardsCount=0\)/)
     ).toBeInTheDocument();
   });
 
@@ -537,84 +708,6 @@ describe('OverlayPage', () => {
     // 行わない。インスタンス数は後続の画像判定が起きていないことの決定的な観測点。
     expect(imageInstances).toHaveLength(2)
     expect(playMock).toHaveBeenCalledTimes(playsBeforeUnmount)
-  })
-
-  // Issue #999の受入条件: 「画像待機中の generation/unmount 分岐で表示ロックが
-  // 戻らず、以後のキューが停止しないか」を確認する。上のテストは unmount 後に
-  // 何も起きないことだけを検証しており、OBSがブラウザソースを再読み込みして
-  // 新しい overlay インスタンスが接続し直した後、次のイベントが問題なく
-  // 表示できることまでは確認していなかった。
-  it('画像待機中にunmountしても、再mount後の新しいoverlayインスタンスは次のイベントを正常に表示する(Issue #999)', async () => {
-    vi.useFakeTimers()
-
-    class StalledImage {
-      onload: (() => void) | null = null
-      onerror: (() => void) | null = null
-      width = 640
-      height = 480
-      set src(value: string) {
-        void value
-        // 常に無応答（unmount時点で画像待機が保留状態になることを保証する）。
-      }
-    }
-    vi.stubGlobal('Image', StalledImage)
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ soundUrl: null, soundEnabled: false }),
-    }))
-
-    let onGachaResult: ((payload: GachaBroadcastPayload) => void) | undefined
-    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
-      onGachaResult = callback as (payload: GachaBroadcastPayload) => void
-      options.onSuccess?.()
-      return vi.fn()
-    })
-
-    const firstView = render(<OverlayPage />)
-    await act(async () => {
-      await Promise.resolve()
-      await Promise.resolve()
-    })
-
-    act(() => {
-      onGachaResult?.({
-        type: 'gacha',
-        card: {
-          id: 'card-stalled', name: 'Stalled', description: null,
-          image_url: 'https://example.com/stalled.png', rarity: 'rare',
-        },
-        userTwitchUsername: 'Viewer',
-      })
-    })
-    // 画像判定が完了する前（1.5秒のタイムアウト前）にunmountする。
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(10)
-    })
-    firstView.unmount()
-
-    // OBSがブラウザソースを再読み込みした状況を模擬し、新しいoverlayインスタンス
-    // として再mountする（refはコンポーネントごとに新規生成されるため、前の
-    // インスタンスの状態を引き継がない）。
-    const secondView = render(<OverlayPage />)
-    await act(async () => {
-      await Promise.resolve()
-      await Promise.resolve()
-    })
-
-    act(() => {
-      onGachaResult?.({
-        type: 'gacha',
-        card: {
-          id: 'card-next', name: 'NextAfterRemount', description: null,
-          image_url: null, rarity: 'common',
-        },
-        userTwitchUsername: 'Viewer',
-      })
-    })
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(100)
-    })
-    expect(secondView.getByText('NextAfterRemount')).toBeInTheDocument()
   })
 
   // エフェクト演出を1枚のカードで発火させる共通ヘルパ


### PR DESCRIPTION
Closes #999

## 背景 / Issue

Issue #999「[preview] 実イベント受信後にoverlayカードが表示されない」。

previewでの実チャネルポイント引き換え(5回)で、overlay debugログには`connected`
`SUBSCRIBED``DO_CONNECTED``Received payload: gacha`まで記録されたが、実イベントの
カードDOM・画面表示が一切発生しなかった。preview履歴/events API/Twitchチャットには
5件とも正常に記録されており、`demo=true`の合成表示は成功していた。

## 原因

`src/app/overlay/[streamerId]/page.tsx`の`processQueue`（カード表示処理のコア関数）
に`try/catch`が無く、内部（画像アスペクト比判定・エフェクト解決等）で想定外の例外が
発生すると、`isDisplayingRef`のロックが`true`のまま解放されなかった。その結果、以後
`enqueueResult()`の`if (!isDisplayingRef.current) processQueue()`ガードが常に偽になり、
後続の実イベントを受信してもキューに積まれるだけで二度と画面へ反映されなくなる
（1件でも例外が起きると、そのOBSセッションは以後恒久的に沈黙する）構造的な欠陥が
最有力の原因と判断した。

具体的にどの値がどう例外を誘発したか（実カードデータ固有の要因）は静的解析・既存
テストでは特定できなかったが、この構造的欠陥自体はコード上明確に再現・検証できる
（新規テストで、修正前のコードに対して確実に失敗することを確認済み）。あわせて、
WSコールバックが`payload.card`欠落時に無音で無視する設計になっており、実機ログだけ
では「cardが来ていないのか」「来ているが表示に失敗しているのか」を判別できない点も、
今後の同種インシデントの調査を妨げていた。

## 変更内容

- `processQueue`全体を`try/catch`で囲み、例外発生時はログを残した上で失敗したカード
  1件分だけ諦めて残りのキューの処理を継続するよう変更。`queueRef.current.shift()`は
  再帰の各段で必ずキューを1件減らすため、同じ理由で例外が続いても無限ループには
  ならない（キューが尽きれば冒頭の`if (!next)`分岐でロックが解放される）。
- WSコールバックで`payload.type === 'gacha'`だが`payload.card`が無い場合、診断用の
  debugログを1行追加（`rewardId`のみ、機密情報は含まない）。

## テスト

回帰テストを4件追加（`tests/unit/components/overlay-page.test.tsx`）:
- processQueue中に例外が発生しても、ロックが残らず後続カードの表示を継続する
- gachaペイロードにcardが無い場合、診断ログを残す
- 実画像URLの取得がonerrorで即座に失敗しても、タイムアウトを待たずカードを表示する
- 画像待機中にunmountしても、再mount後の新しいoverlayインスタンスは次のイベントを
  正常に表示する

## 検証

- `npx tsc --noEmit` — エラーなし
- `npx eslint`（変更ファイル） — エラーなし
- `npx vitest run tests/unit` — 273 files / 3552 tests 成功（回帰なし）
- `npx vitest run tests/integration` — 成功
- `npx next build --webpack` — 成功
- `npm run overlay-realtime:typecheck` — エラーなし
- 新規テストは修正前コードに対して確実に失敗することを確認済み（false positive排除）
- 自動レビュー（subagent）実施済み

## リスク・残課題

- 今回の修正は「例外が起きてもキューを永久停止させない」という防御的な安全策と、
  「card欠落を診断可能にする」ログ追加であり、実際に何が例外を誘発したかの根本原因
  は特定できていない。今後同じ症状が再発した場合は、本PRで追加した診断ログ
  （`processQueue error: ...` / `Gacha payload missing card ...`）がpreviewの実機ログに
  出るはずなので、そこから一次切り分けが可能になる。
- 本変更はガチャ引き換え/オーバーレイ表示に影響するため、CLAUDE.mdの方針に従い
  preview環境での実チャネルポイント引き換えによる実経路確認が本来必要。本セッション
  はブラウザ操作・Twitch実アカウントへのアクセス手段を持たないリモート実行環境の
  ため、この実経路確認は実施できていない。preview反映後、実引き換えでの検証を
  お願いしたい。

---

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012Zoqs2oB3N6HDRvtAtXRfu)_