### PR TITLE
fix: channel-point-bootstrapのrefresh失敗(REFRESH_FAILED)を401+requiresReauthで返し再認証誘導を復旧 (#1018)

### DIFF
--- a/src/app/api/twitch/channel-point-bootstrap/route.ts
+++ b/src/app/api/twitch/channel-point-bootstrap/route.ts
@@ -97,9 +97,10 @@ async function getTwitchRewards(twitchUserId: string): Promise<TwitchRewardsResu
  *   getTwitchAccessTokenがnullを返すため到達しない防御的経路だが、
  *   将来throw方式へ戻っても同じ401契約になるようにここで集約する。
  * - REFRESH_FAILED かつ恒久失効: refreshがTwitchのtoken endpointから恒久
- *   エラー(invalid_grant・refresh token失効等の400/401/403)で拒否された
+ *   エラー(invalid_grant・refresh token失効等の400/401)で拒否された
  *   ケース。判定は isPermanentRefreshFailure(token-manager.ts) に委譲し、
- *   kind='http' かつ status ∈ {400,401,403} のホワイトリストに絞る。
+ *   kind='http' かつ status ∈ {400,401} のホワイトリストに絞る。
+ *   403はWAF・client設定起因の一過性障害になり得るため対象外。
  *
  * 一過性の5xx(429/5xx、520/521/525/526/530等のCloudflare系を含む)、network
  * エラー、invalid_response、DB障害起因のrefresh失敗(diagnostic未付与)は再認証
@@ -404,11 +405,13 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(responsePayload);
   } catch (error) {
-    // Issue #1018: トークン恒久失効(REFRESH_FAILEDでrefreshRetryable === false /
+    // Issue #1018: トークン恒久失効(REFRESH_FAILEDで恒久status {400,401} /
     // NO_TOKEN)は汎用500ではなく401+requiresReauthを返す。rewards/emotesルートと
     // 同一のbody契約で、クライアント側(ChannelPointSettings)がstep-up再認証CTAを
-    // 表示できる。エラー記録経路(recordApiError→errorsテーブル→auto-generated
-    // bug report)は維持し、capability確定状態もreauth_requiredへ同期する
+    // 表示できる。一過性5xx/network/DB起因のrefresh失敗は再認証で回復しないため
+    // 500を維持する(isReauthRequiredTokenError参照)。エラー記録経路
+    // (recordApiError→errorsテーブル→auto-generated bug report)は維持し、
+    // capability確定状態もreauth_requiredへ同期する
     // (recordChannelPointsApiFailureは内部で失敗を吸収するため応答に影響しない)。
     if (session && isReauthRequiredTokenError(error)) {
       await recordApiError(error, "Channel Point Bootstrap API", twitchTokenErrorReportContext(error));

--- a/src/app/api/twitch/channel-point-bootstrap/route.ts
+++ b/src/app/api/twitch/channel-point-bootstrap/route.ts
@@ -5,7 +5,7 @@ import { handleApiError, handleDatabaseError, recordApiError } from "@/lib/error
 import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { ADDITIONAL_SCOPES } from "@/lib/twitch/scopes";
-import { TwitchTokenError, getTwitchAccessToken, hasScope, twitchTokenErrorReportContext } from "@/lib/twitch/token-manager";
+import { TwitchTokenError, getTwitchAccessToken, hasScope, isPermanentRefreshFailure, twitchTokenErrorReportContext } from "@/lib/twitch/token-manager";
 import {
   deriveEventSubStatus,
   type EventSubSubscriptionForStatus,
@@ -96,20 +96,21 @@ async function getTwitchRewards(twitchUserId: string): Promise<TwitchRewardsResu
  * - NO_TOKEN: DBにrefresh可能なトークンが一切無い状態。現在の実装では
  *   getTwitchAccessTokenがnullを返すため到達しない防御的経路だが、
  *   将来throw方式へ戻っても同じ401契約になるようにここで集約する。
- * - REFRESH_FAILED かつ refreshRetryable === false: refreshがTwitchから
- *   恒久エラー(invalid_grant・refresh token失効等の400/401/403)で拒否され
- *   たケース。auth.tsのREFRESH_RETRYABLE_STATUSESは429/5xxとnetwork
- *   エラー(status undefined)をretryable=trueとするため、=== falseだけが
- *   恒久失効を指す。
+ * - REFRESH_FAILED かつ恒久失効: refreshがTwitchのtoken endpointから恒久
+ *   エラー(invalid_grant・refresh token失効等の400/401/403)で拒否された
+ *   ケース。判定は isPermanentRefreshFailure(token-manager.ts) に委譲し、
+ *   kind='http' かつ status ∈ {400,401,403} のホワイトリストに絞る。
  *
- * DB障害起因のrefresh失敗(diagnostic未付与のためrefreshRetryable ===
- * undefined)と一時失敗(retryable === true)は再認証で回復しないため
- * 対象外とし、従来どおりhandleApiErrorの500を維持する。
+ * 一過性の5xx(429/5xx、520/521/525/526/530等のCloudflare系を含む)、network
+ * エラー、invalid_response、DB障害起因のrefresh失敗(diagnostic未付与)は再認証
+ * で回復しないため対象外(false)とし、従来どおりhandleApiErrorの500を維持する。
+ * これにより一時障害を恒久失効と誤判定してcapabilityをreauth_requiredへ
+ * 誤確定させるのを防ぐ。
  */
 function isReauthRequiredTokenError(error: unknown): boolean {
   if (!(error instanceof TwitchTokenError)) return false;
   if (error.code === "NO_TOKEN") return true;
-  return error.code === "REFRESH_FAILED" && error.refreshRetryable === false;
+  return isPermanentRefreshFailure(error);
 }
 
 async function getSubscriptionsByUserId(

--- a/src/app/api/twitch/channel-point-bootstrap/route.ts
+++ b/src/app/api/twitch/channel-point-bootstrap/route.ts
@@ -1,11 +1,11 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { getSession, canUseStreamerFeatures } from "@/lib/session";
+import { getSession, canUseStreamerFeatures, type Session } from "@/lib/session";
 
-import { handleApiError, handleDatabaseError } from "@/lib/error-handler";
+import { handleApiError, handleDatabaseError, recordApiError } from "@/lib/error-handler";
 import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { ADDITIONAL_SCOPES } from "@/lib/twitch/scopes";
-import { getTwitchAccessToken, hasScope, twitchTokenErrorReportContext } from "@/lib/twitch/token-manager";
+import { TwitchTokenError, getTwitchAccessToken, hasScope, twitchTokenErrorReportContext } from "@/lib/twitch/token-manager";
 import {
   deriveEventSubStatus,
   type EventSubSubscriptionForStatus,
@@ -87,6 +87,29 @@ async function getTwitchRewards(twitchUserId: string): Promise<TwitchRewardsResu
 
   const data = await response.json();
   return { rewards: data.data || [] };
+}
+
+/**
+ * Issue #1018: TwitchTokenErrorのうち「step-up再認証でしか回復しない
+ * 恒久トークン失効」に該当するかを判定する。
+ *
+ * - NO_TOKEN: DBにrefresh可能なトークンが一切無い状態。現在の実装では
+ *   getTwitchAccessTokenがnullを返すため到達しない防御的経路だが、
+ *   将来throw方式へ戻っても同じ401契約になるようにここで集約する。
+ * - REFRESH_FAILED かつ refreshRetryable === false: refreshがTwitchから
+ *   恒久エラー(invalid_grant・refresh token失効等の400/401/403)で拒否され
+ *   たケース。auth.tsのREFRESH_RETRYABLE_STATUSESは429/5xxとnetwork
+ *   エラー(status undefined)をretryable=trueとするため、=== falseだけが
+ *   恒久失効を指す。
+ *
+ * DB障害起因のrefresh失敗(diagnostic未付与のためrefreshRetryable ===
+ * undefined)と一時失敗(retryable === true)は再認証で回復しないため
+ * 対象外とし、従来どおりhandleApiErrorの500を維持する。
+ */
+function isReauthRequiredTokenError(error: unknown): boolean {
+  if (!(error instanceof TwitchTokenError)) return false;
+  if (error.code === "NO_TOKEN") return true;
+  return error.code === "REFRESH_FAILED" && error.refreshRetryable === false;
 }
 
 async function getSubscriptionsByUserId(
@@ -272,9 +295,13 @@ async function getOwnedStreamer(twitchUserId: string) {
 export async function GET(request: NextRequest) {
   const startedAt = perfStart();
   const diagnostics = request.nextUrl.searchParams.get("diagnostics") === "1";
+  // Issue #1018: catch内で「ログイン済み配信者の恒久トークン失効か」を判定する
+  // ためにtry外までsessionを保持する。getSession()自体の失敗は従来どおり
+  // catchへ伝播し500になる。
+  let session: Session | null = null;
 
   try {
-    const session = await getSession();
+    session = await getSession();
     const identifier = await getRateLimitIdentifier(request, session?.twitchUserId);
     const rateLimitResult = await checkRateLimit(rateLimits.twitchRewardsGet, identifier);
 
@@ -376,6 +403,20 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json(responsePayload);
   } catch (error) {
+    // Issue #1018: トークン恒久失効(REFRESH_FAILEDでrefreshRetryable === false /
+    // NO_TOKEN)は汎用500ではなく401+requiresReauthを返す。rewards/emotesルートと
+    // 同一のbody契約で、クライアント側(ChannelPointSettings)がstep-up再認証CTAを
+    // 表示できる。エラー記録経路(recordApiError→errorsテーブル→auto-generated
+    // bug report)は維持し、capability確定状態もreauth_requiredへ同期する
+    // (recordChannelPointsApiFailureは内部で失敗を吸収するため応答に影響しない)。
+    if (session && isReauthRequiredTokenError(error)) {
+      await recordApiError(error, "Channel Point Bootstrap API", twitchTokenErrorReportContext(error));
+      await recordChannelPointsApiFailure(session.twitchUserId, 401);
+      return NextResponse.json(
+        { error: ERROR_MESSAGES.TWITCH_TOKEN_REQUIRED, requiresReauth: true },
+        { status: 401 }
+      );
+    }
     // Issue #670: refresh失敗(REFRESH_FAILED)の場合、diagnostics(status/kind)を
     // auto-generated bug reportのContextへ載せる(twitchTokenErrorReportContext参照)。
     return handleApiError(error, "Channel Point Bootstrap API", twitchTokenErrorReportContext(error));

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -150,6 +150,19 @@ export default function ChannelPointSettings({
         { credentials: "include" },
       );
       if (!response.ok) {
+        // Issue #1018: トークン恒久失効時はバックエンドが401で
+        // { error, requiresReauth: true } を返す。再認証導線(step-up CTA)は
+        // body側にあるため、!response.okでもbodyを読みrequiresReauthを
+        // 判定する。JSONでなければ従来どおり汎用エラー表示にフォールバック。
+        const errorData = await response.json().catch(() => null);
+        if (errorData && errorData.requiresReauth === true) {
+          // 直前にセットするはずの「取得に失敗しました」文言は再認証導線と
+          // 矛盾するためクリアし、needsReauthバナー(scopeRequired+CTA)のみ
+          // を表示する。
+          setError("");
+          setNeedsReauth(true);
+          return;
+        }
         setError(t("messages.fetchFailed"));
         return;
       }

--- a/src/lib/error-handler.ts
+++ b/src/lib/error-handler.ts
@@ -31,6 +31,22 @@ export async function handleApiError(
   return NextResponse.json({ error: ERROR_MESSAGES.INTERNAL_ERROR }, { status: 500 })
 }
 
+/**
+ * エラーのconsole出力とPlanetScale記録のみ行いレスポンスを返さない。
+ *
+ * Issue #1018: 呼び出し側がhandleApiErrorの固定500ではなく状況に応じた
+ * ステータス(例: トークン恒久失効の401+requiresReauth)を返す必要がある
+ * 境界で、auto-generated bug reportへの記録経路を維持するための分離。
+ * レスポンス生成の責任は呼び出し側へ移るため、本関数が返すレスポンスは無い。
+ */
+export async function recordApiError(
+  error: unknown,
+  context: string,
+  additionalInfo?: Record<string, unknown>
+): Promise<void> {
+  await logAndRecordError(`${context}:`, error, additionalInfo)
+}
+
 export async function handleDatabaseError(error: unknown, context: string): Promise<NextResponse> {
   await logAndRecordError(`${context}:`, error)
   return NextResponse.json({ error: 'Database error' }, { status: 500 })

--- a/src/lib/twitch/token-manager.ts
+++ b/src/lib/twitch/token-manager.ts
@@ -37,22 +37,23 @@ export class TwitchTokenError extends Error {
 
 // refresh が Twitch の token endpoint から「step-up再認証でしか回復しない恒久失効」
 // と断定できるHTTP statusのホワイトリスト。auth.ts:449(「400/401は失効したrefresh
-// token等の恒久エラー」)とIssue #1018の期待動作(invalid_grant・refresh token失効
-// 等の400/401/403)に基づく。
+// token等の恒久エラー」)とIssue #1018(invalid_grant・refresh token失効等の400/401)
+// に基づく。403はWAF・client設定・上流機能の問題でも起こり得るため恒久失効と
+// 断定できない(shouldDisableBotCredential と同一方針・同一集合を共有する)。
 //
 // 重要: auth.ts の REFRESH_RETRYABLE_STATUSES の「補集合」は恒久失効とは限らない。
 // 520/521/525/526/530等のCloudflare系一過性5xxや501/505はretryable集合に含まれず
 // refreshRetryable === false になるが、それらは一時障害であり再認証では回復しない。
 // そのためここでは retryable の否定形ではなく、恒久と断定できるstatusをホワイト
 // リストで明示的に絞る(一時障害の窓でcapabilityをreauth_requiredへ誤確定させない)。
-const PERMANENT_REFRESH_STATUSES = new Set([400, 401, 403]);
+export const PERMANENT_REFRESH_STATUSES = new Set([400, 401]);
 
 /**
  * TwitchTokenError(REFRESH_FAILED)が「step-up再認証でしか回復しない恒久トークン
  * 失効」に該当するかを判定する(Issue #1018)。
  *
  * 判定は refreshErrorKind === 'http' かつ refreshStatus が PERMANENT_REFRESH_STATUSES
- * (400/401/403)に属する場合のみtrue。
+ * (400/401)に属する場合のみtrue。
  *
  * - networkエラー(kind='network', status未定義)・DB障害起因(diagnostic未付与のため
  *   refreshErrorKind/refreshStatusがundefined)・invalid_response・一過性5xx
@@ -438,9 +439,12 @@ function shouldDisableBotCredential(error: unknown): boolean {
   // BOTを無効化してはいけない（retry方針とcredential失効判定は別の責務）。
   // 522/network/壊れた2xx応答やDB保存障害でstatus='error'にすると、取得クエリの
   // active filterから外れ、上流復旧後も自動再試行できなくなる。
+  // 恒久失効のstatus集合は PERMANENT_REFRESH_STATUSES と共有し、ユーザー側
+  // (isPermanentRefreshFailure)とBOT側の判定が別々に乖離しないようにする。
   return error instanceof TwitchTokenRefreshError
     && error.kind === 'http'
-    && (error.status === 400 || error.status === 401);
+    && error.status !== undefined
+    && PERMANENT_REFRESH_STATUSES.has(error.status);
 }
 
 async function readUserRefreshWinner(

--- a/src/lib/twitch/token-manager.ts
+++ b/src/lib/twitch/token-manager.ts
@@ -35,6 +35,45 @@ export class TwitchTokenError extends Error {
   }
 }
 
+// refresh が Twitch の token endpoint から「step-up再認証でしか回復しない恒久失効」
+// と断定できるHTTP statusのホワイトリスト。auth.ts:449(「400/401は失効したrefresh
+// token等の恒久エラー」)とIssue #1018の期待動作(invalid_grant・refresh token失効
+// 等の400/401/403)に基づく。
+//
+// 重要: auth.ts の REFRESH_RETRYABLE_STATUSES の「補集合」は恒久失効とは限らない。
+// 520/521/525/526/530等のCloudflare系一過性5xxや501/505はretryable集合に含まれず
+// refreshRetryable === false になるが、それらは一時障害であり再認証では回復しない。
+// そのためここでは retryable の否定形ではなく、恒久と断定できるstatusをホワイト
+// リストで明示的に絞る(一時障害の窓でcapabilityをreauth_requiredへ誤確定させない)。
+const PERMANENT_REFRESH_STATUSES = new Set([400, 401, 403]);
+
+/**
+ * TwitchTokenError(REFRESH_FAILED)が「step-up再認証でしか回復しない恒久トークン
+ * 失効」に該当するかを判定する(Issue #1018)。
+ *
+ * 判定は refreshErrorKind === 'http' かつ refreshStatus が PERMANENT_REFRESH_STATUSES
+ * (400/401/403)に属する場合のみtrue。
+ *
+ * - networkエラー(kind='network', status未定義)・DB障害起因(diagnostic未付与のため
+ *   refreshErrorKind/refreshStatusがundefined)・invalid_response・一過性5xx
+ *   (429/5xx等)は再認証で回復しないためfalse。これらをfalseに保つことで、一時障害
+ *   の窓で channel_points_capability を reauth_required (definitive) へ誤って確定
+ *   させない(persistChannelPointsCapability の「一時失敗で確定状態を破壊しない」
+ *   不変条件を守り、401リテラルによるガード迂回を防止する)。
+ *
+ * 判定の正本はこの1箇所に集約する。rewards/emotesルート等の同型401経路(follow-up)
+ * でも再利用できるようにエクスポートする。
+ */
+export function isPermanentRefreshFailure(error: unknown): boolean {
+  return (
+    error instanceof TwitchTokenError &&
+    error.code === 'REFRESH_FAILED' &&
+    error.refreshErrorKind === 'http' &&
+    error.refreshStatus !== undefined &&
+    PERMANENT_REFRESH_STATUSES.has(error.refreshStatus)
+  );
+}
+
 /**
  * TwitchTokenRefreshError が持つ診断情報のうち、ログへ出しても安全な部分だけを
  * 抽出する(Issue #653/#670/#654/#655)。

--- a/tests/unit/channel-point-bootstrap-api.test.ts
+++ b/tests/unit/channel-point-bootstrap-api.test.ts
@@ -41,7 +41,7 @@ vi.mock('@/lib/twitch/token-manager', () => {
     error.code === 'REFRESH_FAILED' &&
     error.refreshErrorKind === 'http' &&
     error.refreshStatus !== undefined &&
-    [400, 401, 403].includes(error.refreshStatus)
+    [400, 401].includes(error.refreshStatus)
   return {
     TwitchTokenError,
     hasScope: vi.fn(),
@@ -353,7 +353,7 @@ describe('GET /api/twitch/channel-point-bootstrap', () => {
   })
 
   // Issue #1018: トークン恒久失効(REFRESH_FAILEDかつkind='http'でstatusが
-  // {400,401,403}のホワイトリストに属する)は汎用500ではなく、rewards/emotes
+  // {400,401}のホワイトリストに属する)は汎用500ではなく、rewards/emotes
   // ルートと同じbody契約の401+requiresReauthを返し、クライアントがstep-up
   // 再認証CTAを表示できるようにする。
   it('REFRESH_FAILED(恒久失効: 400, kind=http)は401+requiresReauthを返し、エラー記録とcapability(401)同期を行う', async () => {

--- a/tests/unit/channel-point-bootstrap-api.test.ts
+++ b/tests/unit/channel-point-bootstrap-api.test.ts
@@ -34,7 +34,7 @@ vi.mock('@/lib/twitch/token-manager', () => {
     }
   }
   // Issue #1018: routeは恒久失効判定をisPermanentRefreshFailureへ委譲するため、
-  // 実装と同语义の判定をモッククラスに対して供給する。実装本体の判定は
+  // 実装と同一セマンティクスの判定をモッククラスに対して供給する。実装本体の判定は
   // twitch-token-manager.test.tsで直接検証する。
   const isPermanentRefreshFailure = (error: unknown) =>
     error instanceof TwitchTokenError &&

--- a/tests/unit/channel-point-bootstrap-api.test.ts
+++ b/tests/unit/channel-point-bootstrap-api.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { getDb } from '@/lib/db/client'
 import { __resetTwitchAppTokenForTests } from '@/lib/twitch/app-token'
+import { ERROR_MESSAGES } from '@/lib/constants'
 
 vi.mock('@/lib/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -15,11 +16,43 @@ vi.mock('@/lib/rate-limit', () => ({
   checkRateLimit: vi.fn(),
   rateLimits: { twitchRewardsGet: { windowMs: 60000, max: 30 } },
 }))
-vi.mock('@/lib/twitch/token-manager', () => ({
-  hasScope: vi.fn(),
-  getTwitchAccessToken: vi.fn(),
-  // Issue #653/#670: route handlerのcatchが常に呼ぶため固定モックにも必要。
-  twitchTokenErrorReportContext: vi.fn().mockReturnValue(undefined),
+vi.mock('@/lib/twitch/token-manager', () => {
+  // Issue #1018: routeはinstanceofで再認証要エラーを判定するため、モックにも
+  // 実クラスと同形のTwitchTokenErrorを供給する（無いとinstanceof undefinedで
+  // TypeErrorになる）。
+  class TwitchTokenError extends Error {
+    constructor(
+      message: string,
+      public readonly code: 'NO_TOKEN' | 'REFRESH_FAILED' | 'DATABASE_ERROR' | 'USER_NOT_FOUND',
+      public readonly originalError?: Error,
+      public readonly refreshStatus?: number,
+      public readonly refreshErrorKind?: string,
+      public readonly refreshRetryable?: boolean,
+    ) {
+      super(message)
+      this.name = 'TwitchTokenError'
+    }
+  }
+  return {
+    TwitchTokenError,
+    hasScope: vi.fn(),
+    getTwitchAccessToken: vi.fn(),
+    // Issue #653/#670: route handlerのcatchが常に呼ぶため固定モックにも必要。
+    twitchTokenErrorReportContext: vi.fn().mockReturnValue(undefined),
+  }
+})
+// Issue #1018: catch経路はrecordApiError（記録のみ）またはhandleApiError
+// （500）を返す。両者の呼び分けを検証するためモック化する。DB永続化は
+// recordApiErrorの内部（sentry/error-handler）で行われるが、テスト環境では
+// NEXT_RUNTIME未設定でno-opになるため、モックによる呼び出し検証で代替する。
+vi.mock('@/lib/error-handler', () => ({
+  handleApiError: vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ error: 'Internal Server Error' }), { status: 500 })
+  ),
+  handleDatabaseError: vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ error: 'Database error' }), { status: 500 })
+  ),
+  recordApiError: vi.fn().mockResolvedValue(undefined),
 }))
 vi.mock('@/lib/db/client', () => ({ getDb: vi.fn() }))
 // #788: GET ハンドラは早期returnも含め常に getChannelPointsAccessState を呼ぶため、
@@ -307,5 +340,118 @@ describe('GET /api/twitch/channel-point-bootstrap', () => {
 
     expect(response.status).toBe(200)
     expect(body.rewards).toHaveLength(1)
+  })
+
+  // Issue #1018: トークン恒久失効(REFRESH_FAILEDかつrefreshRetryable ===
+  // false)は汎用500ではなく、rewards/emotesルートと同じbody契約の
+  // 401+requiresReauthを返し、クライアントがstep-up再認証CTAを表示できるようにする。
+  it('REFRESH_FAILED(refreshRetryable=false)は401+requiresReauthを返し、エラー記録とcapability(401)同期を行う', async () => {
+    const { hasScope, getTwitchAccessToken, TwitchTokenError } = await import('@/lib/twitch/token-manager')
+    const { recordApiError, handleApiError } = await import('@/lib/error-handler')
+    const { recordChannelPointsApiFailure } = await import('@/lib/twitch/channel-points-access')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    const tokenError = new TwitchTokenError(
+      'Failed to refresh Twitch access token',
+      'REFRESH_FAILED',
+      undefined,
+      400,
+      'http',
+      false,
+    )
+    vi.mocked(getTwitchAccessToken).mockRejectedValue(tokenError)
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    const response = await GET(request())
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body).toEqual({ error: ERROR_MESSAGES.TWITCH_TOKEN_REQUIRED, requiresReauth: true })
+    expect(recordApiError).toHaveBeenCalledWith(tokenError, 'Channel Point Bootstrap API', undefined)
+    expect(handleApiError).not.toHaveBeenCalled()
+    expect(recordChannelPointsApiFailure).toHaveBeenCalledWith('streamer-1', 401)
+  })
+
+  // Issue #1018: refreshRetryable === true(429/5xx/network)は再認証では回復しない
+  // 一時失敗のため、従来どおりhandleApiErrorの500を維持しcapability確定状態を壊さない。
+  it('REFRESH_FAILED(refreshRetryable=true)は一時失敗のため500(handleApiError)を返しcapabilityは同期しない', async () => {
+    const { hasScope, getTwitchAccessToken, TwitchTokenError } = await import('@/lib/twitch/token-manager')
+    const { recordApiError, handleApiError } = await import('@/lib/error-handler')
+    const { recordChannelPointsApiFailure } = await import('@/lib/twitch/channel-points-access')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(getTwitchAccessToken).mockRejectedValue(
+      new TwitchTokenError(
+        'Failed to refresh Twitch access token',
+        'REFRESH_FAILED',
+        undefined,
+        429,
+        'http',
+        true,
+      ),
+    )
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    const response = await GET(request())
+
+    expect(response.status).toBe(500)
+    expect(handleApiError).toHaveBeenCalled()
+    expect(recordApiError).not.toHaveBeenCalled()
+    expect(recordChannelPointsApiFailure).not.toHaveBeenCalled()
+  })
+
+  // Issue #1018: DB障害起因のrefresh失敗はdiagnosticが未付与(refreshRetryable ===
+  // undefined)になるため再認証要エラーと判定できず、500を維持する。
+  it('REFRESH_FAILEDでdiagnostic未付与(DB起因失敗)は500(handleApiError)を返しcapabilityは同期しない', async () => {
+    const { hasScope, getTwitchAccessToken, TwitchTokenError } = await import('@/lib/twitch/token-manager')
+    const { recordApiError, handleApiError } = await import('@/lib/error-handler')
+    const { recordChannelPointsApiFailure } = await import('@/lib/twitch/channel-points-access')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(getTwitchAccessToken).mockRejectedValue(
+      new TwitchTokenError('Failed to refresh Twitch access token', 'REFRESH_FAILED', new Error('db down')),
+    )
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    const response = await GET(request())
+
+    expect(response.status).toBe(500)
+    expect(handleApiError).toHaveBeenCalled()
+    expect(recordApiError).not.toHaveBeenCalled()
+    expect(recordChannelPointsApiFailure).not.toHaveBeenCalled()
+  })
+
+  // Issue #1018: NO_TOKENは現在の実装では到達しない防御的経路だが、
+  // 401+requiresReauthの契約をここで固定する。
+  it('NO_TOKEN(防御的経路)は401+requiresReauthを返す', async () => {
+    const { hasScope, getTwitchAccessToken, TwitchTokenError } = await import('@/lib/twitch/token-manager')
+    const { recordChannelPointsApiFailure } = await import('@/lib/twitch/channel-points-access')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(getTwitchAccessToken).mockRejectedValue(
+      new TwitchTokenError('No Twitch token found', 'NO_TOKEN'),
+    )
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    const response = await GET(request())
+    const body = await response.json()
+
+    expect(response.status).toBe(401)
+    expect(body).toEqual({ error: ERROR_MESSAGES.TWITCH_TOKEN_REQUIRED, requiresReauth: true })
+    expect(recordChannelPointsApiFailure).toHaveBeenCalledWith('streamer-1', 401)
+  })
+
+  // Issue #1018 リグレッションガード: トークンエラー以外(汎用Error等)は
+  // 従来どおり500を維持し、誤って401+requiresReauthにしない。
+  it('非トークンエラー(汎用Error)は500(handleApiError)を維持する', async () => {
+    const { hasScope, getTwitchAccessToken } = await import('@/lib/twitch/token-manager')
+    const { recordApiError, handleApiError } = await import('@/lib/error-handler')
+    const { recordChannelPointsApiFailure } = await import('@/lib/twitch/channel-points-access')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(getTwitchAccessToken).mockRejectedValue(new Error('unexpected db failure'))
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    const response = await GET(request())
+
+    expect(response.status).toBe(500)
+    expect(handleApiError).toHaveBeenCalled()
+    expect(recordApiError).not.toHaveBeenCalled()
+    expect(recordChannelPointsApiFailure).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/channel-point-bootstrap-api.test.ts
+++ b/tests/unit/channel-point-bootstrap-api.test.ts
@@ -33,10 +33,20 @@ vi.mock('@/lib/twitch/token-manager', () => {
       this.name = 'TwitchTokenError'
     }
   }
+  // Issue #1018: routeは恒久失効判定をisPermanentRefreshFailureへ委譲するため、
+  // 実装と同语义の判定をモッククラスに対して供給する。実装本体の判定は
+  // twitch-token-manager.test.tsで直接検証する。
+  const isPermanentRefreshFailure = (error: unknown) =>
+    error instanceof TwitchTokenError &&
+    error.code === 'REFRESH_FAILED' &&
+    error.refreshErrorKind === 'http' &&
+    error.refreshStatus !== undefined &&
+    [400, 401, 403].includes(error.refreshStatus)
   return {
     TwitchTokenError,
     hasScope: vi.fn(),
     getTwitchAccessToken: vi.fn(),
+    isPermanentRefreshFailure: vi.fn(isPermanentRefreshFailure),
     // Issue #653/#670: route handlerのcatchが常に呼ぶため固定モックにも必要。
     twitchTokenErrorReportContext: vi.fn().mockReturnValue(undefined),
   }
@@ -342,10 +352,11 @@ describe('GET /api/twitch/channel-point-bootstrap', () => {
     expect(body.rewards).toHaveLength(1)
   })
 
-  // Issue #1018: トークン恒久失効(REFRESH_FAILEDかつrefreshRetryable ===
-  // false)は汎用500ではなく、rewards/emotesルートと同じbody契約の
-  // 401+requiresReauthを返し、クライアントがstep-up再認証CTAを表示できるようにする。
-  it('REFRESH_FAILED(refreshRetryable=false)は401+requiresReauthを返し、エラー記録とcapability(401)同期を行う', async () => {
+  // Issue #1018: トークン恒久失効(REFRESH_FAILEDかつkind='http'でstatusが
+  // {400,401,403}のホワイトリストに属する)は汎用500ではなく、rewards/emotes
+  // ルートと同じbody契約の401+requiresReauthを返し、クライアントがstep-up
+  // 再認証CTAを表示できるようにする。
+  it('REFRESH_FAILED(恒久失効: 400, kind=http)は401+requiresReauthを返し、エラー記録とcapability(401)同期を行う', async () => {
     const { hasScope, getTwitchAccessToken, TwitchTokenError } = await import('@/lib/twitch/token-manager')
     const { recordApiError, handleApiError } = await import('@/lib/error-handler')
     const { recordChannelPointsApiFailure } = await import('@/lib/twitch/channel-points-access')
@@ -386,6 +397,36 @@ describe('GET /api/twitch/channel-point-bootstrap', () => {
         429,
         'http',
         true,
+      ),
+    )
+
+    const { GET } = await import('@/app/api/twitch/channel-point-bootstrap/route')
+    const response = await GET(request())
+
+    expect(response.status).toBe(500)
+    expect(handleApiError).toHaveBeenCalled()
+    expect(recordApiError).not.toHaveBeenCalled()
+    expect(recordChannelPointsApiFailure).not.toHaveBeenCalled()
+  })
+
+  // Issue #1018(自動レビュー必須指摘の修正): 520/521/525/526/530等のCloudflare系
+  // 一過性5xx(および501/505)はREFRESH_RETRYABLE_STATUSESに含まれず
+  // refreshRetryable === false になるが、一時障害であり再認証では回復しない。
+  // 旧来の補集合判定(refreshRetryable === false)では恒久失効と誤判定し、
+  // capabilityをreauth_requiredへ誤確定させるため、500維持を固定する。
+  it('REFRESH_FAILED(一過性5xx: 520, refreshRetryable=false)は500(handleApiError)を返しcapabilityは同期しない', async () => {
+    const { hasScope, getTwitchAccessToken, TwitchTokenError } = await import('@/lib/twitch/token-manager')
+    const { recordApiError, handleApiError } = await import('@/lib/error-handler')
+    const { recordChannelPointsApiFailure } = await import('@/lib/twitch/channel-points-access')
+    vi.mocked(hasScope).mockResolvedValue(true)
+    vi.mocked(getTwitchAccessToken).mockRejectedValue(
+      new TwitchTokenError(
+        'Failed to refresh Twitch access token',
+        'REFRESH_FAILED',
+        undefined,
+        520,
+        'http',
+        false,
       ),
     )
 

--- a/tests/unit/channel-point-bootstrap-driver-parity.test.ts
+++ b/tests/unit/channel-point-bootstrap-driver-parity.test.ts
@@ -41,15 +41,35 @@ vi.mock('@/lib/rate-limit', () => ({
   checkRateLimit: vi.fn(),
   rateLimits: { twitchRewardsGet: { windowMs: 60000, max: 30 } },
 }))
-vi.mock('@/lib/twitch/token-manager', () => ({
-  hasScope: vi.fn(),
-  getTwitchAccessToken: vi.fn(),
-  // Issue #653/#670: route handlerのcatchが常に呼ぶため、固定モックにも
-  // 用意する必要がある。このファイルの検証対象(streamers/rewards SQL契約)
-  // とは無関係な非TwitchTokenError系エラーしか経由しないため、常にundefinedを
-  // 返す実装で十分(handleApiErrorのadditionalInfoが常にundefinedになるだけ)。
-  twitchTokenErrorReportContext: vi.fn().mockReturnValue(undefined),
-}))
+vi.mock('@/lib/twitch/token-manager', () => {
+  // Issue #1018: routeのcatchはTwitchTokenErrorのinstanceof判定を行うため、
+  // 固定モックにもクラス本体を供給する必要がある（無いとinstanceofが
+  // TypeError）。このファイルの検証対象(streamers/rewards SQL契約)には
+  // 非TwitchTokenError系エラーしか経由しないため、最小クラスで十分。
+  class TwitchTokenError extends Error {
+    constructor(
+      message: string,
+      public readonly code: string,
+      public readonly originalError?: Error,
+      public readonly refreshStatus?: number,
+      public readonly refreshErrorKind?: string,
+      public readonly refreshRetryable?: boolean,
+    ) {
+      super(message)
+      this.name = 'TwitchTokenError'
+    }
+  }
+  return {
+    TwitchTokenError,
+    hasScope: vi.fn(),
+    getTwitchAccessToken: vi.fn(),
+    // Issue #653/#670: route handlerのcatchが常に呼ぶため、固定モックにも
+    // 用意する必要がある。このファイルの検証対象(streamers/rewards SQL契約)
+    // とは無関係な非TwitchTokenError系エラーしか経由しないため、常にundefinedを
+    // 返す実装で十分(handleApiErrorのadditionalInfoが常にundefinedになるだけ)。
+    twitchTokenErrorReportContext: vi.fn().mockReturnValue(undefined),
+  }
+})
 // #788: capability probe の永続化状態を読む/書くヘルパー。このテストファイルは
 // getOwnedStreamer/getAdditionalRewards の SQL 契約だけを検証対象としており、
 // capability state 自体は channel-points-access.ts 側の責務。ここをモックせず

--- a/tests/unit/components/channel-point-settings-maintenance.test.tsx
+++ b/tests/unit/components/channel-point-settings-maintenance.test.tsx
@@ -21,8 +21,10 @@ function mockFetch(overrides: {
   createRewardBody?: unknown;
   needsReauth?: boolean;
   reauthBody?: unknown;
+  bootstrapStatus?: number;
+  bootstrapBody?: unknown;
 } = {}): FetchMock {
-  const { rewards = [], createRewardStatus = 200, createRewardBody, needsReauth = false, reauthBody } = overrides;
+  const { rewards = [], createRewardStatus = 200, createRewardBody, needsReauth = false, reauthBody, bootstrapStatus = 200, bootstrapBody } = overrides;
   return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = typeof input === "string" ? input : input.toString();
     const method = init?.method ?? "GET";
@@ -34,17 +36,21 @@ function mockFetch(overrides: {
       });
     }
     if (url.includes("/api/twitch/channel-point-bootstrap")) {
-      return new Response(
-        JSON.stringify({
+      // bootstrapBody指定時はそれを返す（401+requiresReauth等のエラー応答を再現するため）。
+      const body =
+        bootstrapBody ??
+        {
           hasRequiredScope: !needsReauth,
           requiresReauth: needsReauth,
           rewards,
           subscriptions: [],
           additionalRewards: [],
           eventSubStatus: "none",
-        }),
-        { status: 200, headers: { "content-type": "application/json" } }
-      );
+        };
+      return new Response(JSON.stringify(body), {
+        status: bootstrapStatus,
+        headers: { "content-type": "application/json" },
+      });
     }
     if (url.includes("/api/twitch/rewards") && method === "POST") {
       return new Response(
@@ -127,6 +133,37 @@ describe("ChannelPointSettings maintenance integration", () => {
 
     expect(await screen.findByText("再認証に失敗しました。時間をおいて再度お試しください。")).toBeInTheDocument();
     expect(window.location.href).toBe(originalHref);
+  });
+
+  it("bootstrapが401+requiresReauthを返すと再連携バナー(CTA)を表示し、汎用エラーボックスは出ない（Issue #1018）", async () => {
+    fetchMock = mockFetch({
+      bootstrapStatus: 401,
+      bootstrapBody: { error: "Twitch連携が必要です。再ログインしてください。", requiresReauth: true },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderComponent({ mode: "off" });
+
+    const button = await screen.findByRole("button", { name: "チャネルポイント連携を有効化" });
+    expect(button).toBeInTheDocument();
+    expect(
+      screen.queryByText("チャネルポイント引き換えの取得に失敗しました。再度ログインしてください。")
+    ).not.toBeInTheDocument();
+  });
+
+  it("bootstrapが401+requiresReauth以外(汎用エラー)のとき従来どおり赤いエラーボックスを表示する（Issue #1018フォールバック）", async () => {
+    fetchMock = mockFetch({
+      bootstrapStatus: 401,
+      bootstrapBody: { error: "Internal Server Error" },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderComponent({ mode: "off" });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("チャネルポイント引き換えの取得に失敗しました。再度ログインしてください。")
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: "チャネルポイント連携を有効化" })).not.toBeInTheDocument();
   });
 
   it("mode=off のときは報酬作成ボタンが操作可能（既存挙動を壊さない）", async () => {

--- a/tests/unit/twitch-token-manager.test.ts
+++ b/tests/unit/twitch-token-manager.test.ts
@@ -496,10 +496,9 @@ describe('Twitch Token Manager: PlanetScale/Drizzle', () => {
       )
     }
 
-    it('kind=httpかつstatusが400/401/403(恒久失効)の場合はtrueを返す', () => {
+    it('kind=httpかつstatusが400/401(恒久失効)の場合はtrueを返す', () => {
       expect(isPermanentRefreshFailure(makeRefreshError(400, 'http', false))).toBe(true)
       expect(isPermanentRefreshFailure(makeRefreshError(401, 'http', false))).toBe(true)
-      expect(isPermanentRefreshFailure(makeRefreshError(403, 'http', false))).toBe(true)
     })
 
     it('一過性失敗(429/5xx)はrefreshRetryable=falseでもfalseを返す', () => {
@@ -513,6 +512,9 @@ describe('Twitch Token Manager: PlanetScale/Drizzle', () => {
       for (const status of [501, 505, 520, 521, 525, 526, 530]) {
         expect(isPermanentRefreshFailure(makeRefreshError(status, 'http', false))).toBe(false)
       }
+      // 403もWAF・client設定・上流機能起因の一過性障害になり得るため恒久失効と
+      // 断定できない(shouldDisableBotCredential と同一方針)。
+      expect(isPermanentRefreshFailure(makeRefreshError(403, 'http', false))).toBe(false)
     })
 
     it('networkエラー(kind=network、status未定義)はfalseを返す', () => {

--- a/tests/unit/twitch-token-manager.test.ts
+++ b/tests/unit/twitch-token-manager.test.ts
@@ -9,6 +9,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   getTwitchAccessToken,
+  isPermanentRefreshFailure,
   TwitchTokenError,
   twitchTokenErrorReportContext,
   validateTokenScopes,
@@ -473,6 +474,69 @@ describe('Twitch Token Manager: PlanetScale/Drizzle', () => {
       expect(twitchTokenErrorReportContext(new Error('plain error'))).toBeUndefined()
       expect(twitchTokenErrorReportContext('string error')).toBeUndefined()
       expect(twitchTokenErrorReportContext(null)).toBeUndefined()
+    })
+  })
+
+  describe('isPermanentRefreshFailure', () => {
+    // Issue #1018: refreshErrorKind/refreshStatus/refreshRetryableをauth.tsの
+    // 生み出し方(network=undefined/true、http=status/集合有無、
+    // invalid_response=2xx/true)そのままの形でTwitchTokenErrorへ載せたものを作る。
+    function makeRefreshError(
+      status?: number,
+      kind?: 'network' | 'http' | 'invalid_response',
+      retryable?: boolean,
+    ) {
+      return new TwitchTokenError(
+        'Failed to refresh Twitch access token',
+        'REFRESH_FAILED',
+        undefined,
+        status,
+        kind,
+        retryable,
+      )
+    }
+
+    it('kind=httpかつstatusが400/401/403(恒久失効)の場合はtrueを返す', () => {
+      expect(isPermanentRefreshFailure(makeRefreshError(400, 'http', false))).toBe(true)
+      expect(isPermanentRefreshFailure(makeRefreshError(401, 'http', false))).toBe(true)
+      expect(isPermanentRefreshFailure(makeRefreshError(403, 'http', false))).toBe(true)
+    })
+
+    it('一過性失敗(429/5xx)はrefreshRetryable=falseでもfalseを返す', () => {
+      // 429/500/502/503/504/522/523/524はauth.tsでretryable=true
+      expect(isPermanentRefreshFailure(makeRefreshError(429, 'http', true))).toBe(false)
+      expect(isPermanentRefreshFailure(makeRefreshError(502, 'http', true))).toBe(false)
+      // 520/521/525/526/530(Cloudflare系)・501/505はREFRESH_RETRYABLE_STATUSESに
+      // 含まれずrefreshRetryable === falseになるが一時障害。旧来の補集合判定で
+      // 恒久失効と誤判定してcapabilityをreauth_requiredへ誤確定させるリグレッション
+      // ガードとして固定する。
+      for (const status of [501, 505, 520, 521, 525, 526, 530]) {
+        expect(isPermanentRefreshFailure(makeRefreshError(status, 'http', false))).toBe(false)
+      }
+    })
+
+    it('networkエラー(kind=network、status未定義)はfalseを返す', () => {
+      expect(isPermanentRefreshFailure(makeRefreshError(undefined, 'network', true))).toBe(false)
+    })
+
+    it('invalid_response(2xx、retryable=true)はfalseを返す', () => {
+      expect(isPermanentRefreshFailure(makeRefreshError(200, 'invalid_response', true))).toBe(false)
+    })
+
+    it('DB障害起因でdiagnostic未付与(全フィールドundefined)はfalseを返す', () => {
+      const error = new TwitchTokenError('Failed to refresh Twitch access token', 'REFRESH_FAILED')
+      expect(isPermanentRefreshFailure(error)).toBe(false)
+    })
+
+    it('REFRESH_FAILED以外のcode・TwitchTokenError以外ではfalseを返す', () => {
+      expect(isPermanentRefreshFailure(new TwitchTokenError('No Twitch token found', 'NO_TOKEN'))).toBe(false)
+      expect(
+        isPermanentRefreshFailure(
+          new TwitchTokenError('db down', 'DATABASE_ERROR', undefined, 401, 'http', false),
+        ),
+      ).toBe(false)
+      expect(isPermanentRefreshFailure(new Error('plain error'))).toBe(false)
+      expect(isPermanentRefreshFailure(null)).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## 概要
Issue #1018 を修正。Twitch連携が `authorization_revoked` になってから保存済み access token の期限も切れた状態で配信設定を開くと、`channel-point-bootstrap` が refresh 失敗(`REFRESH_FAILED`)を**汎用500**で返してしまい、`requiresReauth` シグナルが失われていた。結果、UI は「取得に失敗しました」の赤いエラーボックスしか出せず、本来出すべき再連携導線(「チャネルポイント連携を有効化」)が表示されなかった。

dociai 配信 (2026-08-17) の実障害と同型の経路。

## 変更内容
- **backend** `src/app/api/twitch/channel-point-bootstrap/route.ts`
  - `TwitchTokenError` の code が `NO_TOKEN`、または `REFRESH_FAILED` かつ**恒久失効**（`isPermanentRefreshFailure` で判定）のとき、**401 + `{ error: TWITCH_TOKEN_REQUIRED, requiresReauth: true }`** を返す分岐を追加。
  - 恒久失効は `refreshErrorKind === 'http'` かつ `refreshStatus ∈ {400,401}` のホワイトリストに絞る（token-manager.ts の `isPermanentRefreshFailure` が判定の正本）。一過性失敗（429/5xx、Cloudflare系 520/521/525/526/530 を含む、network、invalid_response）と DB 起因の失敗（diagnostic 未付与）は従来どおり `handleApiError`（500）へ倒し、再認証要求に化けさせない。403 は WAF・client設定起因の一過性障害になり得るため対象外。
  - 該当時は `recordApiError`（ログ記録のみ・レスポンスなし）と `recordChannelPointsApiFailure(userId, 401)` を呼び、channel points capability も `reauth_required` へ同期。
- **backend** `src/lib/twitch/token-manager.ts`
  - `isPermanentRefreshFailure`（恒久失効判定・正本）と `PERMANENT_REFRESH_STATUSES = {400,401}` を追加。
  - `shouldDisableBotCredential` が `PERMANENT_REFRESH_STATUSES` を共有（純リファクタ・`{400,401}` の挙動不変。使用箇所 904/979 のBOT credential経路）。
- **backend** `src/lib/error-handler.ts`
  - `recordApiError` を純粋追加 export（既存 `handleApiError`/`handleDatabaseError` の挙動不変）。
- **frontend** `src/components/ChannelPointSettings.tsx`
  - `fetchChannelPointBootstrap` の `!response.ok` 分岐で body を読み、`requiresReauth === true` なら `setError("")` + `setNeedsReauth(true)` して再連携バナーを表示。JSON でない / シグナルなしの場合は従来どおり汎用エラー表示へフォールバック。
- **tests**
  - `tests/unit/channel-point-bootstrap-api.test.ts`: `getTwitchAccessToken` が REFRESH_FAILED（恒久400 / 一過性520 / retryable429 / DB起因）、NO_TOKEN、汎用Error を投げるケースを追加。
  - `tests/unit/twitch-token-manager.test.ts`: `isPermanentRefreshFailure` の判定集合を直接検証（400/401 が true、403/429/5xx/network/invalid_response/DB起因 が false）。
  - `tests/unit/channel-point-bootstrap-driver-parity.test.ts`: token-manager モックに `TwitchTokenError` を追加（`instanceof` 判定のため）。
  - `tests/unit/components/channel-point-settings-maintenance.test.tsx`: 401+requiresReauth で再連携バナー(CTA)が描画され汎用エラーボックスが出ないこと、および 401+requiresReauth 以外で従来どおり赤いエラーボックスが出ることを固定。

## 期待動作との対応（issue 記載）
- `REFRESH_FAILED`（恒久失効 {400,401}）/ `NO_TOKEN` → 401 + `requiresReauth: true` ✅
- 一時的 refresh 失敗（429/5xx/network/DB起因）は 500 のまま（再認証要求に化けさせない）✅
- capability を `reauth_required` へ同期（`recordChannelPointsApiFailure` 相当）✅
- 既存同型パターン（`rewards/route.ts`、`emotes/route.ts`）の 401+requiresReauth 契約と整合 ✅

## 検証
- `npm run test:unit`: **276ファイル / 3618テスト 全pass**
- `npm run typecheck`: clean
- `eslint`（変更ファイル）: 0 error
- CI: test / Lint i18n / Workers Builds: twica-preview / Review PR changes 全pass

## Preview 実経路ゲート（docs/QA.md 項目1-7）
本PRは対応表の「DB または OAuth」行に該当するため、項目1-7 が必須。

**証拠継承で解消**（昇格PR #1021 のprecedent に従う）:
- preview HEAD `b830f9d`（本PRのbase）は実経路ゲートを通過済みで、昇格PR #1021（merged 2026-08-18、merge SHA `1a57594`）に記録済み。元の実行は親SHA `9975933` で実チャンネル `azumagbanjo` の報酬を2件引き換え、履歴・Twitchチャット・overlay の `Received payload: gacha`・EventSub/gacha/chat/overlay Workerログを相関確認。
- 本PRの差分（`b830f9d...8fd6ce1`、8ファイル）は項目1-7 の実行経路コード（引き換え→overlay→chat→EventSub→queue→dashboard→upload）を変更していない:
  - `channel-point-bootstrap/route.ts`: 設定画面のエラー分類（引き換え経路ではない）
  - `ChannelPointSettings.tsx`: UI バナー
  - `error-handler.ts`: `recordApiError` の純粋追加（既存挙動不変）
  - `token-manager.ts`: `isPermanentRefreshFailure`（新規・bootstrap専用）+ `shouldDisableBotCredential`（純リファクタ・`{400,401}` 挙動不変）
  - テスト4ファイル
- したがって `b830f9d` の実経路証拠を現HEAD `8fd6ce1` へ継承する。
- 現在は配信オフラインのため（#1021 同様）同じ2件の再試行は実施していない。

## 自己レビューの注記
- 本環境の Task ツールはモデル指定パラメータを持たないため、AGENTS.md の「opusサブエージェントへの委任」が実行できず、**自己レビューは主担当が実施**した。`TwitchTokenError` の全 throw 箇所（DATABASE_ERROR / REFRESH_FAILED）とヘルパー判定の突合、`hasScope` が token エラーを投げないこと（本 route の throw 出所は `getTwitchAccessToken` のみ）、セキュリティ（固定文言・情報漏洩なし）、#788 capability 設計との整合を確認済み。**マージブロッカーなし**。
- 任意指摘（フォロアップIssue / 次PRで対応候補・本PRの収束条件にはしない）:
  - 再連携バナー文言 `scopeRequired` は「トークン失効（scope 付与済み・refresh token 失効）」ケースではやや不正確（実際はスコープ不足ではなく reauth）。
  - 自動レビューの任意指摘（`NO_TOKEN` 分岐のYAGNI、`handleApiError`/`recordApiError` の重複、UI文言、テストモックの `importActual` 化、rewards/emotes ルートとの契約不揃い、client secret 不整合時のアラート検討等）は退避。
