### PR TITLE
test(db): streamers safe columns契約を強化 (#1047)

### DIFF
--- a/tests/unit/streamers-safe-columns.test.ts
+++ b/tests/unit/streamers-safe-columns.test.ts
@@ -1,10 +1,19 @@
+import { getTableColumns } from 'drizzle-orm'
 import { describe, expect, it, vi } from 'vitest'
+import { streamers as streamersTable } from '@/lib/db/schema'
 import {
+  isMissingLiveDirectorySettingsColumnError,
+  isMissingTradeSettingsColumnError,
   LIVE_DIRECTORY_SETTINGS_COLUMNS,
   STREAMERS_SAFE_COLUMNS,
   TRADE_SETTINGS_COLUMNS,
   withLiveDirectorySettingsColumnFallback,
 } from '@/lib/db/streamers-safe-columns'
+
+const DEPLOY_WINDOW_COLUMNS = [
+  ...LIVE_DIRECTORY_SETTINGS_COLUMNS,
+  ...TRADE_SETTINGS_COLUMNS,
+] as const
 
 function missingColumnError(column: string) {
   return Object.assign(new Error(`column "${column}" does not exist`), {
@@ -13,7 +22,7 @@ function missingColumnError(column: string) {
 }
 
 describe('withLiveDirectorySettingsColumnFallback', () => {
-  it.each([...LIVE_DIRECTORY_SETTINGS_COLUMNS, ...TRADE_SETTINGS_COLUMNS])(
+  it.each(DEPLOY_WINDOW_COLUMNS)(
     '%s の未デプロイを検知すると安全な列集合で再試行する',
     async (column) => {
       const attempt = vi.fn(async (useSafeColumns: boolean) => {
@@ -25,6 +34,36 @@ describe('withLiveDirectorySettingsColumnFallback', () => {
       expect(attempt.mock.calls).toEqual([[false], [true]])
     },
   )
+
+  it('対象外の 42703 は握りつぶさず再送出する', async () => {
+    const error = missingColumnError('unrelated_column')
+    const attempt = vi.fn(async () => {
+      throw error
+    })
+
+    await expect(withLiveDirectorySettingsColumnFallback(attempt)).rejects.toBe(error)
+    expect(attempt).toHaveBeenCalledTimes(1)
+    expect(attempt).toHaveBeenCalledWith(false)
+  })
+})
+
+describe('streamers デプロイ窓の列集合契約', () => {
+  it.each(LIVE_DIRECTORY_SETTINGS_COLUMNS)(
+    '%s は live directory 設定列としてのみ検知する',
+    (column) => {
+      const error = missingColumnError(column)
+
+      expect(isMissingLiveDirectorySettingsColumnError(error)).toBe(true)
+      expect(isMissingTradeSettingsColumnError(error)).toBe(false)
+    },
+  )
+
+  it.each(TRADE_SETTINGS_COLUMNS)('%s は trade 設定列としてのみ検知する', (column) => {
+    const error = missingColumnError(column)
+
+    expect(isMissingTradeSettingsColumnError(error)).toBe(true)
+    expect(isMissingLiveDirectorySettingsColumnError(error)).toBe(false)
+  })
 
   it('デプロイ窓の対象列集合を明示的に固定する', () => {
     // isPgMissingNamedColumnError はエラーテキストの部分一致も利用するため、
@@ -39,22 +78,22 @@ describe('withLiveDirectorySettingsColumnFallback', () => {
     ])
   })
 
-  it('安全な列集合にはデプロイ窓で欠落しうる列を含めない', () => {
-    const safeColumnNames = Object.keys(STREAMERS_SAFE_COLUMNS)
+  it('安全な列集合にはデプロイ窓で欠落しうる実SQL列を含めない', () => {
+    const safeColumnNames = Object.values(STREAMERS_SAFE_COLUMNS).map((column) => column.name)
 
-    for (const column of [...LIVE_DIRECTORY_SETTINGS_COLUMNS, ...TRADE_SETTINGS_COLUMNS]) {
+    for (const column of DEPLOY_WINDOW_COLUMNS) {
       expect(safeColumnNames).not.toContain(column)
     }
   })
 
-  it('対象外の 42703 は握りつぶさず再送出する', async () => {
-    const error = missingColumnError('unrelated_column')
-    const attempt = vi.fn(async () => {
-      throw error
-    })
+  it('安全な列集合は streamers 全列からデプロイ窓対象だけを除いた集合と一致する', () => {
+    const deployWindowColumnNames = new Set<string>(DEPLOY_WINDOW_COLUMNS)
+    const allColumnNames = Object.values(getTableColumns(streamersTable)).map((column) => column.name)
+    const expectedSafeColumnNames = allColumnNames.filter(
+      (column) => !deployWindowColumnNames.has(column),
+    )
+    const safeColumnNames = Object.values(STREAMERS_SAFE_COLUMNS).map((column) => column.name)
 
-    await expect(withLiveDirectorySettingsColumnFallback(attempt)).rejects.toBe(error)
-    expect(attempt).toHaveBeenCalledTimes(1)
-    expect(attempt).toHaveBeenCalledWith(false)
+    expect([...safeColumnNames].sort()).toEqual([...expectedSafeColumnNames].sort())
   })
 })


### PR DESCRIPTION
Closes #1047

## 変更内容

`tests/unit/streamers-safe-columns.test.ts` のテスト契約を整理・強化します。

- `STREAMERS_SAFE_COLUMNS` の検証を投影キーではなく Drizzle column の実SQL名 (`column.name`) で行う
- `getTableColumns(streamersTable)` を使い、streamers 全列からデプロイ窓対象4列だけを除いた集合と safe columns が一致することを固定
- live directory / trade の欠落検知関数を直接検証し、対象列グループの責務を明示
- wrapper の再試行挙動と列集合契約の `describe` を分離
- `cross_channel_trade_enabled` と `trade_enabled` の部分一致による回帰を防ぐ exact-array ガードは維持

本番コード・設定・依存関係には変更ありません。

## 検証方針

GitHub Actions と Claude Auto Review を確認し、必須失敗・必須指摘があれば修正して再pushします。任意・ノンブロッキング指摘はフォローアップIssueへ退避します。

Preview実経路ゲートは、本番実行コードへの差分がないテスト専用変更のため対象外です。