### PR TITLE
test(streamers): safe columns契約を明確化 (#1058)

### DIFF
--- a/tests/unit/streamers-safe-columns.test.ts
+++ b/tests/unit/streamers-safe-columns.test.ts
@@ -66,8 +66,8 @@ describe('streamers デプロイ窓の列集合契約', () => {
   })
 
   it('デプロイ窓の対象列集合を明示的に固定する', () => {
-    // isPgMissingNamedColumnError はエラーテキストの部分一致も利用するため、
-    // cross_channel_trade_enabled が trade_enabled の一致だけで偶然通る回帰を防ぐ。
+    // 各列の検知経路自体は上の it.each で直接検証している。
+    // ここでは対象列の追加・削除を意図せず見落とさないよう列集合そのものを固定する。
     expect(LIVE_DIRECTORY_SETTINGS_COLUMNS).toEqual([
       'publish_live_status',
       'publish_stats',
@@ -78,7 +78,17 @@ describe('streamers デプロイ窓の列集合契約', () => {
     ])
   })
 
+  it('安全な列集合の投影キーと実SQL列名が一致する', () => {
+    const mismatches = Object.entries(STREAMERS_SAFE_COLUMNS)
+      .filter(([key, column]) => key !== column.name)
+      .map(([key, column]) => [key, column.name])
+
+    expect(mismatches).toEqual([])
+  })
+
   it('安全な列集合にはデプロイ窓で欠落しうる実SQL列を含めない', () => {
+    // 下の完全一致テストでも検知できるが、デプロイ窓列の混入時に原因を直接示す
+    // 診断用ガードとしてこの否定方向の契約も残す。
     const safeColumnNames = Object.values(STREAMERS_SAFE_COLUMNS).map((column) => column.name)
 
     for (const column of DEPLOY_WINDOW_COLUMNS) {
@@ -87,6 +97,9 @@ describe('streamers デプロイ窓の列集合契約', () => {
   })
 
   it('安全な列集合は streamers 全列からデプロイ窓対象だけを除いた集合と一致する', () => {
+    // schema に新列を追加してこのテストが失敗した場合は、その列が未デプロイの窓を
+    // 持つなら *_SETTINGS_COLUMNS 側へ、既にデプロイ済みの通常列なら
+    // STREAMERS_SAFE_COLUMNS 側へ追加し、フォールバック時の投影漏れを防ぐ。
     const deployWindowColumnNames = new Set<string>(DEPLOY_WINDOW_COLUMNS)
     const allColumnNames = Object.values(getTableColumns(streamersTable)).map((column) => column.name)
     const expectedSafeColumnNames = allColumnNames.filter(
@@ -94,6 +107,6 @@ describe('streamers デプロイ窓の列集合契約', () => {
     )
     const safeColumnNames = Object.values(STREAMERS_SAFE_COLUMNS).map((column) => column.name)
 
-    expect([...safeColumnNames].sort()).toEqual([...expectedSafeColumnNames].sort())
+    expect(safeColumnNames.sort()).toEqual(expectedSafeColumnNames.sort())
   })
 })


### PR DESCRIPTION
## 概要

Issue #1058 のうち、判断不要でテスト内だけで完結するノンブロッキング改善を反映します。

- `STREAMERS_SAFE_COLUMNS` の投影キーと実SQL列名が一致する契約を追加
- safe columns 完全一致テストが失敗した際の更新方針をコメントで明記
- デプロイ窓列を含めない否定テストは、完全一致と論理的に重複する一方で診断性のため残す意図を明記
- `cross_channel_trade_enabled` のコメントを、実際の検証内容（個別検知 + 列集合固定）に合わせて修正
- `.sort()` 前の不要な配列スプレッドを削除

本番コード・設定・依存関係には変更ありません。

source側へ統合列集合をexportする案は設計判断を伴うため #1069 に分離しました。固定2回fixtureのループ抽象化は現状維持でも妥当という元Issueの記載どおり変更していません。

Closes #1058