### PR TITLE
fix(db): canary復旧に実際のfixture識別子を出力

### DIFF
--- a/docs/history/migration/DB_PHASE2_RUNBOOK.md
+++ b/docs/history/migration/DB_PHASE2_RUNBOOK.md
@@ -769,13 +769,14 @@ pg 直結経路（`DB_DRIVER=pg-read`/`pg`）が実際にどの DB へ接続す�
    ROLLBACKする設計〔`withRollbackOnlyTransaction`〕のため通常は発生しないはずの
    異常系だが、万一の場合の復旧手順）:
    1. report findings内の `CANARY_ROLLBACK_TRACE_*` コードのfinding message
-      から、残存しているfixture識別子（`cutover-canary-<uuid>` 形式の
-      `twitch_user_id`、`cutover-canary:<uuid>` 形式の `event_id`）を確認する。
+      から、残存しているfixture識別子（streamersは`cutover-canary-<uuid>`、
+      usersは`cutover-canary-viewer-<uuid>`形式の`twitch_user_id`、
+      `cutover-canary:<uuid>`形式の`event_id`）の**実際の完全な値**を確認する。
    2. target側で該当識別子のfixture streamers行を削除する（`cards`/`gacha_history`
       はON DELETE CASCADEで連鎖的に除去される）:
       `DELETE FROM streamers WHERE twitch_user_id = '<cutover-canary-<uuid>形式の値>';`
    3. fixture users行は`user_cards`経由でのみcascadeするため、別途削除する:
-      `DELETE FROM users WHERE twitch_user_id = '<同上>';`
+      `DELETE FROM users WHERE twitch_user_id = '<cutover-canary-viewer-<uuid>形式の値>';`
    4. 削除後、再度同じ識別子でSELECTし0件になったことを確認する。
    5. **この異常が実際に発生した場合、`withRollbackOnlyTransaction`のROLLBACK保証が
       何らかの理由で機能しなかった可能性がある。単にfixtureを消して手順を続行せず、

--- a/scripts/db-cutover/layer-canary.mjs
+++ b/scripts/db-cutover/layer-canary.mjs
@@ -732,24 +732,24 @@ export async function verifyRollbackTraceless(sql, identifiers) {
     findings.push(
       canaryFail(
         'CANARY_ROLLBACK_TRACE_STREAMERS',
-        `rollback後もstreamers行が残存しています(件数=${streamerRows.length})。復旧: fixture streamers行をtwitch_user_id(cutover-canary-<uuid>形式)で特定しDELETEすれば、cards/gacha_historyへON DELETE CASCADEで連鎖的に除去できます(usersはuser_cards経由でのみcascadeするため別途DELETEが必要、runbook参照)。`
+        `rollback後もstreamers行が残存しています(件数=${streamerRows.length})。復旧: fixture streamers行をtwitch_user_id=${streamerTwitchUserId}で特定しDELETEすれば、cards/gacha_historyへON DELETE CASCADEで連鎖的に除去できます(usersはuser_cards経由でのみcascadeするため別途DELETEが必要、runbook参照)。`
       )
     )
   }
 
   const userRows = await sql`select id from users where twitch_user_id = ${userTwitchUserId}`
   if (userRows.length > 0) {
-    findings.push(canaryFail('CANARY_ROLLBACK_TRACE_USERS', `rollback後もusers行が残存しています(件数=${userRows.length})。復旧: twitch_user_id(cutover-canary-<uuid>形式)で特定しDELETEしてください(user_cardsへON DELETE CASCADEで連鎖します)。`))
+    findings.push(canaryFail('CANARY_ROLLBACK_TRACE_USERS', `rollback後もusers行が残存しています(件数=${userRows.length})。復旧: twitch_user_id=${userTwitchUserId}で特定しDELETEしてください(user_cardsへON DELETE CASCADEで連鎖します)。`))
   }
 
   const historyRows = await sql`select id from gacha_history where event_id = ${eventId}`
   if (historyRows.length > 0) {
-    findings.push(canaryFail('CANARY_ROLLBACK_TRACE_GACHA_HISTORY', `rollback後もgacha_history行が残存しています(件数=${historyRows.length})。復旧: event_id(cutover-canary:<uuid>形式)で特定しDELETEしてください。`))
+    findings.push(canaryFail('CANARY_ROLLBACK_TRACE_GACHA_HISTORY', `rollback後もgacha_history行が残存しています(件数=${historyRows.length})。復旧: event_id=${eventId}で特定しDELETEしてください。`))
   }
 
   const cardRows = await sql`select id from cards where id = ${cardId}::uuid`
   if (cardRows.length > 0) {
-    findings.push(canaryFail('CANARY_ROLLBACK_TRACE_CARDS', `rollback後もcards行(fixture streamer由来)が残存しています(件数=${cardRows.length})。復旧: 対応するfixture streamers行をDELETEすれば連鎖的に除去できます。`))
+    findings.push(canaryFail('CANARY_ROLLBACK_TRACE_CARDS', `rollback後もcards行(fixture streamer由来、id=${cardId})が残存しています(件数=${cardRows.length})。復旧: twitch_user_id=${streamerTwitchUserId}のfixture streamers行をDELETEすれば連鎖的に除去できます。`))
   }
 
   return findings

