### PR TITLE
docs(env): error-reporter Worker名を明記 (#1052)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -91,7 +91,7 @@ NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 # Cloudflare Workers / OpenNext デプロイ設定（Cloudflare Secrets で設定）
 # DB_HEALTH_SECRET=xxx            # /api/admin/db-health の共有シークレット
 # EVENTSUB_HEALTH_SECRET=xxx      # アプリ側 /api/admin/eventsub-health の共有シークレット
-#                                 # Worker側は各環境のアプリと同じ値を、それぞれ
+#                                 # error-reporter Worker側は各環境のアプリと同じ値を、それぞれ
 #                                 # EVENTSUB_HEALTH_SECRET_PROD / EVENTSUB_HEALTH_SECRET_PREVIEW に設定
 #                                 # 詳細: docs/eventsub-subscription-health.md
 # EVENTSUB_REPLAY_SECRET=xxx      # /api/admin/eventsub-replay の共有シークレット


### PR DESCRIPTION
Closes #1052

## 変更内容

`.env.local.example` の `EVENTSUB_HEALTH_SECRET` 注記で、設定先が `error-reporter` Worker であることを明記します。

- production / preview ごとの対応関係はそのまま維持
- 実シークレット値・実行コード・デプロイ設定には変更なし

## 検証方針

コメントのみの差分ですが、GitHub Actions と Claude Auto Review を確認し、必須失敗・必須指摘があれば修正して再pushします。任意指摘はレビュー収束ルールに従いフォローアップIssueへ退避します。

Preview実経路ゲートは、本番実行コードへの差分がないドキュメント変更のため対象外です。