### PR TITLE
fix: clamp rate-limit KV TTL to Cloudflare minimum

### DIFF
--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -133,8 +133,10 @@ export class KVRateLimitStorage implements RateLimitStorage {
 
   async set(key: string, value: RateLimitStore, ttlMs: number): Promise<void> {
     // KV uses seconds for TTL, so convert from milliseconds
-    // KVはTTLに秒を使用するため、ミリ秒から変換
-    const ttlSeconds = Math.ceil(ttlMs / 1000);
+    // KVはTTLに秒を使用し、expirationTtlの最小値は60秒。rate-limit windowの
+    // 終端では残り時間が1秒未満になるため、単純な切り上げだとCloudflareが
+    // expirationTtl: 1を400で拒否し、レート制限がfail-openになる。
+    const ttlSeconds = Math.max(60, Math.ceil(ttlMs / 1000));
     await this.kv.put(key, JSON.stringify(value), {
       expirationTtl: ttlSeconds,
     });

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -88,13 +88,13 @@ describe("KVRateLimitStorage", () => {
     );
   });
 
-  it("TTLはミリ秒から秒へ切り上げる", async () => {
+  it("TTLは秒へ切り上げ、Cloudflare KVの最小60秒を下回らない", async () => {
     const storage = new KVRateLimitStorage(kv as never);
     await storage.set("ratelimit:test", { count: 1, resetTime: 1 }, 1);
     expect(kv.put).toHaveBeenCalledWith(
       "ratelimit:test",
       JSON.stringify({ count: 1, resetTime: 1 }),
-      { expirationTtl: 1 },
+      { expirationTtl: 60 },
     );
   });
 


### PR DESCRIPTION
## 概要

Cloudflare KV の `expirationTtl` 最小値60秒を下回る残存rate-limit windowを60秒へクランプします。window終端で `expirationTtl: 1` が400となり、rate-limitがfail-openになる preview runtime warning を修正します。

Fixes #1062

## 確認済み

- `npx vitest run tests/unit/rate-limit.test.ts`（19件）
- `npm run typecheck`
- 差分の独立レビュー: 必須指摘なし
- `git diff --check`

`src/lib/rate-limit.ts` の既存warning 1件はbaseに既存で、今回の差分起因ではありません。

## preview後の必須確認

共有Worker基盤に該当するため、累積リリースの実経路ゲート（Worker tail、Queue replay、overlay再接続/gap recovery、analysis比較、upload権限・ログ、既存の実引換証跡）を #1034 および #1062 に記録して確認します。main昇格は全ゲート完了まで行いません。
