### PR TITLE
fix(channel-points): refresh失敗をprobeの結果へ変換しauto-generated 500を防ぐ

### DIFF
--- a/src/lib/twitch/channel-points.ts
+++ b/src/lib/twitch/channel-points.ts
@@ -1,5 +1,5 @@
 import { getEnvVar } from '@/lib/env-validation'
-import { getTwitchAccessToken, TwitchTokenError } from './token-manager'
+import { getTwitchAccessToken, isPermanentRefreshFailure, TwitchTokenError } from './token-manager'
 import { logger } from '@/lib/logger.server'
 
 const TWITCH_API_URL = 'https://api.twitch.tv/helix'
@@ -20,7 +20,7 @@ export type ChannelPointsCapabilityReason =
   | 'unexpected_status'
   | 'network_error'
   | 'token_refresh_failed'
-  | 'token_refresh_unavailable'
+  | 'token_refresh_temporarily_failed'
 
 export interface ChannelPointsCapabilityResult {
   capability: ChannelPointsCapability
@@ -179,26 +179,28 @@ export async function probeChannelPointsCapability(
     // 伝播し、handleApiErrorが「REFRESH_FAILED」を500として誤ってauto-generated
     // bug reportに記録していた(Issue #1064)。
     //
-    // refresh tokenが無効化・失効済み(invalid_grant等の非retryable HTTPエラー)な
-    // 場合は再認証以外に復旧手段が無いため、恒久障害として reauth_required/
-    // definitive:true を返す（!accessTokenの分岐と同じ扱い）。429/5xx/networkの
-    // ような一時障害まで reauth_required 化すると、DBに保存済みの確定capability
-    // (available等)を誤って破壊してしまうため、definitive:false の unknown として
-    // 返し、呼び出し元が既存の確定状態を保持できるようにする。
-    const isPermanentRefreshFailure =
-      error instanceof TwitchTokenError &&
-      error.code === 'REFRESH_FAILED' &&
-      error.refreshRetryable === false
+    // 恒久失効かどうかの判定は、退行を避けるため必ず token-manager.ts の正本
+    // isPermanentRefreshFailure() (Issue #1018) へ委譲する。retryableの否定形で
+    // 自前判定すると、Cloudflare由来の一過性5xx(520/521/525/526等)・
+    // kind='invalid_response'・403(WAF等)まで「恒久失効」に誤分類され、一時障害の
+    // 窓でDBの確定capability(available)をreauth_requiredへ誤って上書きしてしまう
+    // (isPermanentRefreshFailureのdoc・PERMANENT_REFRESH_STATUSESのコメント参照)。
+    // 恒久(400/401のhttp)以外 — DB障害・network・その他statusを含む — は
+    // すべて一時障害として扱い、definitive:falseで既存の確定状態を保持する。
+    const permanent = isPermanentRefreshFailure(error)
     logger.warn('[probeChannelPointsCapability] getTwitchAccessToken failed', {
       broadcasterTwitchUserId,
       error: error instanceof Error ? error.message : String(error),
       refreshErrorKind: error instanceof TwitchTokenError ? error.refreshErrorKind : undefined,
       refreshRetryable: error instanceof TwitchTokenError ? error.refreshRetryable : undefined,
     })
-    if (isPermanentRefreshFailure) {
+    if (permanent) {
       return { capability: 'reauth_required', reason: 'token_refresh_failed', definitive: true }
     }
-    return { capability: 'unknown', reason: 'token_refresh_unavailable', definitive: false }
+    // 'unavailable'は既存語彙で「403確定でChannel Points機能自体が無い」を意味する
+    // ため、reasonを'token_refresh_unavailable'にすると意味が逆(一時的に判定不能)に
+    // 読まれかねない。ログ・集計での混同を避けるため、一時性を明示する名前にする。
+    return { capability: 'unknown', reason: 'token_refresh_temporarily_failed', definitive: false }
   }
   if (!accessToken) {
     return { capability: 'reauth_required', reason: 'no_access_token', definitive: true }

--- a/src/lib/twitch/channel-points.ts
+++ b/src/lib/twitch/channel-points.ts
@@ -1,5 +1,5 @@
 import { getEnvVar } from '@/lib/env-validation'
-import { getTwitchAccessToken } from './token-manager'
+import { getTwitchAccessToken, TwitchTokenError } from './token-manager'
 import { logger } from '@/lib/logger.server'
 
 const TWITCH_API_URL = 'https://api.twitch.tv/helix'
@@ -19,6 +19,8 @@ export type ChannelPointsCapabilityReason =
   | 'twitch_server_error'
   | 'unexpected_status'
   | 'network_error'
+  | 'token_refresh_failed'
+  | 'token_refresh_unavailable'
 
 export interface ChannelPointsCapabilityResult {
   capability: ChannelPointsCapability
@@ -165,7 +167,39 @@ export async function cancelRedemption(params: CancelRedemptionParams): Promise<
 export async function probeChannelPointsCapability(
   broadcasterTwitchUserId: string
 ): Promise<ChannelPointsCapabilityResult> {
-  const accessToken = await getTwitchAccessToken(broadcasterTwitchUserId)
+  let accessToken: string | null
+  try {
+    accessToken = await getTwitchAccessToken(broadcasterTwitchUserId)
+  } catch (error) {
+    // getTwitchAccessToken は「トークンが未保存」ならnullを返すが、期限切れ
+    // トークンのrefreshに失敗した場合はTwitchTokenErrorをthrowする(token-manager.ts
+    // getTwitchAccessTokenPg参照)。ここでcatchしないと、この関数の他の失敗経路
+    // （fetch自体の例外・非2xxステータス）と違って結果オブジェクトへ変換されず、
+    // 呼び出し元(POST /api/account/channel-points等)のtry/catchまで未捕捉例外として
+    // 伝播し、handleApiErrorが「REFRESH_FAILED」を500として誤ってauto-generated
+    // bug reportに記録していた(Issue #1064)。
+    //
+    // refresh tokenが無効化・失効済み(invalid_grant等の非retryable HTTPエラー)な
+    // 場合は再認証以外に復旧手段が無いため、恒久障害として reauth_required/
+    // definitive:true を返す（!accessTokenの分岐と同じ扱い）。429/5xx/networkの
+    // ような一時障害まで reauth_required 化すると、DBに保存済みの確定capability
+    // (available等)を誤って破壊してしまうため、definitive:false の unknown として
+    // 返し、呼び出し元が既存の確定状態を保持できるようにする。
+    const isPermanentRefreshFailure =
+      error instanceof TwitchTokenError &&
+      error.code === 'REFRESH_FAILED' &&
+      error.refreshRetryable === false
+    logger.warn('[probeChannelPointsCapability] getTwitchAccessToken failed', {
+      broadcasterTwitchUserId,
+      error: error instanceof Error ? error.message : String(error),
+      refreshErrorKind: error instanceof TwitchTokenError ? error.refreshErrorKind : undefined,
+      refreshRetryable: error instanceof TwitchTokenError ? error.refreshRetryable : undefined,
+    })
+    if (isPermanentRefreshFailure) {
+      return { capability: 'reauth_required', reason: 'token_refresh_failed', definitive: true }
+    }
+    return { capability: 'unknown', reason: 'token_refresh_unavailable', definitive: false }
+  }
   if (!accessToken) {
     return { capability: 'reauth_required', reason: 'no_access_token', definitive: true }
   }

--- a/tests/unit/channel-points-capability-probe.test.ts
+++ b/tests/unit/channel-points-capability-probe.test.ts
@@ -15,8 +15,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 //    （ソースコードのコメントで明示されている契約）
 // 6. getTwitchAccessToken自体が例外(refresh失敗)をthrowした場合も、未捕捉のまま
 //    呼び出し元(API route)へ伝播させず、結果オブジェクトへ変換する(Issue #1064)
-//    - refreshが非retryable(invalid_grant等)で恒久的に失敗 → reauth_required/definitive:true
-//    - refreshがretryable(429/5xx/network)で一時的に失敗 → unknown/definitive:false
+//    - 恒久失効(token-manager.isPermanentRefreshFailure=true。400/401のhttp)
+//      → reauth_required/definitive:true
+//    - それ以外は全て一時障害として扱う(definitive:false)。retryableの否定形では
+//      なく恒久statusのホワイトリストで判定するため(Issue #1018)、520/501/505等の
+//      一過性5xxや403(WAF等)、kind='invalid_response'はretryable=falseでも
+//      恒久扱いにしてはならない — 誤って恒久化するとDBの確定capability(available)を
+//      一時障害中にreauth_requiredへ上書きしてしまう
 
 const mocks = vi.hoisted(() => ({
   getTwitchAccessToken: vi.fn(),
@@ -101,7 +106,7 @@ describe('probeChannelPointsCapability', () => {
     expect(global.fetch).not.toHaveBeenCalled()
   })
 
-  it('getTwitchAccessTokenがretryableなrefresh失敗(TwitchTokenError)をthrowした場合、fetchを呼ばずunknown/token_refresh_unavailableを返す（definitive:false。既存確定状態を破壊してはならない）', async () => {
+  it('getTwitchAccessTokenがretryableなrefresh失敗(TwitchTokenError)をthrowした場合、fetchを呼ばずunknown/token_refresh_temporarily_failedを返す（definitive:false。既存確定状態を破壊してはならない）', async () => {
     const { TwitchTokenError } = await import('@/lib/twitch/token-manager')
     mocks.getTwitchAccessToken.mockRejectedValue(
       new TwitchTokenError('Failed to refresh Twitch access token', 'REFRESH_FAILED', undefined, 503, 'http', true)
@@ -112,7 +117,7 @@ describe('probeChannelPointsCapability', () => {
 
     expect(result).toEqual({
       capability: 'unknown',
-      reason: 'token_refresh_unavailable',
+      reason: 'token_refresh_temporarily_failed',
       definitive: false,
     })
     expect(global.fetch).not.toHaveBeenCalled()
@@ -129,7 +134,55 @@ describe('probeChannelPointsCapability', () => {
 
     expect(result).toEqual({
       capability: 'unknown',
-      reason: 'token_refresh_unavailable',
+      reason: 'token_refresh_temporarily_failed',
+      definitive: false,
+    })
+  })
+
+  it('getTwitchAccessTokenがrefreshStatus=520(retryable=falseだがPERMANENT_REFRESH_STATUSES外)のTwitchTokenErrorをthrowした場合、恒久扱いせずunknown/definitive:falseを返す（Issue #1018: retryableの否定形で恒久判定してはならない）', async () => {
+    const { TwitchTokenError } = await import('@/lib/twitch/token-manager')
+    mocks.getTwitchAccessToken.mockRejectedValue(
+      new TwitchTokenError('Failed to refresh Twitch access token', 'REFRESH_FAILED', undefined, 520, 'http', false)
+    )
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'unknown',
+      reason: 'token_refresh_temporarily_failed',
+      definitive: false,
+    })
+  })
+
+  it('getTwitchAccessTokenがrefreshStatus=403(retryable=falseだが#1018で恒久失効から意図的に除外)のTwitchTokenErrorをthrowした場合も一時障害として扱う（definitive:false）', async () => {
+    const { TwitchTokenError } = await import('@/lib/twitch/token-manager')
+    mocks.getTwitchAccessToken.mockRejectedValue(
+      new TwitchTokenError('Failed to refresh Twitch access token', 'REFRESH_FAILED', undefined, 403, 'http', false)
+    )
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'unknown',
+      reason: 'token_refresh_temporarily_failed',
+      definitive: false,
+    })
+  })
+
+  it('getTwitchAccessTokenがkind=invalid_response(status 200で本文不正)のTwitchTokenErrorをthrowした場合も一時障害として扱う（definitive:false）', async () => {
+    const { TwitchTokenError } = await import('@/lib/twitch/token-manager')
+    mocks.getTwitchAccessToken.mockRejectedValue(
+      new TwitchTokenError('Failed to refresh Twitch access token', 'REFRESH_FAILED', undefined, undefined, 'invalid_response', false)
+    )
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'unknown',
+      reason: 'token_refresh_temporarily_failed',
       definitive: false,
     })
   })

--- a/tests/unit/channel-points-capability-probe.test.ts
+++ b/tests/unit/channel-points-capability-probe.test.ts
@@ -13,14 +13,27 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 // 4. リクエストURL・クエリパラメータ・認証ヘッダーが仕様通りである
 // 5. アクセストークン/Authorizationヘッダーの値がログへ絶対に出力されない
 //    （ソースコードのコメントで明示されている契約）
+// 6. getTwitchAccessToken自体が例外(refresh失敗)をthrowした場合も、未捕捉のまま
+//    呼び出し元(API route)へ伝播させず、結果オブジェクトへ変換する(Issue #1064)
+//    - refreshが非retryable(invalid_grant等)で恒久的に失敗 → reauth_required/definitive:true
+//    - refreshがretryable(429/5xx/network)で一時的に失敗 → unknown/definitive:false
 
 const mocks = vi.hoisted(() => ({
   getTwitchAccessToken: vi.fn(),
 }))
 
-vi.mock('@/lib/twitch/token-manager', () => ({
-  getTwitchAccessToken: mocks.getTwitchAccessToken,
-}))
+// TwitchTokenErrorは実クラスをそのまま使う。channel-points.tsが
+// `error instanceof TwitchTokenError` で判定するため、モック側でも
+// 同じクラス（コンストラクタ引数の並び含む）を再現する必要がある。
+vi.mock('@/lib/twitch/token-manager', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/twitch/token-manager')>(
+    '@/lib/twitch/token-manager'
+  )
+  return {
+    ...actual,
+    getTwitchAccessToken: mocks.getTwitchAccessToken,
+  }
+})
 
 vi.mock('@/lib/logger', () => ({
   logger: {
@@ -69,6 +82,72 @@ describe('probeChannelPointsCapability', () => {
     })
     expect(result.httpStatus).toBeUndefined()
     expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('getTwitchAccessTokenが非retryableなrefresh失敗(TwitchTokenError)をthrowした場合、fetchを呼ばずreauth_required/token_refresh_failedを返す（definitive:true）', async () => {
+    const { TwitchTokenError } = await import('@/lib/twitch/token-manager')
+    mocks.getTwitchAccessToken.mockRejectedValue(
+      new TwitchTokenError('Failed to refresh Twitch access token', 'REFRESH_FAILED', undefined, 400, 'http', false)
+    )
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'reauth_required',
+      reason: 'token_refresh_failed',
+      definitive: true,
+    })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('getTwitchAccessTokenがretryableなrefresh失敗(TwitchTokenError)をthrowした場合、fetchを呼ばずunknown/token_refresh_unavailableを返す（definitive:false。既存確定状態を破壊してはならない）', async () => {
+    const { TwitchTokenError } = await import('@/lib/twitch/token-manager')
+    mocks.getTwitchAccessToken.mockRejectedValue(
+      new TwitchTokenError('Failed to refresh Twitch access token', 'REFRESH_FAILED', undefined, 503, 'http', true)
+    )
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'unknown',
+      reason: 'token_refresh_unavailable',
+      definitive: false,
+    })
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('getTwitchAccessTokenがDATABASE_ERROR等(refreshRetryable未定義)のTwitchTokenErrorをthrowした場合も一時障害として扱う（definitive:false）', async () => {
+    const { TwitchTokenError } = await import('@/lib/twitch/token-manager')
+    mocks.getTwitchAccessToken.mockRejectedValue(
+      new TwitchTokenError('Failed to fetch user tokens from database', 'DATABASE_ERROR')
+    )
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    const result = await probeChannelPointsCapability(BROADCASTER_ID)
+
+    expect(result).toEqual({
+      capability: 'unknown',
+      reason: 'token_refresh_unavailable',
+      definitive: false,
+    })
+  })
+
+  it('getTwitchAccessToken失敗時、logger.warnはエラー分類のみを記録しアクセストークンの値をログへ出力しない', async () => {
+    const { TwitchTokenError } = await import('@/lib/twitch/token-manager')
+    mocks.getTwitchAccessToken.mockRejectedValue(
+      new TwitchTokenError('Failed to refresh Twitch access token', 'REFRESH_FAILED', undefined, 400, 'http', false)
+    )
+
+    const { probeChannelPointsCapability } = await import('@/lib/twitch/channel-points')
+    await probeChannelPointsCapability(BROADCASTER_ID)
+
+    const { logger } = await import('@/lib/logger')
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.error).not.toHaveBeenCalled()
+    expectNoLeak(vi.mocked(logger.warn), FAKE_ACCESS_TOKEN)
+    expectNoLeak(vi.mocked(logger.warn), `Bearer ${FAKE_ACCESS_TOKEN}`)
   })
 
   it('getTwitchAccessTokenをbroadcasterTwitchUserId単一引数で呼び出す', async () => {


### PR DESCRIPTION
## 問題 (Issue #1064)

`POST /api/account/channel-points` が production で `TwitchTokenError: Failed to refresh Twitch access token` を投げ、auto-generated bug report が作成されていた。

原因: `probeChannelPointsCapability()` は内部で `getTwitchAccessToken()` を呼ぶが、この呼び出しを try/catch していなかった。`getTwitchAccessToken()` は「トークン未保存」なら `null` を返すが、**期限切れトークンの refresh に失敗した場合は `TwitchTokenError` を throw する**（`token-manager.ts` の `getTwitchAccessTokenPg` 参照）。この例外は `probeChannelPointsCapability()` の他の失敗経路（fetch自体の例外・非2xxステータス）と違って結果オブジェクトへ変換されず、呼び出し元 `POST /api/account/channel-points` の try/catch まで未捕捉のまま伝播し、`handleApiError` が 500 として記録していた。

## 修正

`getTwitchAccessToken()` の呼び出しを try/catch し、既存の「結果オブジェクトへ変換する」設計に揃えた。恒久失効の判定はIssue #1018で確立済みの正本 `token-manager.isPermanentRefreshFailure()`（400/401のhttpのみを恒久とするホワイトリスト判定）へ委譲する（1回目のレビューで、retryableの否定形による自前判定は520等の一過性5xxや403を誤って恒久扱いする退行だと指摘され、正本へ委譲する形に修正済み）:

- 恒久失効（`isPermanentRefreshFailure()` = true）→ `reauth_required` / `definitive: true`（`!accessToken` の既存分岐と同じ扱い。再認証以外に復旧手段が無いため）
- それ以外（429/5xx/network/DB障害/一過性5xx等すべて）→ `unknown` / `definitive: false`（DB に保存済みの確定 capability を誤って破壊しないため）

`ChannelPointsCapabilityReason` に `token_refresh_failed` / `token_refresh_temporarily_failed` を追加。フロントエンド (`ChannelPointsAccessSection`) は `capability`/`code` のみで分岐し `reason` を見ないため、UI契約への影響はない。

## レビュー

Claude Auto Review 1回目で必須指摘2件（恒久失効判定の自前実装による退行、境界ケースの試験不足）を受け修正・push。2回目のレビューは合格（残りは全て任意指摘）。

## 検証

- `npx vitest run tests/unit/channel-points-capability-probe.test.ts` — 23件 pass（恒久/一時判定の境界ケース含む）
- `npx vitest run tests/unit` — 3658件 全て pass
- `npx tsc --noEmit` — エラーなし
- `npx eslint` (変更ファイル) — エラーなし

## Preview実経路テスト

このPRはガチャ引き換え・オーバーレイ表示・Twitchチャット送信・アップロードに影響しないため、`docs/QA.md` の Preview 実経路ゲート対応表の対象外と判断した。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)