### PR TITLE
docs(env): EventSub health Workerのsecret名を明記 (#1041)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -90,7 +90,8 @@ NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 
 # Cloudflare Workers / OpenNext デプロイ設定（Cloudflare Secrets で設定）
 # DB_HEALTH_SECRET=xxx            # /api/admin/db-health の共有シークレット
-# EVENTSUB_HEALTH_SECRET=xxx      # /api/admin/eventsub-health と error-reporter Cron の共有シークレット
+# EVENTSUB_HEALTH_SECRET=xxx      # アプリ側 /api/admin/eventsub-health。error-reporter Worker は同じ値を EVENTSUB_HEALTH_SECRET_PROD / EVENTSUB_HEALTH_SECRET_PREVIEW で設定
+#                                # 詳細: docs/eventsub-subscription-health.md
 # EVENTSUB_REPLAY_SECRET=xxx      # /api/admin/eventsub-replay の共有シークレット
 # SESSION_COOKIE_SECRET は上記参照（本番は wrangler secret put で設定）
 


### PR DESCRIPTION
Closes #1041

## 変更内容

`.env.local.example` の `EVENTSUB_HEALTH_SECRET` 注記を、実際の設定先ごとの環境変数名まで分かる形へ補足します。

- アプリ本体は `EVENTSUB_HEALTH_SECRET`
- error-reporter Worker は同じ値を `EVENTSUB_HEALTH_SECRET_PROD` / `EVENTSUB_HEALTH_SECRET_PREVIEW` で設定
- 詳細な運用手順として `docs/eventsub-subscription-health.md` を参照する注記を追加

本番コード・実シークレット値・デプロイ設定には変更ありません。

## 検証方針

差分は `.env.local.example` のコメントのみです。GitHub Actions と Claude Auto Review を確認し、必須失敗・必須指摘があれば修正して再pushします。任意指摘はレビュー収束ルールに従いフォローアップIssueへ退避します。

Preview実経路ゲートは、本番実行コードへの差分がないドキュメント変更のため対象外です。