### PR TITLE
test(db): streamers safe columns契約を追加検証 (#1045)

### DIFF
--- a/tests/unit/streamers-safe-columns.test.ts
+++ b/tests/unit/streamers-safe-columns.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
-import { withLiveDirectorySettingsColumnFallback } from '@/lib/db/streamers-safe-columns'
+import {
+  LIVE_DIRECTORY_SETTINGS_COLUMNS,
+  STREAMERS_SAFE_COLUMNS,
+  TRADE_SETTINGS_COLUMNS,
+  withLiveDirectorySettingsColumnFallback,
+} from '@/lib/db/streamers-safe-columns'
 
 function missingColumnError(column: string) {
   return Object.assign(new Error(`column "${column}" does not exist`), {
@@ -8,7 +13,7 @@ function missingColumnError(column: string) {
 }
 
 describe('withLiveDirectorySettingsColumnFallback', () => {
-  it.each(['trade_enabled', 'cross_channel_trade_enabled'] as const)(
+  it.each([...LIVE_DIRECTORY_SETTINGS_COLUMNS, ...TRADE_SETTINGS_COLUMNS])(
     '%s の未デプロイを検知すると安全な列集合で再試行する',
     async (column) => {
       const attempt = vi.fn(async (useSafeColumns: boolean) => {
@@ -20,6 +25,27 @@ describe('withLiveDirectorySettingsColumnFallback', () => {
       expect(attempt.mock.calls).toEqual([[false], [true]])
     },
   )
+
+  it('デプロイ窓の対象列集合を明示的に固定する', () => {
+    // isPgMissingNamedColumnError はエラーテキストの部分一致も利用するため、
+    // cross_channel_trade_enabled が trade_enabled の一致だけで偶然通る回帰を防ぐ。
+    expect(LIVE_DIRECTORY_SETTINGS_COLUMNS).toEqual([
+      'publish_live_status',
+      'publish_stats',
+    ])
+    expect(TRADE_SETTINGS_COLUMNS).toEqual([
+      'trade_enabled',
+      'cross_channel_trade_enabled',
+    ])
+  })
+
+  it('安全な列集合にはデプロイ窓で欠落しうる列を含めない', () => {
+    const safeColumnNames = Object.keys(STREAMERS_SAFE_COLUMNS)
+
+    for (const column of [...LIVE_DIRECTORY_SETTINGS_COLUMNS, ...TRADE_SETTINGS_COLUMNS]) {
+      expect(safeColumnNames).not.toContain(column)
+    }
+  })
 
   it('対象外の 42703 は握りつぶさず再送出する', async () => {
     const error = missingColumnError('unrelated_column')


### PR DESCRIPTION
Closes #1045

## 変更内容

`tests/unit/streamers-safe-columns.test.ts` のみを更新し、PR #1044 の自動レビューで退避されたノンブロッキング改善を反映します。本番コード・設定・依存関係の変更はありません。

- `publish_live_status` / `publish_stats` も `withLiveDirectorySettingsColumnFallback` の直接単体テスト対象へ追加
- `TRADE_SETTINGS_COLUMNS` を正確な2要素配列として固定し、`cross_channel_trade_enabled` が `trade_enabled` の部分一致だけで偶然通る回帰を防止
- `STREAMERS_SAFE_COLUMNS` が live directory / trade のデプロイ窓対象4列を含まないことを直接検証

## 検証方針

変更はテスト1ファイルのみです。GitHub Actions の typecheck / unit / integration / 自動レビューを確認し、必須失敗・必須指摘があれば修正して再pushします。

Preview 実経路ゲートは、本番実行コードへの差分がないテスト専用変更のため対象外です。