### PR TITLE
test(r2): retry試行回数の意味を定数化 (#1056)

### DIFF
--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -59,6 +59,8 @@ vi.mock('@aws-sdk/client-s3', () => ({
 const sendMock = mocks.sendMock
 const getCloudflareContextMock = mocks.getCloudflareContext
 const s3ClientConfigs = mocks.s3ClientConfigs
+const NO_RETRY_ATTEMPTS = 1
+const RETRY_SUCCESS_ATTEMPTS = 3
 
 // 画像・効果音それぞれに必要な env をまとめてスタブする。各テストで vi.stubEnv
 // を繰り返すと画像/効果音の資格情報分岐の是非が読みにくくなるためヘルパへ抽出する。
@@ -168,7 +170,7 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
       expect(input).toMatchObject({ Bucket: 'test-bucket', Key: 'f.png', ContentType: 'image/png' })
       expect(input.Body).toEqual(Buffer.from('img'))
     }
-    expectAllAttemptsUsedConfig(3, {
+    expectAllAttemptsUsedConfig(RETRY_SUCCESS_ATTEMPTS, {
       region: 'auto',
       endpoint: 'https://example.r2.test',
       credentials: { accessKeyId: 'image-key', secretAccessKey: 'image-secret' },
@@ -194,7 +196,7 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
       expect(input).toMatchObject({ Bucket: 'sound-bucket', Key: 'f.mp3', ContentType: 'audio/mpeg' })
       expect(input.Body).toEqual(Buffer.from('snd'))
     }
-    expectAllAttemptsUsedConfig(3, {
+    expectAllAttemptsUsedConfig(RETRY_SUCCESS_ATTEMPTS, {
       region: 'auto',
       endpoint: 'https://example.r2.test',
       credentials: { accessKeyId: 'sound-key', secretAccessKey: 'sound-secret' },
@@ -209,8 +211,7 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
     const result = await uploadToR2WithRetry('f.png', Buffer.from('x'), 'image/png', 3)
 
     expect(result).toEqual({ error: 'AccessDenied: invalid credentials' })
-    // expectedAttempts=1 は「1回だけ試行 = リトライなし」を明示する契約。
-    expectAllAttemptsUsedConfig(1, {
+    expectAllAttemptsUsedConfig(NO_RETRY_ATTEMPTS, {
       region: 'auto',
       endpoint: 'https://example.r2.test',
       credentials: { accessKeyId: 'image-key', secretAccessKey: 'image-secret' },


### PR DESCRIPTION
## 概要
Issue #1056 の軽量フォローアップです。

- `1` を `NO_RETRY_ATTEMPTS` として定数化
- `3` を `RETRY_SUCCESS_ATTEMPTS` として定数化
- AccessDenied 側だけにあった説明コメントを定数名へ寄せ、成功系と恒久エラー系を同じ表現に統一

テストファイル1件のみの変更で、本番コード・設定・依存関係には触れていません。

Closes #1056