### PR TITLE
fix: Twitch 429等の一時障害でchatAnnouncement再試行のreportErrorを止める

### DIFF
--- a/src/lib/services/eventsub-redemption.ts
+++ b/src/lib/services/eventsub-redemption.ts
@@ -570,6 +570,22 @@ export async function postRedemptionNotify(
       }
       const retryState = await retryChatNotification(claim, failureReason);
       deliveryStatePersisted = true;
+      if (retryState === 'pending') {
+        // Issue #1033: Twitch 429（レート制限）等の一時障害は、指数backoffで最大
+        // CHAT_OUTBOX_MAX_ATTEMPTS回まで自動再試行される正常系の一部である。
+        // ここでthrowしてreportErrorへ回すと、自己回復するはずの一時障害が
+        // 再試行のたびに[Error]としてGitHub Issueを量産してしまう
+        // （実際に本番で429が1回発生しただけで自動Issueが起票された）。
+        // 再試行を使い切ってdead化した場合・lease競合でlost-leaseになった場合のみ
+        // 下のthrow/reportErrorへ回し、pendingはwarnログに留めて正常終了する。
+        logger.warn('[postRedemptionNotify] chat announcement retry scheduled', {
+          streamerId: data.streamer.id,
+          broadcasterTwitchUserId: data.broadcasterTwitchUserId,
+          outboxId: claim.id,
+          reason: failureReason,
+        });
+        return;
+      }
       throw new Error(`Chat announcement ${retryState}: ${failureReason}`);
     } catch (error) {
       // sendChatAnnouncement自体の予期しないthrowも一時障害として上限付き再試行へ戻す。
@@ -594,7 +610,9 @@ export async function postRedemptionNotify(
   // 通知失敗をログ出力 + エラー追跡
   // Note: publishCommittedGachaBatch (i=0) は失敗を結果へ閉じ込め、polling回収へ
   // 委ねる設計のため rejected にならない。詳細はpublisher側の構造化warnで追跡する。
-  // chatAnnouncement (i=1) は引き続きエラー時に throw するため、こちらのみ reportError が機能する
+  // chatAnnouncement (i=1) はterminal/aborted/dead/lost-lease時のみthrowするため
+  // reportErrorが機能する。pending（自動再試行予定の一時障害）はchatTask内でwarn
+  // ログのみに留めて正常終了するため、ここには到達しない（Issue #1033）。
   for (const [i, result] of results.entries()) {
     if (result.status === 'rejected') {
       const label = i === 0 ? 'broadcast' : 'chatAnnouncement';

--- a/src/lib/services/eventsub-redemption.ts
+++ b/src/lib/services/eventsub-redemption.ts
@@ -533,9 +533,11 @@ export async function postRedemptionNotify(
         return;
       }
       // 失敗系outcomeにもdegradation（設定BOT恒久失効）が付与される。token-managerは
-      // 永続報告せず所有境界の1回報告へ委ねる契約のため、DLQ reason・retry reason・
-      // throw経由のreportErrorへ畳み込み、本人credential障害と同時発生しても
-      // 「設定BOTが要再認証」の直接シグナルを欠落させない。
+      // 永続報告せず所有境界の1回報告へ委ねる契約のため、DLQ reason・retry reasonへ
+      // 畳み込む。Issue #1033以降、retryable + degradationがpendingへ戻る経路は
+      // 下のpending分岐でreportErrorへ到達しなくなったため、「設定BOTが要再認証」の
+      // シグナルはこの経路では欠落しないが即時ではなくなり、最終的にdead化した時
+      // （またはfallback送信成功時のchatDegradation通報）まで遅延する。
       const failureReason = formatChatFailureReason(outcome.reason, outcome.degradation);
       if (outcome.outcome === 'terminal') {
         const persisted = await deadLetterChatNotification(claim, failureReason);

--- a/src/lib/services/eventsub-redemption.ts
+++ b/src/lib/services/eventsub-redemption.ts
@@ -610,9 +610,13 @@ export async function postRedemptionNotify(
   // 通知失敗をログ出力 + エラー追跡
   // Note: publishCommittedGachaBatch (i=0) は失敗を結果へ閉じ込め、polling回収へ
   // 委ねる設計のため rejected にならない。詳細はpublisher側の構造化warnで追跡する。
-  // chatAnnouncement (i=1) はterminal/aborted/dead/lost-lease時のみthrowするため
-  // reportErrorが機能する。pending（自動再試行予定の一時障害）はchatTask内でwarn
-  // ログのみに留めて正常終了するため、ここには到達しない（Issue #1033）。
+  // chatAnnouncement (i=1): retryable outcome経由でretryChatNotificationが'pending'を
+  // 返した場合はchatTask内でwarnログのみに留めて正常終了するため、ここには到達しない
+  // （Issue #1033）。一方、sendChatAnnouncement自体が予期せずthrowした場合の catch
+  // ブロックは、行を'pending'へ戻したうえでそのままrethrowする契約を維持しており
+  // （呼び出し元コード自体のバグを揉み消さないため）、この経路はoutbox行がpendingで
+  // あってもreportErrorに到達する。したがってterminal/aborted/dead/lost-lease時に
+  // 加え、この「想定外throw」時にもreportErrorが機能する。
   for (const [i, result] of results.entries()) {
     if (result.status === 'rejected') {
       const label = i === 0 ? 'broadcast' : 'chatAnnouncement';

--- a/tests/unit/eventsub-user-card-counts-driver-parity.test.ts
+++ b/tests/unit/eventsub-user-card-counts-driver-parity.test.ts
@@ -572,13 +572,20 @@ describe('EventSub get_user_card_counts PlanetScale経路 (#573/#708)', () => {
     )
   })
 
+  // Issue #1033: pending（自動再試行予定の一時障害）はもうreportErrorしない。
+  // 旧実装は retryChatNotification が 'pending' を返しても常にthrowしており、
+  // Twitch 429のような自己回復するレート制限が1回起きるだけで
+  // reportError経由の自動GitHub Issueが量産されていた（本番実測で確認）。
+  // pendingはbackoffで自動再試行される正常系のため、warnログのみに留め
+  // reportErrorには到達しないことをここで固定する。
   it.each([
     ['scope確認不能', 'eventsub-chat-scope-unavailable', 'unable to verify user:write:chat scope'],
     ['BOT一時解決不能', 'eventsub-chat-bot-unavailable', 'configured BOT credential is temporarily unavailable'],
     ['本人token DB障害', 'eventsub-chat-token-unavailable', 'chat sender credential is temporarily unavailable'],
     ['Twitch 503', 'eventsub-chat-503', 'Twitch API 503'],
     ['network障害', 'eventsub-chat-network', 'ECONNRESET'],
-  ])('%sはlive outboxを再試行へ戻し、DLQ化せずreportErrorする', async (_label, batchId, reason) => {
+    ['Twitch 429 (#1033)', 'eventsub-chat-429', 'Twitch API 429: Your message was not sent because you are sending messages too quickly.'],
+  ])('%sはlive outboxを再試行へ戻し、DLQ化もreportErrorもしない', async (_label, batchId, reason) => {
     mocks.sendChatMessageDetailed.mockResolvedValueOnce({
       outcome: 'retryable',
       reason,
@@ -607,13 +614,11 @@ describe('EventSub get_user_card_counts PlanetScale経路 (#573/#708)', () => {
     )
     expect(mocks.deadLetterChatNotification).not.toHaveBeenCalled()
     expect(mocks.markChatNotificationSent).not.toHaveBeenCalled()
-    expect(mockReportError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: `Chat announcement pending: ${reason}`,
-      }),
-      expect.objectContaining({ context: 'eventsub:postRedemptionNotify:chatAnnouncement' }),
+    expect(mockReportError).not.toHaveBeenCalled()
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      '[postRedemptionNotify] chat announcement retry scheduled',
+      expect.objectContaining({ streamerId: 'streamer-1', reason }),
     )
-    expect(mockReportError).toHaveBeenCalledTimes(1)
   })
 
   it('missing_scopeでもlive DLQ更新がleaseを失った場合はreportErrorする', async () => {

--- a/tests/unit/post-redemption-notify-chat-retry.test.ts
+++ b/tests/unit/post-redemption-notify-chat-retry.test.ts
@@ -94,7 +94,9 @@ const claim = {
   payload: {},
   leaseId: 'lease-1',
   attemptCount: 1,
-  createdAt: new Date().toISOString(),
+  // レビュー指摘: 期待値に使わない非決定値(new Date())はテストの再現性を
+  // 落とすだけなので、固定文字列にする。
+  createdAt: '2026-01-01T00:00:00.000Z',
 }
 
 describe('postRedemptionNotify: chatAnnouncement retryState別のreportError到達可否 (#1033)', () => {
@@ -120,6 +122,9 @@ describe('postRedemptionNotify: chatAnnouncement retryState別のreportError到�
 
     await postRedemptionNotify(notifyData)
 
+    // レビュー指摘: 呼び出し回数も固定し、将来early returnを外してcatch経路と
+    // 二重にretryChatNotificationを叩く退行(deliveryStatePersistedの扱いミス)を検知する。
+    expect(mockRetry).toHaveBeenCalledTimes(1)
     expect(mockRetry).toHaveBeenCalledWith(
       claim,
       expect.stringContaining('too quickly'),
@@ -150,6 +155,12 @@ describe('postRedemptionNotify: chatAnnouncement retryState別のreportError到�
         streamerId: 'streamer-1',
       }),
     )
+    // レビュー指摘: pending分岐の判定条件が誤って広がる退行(例: retryState !== 'dead'
+    // のような反転ミス)を検知するため、pending専用のwarnログが出ないことも固定する。
+    expect(mockLoggerWarn).not.toHaveBeenCalledWith(
+      '[postRedemptionNotify] chat announcement retry scheduled',
+      expect.anything(),
+    )
   })
 
   it('lost-lease（lease競合で更新不能）の場合も従来通りreportErrorを呼ぶ', async () => {
@@ -166,6 +177,10 @@ describe('postRedemptionNotify: chatAnnouncement retryState別のreportError到�
         context: 'eventsub:postRedemptionNotify:chatAnnouncement',
         streamerId: 'streamer-1',
       }),
+    )
+    expect(mockLoggerWarn).not.toHaveBeenCalledWith(
+      '[postRedemptionNotify] chat announcement retry scheduled',
+      expect.anything(),
     )
   })
 })

--- a/tests/unit/post-redemption-notify-chat-retry.test.ts
+++ b/tests/unit/post-redemption-notify-chat-retry.test.ts
@@ -138,8 +138,13 @@ describe('postRedemptionNotify: chatAnnouncement retryState別のreportError到�
 
     await postRedemptionNotify(notifyData)
 
+    // レビュー指摘: expect.any(Error)だけだとretryStateの文字列連結が壊れても
+    // 検知できないため、メッセージ本文と呼び出し回数まで固定する。
+    expect(mockReportError).toHaveBeenCalledTimes(1)
     expect(mockReportError).toHaveBeenCalledWith(
-      expect.any(Error),
+      expect.objectContaining({
+        message: expect.stringContaining('Chat announcement dead: '),
+      }),
       expect.objectContaining({
         context: 'eventsub:postRedemptionNotify:chatAnnouncement',
         streamerId: 'streamer-1',
@@ -152,8 +157,11 @@ describe('postRedemptionNotify: chatAnnouncement retryState別のreportError到�
 
     await postRedemptionNotify(notifyData)
 
+    expect(mockReportError).toHaveBeenCalledTimes(1)
     expect(mockReportError).toHaveBeenCalledWith(
-      expect.any(Error),
+      expect.objectContaining({
+        message: expect.stringContaining('Chat announcement lost-lease: '),
+      }),
       expect.objectContaining({
         context: 'eventsub:postRedemptionNotify:chatAnnouncement',
         streamerId: 'streamer-1',

--- a/tests/unit/post-redemption-notify-chat-retry.test.ts
+++ b/tests/unit/post-redemption-notify-chat-retry.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { postRedemptionNotify, type RedemptionNotifyData } from '@/lib/services/eventsub-redemption'
+import { TwitchChatService } from '@/lib/twitch/chat-service'
+import { reportError } from '@/lib/sentry/error-handler'
+import { logger } from '@/lib/logger.server'
+import {
+  claimChatNotificationBatch,
+  decodeChatNotificationPayload,
+  retryChatNotification,
+  markChatNotificationSent,
+  deadLetterChatNotification,
+} from '@/lib/services/chat-notification-outbox'
+
+/**
+ * Issue #1033: Twitch 429（レート制限）のような一時障害は
+ * chat_notification_outbox が自動的に再試行するpending状態であり、正常系の
+ * 一部である。にもかかわらず旧実装は retryState を問わず常にthrowしており、
+ * postRedemptionNotify 呼び出し元の Promise.allSettled 経由で
+ * reportError（[Error] 発報 → 自動Issue化）まで到達していた。
+ * 本番で429が1回起きただけでGitHub Issueが自動作成されるノイズの原因になっていた。
+ *
+ * ここでは retryChatNotification の戻り値ごとに reportError が呼ばれるか/
+ * 呼ばれないかを固定する:
+ * - 'pending'（自動再試行予定）: reportErrorを呼ばずwarnログのみ
+ * - 'dead'（再試行を使い切った）: 従来通りreportErrorを呼ぶ
+ */
+
+vi.mock('@/lib/services/chat-notification-outbox', () => ({
+  claimChatNotificationBatch: vi.fn(),
+  decodeChatNotificationPayload: vi.fn(),
+  deadLetterChatNotification: vi.fn(),
+  markChatNotificationSent: vi.fn(),
+  renewChatNotificationLease: vi.fn(),
+  retryChatNotification: vi.fn(),
+}))
+
+vi.mock('@/lib/overlay-realtime/publisher', () => ({
+  publishCommittedGachaBatch: vi.fn().mockResolvedValue({ outcome: 'skipped', attempts: 0 }),
+}))
+
+vi.mock('@/lib/sentry/error-handler', () => ({
+  reportError: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/logger.server', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+const mockClaim = vi.mocked(claimChatNotificationBatch)
+const mockDecode = vi.mocked(decodeChatNotificationPayload)
+const mockRetry = vi.mocked(retryChatNotification)
+const mockMarkSent = vi.mocked(markChatNotificationSent)
+const mockDeadLetter = vi.mocked(deadLetterChatNotification)
+const mockReportError = vi.mocked(reportError)
+const mockLoggerWarn = vi.mocked(logger.warn)
+
+const streamer = {
+  id: 'streamer-1',
+  chat_announcement_enabled: true,
+  chat_announcement_template: '{user} got {card}',
+  chat_announcement_multi_template: null,
+  chat_announcement_multi_show_cards: false,
+}
+
+const card = {
+  id: 'card-1',
+  name: 'Alpha',
+  description: null,
+  image_url: null,
+  rarity: 'common',
+  drop_rate: 1,
+}
+
+const notifyData: RedemptionNotifyData = {
+  gachaResult: {
+    type: 'gacha',
+    card,
+    userTwitchUsername: 'Viewer',
+  },
+  broadcasterTwitchUserId: '130871908',
+  streamer,
+  userId: 'viewer-1',
+  batchId: 'batch-1',
+}
+
+const claim = {
+  id: 'outbox-1',
+  batchId: 'batch-1',
+  payloadVersion: 1,
+  payload: {},
+  leaseId: 'lease-1',
+  attemptCount: 1,
+  createdAt: new Date().toISOString(),
+}
+
+describe('postRedemptionNotify: chatAnnouncement retryState別のreportError到達可否 (#1033)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockClaim.mockResolvedValue(claim)
+    mockDecode.mockReturnValue({
+      ...notifyData,
+      chatSnapshot: undefined,
+    })
+    vi.spyOn(TwitchChatService.prototype, 'sendChatMessageDetailed').mockResolvedValue({
+      outcome: 'retryable',
+      reason: 'Twitch API 429: Your message was not sent because you are sending messages too quickly.',
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('pending（自動再試行予定）の場合はreportErrorを呼ばずwarnログのみ残す', async () => {
+    mockRetry.mockResolvedValue('pending')
+
+    await postRedemptionNotify(notifyData)
+
+    expect(mockRetry).toHaveBeenCalledWith(
+      claim,
+      expect.stringContaining('too quickly'),
+    )
+    expect(mockReportError).not.toHaveBeenCalled()
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      '[postRedemptionNotify] chat announcement retry scheduled',
+      expect.objectContaining({ streamerId: 'streamer-1', outboxId: 'outbox-1' }),
+    )
+    expect(mockMarkSent).not.toHaveBeenCalled()
+    expect(mockDeadLetter).not.toHaveBeenCalled()
+  })
+
+  it('dead（再試行を使い切った）の場合は従来通りreportErrorを呼ぶ', async () => {
+    mockRetry.mockResolvedValue('dead')
+
+    await postRedemptionNotify(notifyData)
+
+    expect(mockReportError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        context: 'eventsub:postRedemptionNotify:chatAnnouncement',
+        streamerId: 'streamer-1',
+      }),
+    )
+  })
+
+  it('lost-lease（lease競合で更新不能）の場合も従来通りreportErrorを呼ぶ', async () => {
+    mockRetry.mockResolvedValue('lost-lease')
+
+    await postRedemptionNotify(notifyData)
+
+    expect(mockReportError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        context: 'eventsub:postRedemptionNotify:chatAnnouncement',
+        streamerId: 'streamer-1',
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## 背景 / Issue

Fixes #1033

本番で以下のエラーレポートが自動起票された:

```
Chat announcement pending: Twitch API 429: Your message was not sent because you are sending messages too quickly.
```

`context: eventsub:postRedemptionNotify:chatAnnouncement`

## 原因

`postRedemptionNotify`（`src/lib/services/eventsub-redemption.ts`）のチャット通知経路は、Twitch API 429（レート制限）のような一時障害を `chat_notification_outbox` テーブルの指数バックオフで最大5回まで自動再試行する設計になっている（`retryChatNotification` が `'pending'` を返す = 正常に再試行がスケジュールされた状態）。

しかし旧実装は `retryChatNotification` の戻り値（`'pending' | 'dead' | 'lost-lease'`）を問わず常に `throw` していたため、`Promise.allSettled` の rejection 経由で `reportError` に到達し、**自己回復するはずの一時的なレート制限が1回起きただけで `[Error]` ラベルの自動 GitHub Issue が作られてしまっていた**（ノイズ）。

## 修正内容

- `retryState === 'pending'`（＝自動再試行が正常にスケジュールされた場合）は `throw` せず、`logger.warn` によるログのみに留めて正常終了するように変更。
- `'dead'`（再試行を使い切ってDLQ化）・`'lost-lease'`（lease競合で更新不能）は従来通り `throw` → `reportError` する（実際に対応が必要なケースなので維持）。
- 予期しない例外（`sendChatAnnouncement` 自体の throw 等）を拾う catch ブロックの挙動は変更していない（本 Issue はクラス分けされた 429/5xx 等の `retryable` outcome 経路が対象のため）。

## テスト

- 新規: `tests/unit/post-redemption-notify-chat-retry.test.ts`
  - `pending` → `reportError` が呼ばれないこと / `warn` ログが出ることを固定
  - `dead` / `lost-lease` → 従来通り `reportError` が呼ばれることを固定
- 既存: `tests/unit/eventsub-user-card-counts-driver-parity.test.ts` の該当ケースを、旧（誤った）期待値「pendingでもreportErrorする」から新しい契約「pendingはreportErrorしない」に更新し、429ケースも追加。
- `npm run test:unit`: 277 files / 3608 tests 全て pass
- `npx eslint` / `npx tsc --noEmit`: エラーなし

## 影響範囲

- チャット通知の実際の配送・再試行ロジック（DB更新、backoff、DLQ化条件）は変更していない。挙動が変わるのはエラーレポート／ログの発報有無のみ。
- ガチャ確定・カード付与・EventSubレスポンス自体には影響しない（このコードパスは `waitUntil()` 内のバックグラウンド通知処理）。

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYS9SuikckZ3BWcwQSUPA4)_