### PR TITLE
chore: main マージ時に Discord 通知を送る

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -14,13 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-      REPOSITORY: ${{ github.repository }}
+      REPOSITORY_NAME: ${{ github.event.repository.name }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_URL: ${{ github.event.pull_request.html_url }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       HEAD_REF: ${{ github.event.pull_request.head.ref }}
-      MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
 
     steps:
       - name: Validate webhook configuration
@@ -35,28 +34,22 @@ jobs:
         shell: bash
         run: |
           payload=$(jq -n \
-            --arg repository "$REPOSITORY" \
+            --arg repository "$REPOSITORY_NAME" \
             --arg number "$PR_NUMBER" \
             --arg title "$PR_TITLE" \
             --arg url "$PR_URL" \
             --arg author "$PR_AUTHOR" \
             --arg head_ref "$HEAD_REF" \
-            --arg merge_sha "$MERGE_SHA" \
             '{
               username: "twica GitHub",
-              content: ("✅ **" + $repository + "** の `main` に PR #" + $number + " がマージされました。"),
-              allowed_mentions: {parse: []},
-              embeds: [
-                {
-                  title: $title,
-                  url: $url,
-                  fields: [
-                    {name: "Author", value: ("@" + $author), inline: true},
-                    {name: "Source", value: ("`" + $head_ref + "` → `main`"), inline: true},
-                    {name: "Merge commit", value: ("`" + $merge_sha + "`"), inline: false}
-                  ]
-                }
-              ]
+              content: (
+                "🚀 **" + $repository + " が更新されました**\n\n" +
+                "**#" + $number + " " + $title + "**\n" +
+                "`" + $head_ref + " → main`\n" +
+                "by " + $author + "\n\n" +
+                "🔗 [Pull Requestを見る](" + $url + ")"
+              ),
+              allowed_mentions: {parse: []}
             }')
 
           curl \

--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -1,0 +1,72 @@
+name: Notify Discord on main merge
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      REPOSITORY: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+
+    steps:
+      - name: Validate webhook configuration
+        shell: bash
+        run: |
+          if [[ -z "$DISCORD_WEBHOOK_URL" ]]; then
+            echo "::error::Repository secret DISCORD_WEBHOOK_URL is not configured."
+            exit 1
+          fi
+
+      - name: Send merge notification to Discord
+        shell: bash
+        run: |
+          payload=$(jq -n \
+            --arg repository "$REPOSITORY" \
+            --arg number "$PR_NUMBER" \
+            --arg title "$PR_TITLE" \
+            --arg url "$PR_URL" \
+            --arg author "$PR_AUTHOR" \
+            --arg head_ref "$HEAD_REF" \
+            --arg merge_sha "$MERGE_SHA" \
+            '{
+              username: "twica GitHub",
+              content: ("✅ **" + $repository + "** の `main` に PR #" + $number + " がマージされました。"),
+              allowed_mentions: {parse: []},
+              embeds: [
+                {
+                  title: $title,
+                  url: $url,
+                  fields: [
+                    {name: "Author", value: ("@" + $author), inline: true},
+                    {name: "Source", value: ("`" + $head_ref + "` → `main`"), inline: true},
+                    {name: "Merge commit", value: ("`" + $merge_sha + "`"), inline: false}
+                  ]
+                }
+              ]
+            }')
+
+          curl \
+            --fail-with-body \
+            --silent \
+            --show-error \
+            --retry 3 \
+            --retry-all-errors \
+            --connect-timeout 10 \
+            --max-time 30 \
+            -H 'Content-Type: application/json' \
+            -d "$payload" \
+            "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
## 概要

`main` 向け Pull Request が実際にマージされたとき、Discord Webhook に通知する GitHub Actions ワークフローを追加します。

## 変更内容

- `pull_request_target` の `closed` を監視し、base が `main` の場合だけ対象
- `merged == true` の PR のみ通知（単なる close や main への直接 push は通知しない）
- 通知文は人間向けの簡潔な形式にし、リポジトリ名、PR番号・タイトル、元ブランチ、作成者、PRリンクを表示
- PRタイトル等に `@everyone` / `@here` が含まれても Discord メンションを発生させない
- 外部 GitHub Action は使わず `curl` + `jq` のみで送信
- Webhook URL は Repository Secret `DISCORD_WEBHOOK_URL` から取得

## 通知例

```text
🚀 twica が更新されました

#1026 main マージ時に Discord 通知を送る
preview → main
by azumag

🔗 Pull Requestを見る
```

実際の Discord では見出し部分を太字にし、`Pull Requestを見る` は対象PRへのリンクになります。

## 必要な設定

Repository Settings → Secrets and variables → Actions で、以下の Repository Secret を追加してください。

- `DISCORD_WEBHOOK_URL`: 通知先 Discord チャンネルの Webhook URL

Secret が未設定の場合は通知ジョブを明示的に失敗させ、設定漏れが分かるようにしています。

## セキュリティ

`pull_request_target` を使用しますが、PR ブランチの checkout やスクリプト実行は一切行いません。イベントメタデータを Discord に送る処理だけに限定しています。