### PR TITLE
test(r2): アップロードリトライ結線テストをrunAllTimers・env明示・全試行buffer検証で改善 (#1006)

### DIFF
--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -11,13 +11,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // 同一モジュール内の関数として直接呼ぶため、vi.spyOn等でのモック差し替えは効かない
 // （同一モジュール内呼び出しはexportされたbindingを経由しないため）。
 //
-// そこで2種類のテストで公開関数を実際に実行し、内部の結線を検証する:
+// そこで4種類5件のテストで公開関数を実際に実行し、内部の結線を検証する:
 // 1. R2バインディング・環境変数がどちらも無い状態（下記の明示的なモックで再現）で呼び出し、
 //    実際のuploadToR2/uploadSoundToR2が投げる「環境変数が無い」という恒久エラーが
-//    1回の試行だけでそのまま返ることを確認する（バックオフ待機が発生しないため高速）。
+//    1回の試行だけでそのまま返ることを確認する（画像・効果音の2件。バックオフ
+//    待機が発生しないため高速）。
 // 2. @aws-sdk/client-s3をモックし、Issue #976/#977で問題になった「(10001)」エラーを
-//    2回返した後に成功するシナリオで、uploadToR2WithRetryが実際にリトライして
-//    最終的に成功を返すことを確認する（実際のsetTimeoutを使うため数秒かかる）。
+//    2回返した後に成功するシナリオで、uploadToR2WithRetry/uploadSoundToR2WithRetryが
+//    実際にリトライして最終的に成功を返すことを確認する（画像・効果音の2件。
+//    PutObjectCommandへ渡るBucket/Key/Body/ContentTypeも検証し、リトライ中に引数や
+//    bufferを取り違えていないことを確認する）。
+// 3. 恒久エラー（AccessDenied）はS3 SDK経由でも1回の試行で打ち切り、リトライ
+//    しないことを確認する。
+// 4. リトライ間の指数バックオフは vi.useFakeTimers() + advanceTimersByTimeAsync で
+//    進め、実setTimeoutによる待機時間（約3秒）をテスト実行時間に乗せない。
 //
 // @opennextjs/cloudflareはgetR2Bindingが動的importする（src/lib/r2-client.ts）。
 // モックしないと、Node.js実行環境（Vitest）でgetCloudflareContext({async:true})が
@@ -39,19 +46,21 @@ vi.mock('@aws-sdk/client-s3', () => ({
 const sendMock = mocks.sendMock
 
 describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
-  const ORIGINAL_ENV = { ...process.env }
-
   beforeEach(() => {
     sendMock.mockReset()
   })
 
   afterEach(() => {
-    process.env = { ...ORIGINAL_ENV }
+    // 環境変数はテストごとに vi.stubEnv で設定・削除し、ここで必ず元へ戻す。
+    vi.unstubAllEnvs()
+    // リトライ系テストは fake timers を使うため、後続テストへ影響を残さない。
+    vi.useRealTimers()
   })
 
   it('R2バインディング・環境変数がどちらも無い場合、実際のuploadToR2が投げる恒久エラーを1回の試行で返す', async () => {
-    delete process.env.R2_BUCKET_NAME
-    process.env.R2_PUBLIC_URL = 'https://example.test'
+    // R2_BUCKET_NAME は「未設定」を再現するため明示的に削除する
+    vi.stubEnv('R2_BUCKET_NAME', undefined)
+    vi.stubEnv('R2_PUBLIC_URL', 'https://example.test')
 
     const { uploadToR2WithRetry } = await import('@/lib/r2-client')
     const result = await uploadToR2WithRetry('f.png', Buffer.from('x'), 'image/png', 3)
@@ -61,8 +70,8 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
   })
 
   it('R2バインディング・環境変数がどちらも無い場合、実際のuploadSoundToR2が投げる恒久エラーを1回の試行で返す', async () => {
-    delete process.env.R2_SOUND_BUCKET_NAME
-    process.env.R2_SOUND_PUBLIC_URL = 'https://example.test'
+    vi.stubEnv('R2_SOUND_BUCKET_NAME', undefined)
+    vi.stubEnv('R2_SOUND_PUBLIC_URL', 'https://example.test')
 
     const { uploadSoundToR2WithRetry } = await import('@/lib/r2-client')
     const result = await uploadSoundToR2WithRetry('f.mp3', Buffer.from('x'), 'audio/mpeg', 3)
@@ -72,33 +81,62 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
   })
 
   it('R2固有のInternalError(10001)が2回続いた後に成功すれば、uploadToR2WithRetryは実際にリトライして成功を返す (Issue #976/#977/#980の回帰防止)', async () => {
-    process.env.R2_PUBLIC_URL = 'https://example.test'
-    process.env.R2_BUCKET_NAME = 'test-bucket'
-    process.env.R2_ENDPOINT = 'https://example.r2.test'
-    process.env.R2_ACCESS_KEY_ID = 'fake-key'
-    process.env.R2_SECRET_ACCESS_KEY = 'fake-secret'
+    vi.useFakeTimers()
+    vi.stubEnv('R2_PUBLIC_URL', 'https://example.test')
+    vi.stubEnv('R2_BUCKET_NAME', 'test-bucket')
+    vi.stubEnv('R2_ENDPOINT', 'https://example.r2.test')
+    vi.stubEnv('R2_ACCESS_KEY_ID', 'fake-key')
+    vi.stubEnv('R2_SECRET_ACCESS_KEY', 'fake-secret')
     sendMock
       .mockRejectedValueOnce(new Error('put: We encountered an internal error. Please try again. (10001)'))
       .mockRejectedValueOnce(new Error('put: We encountered an internal error. Please try again. (10001)'))
       .mockResolvedValueOnce({})
 
     const { uploadToR2WithRetry } = await import('@/lib/r2-client')
-    const result = await uploadToR2WithRetry('f.png', Buffer.from('x'), 'image/png', 3)
+    const pending = uploadToR2WithRetry('f.png', Buffer.from('x'), 'image/png', 3)
+    // 指数バックオフ（1s + 2s）を実時間で待たずに進める
+    await vi.advanceTimersByTimeAsync(3000)
+    const result = await pending
 
     expect(result).toEqual({ url: 'https://example.test/f.png' })
     expect(sendMock).toHaveBeenCalledTimes(3)
-    // fileName/contentTypeが最後まで正しく引き継がれてPutObjectCommandへ渡っていることを確認する
-    // （リトライのたびに引数を取り違えていないことの検証）
+    // fileName/buffer/contentTypeが最後まで正しく引き継がれてPutObjectCommandへ渡っていることを確認する
+    // （リトライのたびに引数やbufferを取り違えていないことの検証）
     const lastCallInput = sendMock.mock.calls[2][0].input
     expect(lastCallInput).toMatchObject({ Bucket: 'test-bucket', Key: 'f.png', ContentType: 'image/png' })
-  }, 15000)
+    expect(lastCallInput.Body).toEqual(Buffer.from('x'))
+  })
+
+  it('効果音側もR2固有のInternalError(10001)が2回続いた後に成功すれば、uploadSoundToR2WithRetryはリトライして成功し、sound用のenvとURLを使う', async () => {
+    vi.useFakeTimers()
+    vi.stubEnv('R2_SOUND_PUBLIC_URL', 'https://sounds.example.test')
+    vi.stubEnv('R2_SOUND_BUCKET_NAME', 'sound-bucket')
+    vi.stubEnv('R2_ENDPOINT', 'https://example.r2.test')
+    vi.stubEnv('R2_SOUND_ACCESS_KEY_ID', 'fake-key')
+    vi.stubEnv('R2_SOUND_SECRET_ACCESS_KEY', 'fake-secret')
+    sendMock
+      .mockRejectedValueOnce(new Error('put: We encountered an internal error. Please try again. (10001)'))
+      .mockRejectedValueOnce(new Error('put: We encountered an internal error. Please try again. (10001)'))
+      .mockResolvedValueOnce({})
+
+    const { uploadSoundToR2WithRetry } = await import('@/lib/r2-client')
+    const pending = uploadSoundToR2WithRetry('f.mp3', Buffer.from('x'), 'audio/mpeg', 3)
+    await vi.advanceTimersByTimeAsync(3000)
+    const result = await pending
+
+    expect(result).toEqual({ url: 'https://sounds.example.test/f.mp3' })
+    expect(sendMock).toHaveBeenCalledTimes(3)
+    const lastCallInput = sendMock.mock.calls[2][0].input
+    expect(lastCallInput).toMatchObject({ Bucket: 'sound-bucket', Key: 'f.mp3', ContentType: 'audio/mpeg' })
+    expect(lastCallInput.Body).toEqual(Buffer.from('x'))
+  })
 
   it('恒久エラー（AccessDenied）はS3 SDK経由でも1回の試行で打ち切り、リトライしない', async () => {
-    process.env.R2_PUBLIC_URL = 'https://example.test'
-    process.env.R2_BUCKET_NAME = 'test-bucket'
-    process.env.R2_ENDPOINT = 'https://example.r2.test'
-    process.env.R2_ACCESS_KEY_ID = 'fake-key'
-    process.env.R2_SECRET_ACCESS_KEY = 'fake-secret'
+    vi.stubEnv('R2_PUBLIC_URL', 'https://example.test')
+    vi.stubEnv('R2_BUCKET_NAME', 'test-bucket')
+    vi.stubEnv('R2_ENDPOINT', 'https://example.r2.test')
+    vi.stubEnv('R2_ACCESS_KEY_ID', 'fake-key')
+    vi.stubEnv('R2_SECRET_ACCESS_KEY', 'fake-secret')
     sendMock.mockRejectedValue(new Error('AccessDenied: invalid credentials'))
 
     const { uploadToR2WithRetry } = await import('@/lib/r2-client')

--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -11,11 +11,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // 同一モジュール内の関数として直接呼ぶため、vi.spyOn等でのモック差し替えは効かない
 // （同一モジュール内呼び出しはexportされたbindingを経由しないため）。
 //
-// そこで4種類5件のテストで公開関数を実際に実行し、内部の結線を検証する:
+// そこで3種類5件のテストで公開関数を実際に実行し、内部の結線を検証する:
 // 1. R2バインディング・環境変数がどちらも無い状態（下記の明示的なモックで再現）で呼び出し、
 //    実際のuploadToR2/uploadSoundToR2が投げる「環境変数が無い」という恒久エラーが
-//    1回の試行だけでそのまま返ることを確認する（画像・効果音の2件。バックオフ
-//    待機が発生しないため高速）。
+//    1回の試行だけでそのまま返ることを確認する（画像・効果音の2件）。
 // 2. @aws-sdk/client-s3をモックし、Issue #976/#977で問題になった「(10001)」エラーを
 //    2回返した後に成功するシナリオで、uploadToR2WithRetry/uploadSoundToR2WithRetryが
 //    実際にリトライして最終的に成功を返すことを確認する（画像・効果音の2件。
@@ -23,8 +22,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 //    bufferを取り違えていないことを確認する）。
 // 3. 恒久エラー（AccessDenied）はS3 SDK経由でも1回の試行で打ち切り、リトライ
 //    しないことを確認する。
-// 4. リトライ間の指数バックオフは vi.useFakeTimers() + advanceTimersByTimeAsync で
-//    進め、実setTimeoutによる待機時間（約3秒）をテスト実行時間に乗せない。
+//
+// なお、リトライ間の指数バックオフは vi.useFakeTimers() + runAllTimersAsync() で
+// 進め、実setTimeoutによる待機時間（約3秒）をテスト実行時間に乗せない。待機値へ
+// 依存しないため、バックオフの基数や試行回数が変わってもアサーションは壊れない。
 //
 // @opennextjs/cloudflareはgetR2Bindingが動的importする（src/lib/r2-client.ts）。
 // モックしないと、Node.js実行環境（Vitest）でgetCloudflareContext({async:true})が
@@ -87,24 +88,30 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
     vi.stubEnv('R2_ENDPOINT', 'https://example.r2.test')
     vi.stubEnv('R2_ACCESS_KEY_ID', 'fake-key')
     vi.stubEnv('R2_SECRET_ACCESS_KEY', 'fake-secret')
+    // s3UploadがclientType 'images' を誤って 'sounds' 側の資格情報を選ばないことを
+    // 実行環境の有無へ暗黙依存させず、ここで明示的に未設定へ固定する。
+    vi.stubEnv('R2_SOUND_ACCESS_KEY_ID', undefined)
+    vi.stubEnv('R2_SOUND_SECRET_ACCESS_KEY', undefined)
     sendMock
       .mockRejectedValueOnce(new Error('put: We encountered an internal error. Please try again. (10001)'))
       .mockRejectedValueOnce(new Error('put: We encountered an internal error. Please try again. (10001)'))
       .mockResolvedValueOnce({})
 
     const { uploadToR2WithRetry } = await import('@/lib/r2-client')
-    const pending = uploadToR2WithRetry('f.png', Buffer.from('x'), 'image/png', 3)
-    // 指数バックオフ（1s + 2s）を実時間で待たずに進める
-    await vi.advanceTimersByTimeAsync(3000)
+    const pending = uploadToR2WithRetry('f.png', Buffer.from('img'), 'image/png', 3)
+    // 保留中の指数バックオフを実時間で待たずに全て進める
+    await vi.runAllTimersAsync()
     const result = await pending
 
     expect(result).toEqual({ url: 'https://example.test/f.png' })
     expect(sendMock).toHaveBeenCalledTimes(3)
-    // fileName/buffer/contentTypeが最後まで正しく引き継がれてPutObjectCommandへ渡っていることを確認する
-    // （リトライのたびに引数やbufferを取り違えていないことの検証）
-    const lastCallInput = sendMock.mock.calls[2][0].input
-    expect(lastCallInput).toMatchObject({ Bucket: 'test-bucket', Key: 'f.png', ContentType: 'image/png' })
-    expect(lastCallInput.Body).toEqual(Buffer.from('x'))
+    // 全試行の入力が常に正しいことを確認する（リトライのたびに引数やbufferを
+    // 取り違えていないことの検証。最終試行だけを見ると途中の取り違えが素通りする）
+    for (const call of sendMock.mock.calls) {
+      const input = call[0].input
+      expect(input).toMatchObject({ Bucket: 'test-bucket', Key: 'f.png', ContentType: 'image/png' })
+      expect(input.Body).toEqual(Buffer.from('img'))
+    }
   })
 
   it('効果音側もR2固有のInternalError(10001)が2回続いた後に成功すれば、uploadSoundToR2WithRetryはリトライして成功し、sound用のenvとURLを使う', async () => {
@@ -114,21 +121,26 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
     vi.stubEnv('R2_ENDPOINT', 'https://example.r2.test')
     vi.stubEnv('R2_SOUND_ACCESS_KEY_ID', 'fake-key')
     vi.stubEnv('R2_SOUND_SECRET_ACCESS_KEY', 'fake-secret')
+    // 画像側の資格情報が環境に存在しても、sound分岐が誤って選ばないことを固定する
+    vi.stubEnv('R2_ACCESS_KEY_ID', undefined)
+    vi.stubEnv('R2_SECRET_ACCESS_KEY', undefined)
     sendMock
       .mockRejectedValueOnce(new Error('put: We encountered an internal error. Please try again. (10001)'))
       .mockRejectedValueOnce(new Error('put: We encountered an internal error. Please try again. (10001)'))
       .mockResolvedValueOnce({})
 
     const { uploadSoundToR2WithRetry } = await import('@/lib/r2-client')
-    const pending = uploadSoundToR2WithRetry('f.mp3', Buffer.from('x'), 'audio/mpeg', 3)
-    await vi.advanceTimersByTimeAsync(3000)
+    const pending = uploadSoundToR2WithRetry('f.mp3', Buffer.from('snd'), 'audio/mpeg', 3)
+    await vi.runAllTimersAsync()
     const result = await pending
 
     expect(result).toEqual({ url: 'https://sounds.example.test/f.mp3' })
     expect(sendMock).toHaveBeenCalledTimes(3)
-    const lastCallInput = sendMock.mock.calls[2][0].input
-    expect(lastCallInput).toMatchObject({ Bucket: 'sound-bucket', Key: 'f.mp3', ContentType: 'audio/mpeg' })
-    expect(lastCallInput.Body).toEqual(Buffer.from('x'))
+    for (const call of sendMock.mock.calls) {
+      const input = call[0].input
+      expect(input).toMatchObject({ Bucket: 'sound-bucket', Key: 'f.mp3', ContentType: 'audio/mpeg' })
+      expect(input.Body).toEqual(Buffer.from('snd'))
+    }
   })
 
   it('恒久エラー（AccessDenied）はS3 SDK経由でも1回の試行で打ち切り、リトライしない', async () => {
@@ -137,6 +149,8 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
     vi.stubEnv('R2_ENDPOINT', 'https://example.r2.test')
     vi.stubEnv('R2_ACCESS_KEY_ID', 'fake-key')
     vi.stubEnv('R2_SECRET_ACCESS_KEY', 'fake-secret')
+    vi.stubEnv('R2_SOUND_ACCESS_KEY_ID', undefined)
+    vi.stubEnv('R2_SOUND_SECRET_ACCESS_KEY', undefined)
     sendMock.mockRejectedValue(new Error('AccessDenied: invalid credentials'))
 
     const { uploadToR2WithRetry } = await import('@/lib/r2-client')


### PR DESCRIPTION
## 背景 / Issue

Closes #1006

#987（PR #1005）の自動レビューで挙がった任意指摘4点を、テストファイル `tests/unit/r2-client-upload-retry-wiring.test.ts` のみに閉じて対応する（本番コード `src/lib/r2-client.ts` は変更なし）。

## 変更内容

1. **バックオフ値への密結合を解消**: リトライ成功テストの `vi.advanceTimersByTimeAsync(3000)` を `vi.runAllTimersAsync()` に変更。保留タイマーを再帰的に全消化するため、バックオフの基数変更・ジッタ追加・試行回数増加があっても「30秒テストタイムアウト」ではなくアサーション失敗として検出できる。
2. **env判別の環境依存を排除**: 効果音テストで `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` を `vi.stubEnv(..., undefined)` で明示的に未設定化（画像テストも対称に `R2_SOUND_*` を明示的に落とす）。実行環境の `.env` や CI に画像用キーが存在しても判別が静かに無効化されない。
3. **buffer検証を全試行に拡張**: 画像用 `Buffer.from('img')` / 効果音用 `Buffer.from('snd')` とペイロードを区別し、`sendMock.mock.calls` の全試行について `Bucket/Key/Body/ContentType` を検証。最終試行だけを見る方式で素通りしていた試行間・画像/効果音間の取り違えを検出できる。
4. **ヘッダコメントを実態に一致**: 「4種類5件」を実際の「3種類5件」に修正し、fake timers の説明は「なお〜」の別段落へ分離。

## 依存

- このブランチは #1005（#987 対応）のブランチから分岐している。差分は #1006 の変更のみで、#1005 が先にマージされる前提（依存 PR）。

## 検証

- `npx vitest run tests/unit/r2-client-upload-retry-wiring.test.ts` — 5件すべて成功（120ms）
- `npx tsc --noEmit` — エラーなし
- `npx eslint tests/unit/r2-client-upload-retry-wiring.test.ts` — エラーなし
- `npx vitest run tests/unit` — 273 files / 3555 tests すべて成功

## リスク

- テストファイルのみの変更で、本番コード・動作は変更しない
- 変更分類: 静的/CI検証（リトライ結線テストは引き換え経路へ到達しないため実引き換え不要）