### PR TITLE
test(r2): retry wiringテストの追加契約を統一 (#1039)

### DIFF
--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -30,6 +30,8 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 // アサーションで1回打ち切りを固定する。将来、恒久エラーが誤ってtransient判定へ回帰した
 // 場合は1s+2s+4sの最大約7秒を実時間で待ってから失敗するが、現行testTimeout（30秒）内で
 // 確実に検知できるため、通常系へ不要なfake timers前提を増やさない簡潔性を優先する。
+// withR2UploadRetry のバックオフ式や既定リトライ回数を変更する場合は、この30秒以内という
+// 前提も併せて見直し、必要なら恒久エラー系をfake timers化するかtestTimeoutを再設定する。
 //
 // @opennextjs/cloudflareはgetR2Bindingが動的importする（src/lib/r2-client.ts）。
 // モックしないと、Node.js実行環境（Vitest）でgetCloudflareContext({async:true})が
@@ -207,6 +209,10 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
     const result = await uploadToR2WithRetry('f.png', Buffer.from('x'), 'image/png', 3)
 
     expect(result).toEqual({ error: 'AccessDenied: invalid credentials' })
-    expect(sendMock).toHaveBeenCalledTimes(1)
+    expectAllAttemptsUsedConfig(1, {
+      region: 'auto',
+      endpoint: 'https://example.r2.test',
+      credentials: { accessKeyId: 'image-key', secretAccessKey: 'image-secret' },
+    })
   })
 })


### PR DESCRIPTION
Closes #1039

## 変更内容

`tests/unit/r2-client-upload-retry-wiring.test.ts` のみを更新し、PR #1038 の Claude Auto Review で退避された2件のノンブロッキング改善を反映します。本番コード・設定・依存関係の変更はありません。

- AccessDenied の恒久エラーケースも `expectAllAttemptsUsedConfig(1, ...)` を使い、1回打ち切りだけでなく S3Client の生成回数と endpoint / credentials 契約まで他のS3経路と同じヘルパで固定
- `withR2UploadRetry` のバックオフ式や既定リトライ回数を変更する場合、real timers を使う恒久エラー系の30秒 testTimeout 前提も再評価する必要がある旨をヘッダコメントへ追記

## 検証方針

差分はテストファイル1件のみ（+8/-2）です。GitHub Actions と Claude Auto Review を確認し、必須指摘またはCI失敗があれば同PRで修正して再pushします。任意指摘はレビュー収束ルールに従いフォローアップIssueへ退避します。

本番経路の差分がないテスト専用変更のため、Preview実経路ゲートの追加実施対象外です。