### PR TITLE
test(r2): AccessDenied契約を読みやすくする (#1043)

### DIFF
--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -209,6 +209,7 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
     const result = await uploadToR2WithRetry('f.png', Buffer.from('x'), 'image/png', 3)
 
     expect(result).toEqual({ error: 'AccessDenied: invalid credentials' })
+    // expectedAttempts=1 は「1回だけ試行 = リトライなし」を明示する契約。
     expectAllAttemptsUsedConfig(1, {
       region: 'auto',
       endpoint: 'https://example.r2.test',


### PR DESCRIPTION
Closes #1043

## 変更内容

`tests/unit/r2-client-upload-retry-wiring.test.ts` の軽量フォローアップです。

- AccessDenied ケースの `expectAllAttemptsUsedConfig(1, ...)` 直前に、`1` が「1回だけ試行 = リトライなし」の契約であることを短く明記
- PR #1042 で失われていたファイル末尾改行を復元

本番コード・設定・依存関係には変更ありません。

## 検証方針

テスト専用の可読性・ファイル衛生変更です。GitHub Actions と Claude Auto Review を確認し、必須失敗・必須指摘があれば修正して再pushします。任意指摘はレビュー収束ルールに従いフォローアップIssueへ退避します。

Preview実経路ゲートは、本番実行コードへの差分がないテスト専用変更のため対象外です。