### PR TITLE
docs(env): EventSub health secretをenv例へ追加 (#1010)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -90,6 +90,7 @@ NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 
 # Cloudflare Workers / OpenNext デプロイ設定（Cloudflare Secrets で設定）
 # DB_HEALTH_SECRET=xxx            # /api/admin/db-health の共有シークレット
+# EVENTSUB_HEALTH_SECRET=xxx      # /api/admin/eventsub-health と error-reporter Cron の共有シークレット
 # EVENTSUB_REPLAY_SECRET=xxx      # /api/admin/eventsub-replay の共有シークレット
 # SESSION_COOKIE_SECRET は上記参照（本番は wrangler secret put で設定）
 


### PR DESCRIPTION
## 概要

Issue #1010 のノンブロッキング改善事項 **#6（`.env.local.example` に `EVENTSUB_HEALTH_SECRET` の記載が無い）** を対応します。

## 変更内容

- `.env.local.example` の Cloudflare Workers / OpenNext 用シークレット一覧へ `EVENTSUB_HEALTH_SECRET` を追加
- `/api/admin/eventsub-health` と error-reporter Cron の共有シークレットであることをコメントで明記

本番コード・設定値・シークレット実値の変更はありません。ドキュメント用テンプレートへの1行追加のみです。

## 検証方針

差分が `.env.local.example` の1行のみであることを確認済みです。GitHub Actions と Claude Auto Review を確認し、必須指摘またはCI失敗があれば同PRで修正します。任意指摘はレビュー収束ルールに従いフォローアップIssueへ退避します。

Preview実経路ゲートの対象となる本番経路変更はありません。

Refs #1010