--- a/tests/unit/db-cutover-layer-canary.test.ts
+++ b/tests/unit/db-cutover-layer-canary.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  buildFixtureIdentifiers,
+  verifyRollbackTraceless,
+} from '../../scripts/db-cutover/layer-canary.mjs'
+
+const RUN_ID = '00000000-0000-4000-8000-000000000001'
+
+describe('db cutover layer canary fixture identifiers', () => {
+  it('配信者と通常視聴者を別のTwitch ID形式で識別する', () => {
+    expect(buildFixtureIdentifiers(RUN_ID)).toEqual({
+      runId: RUN_ID,
+      streamerTwitchUserId: `cutover-canary-${RUN_ID}`,
+      userTwitchUserId: `cutover-canary-viewer-${RUN_ID}`,
+      eventId: `cutover-canary:${RUN_ID}`,
+    })
+  })
+
+  it('users残存時の復旧文言が実際のviewer専用識別子を案内する', async () => {
+    // verifyRollbackTracelessはstreamers/users/history/cardsの順で4つのSELECTを行う。
+    // usersだけを残存扱いにして、findingが実際にINSERTしたviewer ID形式を案内する
+    // ことを固定する。誤った配信者IDでDELETEするとusers行だけ残るため運用上必須。
+    const sqlMock = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 'fixture-user' }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+    const sql = sqlMock as unknown as Parameters<typeof verifyRollbackTraceless>[0]
+
+    const findings = await verifyRollbackTraceless(sql, {
+      ...buildFixtureIdentifiers(RUN_ID),
+      cardId: null,
+    })
+
+    expect(findings).toHaveLength(1)
+    expect(findings[0]).toMatchObject({
+      severity: 'fail',
+      code: 'CANARY_ROLLBACK_TRACE_USERS',
+      side: 'target',
+    })
+    expect(findings[0].message).toContain(
+      `twitch_user_id=cutover-canary-viewer-${RUN_ID}`,
+    )
+    expect(findings[0].message).not.toContain('cutover-canary-<uuid>')
+  })
+})


### PR DESCRIPTION
## 概要

DB layer canary の rollback trace finding とrunbookが、実際にDELETE対象を特定できるよう正確なfixture識別子を示すようにします。

- streamers / users / gacha_history / cards の4種findingに正しい実識別子を表示
- usersのfixture形式を cutover-canary-viewer-UUID と明記
- rollback traceの単体テストを追加

Refs #1036

## 検証

- npx vitest run tests/unit/db-cutover-layer-canary.test.ts
- npm run typecheck
- npx eslint scripts/db-cutover/layer-canary.mjs tests/unit/db-cutover-layer-canary.test.ts
- git diff --check

## リリース

診断文言・runbook・単体テストのみで、EventSub/gacha/overlay/chat/uploadの実行経路を変更しません。単体では実引き換え不要ですが、preview→mainの累積実経路ゲートを免除しません。