### PR TITLE
docs(env): EventSub health secret注記を明確化 (#1050)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -90,8 +90,10 @@ NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 
 # Cloudflare Workers / OpenNext デプロイ設定（Cloudflare Secrets で設定）
 # DB_HEALTH_SECRET=xxx            # /api/admin/db-health の共有シークレット
-# EVENTSUB_HEALTH_SECRET=xxx      # アプリ側 /api/admin/eventsub-health。error-reporter Worker は同じ値を EVENTSUB_HEALTH_SECRET_PROD / EVENTSUB_HEALTH_SECRET_PREVIEW で設定
-#                                # 詳細: docs/eventsub-subscription-health.md
+# EVENTSUB_HEALTH_SECRET=xxx      # アプリ側 /api/admin/eventsub-health の共有シークレット
+#                                 # Worker側は各環境のアプリと同じ値を、それぞれ
+#                                 # EVENTSUB_HEALTH_SECRET_PROD / EVENTSUB_HEALTH_SECRET_PREVIEW に設定
+#                                 # 詳細: docs/eventsub-subscription-health.md
 # EVENTSUB_REPLAY_SECRET=xxx      # /api/admin/eventsub-replay の共有シークレット
 # SESSION_COOKIE_SECRET は上記参照（本番は wrangler secret put で設定）
 


### PR DESCRIPTION
Closes #1050

## 変更内容

`.env.local.example` の `EVENTSUB_HEALTH_SECRET` 注記だけを整理し、PR #1049 の自動レビューで退避されたノンブロッキング改善を反映します。

- 継続コメントのカラムを揃える
- production / preview それぞれで、アプリ側 `EVENTSUB_HEALTH_SECRET` と Worker 側の対応変数へ同じ値を設定することを明確化
- 1行目を短くし、詳細は既存の `docs/eventsub-subscription-health.md` へ委ねる

本番コード・実シークレット値・デプロイ設定には変更ありません。

## 検証方針

コメントのみの差分ですが、GitHub Actions と Claude Auto Review を確認し、必須失敗・必須指摘があれば修正して再pushします。任意指摘はレビュー収束ルールに従いフォローアップIssueへ退避します。

Preview実経路ゲートは、本番実行コードへの差分がないドキュメント変更のため対象外です。