### PR TITLE
test(r2): アップロードリトライ結線テストをflaky対策・試行回数検証・credentials直接検証で改善 (#1008)

### DIFF
--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // uploadToR2WithRetry / uploadSoundToR2WithRetry（公開関数）のエンドツーエンドテスト。
 //
@@ -11,7 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // 同一モジュール内の関数として直接呼ぶため、vi.spyOn等でのモック差し替えは効かない
 // （同一モジュール内呼び出しはexportされたbindingを経由しないため）。
 //
-// そこで3種類5件のテストで公開関数を実際に実行し、内部の結線を検証する:
+// そこで3種類のテストで公開関数を実際に実行し、内部の結線を検証する:
 // 1. R2バインディング・環境変数がどちらも無い状態（下記の明示的なモックで再現）で呼び出し、
 //    実際のuploadToR2/uploadSoundToR2が投げる「環境変数が無い」という恒久エラーが
 //    1回の試行だけでそのまま返ることを確認する（画像・効果音の2件）。
@@ -24,8 +24,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 //    しないことを確認する。
 //
 // なお、リトライ間の指数バックオフは vi.useFakeTimers() + runAllTimersAsync() で
-// 進め、実setTimeoutによる待機時間（約3秒）をテスト実行時間に乗せない。待機値へ
-// 依存しないため、バックオフの基数や試行回数が変わってもアサーションは壊れない。
+// 進め、実setTimeoutによる待機時間をテスト実行時間に乗せない。待機値へ依存しない
+// ため、バックオフの基数や試行回数が変わってもアサーションは壊れない。
 //
 // @opennextjs/cloudflareはgetR2Bindingが動的importする（src/lib/r2-client.ts）。
 // モックしないと、Node.js実行環境（Vitest）でgetCloudflareContext({async:true})が
@@ -36,19 +36,59 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const mocks = vi.hoisted(() => ({
   sendMock: vi.fn(),
   getCloudflareContext: vi.fn(async () => ({ env: {} })),
+  // S3Client へ渡る config（endpoint / credentials）を捕捉し、画像・効果音の
+  // 資格情報分岐が正しいキー名を選ぶことを直接検証するために保持する。
+  s3ClientConfigs: [] as Array<Record<string, unknown>>,
 }))
 vi.mock('@opennextjs/cloudflare', () => ({
   getCloudflareContext: mocks.getCloudflareContext,
 }))
 vi.mock('@aws-sdk/client-s3', () => ({
-  S3Client: vi.fn().mockImplementation(() => ({ send: mocks.sendMock })),
+  S3Client: vi.fn().mockImplementation((config: Record<string, unknown>) => {
+    mocks.s3ClientConfigs.push(config)
+    return { send: mocks.sendMock }
+  }),
   PutObjectCommand: vi.fn().mockImplementation((input: unknown) => ({ input })),
 }))
 const sendMock = mocks.sendMock
+const s3ClientConfigs = mocks.s3ClientConfigs
+
+// 画像・効果音それぞれに必要な env をまとめてスタブする。各テストで vi.stubEnv
+// を繰り返すと画像/効果音の資格情報分岐の是非が読みにくくなるためヘルパへ抽出する。
+function stubImageEnv(): void {
+  vi.stubEnv('R2_PUBLIC_URL', 'https://example.test')
+  vi.stubEnv('R2_BUCKET_NAME', 'test-bucket')
+  vi.stubEnv('R2_ENDPOINT', 'https://example.r2.test')
+  vi.stubEnv('R2_ACCESS_KEY_ID', 'image-key')
+  vi.stubEnv('R2_SECRET_ACCESS_KEY', 'image-secret')
+  // 効果音側の資格情報が環境に存在しても、画像分岐が誤って選ばないことを固定する。
+  vi.stubEnv('R2_SOUND_ACCESS_KEY_ID', undefined)
+  vi.stubEnv('R2_SOUND_SECRET_ACCESS_KEY', undefined)
+}
+
+function stubSoundEnv(): void {
+  vi.stubEnv('R2_SOUND_PUBLIC_URL', 'https://sounds.example.test')
+  vi.stubEnv('R2_SOUND_BUCKET_NAME', 'sound-bucket')
+  vi.stubEnv('R2_ENDPOINT', 'https://example.r2.test')
+  vi.stubEnv('R2_SOUND_ACCESS_KEY_ID', 'sound-key')
+  vi.stubEnv('R2_SOUND_SECRET_ACCESS_KEY', 'sound-secret')
+  // 画像側の資格情報が環境に存在しても、sound分岐が誤って選ばないことを固定する。
+  vi.stubEnv('R2_ACCESS_KEY_ID', undefined)
+  vi.stubEnv('R2_SECRET_ACCESS_KEY', undefined)
+}
 
 describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
+  beforeAll(async () => {
+    // #1008: fake timers を有効にする前に @aws-sdk/client-s3 を一度解決しておき、
+    // s3Upload() 内の初回動的 import が1マクロタスクを超えて解決されるケースに
+    // 起因する runAllTimersAsync のハング（testTimeout 30秒で失敗しうる flaky）を
+    // 回避する。
+    await import('@aws-sdk/client-s3')
+  })
+
   beforeEach(() => {
     sendMock.mockReset()
+    s3ClientConfigs.length = 0
   })
 
   afterEach(() => {
@@ -62,36 +102,33 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
     // R2_BUCKET_NAME は「未設定」を再現するため明示的に削除する
     vi.stubEnv('R2_BUCKET_NAME', undefined)
     vi.stubEnv('R2_PUBLIC_URL', 'https://example.test')
+    // 恒久エラー時はリトライのバックオフ sleep が登録されないことを「試行回数」の代わりに検証する。
+    vi.useFakeTimers()
 
     const { uploadToR2WithRetry } = await import('@/lib/r2-client')
     const result = await uploadToR2WithRetry('f.png', Buffer.from('x'), 'image/png', 3)
 
     expect(result).toEqual({ error: 'Missing R2_BUCKET_NAME environment variable' })
     expect(sendMock).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
   })
 
   it('R2バインディング・環境変数がどちらも無い場合、実際のuploadSoundToR2が投げる恒久エラーを1回の試行で返す', async () => {
     vi.stubEnv('R2_SOUND_BUCKET_NAME', undefined)
     vi.stubEnv('R2_SOUND_PUBLIC_URL', 'https://example.test')
+    vi.useFakeTimers()
 
     const { uploadSoundToR2WithRetry } = await import('@/lib/r2-client')
     const result = await uploadSoundToR2WithRetry('f.mp3', Buffer.from('x'), 'audio/mpeg', 3)
 
     expect(result).toEqual({ error: 'Missing R2_SOUND_BUCKET_NAME environment variable' })
     expect(sendMock).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
   })
 
   it('R2固有のInternalError(10001)が2回続いた後に成功すれば、uploadToR2WithRetryは実際にリトライして成功を返す (Issue #976/#977/#980の回帰防止)', async () => {
     vi.useFakeTimers()
-    vi.stubEnv('R2_PUBLIC_URL', 'https://example.test')
-    vi.stubEnv('R2_BUCKET_NAME', 'test-bucket')
-    vi.stubEnv('R2_ENDPOINT', 'https://example.r2.test')
-    vi.stubEnv('R2_ACCESS_KEY_ID', 'fake-key')
-    vi.stubEnv('R2_SECRET_ACCESS_KEY', 'fake-secret')
-    // s3UploadがclientType 'images' を誤って 'sounds' 側の資格情報を選ばないことを
-    // 実行環境の有無へ暗黙依存させず、ここで明示的に未設定へ固定する。
-    vi.stubEnv('R2_SOUND_ACCESS_KEY_ID', undefined)
-    vi.stubEnv('R2_SOUND_SECRET_ACCESS_KEY', undefined)
+    stubImageEnv()
     sendMock
       .mockRejectedValueOnce(new Error('put: We encountered an internal error. Please try again. (10001)'))
       .mockRejectedValueOnce(new Error('put: We encountered an internal error. Please try again. (10001)'))
@@ -112,18 +149,19 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
       expect(input).toMatchObject({ Bucket: 'test-bucket', Key: 'f.png', ContentType: 'image/png' })
       expect(input.Body).toEqual(Buffer.from('img'))
     }
+    // 画像分岐が画像用の資格情報キー名を選ぶことを直接検証する（キー名の対応を明示）。
+    expect(s3ClientConfigs[0]).toEqual(
+      expect.objectContaining({
+        region: 'auto',
+        endpoint: 'https://example.r2.test',
+        credentials: { accessKeyId: 'image-key', secretAccessKey: 'image-secret' },
+      }),
+    )
   })
 
   it('効果音側もR2固有のInternalError(10001)が2回続いた後に成功すれば、uploadSoundToR2WithRetryはリトライして成功し、sound用のenvとURLを使う', async () => {
     vi.useFakeTimers()
-    vi.stubEnv('R2_SOUND_PUBLIC_URL', 'https://sounds.example.test')
-    vi.stubEnv('R2_SOUND_BUCKET_NAME', 'sound-bucket')
-    vi.stubEnv('R2_ENDPOINT', 'https://example.r2.test')
-    vi.stubEnv('R2_SOUND_ACCESS_KEY_ID', 'fake-key')
-    vi.stubEnv('R2_SOUND_SECRET_ACCESS_KEY', 'fake-secret')
-    // 画像側の資格情報が環境に存在しても、sound分岐が誤って選ばないことを固定する
-    vi.stubEnv('R2_ACCESS_KEY_ID', undefined)
-    vi.stubEnv('R2_SECRET_ACCESS_KEY', undefined)
+    stubSoundEnv()
     sendMock
       .mockRejectedValueOnce(new Error('put: We encountered an internal error. Please try again. (10001)'))
       .mockRejectedValueOnce(new Error('put: We encountered an internal error. Please try again. (10001)'))
@@ -141,16 +179,18 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
       expect(input).toMatchObject({ Bucket: 'sound-bucket', Key: 'f.mp3', ContentType: 'audio/mpeg' })
       expect(input.Body).toEqual(Buffer.from('snd'))
     }
+    // sound分岐がsound用の資格情報キー名を選ぶことを直接検証する（アンビエント環境へ依存しない）。
+    expect(s3ClientConfigs[0]).toEqual(
+      expect.objectContaining({
+        region: 'auto',
+        endpoint: 'https://example.r2.test',
+        credentials: { accessKeyId: 'sound-key', secretAccessKey: 'sound-secret' },
+      }),
+    )
   })
 
   it('恒久エラー（AccessDenied）はS3 SDK経由でも1回の試行で打ち切り、リトライしない', async () => {
-    vi.stubEnv('R2_PUBLIC_URL', 'https://example.test')
-    vi.stubEnv('R2_BUCKET_NAME', 'test-bucket')
-    vi.stubEnv('R2_ENDPOINT', 'https://example.r2.test')
-    vi.stubEnv('R2_ACCESS_KEY_ID', 'fake-key')
-    vi.stubEnv('R2_SECRET_ACCESS_KEY', 'fake-secret')
-    vi.stubEnv('R2_SOUND_ACCESS_KEY_ID', undefined)
-    vi.stubEnv('R2_SOUND_SECRET_ACCESS_KEY', undefined)
+    stubImageEnv()
     sendMock.mockRejectedValue(new Error('AccessDenied: invalid credentials'))
 
     const { uploadToR2WithRetry } = await import('@/lib/r2-client')


### PR DESCRIPTION
Closes #1008

## 変更内容

`tests/unit/r2-client-upload-retry-wiring.test.ts` のテスト資産を改善（本番コードは無変更）。

1. **fake timers と初回動的 import のレース対策**: `beforeAll` で `@aws-sdk/client-s3` を一度解決し、`s3Upload()` 内の初回動的 import が1マクロタスクを超えて解決されるケースに起因する `runAllTimersAsync` のハング（30秒タイムアウトで失敗しうる flaky）を回避。
2. **恒久エラーテストの「1回の試行で返る」検証を実化**: 画像・効果音の恒久エラーテストで `vi.useFakeTimers()` を有効化し、`expect(vi.getTimerCount()).toBe(0)` を追加。リトライのバックオフ sleep が登録されないことを直接検証。
3. **テスト3・4および各テストで重複していた env スタブを整理**: `stubImageEnv()` / `stubSoundEnv()` ヘルパへ抽出。
4. **ヘッダーコメントの件数直書きを除去**: 「3種類5件」の直書きを「3種類」に修正（テスト追加で腐敗しにくくする）。
5. **S3Client の config を直接検証**: `S3Client` モックが受け取る config（endpoint / credentials）を捕捉し、画像・効果音のリトライテストでキー名の対応（`R2_ACCESS_KEY_ID` → `accessKeyId` / `R2_SOUND_ACCESS_KEY_ID` → `accessKeyId`）を明示的に assert。アンビエント環境の env 有無への暗黙依存を排除。

## 検証

- `npx vitest run --cache=false tests/unit/r2-client-upload-retry-wiring.test.ts` → 5 tests passed
- `npx tsc --noEmit` → エラーなし
- `npx eslint tests/unit/r2-client-upload-retry-wiring.test.ts` → エラーなし

## リスク

テストのみの変更で本番コードに触れない。変更分類は「静的・CI検証」に該当。

## 実引き換え不要の理由

EventSub・gacha・outbox・chat送信・overlay配信・`{packName}` 解決といった引き換え経路には一切影響しない。対象は unit テスト資産のみ。