### PR TITLE
docs(env): EventSub replay secretのWorker対応を明記 (#1054)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -91,10 +91,12 @@ NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 # Cloudflare Workers / OpenNext デプロイ設定（Cloudflare Secrets で設定）
 # DB_HEALTH_SECRET=xxx            # /api/admin/db-health の共有シークレット
 # EVENTSUB_HEALTH_SECRET=xxx      # アプリ側 /api/admin/eventsub-health の共有シークレット
-#                                 # error-reporter Worker側は各環境のアプリと同じ値を、それぞれ
+#                                 # workers/error-reporter（twica-error-reporter）側は各環境のアプリと同じ値を、それぞれ
 #                                 # EVENTSUB_HEALTH_SECRET_PROD / EVENTSUB_HEALTH_SECRET_PREVIEW に設定
 #                                 # 詳細: docs/eventsub-subscription-health.md
 # EVENTSUB_REPLAY_SECRET=xxx      # /api/admin/eventsub-replay の共有シークレット
+#                                 # workers/error-reporter（twica-error-reporter）側は各環境のアプリと同じ値を、それぞれ
+#                                 # EVENTSUB_REPLAY_SECRET_PROD / EVENTSUB_REPLAY_SECRET_PREVIEW に設定
 # SESSION_COOKIE_SECRET は上記参照（本番は wrangler secret put で設定）
 
 # Overlay Realtime（WebSocket 配信）


### PR DESCRIPTION
## 概要
Issue #1054 の軽量フォローアップです。

- `.env.local.example` の EventSub health secret 注記で Worker のディレクトリ名 / デプロイ名を併記
- `EVENTSUB_REPLAY_SECRET` にも error-reporter Worker 側の `EVENTSUB_REPLAY_SECRET_PROD` / `EVENTSUB_REPLAY_SECRET_PREVIEW` 対応を明記
- 実シークレット値、実行コード、デプロイ設定、依存関係は変更しません

`workers/error-reporter/wrangler.toml` の `name = "twica-error-reporter"` と required secrets の説明に合わせた文書整合のみです。

Closes #1054