### PR TITLE
test(db): trade設定列のデプロイ窓フォールバックを直接検証 (#1013)

### DIFF
--- a/tests/unit/streamers-safe-columns.test.ts
+++ b/tests/unit/streamers-safe-columns.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+import { withLiveDirectorySettingsColumnFallback } from '@/lib/db/streamers-safe-columns'
+
+function missingColumnError(column: string) {
+  return Object.assign(new Error(`column "${column}" does not exist`), {
+    code: '42703',
+  })
+}
+
+describe('withLiveDirectorySettingsColumnFallback', () => {
+  it.each(['trade_enabled', 'cross_channel_trade_enabled'] as const)(
+    '%s の未デプロイを検知すると安全な列集合で再試行する',
+    async (column) => {
+      const attempt = vi.fn(async (useSafeColumns: boolean) => {
+        if (!useSafeColumns) throw missingColumnError(column)
+        return 'safe-columns'
+      })
+
+      await expect(withLiveDirectorySettingsColumnFallback(attempt)).resolves.toBe('safe-columns')
+      expect(attempt.mock.calls).toEqual([[false], [true]])
+    },
+  )
+
+  it('対象外の 42703 は握りつぶさず再送出する', async () => {
+    const error = missingColumnError('unrelated_column')
+    const attempt = vi.fn(async () => {
+      throw error
+    })
+
+    await expect(withLiveDirectorySettingsColumnFallback(attempt)).rejects.toBe(error)
+    expect(attempt).toHaveBeenCalledTimes(1)
+    expect(attempt).toHaveBeenCalledWith(false)
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1013 のノンブロッキング改善 **#9（`isMissingTradeSettingsColumnError` の検知経路が未テスト）** を対応します。

## 変更内容

- `tests/unit/streamers-safe-columns.test.ts` を追加
- `trade_enabled` / `cross_channel_trade_enabled` の SQLSTATE 42703 をそれぞれ与え、`withLiveDirectorySettingsColumnFallback` が全列試行から安全列試行へ切り替えることを直接検証
- 対象外の 42703 は握りつぶさず再送出し、再試行しないことも固定

既存の大きな `dashboard-data-driver-parity.test.ts` fixture を複製せず、今回未カバーだった判定ヘルパーの分岐だけを小さな単体テストで固定します。本番コード・設定・依存関係の変更はありません。

## 検証方針

この実行環境では GitHub への外部DNS解決ができずローカル clone/npm 実行ができないため、GitHub Actions を正本として確認します。CI失敗または必須レビュー指摘があれば同PRで修正して再pushします。任意指摘はレビュー収束ルールに従いフォローアップIssueへ退避します。

テスト専用変更で本番経路差分がないため、Preview実経路ゲートの追加実施対象外です。

Refs #1013