### PR TITLE
fix(analysis): analysis dashboard集計の自動比較スクリプトを追加 (#1077)

### DIFF
--- a/docs/QA.md
+++ b/docs/QA.md
@@ -39,7 +39,7 @@ analysis dashboard は `analysis/` で `npm ci`, `npx tsc --noEmit`, `npm run bu
 3. 各結果の chat メッセージが送信される。
 4. EventSub direct と Queue replay の両経路を確認する。
 5. overlay WebSocket を再接続し、polling gap recovery で欠落・重複がないことを確認する。
-6. analysis dashboard の主要集計が PlanetScale の値と一致することを確認する。
+6. analysis dashboard の主要集計が PlanetScale の値と一致することを確認する（`npm run check:analysis-dashboard-vs-sql`、`docs/analysis-dashboard-db-permissions.md`「確認手順」参照。対象環境の限定read接続文字列が実行環境に無い場合は、ブラウザ目視ではなくこの未接続自体を証跡として起票する）。
 7. 対象ファイルのアップロード、保存先からの取得、権限境界、Workerログを確認する。
 
 production 反映後は同じ主要経路を smoke test し、旧 provider の outbound request と

--- a/docs/QA.md
+++ b/docs/QA.md
@@ -39,7 +39,7 @@ analysis dashboard は `analysis/` で `npm ci`, `npx tsc --noEmit`, `npm run bu
 3. 各結果の chat メッセージが送信される。
 4. EventSub direct と Queue replay の両経路を確認する。
 5. overlay WebSocket を再接続し、polling gap recovery で欠落・重複がないことを確認する。
-6. analysis dashboard の主要集計が PlanetScale の値と一致することを確認する（`npm run check:analysis-dashboard-vs-sql`、`docs/analysis-dashboard-db-permissions.md`「確認手順」参照。対象環境の限定read接続文字列が実行環境に無い場合は、ブラウザ目視ではなくこの未接続自体を証跡として起票する）。
+6. analysis dashboard の主要集計が PlanetScale の値と一致することを確認する（`npm run check:analysis-dashboard-vs-sql`、`docs/analysis-dashboard-db-permissions.md`「確認手順」参照。対象環境の限定read接続文字列が実行環境に無い場合は、ブラウザ目視ではなくこの未接続自体を証跡として起票する）。このスクリプトはRPCと基礎集計SQLの数値一致のみを検証し、`adminApiPg.ts` → UI への表示ラベル・フィールド結線までは検証しないため、UI側の目視確認も引き続き併用する。
 7. 対象ファイルのアップロード、保存先からの取得、権限境界、Workerログを確認する。
 
 production 反映後は同じ主要経路を smoke test し、旧 provider の outbound request と

--- a/docs/analysis-dashboard-db-permissions.md
+++ b/docs/analysis-dashboard-db-permissions.md
@@ -40,6 +40,15 @@ Cloudflare Worker の Hyperdrive binding を共有しません。接続先は
 2. 読み取り endpoint で集計 RPC が成功することを確認する。
 3. 必要な管理操作だけを実施し、許可していない DML が拒否されることを確認する。
 4. `permission denied`、RPC 欠落、接続失敗を成功扱いにしていないことをログとテストで確認する。
+5. `get_analysis_*()` RPC 自体の集計が正しいことは、`npm run check:analysis-dashboard-vs-sql`
+   （`scripts/compare-analysis-dashboard-vs-sql.js`, #1077）で検証する。RPCを経由しない
+   素朴な COUNT/GROUP BY を独立に発行し、`get_analysis_overview` /
+   `get_analysis_users_summary` / `get_analysis_streamers_summary` /
+   `get_analysis_gacha_summary` の戻り値（users/streamers/cards、
+   today/week/month/total gacha、unique users、rarity）と突き合わせる。
+   `DASHBOARD_DATABASE_URL`（無ければ `DATABASE_URL_PLANETSCALE` /
+   `PLANETSCALE_DATABASE_URL`）に対象環境の限定readロール接続文字列を設定して実行する。
+   出力はその場の差分調査用であり、Issue/PR/ログへ実数値を転記しない。
 
 新しい dashboard endpoint を追加するときは、SQL を文字列連結で組み立てず、
 postgres.js のパラメータ化を使います。権限追加は endpoint ごとに必要性を説明し、

--- a/docs/analysis-dashboard-db-permissions.md
+++ b/docs/analysis-dashboard-db-permissions.md
@@ -41,14 +41,17 @@ Cloudflare Worker の Hyperdrive binding を共有しません。接続先は
 3. 必要な管理操作だけを実施し、許可していない DML が拒否されることを確認する。
 4. `permission denied`、RPC 欠落、接続失敗を成功扱いにしていないことをログとテストで確認する。
 5. `get_analysis_*()` RPC 自体の集計が正しいことは、`npm run check:analysis-dashboard-vs-sql`
-   （`scripts/compare-analysis-dashboard-vs-sql.js`, #1077）で検証する。RPCを経由しない
+   （`scripts/compare-analysis-dashboard-vs-sql.mjs`, #1077）で検証する。RPCを経由しない
    素朴な COUNT/GROUP BY を独立に発行し、`get_analysis_overview` /
    `get_analysis_users_summary` / `get_analysis_streamers_summary` /
    `get_analysis_gacha_summary` の戻り値（users/streamers/cards、
    today/week/month/total gacha、unique users、rarity）と突き合わせる。
-   `DASHBOARD_DATABASE_URL`（無ければ `DATABASE_URL_PLANETSCALE` /
-   `PLANETSCALE_DATABASE_URL`）に対象環境の限定readロール接続文字列を設定して実行する。
-   出力はその場の差分調査用であり、Issue/PR/ログへ実数値を転記しない。
+   `DASHBOARD_DATABASE_URL` にのみ対象環境の限定readロール接続文字列を設定して実行する
+   （`DATABASE_URL_PLANETSCALE`/`PLANETSCALE_DATABASE_URL` はそれぞれ用途・権限が別の
+   接続文字列のためフォールバックしない。誤って management ロールで preview を検証したつもりが
+   production に接続するような事故を防ぐため）。全クエリは単一の read-only スナップショット
+   （`REPEATABLE READ READ ONLY`）内で発行するため、比較の途中に書き込みが挟まっても
+   誤検知しない。出力はその場の差分調査用であり、Issue/PR/ログへ実数値を転記しない。
 
 新しい dashboard endpoint を追加するときは、SQL を文字列連結で組み立てず、
 postgres.js のパラメータ化を使います。権限追加は endpoint ごとに必要性を説明し、

--- a/docs/analysis-dashboard-db-permissions.md
+++ b/docs/analysis-dashboard-db-permissions.md
@@ -52,6 +52,12 @@ Cloudflare Worker の Hyperdrive binding を共有しません。接続先は
    production に接続するような事故を防ぐため）。全クエリは単一の read-only スナップショット
    （`REPEATABLE READ READ ONLY`）内で発行するため、比較の途中に書き込みが挟まっても
    誤検知しない。出力はその場の差分調査用であり、Issue/PR/ログへ実数値を転記しない。
+   全期間の `gacha_history` を走査する集計は production 規模では既定の
+   `statement_timeout`（30秒）を超えうる。その場合は不一致ではなくタイムアウトである旨が
+   出力されるので、`DASHBOARD_COMPARE_STATEMENT_TIMEOUT`（例: `"2min"`）で上限を延ばして
+   再実行する。なお today/week/month の境界式は RPC 側の定義をほぼ書き写しているため、
+   境界定義そのものが最初から誤っているケース（両側が同じ誤りを持つ）はこの比較では
+   検出できない。
 
 新しい dashboard endpoint を追加するときは、SQL を文字列連結で組み立てず、
 postgres.js のパラメータ化を使います。権限追加は endpoint ごとに必要性を説明し、

--- a/docs/analysis-dashboard-db-permissions.md
+++ b/docs/analysis-dashboard-db-permissions.md
@@ -52,9 +52,10 @@ Cloudflare Worker の Hyperdrive binding を共有しません。接続先は
    production に接続するような事故を防ぐため）。全クエリは単一の read-only スナップショット
    （`REPEATABLE READ READ ONLY`）内で発行するため、比較の途中に書き込みが挟まっても
    誤検知しない。出力はその場の差分調査用であり、Issue/PR/ログへ実数値を転記しない。
-   全期間の `gacha_history` を走査する集計は production 規模では既定の
-   `statement_timeout`（30秒）を超えうる。その場合は不一致ではなくタイムアウトである旨が
-   出力されるので、`DASHBOARD_COMPARE_STATEMENT_TIMEOUT`（例: `"2min"`）で上限を延ばして
+   全期間の `gacha_history` を走査する集計は production 規模では本スクリプトの既定値
+   （30秒。PostgreSQL自体の既定は無制限）を超えうる。その場合は不一致ではなくタイムアウト
+   である旨が出力されるので、`DASHBOARD_COMPARE_STATEMENT_TIMEOUT`（例: `"2min"`。`0`は
+   タイムアウト自体を無効化してしまうため拒否される）で上限を延ばして
    再実行する。なお today/week/month の境界式は RPC 側の定義をほぼ書き写しているため、
    境界定義そのものが最初から誤っているケース（両側が同じ誤りを持つ）はこの比較では
    検出できない。

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "check:maintenance-surfaces": "node scripts/check-maintenance-surfaces.js",
     "probe:maintenance": "node scripts/probe-maintenance-write-surfaces.js",
     "replay:maintenance-eventsub": "node scripts/replay-maintenance-eventsub.js",
-    "check:analysis-dashboard-vs-sql": "node scripts/compare-analysis-dashboard-vs-sql.js",
+    "check:analysis-dashboard-vs-sql": "node scripts/compare-analysis-dashboard-vs-sql.mjs",
     "error-reporter:deploy": "cd workers/error-reporter && OPEN_NEXT_DEPLOY=true npx wrangler deploy",
     "error-reporter:tail": "cd workers/error-reporter && npx wrangler tail"
   },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "check:maintenance-surfaces": "node scripts/check-maintenance-surfaces.js",
     "probe:maintenance": "node scripts/probe-maintenance-write-surfaces.js",
     "replay:maintenance-eventsub": "node scripts/replay-maintenance-eventsub.js",
+    "check:analysis-dashboard-vs-sql": "node scripts/compare-analysis-dashboard-vs-sql.js",
     "error-reporter:deploy": "cd workers/error-reporter && OPEN_NEXT_DEPLOY=true npx wrangler deploy",
     "error-reporter:tail": "cd workers/error-reporter && npx wrangler tail"
   },

--- a/scripts/compare-analysis-dashboard-vs-sql.js
+++ b/scripts/compare-analysis-dashboard-vs-sql.js
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+
+/**
+ * analysis dashboard の主要集計を、`get_analysis_*()` RPC とは独立に計算した
+ * 基礎集計SQLと突き合わせる検証スクリプト (#1077)
+ *
+ * 背景:
+ *   docs/QA.md の Preview 実経路ゲート #6「analysis dashboard の主要集計が
+ *   PlanetScale の値と一致することを確認する」は、これまでダッシュボードを
+ *   ブラウザで開いて目視するだけの手動確認だった。ダッシュボードの表示値は
+ *   `analysis/dev/adminApiPg.ts` 経由で `get_analysis_*()` RPC
+ *   （00073_add_analysis_dashboard_rpcs.sql / 20260731120000_paginate_analysis_dashboard.sql）
+ *   を呼んでいるだけなので、RPC自体にバグがあってもブラウザ目視では検出できない。
+ *   このスクリプトは RPC を経由しない素朴な COUNT/GROUP BY を独立に発行し、
+ *   RPC の戻り値と数値が一致するかを機械的に検証する（#1077 Issueの
+ *   「既存の自動比較workflow/scriptはありません」を埋める）。
+ *
+ * 対象外:
+ *   本スクリプトは接続文字列を要求するだけで、preview専用の限定readロールを
+ *   自動で払い出すものではない。preview用ロールの発行・接続文字列の安全な
+ *   実行環境への注入は運用側の作業であり（docs/analysis-dashboard-db-permissions.md
+ *   「ロール変更は PlanetScale の管理接続を持つ担当者が...」参照）、本スクリプトの
+ *   スコープ外。
+ *
+ * 使い方:
+ *   DASHBOARD_DATABASE_URL="postgres://..." node scripts/compare-analysis-dashboard-vs-sql.js
+ *   （`DASHBOARD_DATABASE_URL` が無い場合は `DATABASE_URL_PLANETSCALE`、
+ *    `PLANETSCALE_DATABASE_URL` の順にフォールバックする。#1077 Issueが列挙した
+ *    3つの環境変数名と揃えてある。preview / production の限定readロール接続文字列を
+ *    渡すこと。DB接続が必要なためCIでは実行しない）
+ *
+ * 出力上の注意:
+ *   差分調査のためその場でターミナルへ数値を表示する。この出力をIssue/PR/ログへ
+ *   恒久的に転記しない（CLAUDE.mdのredaction方針、docs/QA.mdの証拠redaction方針と
+ *   同じ理由）。
+ */
+
+'use strict'
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const core = require('./lib/db-migrate-core')
+
+/**
+ * #1077 Issue本文が列挙した3つの環境変数名を優先順に解決する。
+ * `DASHBOARD_DATABASE_URL` が `analysis/dev/adminApiPg.ts` の正本契約のため最優先。
+ */
+function resolveConnectionString(env) {
+  return (
+    env.DASHBOARD_DATABASE_URL?.trim() ||
+    env.DATABASE_URL_PLANETSCALE?.trim() ||
+    env.PLANETSCALE_DATABASE_URL?.trim() ||
+    ''
+  )
+}
+
+/**
+ * `get_analysis_*()` RPCを経由しない基礎集計。RPC定義
+ * （00073_add_analysis_dashboard_rpcs.sql の get_analysis_overview /
+ *   get_analysis_gacha_summary、20260731120000_paginate_analysis_dashboard.sql の
+ *   get_analysis_users_summary / get_analysis_streamers_summary）と同じ境界定義
+ *  （today = date_trunc('day', now())、week = now() - interval '7 days'、
+ *   month = date_trunc('month', now())）を独立に書き下す。
+ *
+ * rarityDistributionは配列のため、この関数では { [rarity]: count } のオブジェクトに
+ * 変換してRPC側と比較しやすくする。
+ */
+async function fetchBasicAggregates(sql) {
+  const [totals] = await sql`
+    SELECT
+      (SELECT COUNT(*)::INTEGER FROM users) AS total_users,
+      (SELECT COUNT(*)::INTEGER FROM streamers) AS total_streamers,
+      (SELECT COUNT(*)::INTEGER FROM cards) AS total_cards,
+      (SELECT COUNT(*)::INTEGER FROM user_cards) AS total_user_cards,
+      (SELECT COUNT(*)::INTEGER FROM users WHERE tos_accepted_at IS NOT NULL) AS users_with_tos,
+      (SELECT COUNT(DISTINCT user_id)::INTEGER FROM user_cards) AS users_with_cards,
+      (SELECT COUNT(*)::INTEGER FROM gacha_history) AS total_gacha,
+      (SELECT COUNT(DISTINCT user_twitch_id)::INTEGER FROM gacha_history) AS unique_users,
+      (
+        SELECT COUNT(*)::INTEGER FROM gacha_history gh
+        WHERE gh.redeemed_at >= date_trunc('day', now())
+      ) AS today_gacha,
+      (
+        SELECT COUNT(*)::INTEGER FROM gacha_history gh
+        WHERE gh.redeemed_at >= now() - interval '7 days'
+      ) AS week_gacha,
+      (
+        SELECT COUNT(*)::INTEGER FROM gacha_history gh
+        WHERE gh.redeemed_at >= date_trunc('month', now())
+      ) AS month_gacha
+  `
+
+  const rarityRows = await sql`
+    SELECT c.rarity AS rarity, COUNT(*)::INTEGER AS draw_count
+    FROM gacha_history gh
+    JOIN cards c ON c.id = gh.card_id
+    GROUP BY c.rarity
+    HAVING COUNT(*) > 0
+  `
+  const rarityDistribution = Object.fromEntries(
+    rarityRows.map((row) => [row.rarity, row.draw_count])
+  )
+
+  return {
+    totalUsers: totals.total_users,
+    totalStreamers: totals.total_streamers,
+    totalCards: totals.total_cards,
+    totalUserCards: totals.total_user_cards,
+    usersWithTos: totals.users_with_tos,
+    usersWithCards: totals.users_with_cards,
+    totalGacha: totals.total_gacha,
+    uniqueUsers: totals.unique_users,
+    todayGacha: totals.today_gacha,
+    weekGacha: totals.week_gacha,
+    monthGacha: totals.month_gacha,
+    rarityDistribution,
+  }
+}
+
+/** ダッシュボードが実際に呼ぶ `get_analysis_*()` RPCから同じ形の値を抽出する。 */
+async function fetchRpcAggregates(sql) {
+  const [[overviewRow], [usersSummaryRow], [streamersSummaryRow], [gachaTotalRow]] =
+    await Promise.all([
+      sql`SELECT get_analysis_overview() AS result`,
+      sql`SELECT get_analysis_users_summary() AS result`,
+      sql`SELECT get_analysis_streamers_summary() AS result`,
+      sql`SELECT get_analysis_gacha_summary(NULL, NULL) AS result`,
+    ])
+
+  const overview = overviewRow.result
+  const usersSummary = usersSummaryRow.result
+  const streamersSummary = streamersSummaryRow.result
+  const gachaTotal = gachaTotalRow.result
+
+  const rarityDistribution = Object.fromEntries(
+    (gachaTotal.rarityDistribution ?? []).map((entry) => [entry.rarity, entry.value])
+  )
+
+  return {
+    totalUsers: overview.stats.totalUsers,
+    totalStreamers: overview.stats.totalStreamers,
+    totalCards: overview.stats.totalCards,
+    totalUserCards: usersSummary.totalCards,
+    usersWithTos: usersSummary.usersWithTos,
+    usersWithCards: usersSummary.usersWithCards,
+    totalGacha: gachaTotal.totalGacha,
+    uniqueUsers: gachaTotal.uniqueUsers,
+    todayGacha: overview.stats.todayGacha,
+    weekGacha: overview.stats.weekGacha,
+    monthGacha: overview.stats.monthGacha,
+    rarityDistribution,
+    // streamersSummaryのtotalStreamers/totalCardsはget_analysis_streamers_summary()の
+    // 独立計算経路のため、overview.stats由来の値と別に併記して食い違いも検出する。
+    streamersSummaryTotalStreamers: streamersSummary.totalStreamers,
+    streamersSummaryTotalCards: streamersSummary.totalCards,
+  }
+}
+
+/**
+ * 基礎集計RPC双方の数値を突き合わせ、不一致のリストを返す。DB接続なしで
+ * 単体テストできるよう純粋関数として切り出す（verify-db-schema.jsのdiffSchemasと
+ * 同じ方針）。
+ *
+ * rarityDistributionはキー集合の和集合で比較し、片方にしか無いrarityは
+ * もう片方を0として扱う（0件のrarityはRPC側で`HAVING COUNT(*) > 0`により
+ * 配列に現れないため、この基礎集計側も同じ条件でフィルタ済み。両者とも
+ * 出現しないキーは比較対象にならない）。
+ */
+function diffAggregates(basic, rpc) {
+  const diffs = []
+  const scalarMetrics = [
+    'totalUsers',
+    'totalStreamers',
+    'totalCards',
+    'totalUserCards',
+    'usersWithTos',
+    'usersWithCards',
+    'totalGacha',
+    'uniqueUsers',
+    'todayGacha',
+    'weekGacha',
+    'monthGacha',
+  ]
+
+  for (const metric of scalarMetrics) {
+    if (basic[metric] !== rpc[metric]) {
+      diffs.push({ metric, expected: basic[metric], actual: rpc[metric] })
+    }
+  }
+
+  if (rpc.streamersSummaryTotalStreamers !== undefined) {
+    if (basic.totalStreamers !== rpc.streamersSummaryTotalStreamers) {
+      diffs.push({
+        metric: 'streamersSummary.totalStreamers',
+        expected: basic.totalStreamers,
+        actual: rpc.streamersSummaryTotalStreamers,
+      })
+    }
+    if (basic.totalCards !== rpc.streamersSummaryTotalCards) {
+      diffs.push({
+        metric: 'streamersSummary.totalCards',
+        expected: basic.totalCards,
+        actual: rpc.streamersSummaryTotalCards,
+      })
+    }
+  }
+
+  const rarityKeys = new Set([
+    ...Object.keys(basic.rarityDistribution ?? {}),
+    ...Object.keys(rpc.rarityDistribution ?? {}),
+  ])
+  for (const rarity of rarityKeys) {
+    const expected = basic.rarityDistribution?.[rarity] ?? 0
+    const actual = rpc.rarityDistribution?.[rarity] ?? 0
+    if (expected !== actual) {
+      diffs.push({ metric: `rarityDistribution.${rarity}`, expected, actual })
+    }
+  }
+
+  return diffs
+}
+
+function printDiffTable(diffs) {
+  const headers = ['METRIC', '基礎集計SQL', 'get_analysis_* RPC']
+  const rows = diffs.map((d) => [d.metric, String(d.expected), String(d.actual)])
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)))
+  const line = (cells) => cells.map((c, i) => c.padEnd(widths[i])).join('  ')
+
+  console.log(line(headers))
+  console.log(line(widths.map((w) => '-'.repeat(w))))
+  for (const row of rows) {
+    console.log(line(row))
+  }
+}
+
+async function main() {
+  const connectionString = resolveConnectionString(process.env)
+  if (!connectionString) {
+    console.error(
+      'Usage: DASHBOARD_DATABASE_URL="postgres://..." node scripts/compare-analysis-dashboard-vs-sql.js'
+    )
+    console.error(
+      'None of DASHBOARD_DATABASE_URL, DATABASE_URL_PLANETSCALE, PLANETSCALE_DATABASE_URL is set.'
+    )
+    console.error(
+      'Use a preview- or production-scoped limited read role connection string (see docs/analysis-dashboard-db-permissions.md).'
+    )
+    process.exit(2)
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const postgres = require('postgres')
+  const sql = postgres(core.stripPostgresJsIncompatibleSslParams(connectionString), {
+    max: 1,
+    connect_timeout: 15,
+  })
+
+  let exitCode = 0
+  try {
+    const [basic, rpc] = await Promise.all([fetchBasicAggregates(sql), fetchRpcAggregates(sql)])
+    const diffs = diffAggregates(basic, rpc)
+
+    if (diffs.length === 0) {
+      console.log(
+        'OK: analysis dashboard の get_analysis_* RPC は基礎集計SQLと一致しました。'
+      )
+    } else {
+      console.error(`\n${diffs.length}件の不一致が見つかりました:\n`)
+      printDiffTable(diffs)
+      exitCode = 1
+    }
+  } catch (error) {
+    console.error('analysis dashboard の集計比較に失敗しました:')
+    console.error(error instanceof Error ? error.message : error)
+    exitCode = 2
+  } finally {
+    await sql.end({ timeout: 5 })
+  }
+  process.exit(exitCode)
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error)
+    process.exit(2)
+  })
+}
+
+module.exports = {
+  resolveConnectionString,
+  fetchBasicAggregates,
+  fetchRpcAggregates,
+  diffAggregates,
+}

--- a/scripts/compare-analysis-dashboard-vs-sql.mjs
+++ b/scripts/compare-analysis-dashboard-vs-sql.mjs
@@ -15,6 +15,15 @@
  *   RPC の戻り値と数値が一致するかを機械的に検証する（#1077 Issueの
  *   「既存の自動比較workflow/scriptはありません」を埋める）。
  *
+ * 検証範囲の限界 (#1081 PR 2回目レビュー【任意】指摘):
+ *   `fetchBasicAggregates` の today/week/month 境界式は RPC 側の定義をほぼ逐語的に
+ *   書き写している。そのため検出できるのは主に「RPCの欠落・戻り値の形状変化・
+ *   実装ドリフト（RPCだけが後から書き換わり基礎集計とズレるケース）」であり、
+ *   境界定義そのものが最初から両側で同じ誤りを持っていた場合（例: `weekGacha`の
+ *   意図が実は暦週であるべきなのに両方とも直近7日で実装されている、等）は
+ *   この比較では検出できない。totalUsers/totalStreamers/totalCards等の単純な
+ *   全件COUNTは書き写しの余地がほぼ無いため、この限界は主に日次境界系の指標に限られる。
+ *
  * 対象外:
  *   本スクリプトは接続文字列を要求するだけで、preview専用の限定readロールを
  *   自動で払い出すものではない。preview用ロールの発行・接続文字列の安全な
@@ -52,8 +61,6 @@
  *   同じ理由）。エラーメッセージは`redactSecretsFromText`で接続文字列のパスワード部分を
  *   除去してから出力する。
  */
-
-'use strict'
 
 import { createRequire } from 'module'
 import { fileURLToPath } from 'url'
@@ -137,15 +144,18 @@ async function fetchBasicAggregates(tx) {
 /**
  * ダッシュボードが実際に呼ぶ `get_analysis_*()` RPCから同じ形の値を抽出する。
  * `fetchBasicAggregates` と同じ`tx`（`withReadOnlySnapshot`のcallback引数）で呼ぶこと。
+ *
+ * 4本のRPCは`Promise.all`で並行発行せず逐次`await`する（#1081 PR 2回目レビュー
+ * 【任意】指摘: `max: 1`の単一接続・単一トランザクションでは`scripts/db-cutover/
+ * layer-invariants.mjs`が明記するとおり並行発行しても直列実行されるだけで見た目上の
+ * 並行化に意味が無い。逆に1文が失敗すると後続が`current transaction is aborted`に
+ * なり、`permission denied for function`等の本来の原因が読み取りにくくなる副作用がある）。
  */
 async function fetchRpcAggregates(tx) {
-  const [[overviewRow], [usersSummaryRow], [streamersSummaryRow], [gachaTotalRow]] =
-    await Promise.all([
-      tx`SELECT get_analysis_overview() AS result`,
-      tx`SELECT get_analysis_users_summary() AS result`,
-      tx`SELECT get_analysis_streamers_summary() AS result`,
-      tx`SELECT get_analysis_gacha_summary(NULL, NULL) AS result`,
-    ])
+  const [overviewRow] = await tx`SELECT get_analysis_overview() AS result`
+  const [usersSummaryRow] = await tx`SELECT get_analysis_users_summary() AS result`
+  const [streamersSummaryRow] = await tx`SELECT get_analysis_streamers_summary() AS result`
+  const [gachaTotalRow] = await tx`SELECT get_analysis_gacha_summary(NULL, NULL) AS result`
 
   const overview = overviewRow.result
   const usersSummary = usersSummaryRow.result
@@ -169,8 +179,12 @@ async function fetchRpcAggregates(tx) {
     weekGacha: overview.stats.weekGacha,
     monthGacha: overview.stats.monthGacha,
     rarityDistribution,
-    // streamersSummaryのtotalStreamers/totalCardsはget_analysis_streamers_summary()の
-    // 独立計算経路のため、overview.stats由来の値と別に併記して食い違いも検出する。
+    // usersSummary/streamersSummaryのtotalUsers・totalStreamers・totalCardsは
+    // get_analysis_users_summary()/get_analysis_streamers_summary()という独立計算経路の
+    // ため、overview.stats由来の値と別に併記して食い違いも検出する
+    // （#1081 PR 2回目レビュー【任意】指摘: streamersSummaryだけ併記してusersSummaryを
+    // 併記しないのは非対称だった）。
+    usersSummaryTotalUsers: usersSummary.totalUsers,
     streamersSummaryTotalStreamers: streamersSummary.totalStreamers,
     streamersSummaryTotalCards: streamersSummary.totalCards,
   }
@@ -213,6 +227,14 @@ function diffAggregates(basic, rpc) {
     }
   }
 
+  if (basic.totalUsers !== rpc.usersSummaryTotalUsers) {
+    diffs.push({
+      metric: 'usersSummary.totalUsers',
+      expected: basic.totalUsers,
+      actual: rpc.usersSummaryTotalUsers,
+    })
+  }
+
   if (basic.totalStreamers !== rpc.streamersSummaryTotalStreamers) {
     diffs.push({
       metric: 'streamersSummary.totalStreamers',
@@ -241,6 +263,34 @@ function diffAggregates(basic, rpc) {
   }
 
   return diffs
+}
+
+// PostgreSQLがstatement_timeoutで文を強制キャンセルした際のSQLSTATE（query_canceled）。
+// 57014はstatement_timeout以外（pg_cancel_backend等）でも使われるが、本スクリプトは
+// 自分でtimeoutを設定した直後のクエリでしか使わないため、実質的にtimeout起因と同定できる。
+const QUERY_CANCELED_SQLSTATE = '57014'
+
+// PostgreSQLのGUC時間値として妥当な形式（例: '30s', '2min', '500ms'）。単位省略時は
+// ミリ秒扱い（PostgreSQLの既定）。
+const STATEMENT_TIMEOUT_PATTERN = /^\d+(ms|s|min|h|d)?$/
+
+/**
+ * `get_analysis_gacha_summary(NULL, NULL)` の statement_timeout を環境変数で上書き
+ * できるようにする（#1081 PR 2回目レビュー【任意】指摘: production規模では全期間走査が
+ * 既定の30秒を超えうり、その場合「不一致」ではなく「タイムアウト」なのに見分けが
+ * つきにくい）。`tx.unsafe()` へそのまま埋め込むため、PostgreSQLのGUC時間値として
+ * 妥当な形式であることを検証してから返す（任意の文字列をSQLへ混入させないための
+ * 安全側の入力検証。DB接続なしで単体テストできるよう純粋関数として切り出す）。
+ */
+function resolveStatementTimeout(env) {
+  const raw = env.DASHBOARD_COMPARE_STATEMENT_TIMEOUT?.trim()
+  if (!raw) return '30s'
+  if (!STATEMENT_TIMEOUT_PATTERN.test(raw)) {
+    throw new Error(
+      `DASHBOARD_COMPARE_STATEMENT_TIMEOUT の形式が不正です（例: "30s", "2min"）: "${raw}"`
+    )
+  }
+  return raw
 }
 
 function printDiffTable(diffs) {
@@ -277,24 +327,38 @@ async function main() {
     return
   }
 
+  // postgres(...) の呼び出しも含めて全てtry内に置く（#1081 PR 2回目レビュー【必須】指摘:
+  // 以前はpostgres(...)がtryの外にあり、接続文字列の形式不正等でここが同期的に
+  // throwすると`main().catch`側の生の`console.error(error)`にそのまま渡っていた。
+  // Node標準のURL解析エラー（ERR_INVALID_URL）は入力文字列自体をエラーオブジェクトの
+  // プロパティとして保持するため、util.inspect経由でconsole.errorに渡すと接続文字列
+  // （パスワード含む）がそのまま端末へ出てしまう。tryの内側に置くことで、この経路も
+  // 下記catchのredactErrorを必ず通す）。
   let sql
   let exitCode = 0
   try {
-    // 接続文字列のparse自体が失敗するケースもredaction対象に含めるため、postgres()の生成を
-    // 必ずtry内で行う。ERR_INVALID_URLは入力URLをown propertyとして保持しうるため、
-    // 生のErrorオブジェクトをconsole.errorへ渡さない。
+    // 全期間のgacha_historyを走査する get_analysis_gacha_summary(NULL, NULL) は
+    // ダッシュボードUIの既定（直近7日）より重いクエリになりうるため、想定外に長時間
+    // ブロックしないよう安全弁を固定する（scripts/db-cutover/snapshot.mjsの
+    // withRollbackOnlyTransactionと同じ理由・同じ方式）。production規模では既定値の
+    // 30秒を超えうるため、DASHBOARD_COMPARE_STATEMENT_TIMEOUTで上書きできるようにする
+    // （#1081 PR 2回目レビュー【任意】指摘）。不正な形式は接続前にfail fastする。
+    const statementTimeout = resolveStatementTimeout(process.env)
+
     sql = postgres(core.stripPostgresJsIncompatibleSslParams(connectionString), {
       max: 1,
       connect_timeout: 15,
     })
 
     const diffs = await withReadOnlySnapshot(sql, async (tx) => {
-      // 全期間のgacha_historyを走査する get_analysis_gacha_summary(NULL, NULL) は
-      // ダッシュボードUIの既定（直近7日）より重いクエリになりうるため、検証スクリプトが
-      // 想定外に長時間ブロックしないよう安全弁を固定する
-      // （scripts/db-cutover/snapshot.mjsのwithRollbackOnlyTransactionと同じ理由・同じ方式）。
-      await tx.unsafe(`SET LOCAL statement_timeout = '30s'`)
-      const [basic, rpc] = await Promise.all([fetchBasicAggregates(tx), fetchRpcAggregates(tx)])
+      await tx.unsafe(`SET LOCAL statement_timeout = '${statementTimeout}'`)
+      // 単一接続（max: 1）の単一トランザクション内では並行発行しても直列実行される
+      // だけで意味が無く、1文の失敗が後続を`current transaction is aborted`にして
+      // 本来のエラー原因を読み取りにくくする副作用があるため逐次awaitする
+      // （#1081 PR 2回目レビュー【任意】指摘、scripts/db-cutover/layer-invariants.mjs
+      // と同じ方針）。
+      const basic = await fetchBasicAggregates(tx)
+      const rpc = await fetchRpcAggregates(tx)
       return diffAggregates(basic, rpc)
     })
 
@@ -306,8 +370,22 @@ async function main() {
       exitCode = 1
     }
   } catch (error) {
+    const message = redactError(error, connectionString)
+    const code =
+      error && typeof error === 'object' && typeof error.code === 'string' ? error.code : undefined
+
     console.error('analysis dashboard の集計比較に失敗しました:')
-    console.error(redactError(error, connectionString))
+    if (code === QUERY_CANCELED_SQLSTATE) {
+      // #1081 PR 2回目レビュー【任意】指摘: タイムアウトを「不一致」と混同しないよう
+      // 明示的に区別する（RPCのバグではなく実行時間の問題であることを示す）。
+      console.error(
+        'クエリがタイムアウトしました（RPCの不一致ではなく実行時間の問題です）。DASHBOARD_COMPARE_STATEMENT_TIMEOUT で上限を延ばして再実行してください。'
+      )
+    }
+    // postgres.jsのエラーはcode/detail/hintを持つ。「ロールにEXECUTEが無い」
+    // 「RPC未適用」等の切り分けにcodeが有用なため付記する（#1081 PR 2回目レビュー
+    // 【任意】指摘）。
+    console.error(code ? `[${code}] ${message}` : message)
     exitCode = 2
   } finally {
     if (sql) {
@@ -326,10 +404,16 @@ async function main() {
 if (process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url)) {
   main().catch(() => {
     // main内で接続文字列をredactできる経路はすべて処理する。ここは想定外の最終安全弁なので、
-    // Errorオブジェクト自体は出力せずcredential混入の可能性を排除する。
+    // Errorオブジェクト自体（stackも含め）は出力せずcredential混入の可能性を排除する。
     console.error('analysis dashboard の集計比較で想定外のエラーが発生しました。')
     process.exitCode = 2
   })
 }
 
-export { resolveDashboardDatabaseUrl, fetchBasicAggregates, fetchRpcAggregates, diffAggregates }
+export {
+  resolveDashboardDatabaseUrl,
+  resolveStatementTimeout,
+  fetchBasicAggregates,
+  fetchRpcAggregates,
+  diffAggregates,
+}

--- a/scripts/compare-analysis-dashboard-vs-sql.mjs
+++ b/scripts/compare-analysis-dashboard-vs-sql.mjs
@@ -271,23 +271,29 @@ function diffAggregates(basic, rpc) {
 const QUERY_CANCELED_SQLSTATE = '57014'
 
 // PostgreSQLのGUC時間値として妥当な形式（例: '30s', '2min', '500ms'）。単位省略時は
-// ミリ秒扱い（PostgreSQLの既定）。
-const STATEMENT_TIMEOUT_PATTERN = /^\d+(ms|s|min|h|d)?$/
+// ミリ秒扱い（PostgreSQLの既定）。第1捕捉群（数値部分）を0判定に使う。
+const STATEMENT_TIMEOUT_PATTERN = /^(\d+)(?:ms|s|min|h|d)?$/
 
 /**
- * `get_analysis_gacha_summary(NULL, NULL)` の statement_timeout を環境変数で上書き
- * できるようにする（#1081 PR 2回目レビュー【任意】指摘: production規模では全期間走査が
- * 既定の30秒を超えうり、その場合「不一致」ではなく「タイムアウト」なのに見分けが
- * つきにくい）。`tx.unsafe()` へそのまま埋め込むため、PostgreSQLのGUC時間値として
- * 妥当な形式であることを検証してから返す（任意の文字列をSQLへ混入させないための
- * 安全側の入力検証。DB接続なしで単体テストできるよう純粋関数として切り出す）。
+ * `get_analysis_gacha_summary(NULL, NULL)` の statement_timeout（本スクリプトの既定値は
+ * 30秒。PostgreSQL自体の既定は無制限）を環境変数で上書きできるようにする
+ * （production規模では全期間走査が既定の30秒を超えうり、その場合「不一致」ではなく
+ * 「タイムアウト」なのに見分けがつきにくいため）。`tx.unsafe()` へそのまま埋め込むため、
+ * PostgreSQLのGUC時間値として妥当な形式であることを検証してから返す（任意の文字列を
+ * SQLへ混入させないための安全側の入力検証。DB接続なしで単体テストできるよう純粋関数
+ * として切り出す）。
+ *
+ * `0`（またはそれと等価な"0ms"等）は明示的に拒否する。PostgreSQLはstatement_timeout=0を
+ * 「無制限」として扱うため、これを許すと安全弁（想定外の長時間ブロック防止）が環境変数
+ * だけで完全に無効化できてしまい、このタイムアウトを設ける意図と食い違う。
  */
 function resolveStatementTimeout(env) {
   const raw = env.DASHBOARD_COMPARE_STATEMENT_TIMEOUT?.trim()
   if (!raw) return '30s'
-  if (!STATEMENT_TIMEOUT_PATTERN.test(raw)) {
+  const match = STATEMENT_TIMEOUT_PATTERN.exec(raw)
+  if (!match || Number(match[1]) === 0) {
     throw new Error(
-      `DASHBOARD_COMPARE_STATEMENT_TIMEOUT の形式が不正です（例: "30s", "2min"）: "${raw}"`
+      `DASHBOARD_COMPARE_STATEMENT_TIMEOUT の形式が不正です（0は無制限を意味するため拒否。例: "30s", "2min"）: "${raw}"`
     )
   }
   return raw
@@ -394,7 +400,11 @@ async function main() {
       } catch (error) {
         console.error('analysis dashboard のDB接続終了処理に失敗しました:')
         console.error(redactError(error, connectionString))
-        exitCode = 2
+        // 比較自体は完了し不一致が見つかっていた場合（exitCode === 1）を、接続終了処理の
+        // 失敗で上書きしない。「不一致あり」という結果は接続終了の成否と独立した事実であり、
+        // 終了コードから判別できなくなると呼び出し元（CI/シェルスクリプト）が
+        // 「不一致」と「クローズ失敗」を区別できなくなる。
+        if (exitCode === 0) exitCode = 2
       }
     }
   }
@@ -402,10 +412,17 @@ async function main() {
 }
 
 if (process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url)) {
-  main().catch(() => {
+  main().catch((error) => {
     // main内で接続文字列をredactできる経路はすべて処理する。ここは想定外の最終安全弁なので、
     // Errorオブジェクト自体（stackも含め）は出力せずcredential混入の可能性を排除する。
-    console.error('analysis dashboard の集計比較で想定外のエラーが発生しました。')
+    // ただしSQLSTATE/Nodeエラーコード（error.code）は接続文字列を含まず切り分けに有用なため、
+    // 存在すれば安全に付記する。
+    const code = error && typeof error === 'object' && typeof error.code === 'string' ? error.code : undefined
+    console.error(
+      code
+        ? `analysis dashboard の集計比較で想定外のエラーが発生しました。[${code}]`
+        : 'analysis dashboard の集計比較で想定外のエラーが発生しました。'
+    )
     process.exitCode = 2
   })
 }

--- a/scripts/compare-analysis-dashboard-vs-sql.mjs
+++ b/scripts/compare-analysis-dashboard-vs-sql.mjs
@@ -256,6 +256,13 @@ function printDiffTable(diffs) {
   }
 }
 
+function redactError(error, connectionString) {
+  return core.redactSecretsFromText(
+    error instanceof Error ? error.message : String(error),
+    connectionString
+  )
+}
+
 async function main() {
   const connectionString = resolveDashboardDatabaseUrl(process.env)
   if (!connectionString) {
@@ -270,13 +277,17 @@ async function main() {
     return
   }
 
-  const sql = postgres(core.stripPostgresJsIncompatibleSslParams(connectionString), {
-    max: 1,
-    connect_timeout: 15,
-  })
-
+  let sql
   let exitCode = 0
   try {
+    // 接続文字列のparse自体が失敗するケースもredaction対象に含めるため、postgres()の生成を
+    // 必ずtry内で行う。ERR_INVALID_URLは入力URLをown propertyとして保持しうるため、
+    // 生のErrorオブジェクトをconsole.errorへ渡さない。
+    sql = postgres(core.stripPostgresJsIncompatibleSslParams(connectionString), {
+      max: 1,
+      connect_timeout: 15,
+    })
+
     const diffs = await withReadOnlySnapshot(sql, async (tx) => {
       // 全期間のgacha_historyを走査する get_analysis_gacha_summary(NULL, NULL) は
       // ダッシュボードUIの既定（直近7日）より重いクエリになりうるため、検証スクリプトが
@@ -295,22 +306,28 @@ async function main() {
       exitCode = 1
     }
   } catch (error) {
-    const message = core.redactSecretsFromText(
-      error instanceof Error ? error.message : String(error),
-      connectionString
-    )
     console.error('analysis dashboard の集計比較に失敗しました:')
-    console.error(message)
+    console.error(redactError(error, connectionString))
     exitCode = 2
   } finally {
-    await sql.end({ timeout: 5 })
+    if (sql) {
+      try {
+        await sql.end({ timeout: 5 })
+      } catch (error) {
+        console.error('analysis dashboard のDB接続終了処理に失敗しました:')
+        console.error(redactError(error, connectionString))
+        exitCode = 2
+      }
+    }
   }
   process.exitCode = exitCode
 }
 
 if (process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url)) {
-  main().catch((error) => {
-    console.error(error)
+  main().catch(() => {
+    // main内で接続文字列をredactできる経路はすべて処理する。ここは想定外の最終安全弁なので、
+    // Errorオブジェクト自体は出力せずcredential混入の可能性を排除する。
+    console.error('analysis dashboard の集計比較で想定外のエラーが発生しました。')
     process.exitCode = 2
   })
 }

--- a/scripts/compare-analysis-dashboard-vs-sql.mjs
+++ b/scripts/compare-analysis-dashboard-vs-sql.mjs
@@ -22,35 +22,50 @@
  *   「ロール変更は PlanetScale の管理接続を持つ担当者が...」参照）、本スクリプトの
  *   スコープ外。
  *
+ * 接続文字列は `DASHBOARD_DATABASE_URL` のみを受け付ける（`DATABASE_URL_PLANETSCALE`
+ * や `PLANETSCALE_DATABASE_URL` へはフォールバックしない）。#1077 PR初版レビュー
+ * 【必須】指摘: この2つは用途・権限が別の接続文字列であり
+ * （`DATABASE_URL_PLANETSCALE` は `next dev` 用のアプリ接続、
+ *  `PLANETSCALE_DATABASE_URL` は migration/DDL 用の管理接続。いずれもdashboard用の
+ *  限定readロールではない）、フォールバックすると「previewを検証したつもりで
+ *  本番へ管理権限で接続し、しかも成功扱いになる」事故が起きうる。
+ *  `analysis/dev/adminApiPg.ts` の `resolveDashboardDatabaseUrl`（「無関係な値へ
+ *  黙ってフォールバックさせず明示的に失敗させる」#570と同じ安全側方針）と同じ
+ *  単一契約に揃える。
+ *
  * 使い方:
- *   DASHBOARD_DATABASE_URL="postgres://..." node scripts/compare-analysis-dashboard-vs-sql.js
- *   （`DASHBOARD_DATABASE_URL` が無い場合は `DATABASE_URL_PLANETSCALE`、
- *    `PLANETSCALE_DATABASE_URL` の順にフォールバックする。#1077 Issueが列挙した
- *    3つの環境変数名と揃えてある。preview / production の限定readロール接続文字列を
- *    渡すこと。DB接続が必要なためCIでは実行しない）
+ *   DASHBOARD_DATABASE_URL="postgres://..." node scripts/compare-analysis-dashboard-vs-sql.mjs
+ *   （preview / production の限定readロール接続文字列を渡すこと。
+ *    DB接続が必要なためCIでは実行しない）
+ *
+ * スナップショット一貫性について (#1077 PR初版レビュー【必須】指摘):
+ *   基礎集計クエリとRPC呼び出しを別々のトランザクションで発行すると、本ゲートの想定運用
+ *   （docs/QA.md「実チャネルポイント引き換えを複数回行う」直後に実行する）では、比較中に
+ *   起きる書き込みや`weekGacha`の移動窓境界の出入りだけでRPCのバグが無くても不一致が
+ *   出る（誤検知でIssueを起票しうる）。全クエリを`scripts/db-cutover/snapshot.mjs`の
+ *   `withReadOnlySnapshot`（`BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY`、
+ *   常にROLLBACK）に包み、単一スナップショット上で発行することでこれを防ぐ。
  *
  * 出力上の注意:
  *   差分調査のためその場でターミナルへ数値を表示する。この出力をIssue/PR/ログへ
  *   恒久的に転記しない（CLAUDE.mdのredaction方針、docs/QA.mdの証拠redaction方針と
- *   同じ理由）。
+ *   同じ理由）。エラーメッセージは`redactSecretsFromText`で接続文字列のパスワード部分を
+ *   除去してから出力する。
  */
 
 'use strict'
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const core = require('./lib/db-migrate-core')
+import { createRequire } from 'module'
+import { fileURLToPath } from 'url'
+import postgres from 'postgres'
+import { withReadOnlySnapshot } from './db-cutover/snapshot.mjs'
 
-/**
- * #1077 Issue本文が列挙した3つの環境変数名を優先順に解決する。
- * `DASHBOARD_DATABASE_URL` が `analysis/dev/adminApiPg.ts` の正本契約のため最優先。
- */
-function resolveConnectionString(env) {
-  return (
-    env.DASHBOARD_DATABASE_URL?.trim() ||
-    env.DATABASE_URL_PLANETSCALE?.trim() ||
-    env.PLANETSCALE_DATABASE_URL?.trim() ||
-    ''
-  )
+const require = createRequire(import.meta.url)
+const core = require('./lib/db-migrate-core.js')
+
+/** `analysis/dev/adminApiPg.ts` の `resolveDashboardDatabaseUrl` と同じ単一契約。 */
+function resolveDashboardDatabaseUrl(env) {
+  return env.DASHBOARD_DATABASE_URL?.trim() || ''
 }
 
 /**
@@ -61,11 +76,15 @@ function resolveConnectionString(env) {
  *  （today = date_trunc('day', now())、week = now() - interval '7 days'、
  *   month = date_trunc('month', now())）を独立に書き下す。
  *
+ * 呼び出し元は必ず`withReadOnlySnapshot`のcallback内（トランザクションスコープの`tx`）で
+ * 呼ぶこと。トップレベルの`sql`を渡すと`fetchRpcAggregates`と別スナップショットになり、
+ * 比較の一貫性が崩れる。
+ *
  * rarityDistributionは配列のため、この関数では { [rarity]: count } のオブジェクトに
  * 変換してRPC側と比較しやすくする。
  */
-async function fetchBasicAggregates(sql) {
-  const [totals] = await sql`
+async function fetchBasicAggregates(tx) {
+  const [totals] = await tx`
     SELECT
       (SELECT COUNT(*)::INTEGER FROM users) AS total_users,
       (SELECT COUNT(*)::INTEGER FROM streamers) AS total_streamers,
@@ -89,12 +108,11 @@ async function fetchBasicAggregates(sql) {
       ) AS month_gacha
   `
 
-  const rarityRows = await sql`
+  const rarityRows = await tx`
     SELECT c.rarity AS rarity, COUNT(*)::INTEGER AS draw_count
     FROM gacha_history gh
     JOIN cards c ON c.id = gh.card_id
     GROUP BY c.rarity
-    HAVING COUNT(*) > 0
   `
   const rarityDistribution = Object.fromEntries(
     rarityRows.map((row) => [row.rarity, row.draw_count])
@@ -116,14 +134,17 @@ async function fetchBasicAggregates(sql) {
   }
 }
 
-/** ダッシュボードが実際に呼ぶ `get_analysis_*()` RPCから同じ形の値を抽出する。 */
-async function fetchRpcAggregates(sql) {
+/**
+ * ダッシュボードが実際に呼ぶ `get_analysis_*()` RPCから同じ形の値を抽出する。
+ * `fetchBasicAggregates` と同じ`tx`（`withReadOnlySnapshot`のcallback引数）で呼ぶこと。
+ */
+async function fetchRpcAggregates(tx) {
   const [[overviewRow], [usersSummaryRow], [streamersSummaryRow], [gachaTotalRow]] =
     await Promise.all([
-      sql`SELECT get_analysis_overview() AS result`,
-      sql`SELECT get_analysis_users_summary() AS result`,
-      sql`SELECT get_analysis_streamers_summary() AS result`,
-      sql`SELECT get_analysis_gacha_summary(NULL, NULL) AS result`,
+      tx`SELECT get_analysis_overview() AS result`,
+      tx`SELECT get_analysis_users_summary() AS result`,
+      tx`SELECT get_analysis_streamers_summary() AS result`,
+      tx`SELECT get_analysis_gacha_summary(NULL, NULL) AS result`,
     ])
 
   const overview = overviewRow.result
@@ -160,10 +181,15 @@ async function fetchRpcAggregates(sql) {
  * 単体テストできるよう純粋関数として切り出す（verify-db-schema.jsのdiffSchemasと
  * 同じ方針）。
  *
+ * scalarMetricsとstreamersSummary系はいずれも無条件で比較する（#1077 PR初版レビュー
+ * 【必須】指摘: `rpc`側のキーが`undefined`のケース——例えば`get_analysis_streamers_summary()`
+ * が将来`totalStreamers`を返さなくなる退行——を`!== undefined`ガードでスキップすると
+ * 「RPC欠落を成功扱いにする」ことになり、docs/analysis-dashboard-db-permissions.mdの
+ * 確認手順4「RPC 欠落...を成功扱いにしていないことを確認する」と矛盾する。ガード無しで
+ * 常に比較すれば、欠落時は`expected: <値>, actual: undefined`という差分として報告される）。
+ *
  * rarityDistributionはキー集合の和集合で比較し、片方にしか無いrarityは
- * もう片方を0として扱う（0件のrarityはRPC側で`HAVING COUNT(*) > 0`により
- * 配列に現れないため、この基礎集計側も同じ条件でフィルタ済み。両者とも
- * 出現しないキーは比較対象にならない）。
+ * もう片方を0として扱う。
  */
 function diffAggregates(basic, rpc) {
   const diffs = []
@@ -187,21 +213,19 @@ function diffAggregates(basic, rpc) {
     }
   }
 
-  if (rpc.streamersSummaryTotalStreamers !== undefined) {
-    if (basic.totalStreamers !== rpc.streamersSummaryTotalStreamers) {
-      diffs.push({
-        metric: 'streamersSummary.totalStreamers',
-        expected: basic.totalStreamers,
-        actual: rpc.streamersSummaryTotalStreamers,
-      })
-    }
-    if (basic.totalCards !== rpc.streamersSummaryTotalCards) {
-      diffs.push({
-        metric: 'streamersSummary.totalCards',
-        expected: basic.totalCards,
-        actual: rpc.streamersSummaryTotalCards,
-      })
-    }
+  if (basic.totalStreamers !== rpc.streamersSummaryTotalStreamers) {
+    diffs.push({
+      metric: 'streamersSummary.totalStreamers',
+      expected: basic.totalStreamers,
+      actual: rpc.streamersSummaryTotalStreamers,
+    })
+  }
+  if (basic.totalCards !== rpc.streamersSummaryTotalCards) {
+    diffs.push({
+      metric: 'streamersSummary.totalCards',
+      expected: basic.totalCards,
+      actual: rpc.streamersSummaryTotalCards,
+    })
   }
 
   const rarityKeys = new Set([
@@ -233,22 +257,19 @@ function printDiffTable(diffs) {
 }
 
 async function main() {
-  const connectionString = resolveConnectionString(process.env)
+  const connectionString = resolveDashboardDatabaseUrl(process.env)
   if (!connectionString) {
     console.error(
-      'Usage: DASHBOARD_DATABASE_URL="postgres://..." node scripts/compare-analysis-dashboard-vs-sql.js'
+      'Usage: DASHBOARD_DATABASE_URL="postgres://..." node scripts/compare-analysis-dashboard-vs-sql.mjs'
     )
+    console.error('DASHBOARD_DATABASE_URL の設定が必要です。')
     console.error(
-      'None of DASHBOARD_DATABASE_URL, DATABASE_URL_PLANETSCALE, PLANETSCALE_DATABASE_URL is set.'
+      '対象環境（preview/production）の限定readロール接続文字列を渡すこと（docs/analysis-dashboard-db-permissions.md参照）。'
     )
-    console.error(
-      'Use a preview- or production-scoped limited read role connection string (see docs/analysis-dashboard-db-permissions.md).'
-    )
-    process.exit(2)
+    process.exitCode = 2
+    return
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const postgres = require('postgres')
   const sql = postgres(core.stripPostgresJsIncompatibleSslParams(connectionString), {
     max: 1,
     connect_timeout: 15,
@@ -256,38 +277,42 @@ async function main() {
 
   let exitCode = 0
   try {
-    const [basic, rpc] = await Promise.all([fetchBasicAggregates(sql), fetchRpcAggregates(sql)])
-    const diffs = diffAggregates(basic, rpc)
+    const diffs = await withReadOnlySnapshot(sql, async (tx) => {
+      // 全期間のgacha_historyを走査する get_analysis_gacha_summary(NULL, NULL) は
+      // ダッシュボードUIの既定（直近7日）より重いクエリになりうるため、検証スクリプトが
+      // 想定外に長時間ブロックしないよう安全弁を固定する
+      // （scripts/db-cutover/snapshot.mjsのwithRollbackOnlyTransactionと同じ理由・同じ方式）。
+      await tx.unsafe(`SET LOCAL statement_timeout = '30s'`)
+      const [basic, rpc] = await Promise.all([fetchBasicAggregates(tx), fetchRpcAggregates(tx)])
+      return diffAggregates(basic, rpc)
+    })
 
     if (diffs.length === 0) {
-      console.log(
-        'OK: analysis dashboard の get_analysis_* RPC は基礎集計SQLと一致しました。'
-      )
+      console.log('OK: analysis dashboard の get_analysis_* RPC は基礎集計SQLと一致しました。')
     } else {
-      console.error(`\n${diffs.length}件の不一致が見つかりました:\n`)
+      console.log(`${diffs.length}件の不一致が見つかりました:\n`)
       printDiffTable(diffs)
       exitCode = 1
     }
   } catch (error) {
+    const message = core.redactSecretsFromText(
+      error instanceof Error ? error.message : String(error),
+      connectionString
+    )
     console.error('analysis dashboard の集計比較に失敗しました:')
-    console.error(error instanceof Error ? error.message : error)
+    console.error(message)
     exitCode = 2
   } finally {
     await sql.end({ timeout: 5 })
   }
-  process.exit(exitCode)
+  process.exitCode = exitCode
 }
 
-if (require.main === module) {
+if (process.argv[1] && process.argv[1] === fileURLToPath(import.meta.url)) {
   main().catch((error) => {
     console.error(error)
-    process.exit(2)
+    process.exitCode = 2
   })
 }
 
-module.exports = {
-  resolveConnectionString,
-  fetchBasicAggregates,
-  fetchRpcAggregates,
-  diffAggregates,
-}
+export { resolveDashboardDatabaseUrl, fetchBasicAggregates, fetchRpcAggregates, diffAggregates }

--- a/tests/unit/compare-analysis-dashboard-vs-sql.test.ts
+++ b/tests/unit/compare-analysis-dashboard-vs-sql.test.ts
@@ -68,6 +68,20 @@ describe('resolveStatementTimeout', () => {
     ).toThrow(/DASHBOARD_COMPARE_STATEMENT_TIMEOUT の形式が不正です/)
   })
 
+  it('0（またはその単位付き表記）はタイムアウト無効化を意味するため拒否する', () => {
+    // PostgreSQLはstatement_timeout=0を「無制限」として扱うため、これを許すと
+    // 「想定外に長時間ブロックしないための安全弁」が環境変数だけで無効化できてしまう。
+    expect(() => resolveStatementTimeout({ DASHBOARD_COMPARE_STATEMENT_TIMEOUT: '0' })).toThrow(
+      /0は無制限を意味するため拒否/
+    )
+    expect(() => resolveStatementTimeout({ DASHBOARD_COMPARE_STATEMENT_TIMEOUT: '0s' })).toThrow(
+      /0は無制限を意味するため拒否/
+    )
+    expect(() => resolveStatementTimeout({ DASHBOARD_COMPARE_STATEMENT_TIMEOUT: '0ms' })).toThrow(
+      /0は無制限を意味するため拒否/
+    )
+  })
+
   it('空白のみの値は未設定として扱い既定値を返す', () => {
     expect(resolveStatementTimeout({ DASHBOARD_COMPARE_STATEMENT_TIMEOUT: '   ' })).toBe('30s')
   })

--- a/tests/unit/compare-analysis-dashboard-vs-sql.test.ts
+++ b/tests/unit/compare-analysis-dashboard-vs-sql.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveConnectionString,
+  diffAggregates,
+} from '../../scripts/compare-analysis-dashboard-vs-sql.js'
+
+/**
+ * scripts/compare-analysis-dashboard-vs-sql.js の純粋関数に対する単体テスト (#1077)。
+ * DB接続は一切行わない。scripts/lib/db-migrate-core.test.ts と同じ流儀
+ * （DB接続を伴わない純粋関数だけを対象に切り出してテストする）。
+ */
+
+describe('resolveConnectionString', () => {
+  it('DASHBOARD_DATABASE_URL を最優先で使う', () => {
+    const url = resolveConnectionString({
+      DASHBOARD_DATABASE_URL: 'postgres://dashboard',
+      DATABASE_URL_PLANETSCALE: 'postgres://planetscale',
+      PLANETSCALE_DATABASE_URL: 'postgres://legacy',
+    })
+    expect(url).toBe('postgres://dashboard')
+  })
+
+  it('DASHBOARD_DATABASE_URL が無い場合は DATABASE_URL_PLANETSCALE にフォールバックする', () => {
+    const url = resolveConnectionString({
+      DATABASE_URL_PLANETSCALE: 'postgres://planetscale',
+      PLANETSCALE_DATABASE_URL: 'postgres://legacy',
+    })
+    expect(url).toBe('postgres://planetscale')
+  })
+
+  it('前2つが無い場合は PLANETSCALE_DATABASE_URL にフォールバックする', () => {
+    const url = resolveConnectionString({ PLANETSCALE_DATABASE_URL: 'postgres://legacy' })
+    expect(url).toBe('postgres://legacy')
+  })
+
+  it('空文字は未設定として扱う（前後空白のみの値でフォールバックを止めない）', () => {
+    const url = resolveConnectionString({
+      DASHBOARD_DATABASE_URL: '   ',
+      DATABASE_URL_PLANETSCALE: 'postgres://planetscale',
+    })
+    expect(url).toBe('postgres://planetscale')
+  })
+
+  it('いずれも無い場合は空文字を返す', () => {
+    expect(resolveConnectionString({})).toBe('')
+  })
+})
+
+describe('diffAggregates', () => {
+  const baseBasic = {
+    totalUsers: 10,
+    totalStreamers: 3,
+    totalCards: 20,
+    totalUserCards: 40,
+    usersWithTos: 8,
+    usersWithCards: 6,
+    totalGacha: 100,
+    uniqueUsers: 9,
+    todayGacha: 5,
+    weekGacha: 30,
+    monthGacha: 80,
+    rarityDistribution: { common: 70, rare: 25, legendary: 5 },
+  }
+  const baseRpc = {
+    ...baseBasic,
+    rarityDistribution: { ...baseBasic.rarityDistribution },
+    streamersSummaryTotalStreamers: baseBasic.totalStreamers,
+    streamersSummaryTotalCards: baseBasic.totalCards,
+  }
+
+  it('全項目が一致する場合は空配列を返す', () => {
+    expect(diffAggregates(baseBasic, baseRpc)).toEqual([])
+  })
+
+  it('スカラー指標の不一致を検出する', () => {
+    const rpc = { ...baseRpc, totalUsers: 11, weekGacha: 31 }
+    const diffs = diffAggregates(baseBasic, rpc)
+    expect(diffs).toEqual(
+      expect.arrayContaining([
+        { metric: 'totalUsers', expected: 10, actual: 11 },
+        { metric: 'weekGacha', expected: 30, actual: 31 },
+      ])
+    )
+    expect(diffs).toHaveLength(2)
+  })
+
+  it('get_analysis_streamers_summary() 由来のtotalStreamers/totalCardsの食い違いも検出する', () => {
+    const rpc = { ...baseRpc, streamersSummaryTotalStreamers: 4 }
+    const diffs = diffAggregates(baseBasic, rpc)
+    expect(diffs).toEqual([
+      { metric: 'streamersSummary.totalStreamers', expected: 3, actual: 4 },
+    ])
+  })
+
+  it('rarityDistributionの不一致をrarityごとに報告する', () => {
+    const rpc = { ...baseRpc, rarityDistribution: { common: 70, rare: 26, legendary: 5 } }
+    const diffs = diffAggregates(baseBasic, rpc)
+    expect(diffs).toEqual([
+      { metric: 'rarityDistribution.rare', expected: 25, actual: 26 },
+    ])
+  })
+
+  it('片方にしか無いrarityはもう片方を0として比較する', () => {
+    const basic = {
+      ...baseBasic,
+      rarityDistribution: { ...baseBasic.rarityDistribution, epic: 2 },
+    }
+    const diffs = diffAggregates(basic, baseRpc)
+    expect(diffs).toEqual([{ metric: 'rarityDistribution.epic', expected: 2, actual: 0 }])
+  })
+})

--- a/tests/unit/compare-analysis-dashboard-vs-sql.test.ts
+++ b/tests/unit/compare-analysis-dashboard-vs-sql.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   resolveDashboardDatabaseUrl,
+  resolveStatementTimeout,
   diffAggregates,
+  fetchBasicAggregates,
   fetchRpcAggregates,
 } from '../../scripts/compare-analysis-dashboard-vs-sql.mjs'
 
@@ -45,6 +47,32 @@ describe('resolveDashboardDatabaseUrl', () => {
   })
 })
 
+describe('resolveStatementTimeout', () => {
+  it('未設定なら既定の30sを返す', () => {
+    expect(resolveStatementTimeout({})).toBe('30s')
+  })
+
+  it('妥当な形式ならそのまま返す', () => {
+    expect(resolveStatementTimeout({ DASHBOARD_COMPARE_STATEMENT_TIMEOUT: '2min' })).toBe('2min')
+    expect(resolveStatementTimeout({ DASHBOARD_COMPARE_STATEMENT_TIMEOUT: '500ms' })).toBe('500ms')
+    expect(resolveStatementTimeout({ DASHBOARD_COMPARE_STATEMENT_TIMEOUT: '90' })).toBe('90')
+  })
+
+  it('前後の空白を除去する', () => {
+    expect(resolveStatementTimeout({ DASHBOARD_COMPARE_STATEMENT_TIMEOUT: '  60s  ' })).toBe('60s')
+  })
+
+  it('不正な形式はエラーを投げる（tx.unsafe()へ混入させないための入力検証）', () => {
+    expect(() =>
+      resolveStatementTimeout({ DASHBOARD_COMPARE_STATEMENT_TIMEOUT: "30s'; DROP TABLE users; --" })
+    ).toThrow(/DASHBOARD_COMPARE_STATEMENT_TIMEOUT の形式が不正です/)
+  })
+
+  it('空白のみの値は未設定として扱い既定値を返す', () => {
+    expect(resolveStatementTimeout({ DASHBOARD_COMPARE_STATEMENT_TIMEOUT: '   ' })).toBe('30s')
+  })
+})
+
 describe('diffAggregates', () => {
   const baseBasic = {
     totalUsers: 10,
@@ -63,6 +91,7 @@ describe('diffAggregates', () => {
   const baseRpc = {
     ...baseBasic,
     rarityDistribution: { ...baseBasic.rarityDistribution },
+    usersSummaryTotalUsers: baseBasic.totalUsers,
     streamersSummaryTotalStreamers: baseBasic.totalStreamers,
     streamersSummaryTotalCards: baseBasic.totalCards,
   }
@@ -83,29 +112,37 @@ describe('diffAggregates', () => {
     expect(diffs).toHaveLength(2)
   })
 
+  it('get_analysis_users_summary() 由来のtotalUsersの食い違いを検出する', () => {
+    const rpc = { ...baseRpc, usersSummaryTotalUsers: 11 }
+    const diffs = diffAggregates(baseBasic, rpc)
+    expect(diffs).toEqual([{ metric: 'usersSummary.totalUsers', expected: 10, actual: 11 }])
+  })
+
   it('get_analysis_streamers_summary() 由来のtotalStreamers/totalCardsの食い違いも検出する', () => {
     const rpc = { ...baseRpc, streamersSummaryTotalStreamers: 4 }
     const diffs = diffAggregates(baseBasic, rpc)
     expect(diffs).toEqual([{ metric: 'streamersSummary.totalStreamers', expected: 3, actual: 4 }])
   })
 
-  it('streamersSummaryの値がRPCから消えた場合(undefined)も差分として検出する', () => {
+  it('usersSummary/streamersSummaryの値がRPCから消えた場合(undefined)も差分として検出する', () => {
     // #1077 PR初版レビュー【必須】指摘の回帰テスト: get_analysis_streamers_summary() が
     // 将来totalStreamers/totalCardsキーを返さなくなる退行が「成功扱い」にならないことを
     // 固定する（以前はrpc値がundefinedだとこの比較自体をスキップしていた）。
     const rpc = {
       ...baseRpc,
+      usersSummaryTotalUsers: undefined,
       streamersSummaryTotalStreamers: undefined,
       streamersSummaryTotalCards: undefined,
     }
     const diffs = diffAggregates(baseBasic, rpc)
     expect(diffs).toEqual(
       expect.arrayContaining([
+        { metric: 'usersSummary.totalUsers', expected: 10, actual: undefined },
         { metric: 'streamersSummary.totalStreamers', expected: 3, actual: undefined },
         { metric: 'streamersSummary.totalCards', expected: 20, actual: undefined },
       ])
     )
-    expect(diffs).toHaveLength(2)
+    expect(diffs).toHaveLength(3)
   })
 
   it('rarityDistributionの不一致をrarityごとに報告する', () => {
@@ -126,48 +163,144 @@ describe('diffAggregates', () => {
 
 /**
  * postgres.js のタグ付きテンプレート呼び出しを模す最小限のfake sql。
- * fetchRpcAggregatesは`${}`によるfragment合成をしない単純な呼び出ししかしないため、
- * クエリ文字列に含まれるRPC関数名で分岐して固定レスポンスを返すだけで十分
- * （tests/unit/analysis-admin-db-driver.test.ts のfakeSqlTagより大幅に単純化できる）。
+ * fetchBasicAggregates/fetchRpcAggregatesはいずれも`${}`によるfragment合成をしない
+ * 単純な呼び出ししかしないため、クエリ文字列に含まれる目印文字列で分岐して固定
+ * レスポンスを返すだけで十分（tests/unit/analysis-admin-db-driver.test.ts の
+ * fakeSqlTagより大幅に単純化できる）。呼び出し順序に依存しないよう、
+ * 目印文字列とレスポンスの配列を渡して都度先頭から一致するものを探す。
  */
-function makeFakeRpcSql(responses: Array<[string, unknown]>) {
+function makeFakeSql(responses: Array<[string, unknown]>) {
   return (strings: readonly string[]) => {
     const text = strings.join('')
     for (const [marker, result] of responses) {
-      if (text.includes(marker)) return Promise.resolve([{ result }])
+      if (text.includes(marker)) return Promise.resolve(result)
     }
-    throw new Error(`makeFakeRpcSql: no matching response for query: ${text}`)
+    throw new Error(`makeFakeSql: no matching response for query: ${text}`)
   }
 }
 
+describe('fetchBasicAggregates', () => {
+  it('基礎集計クエリと rarity 内訳クエリの結果を正しいキーへ写像する', async () => {
+    // #1081 PR 2回目レビュー【任意】指摘: SQLの列名（total_user_cards等）→返却キーの
+    // 写像ミスは「一致した」と誤報告する最も危険な箇所のため、fetchRpcAggregatesと
+    // 同様にfake sqlで固定する。
+    const tx = makeFakeSql([
+      [
+        'total_users',
+        [
+          {
+            total_users: 10,
+            total_streamers: 3,
+            total_cards: 20,
+            total_user_cards: 40,
+            users_with_tos: 8,
+            users_with_cards: 6,
+            total_gacha: 100,
+            unique_users: 9,
+            today_gacha: 5,
+            week_gacha: 30,
+            month_gacha: 80,
+          },
+        ],
+      ],
+      [
+        'GROUP BY c.rarity',
+        [
+          { rarity: 'common', draw_count: 70 },
+          { rarity: 'rare', draw_count: 25 },
+          { rarity: 'legendary', draw_count: 5 },
+        ],
+      ],
+    ])
+
+    const result = await fetchBasicAggregates(tx)
+
+    expect(result).toEqual({
+      totalUsers: 10,
+      totalStreamers: 3,
+      totalCards: 20,
+      totalUserCards: 40,
+      usersWithTos: 8,
+      usersWithCards: 6,
+      totalGacha: 100,
+      uniqueUsers: 9,
+      todayGacha: 5,
+      weekGacha: 30,
+      monthGacha: 80,
+      rarityDistribution: { common: 70, rare: 25, legendary: 5 },
+    })
+  })
+
+  it('gacha_historyが0件でrarity内訳が空でもrarityDistributionは空オブジェクトになる', async () => {
+    const tx = makeFakeSql([
+      [
+        'total_users',
+        [
+          {
+            total_users: 0,
+            total_streamers: 0,
+            total_cards: 0,
+            total_user_cards: 0,
+            users_with_tos: 0,
+            users_with_cards: 0,
+            total_gacha: 0,
+            unique_users: 0,
+            today_gacha: 0,
+            week_gacha: 0,
+            month_gacha: 0,
+          },
+        ],
+      ],
+      ['GROUP BY c.rarity', []],
+    ])
+
+    const result = await fetchBasicAggregates(tx)
+    expect(result.rarityDistribution).toEqual({})
+  })
+})
+
 describe('fetchRpcAggregates', () => {
   it('4つのRPCの戻り値を正しいキーへ写像する', async () => {
-    const tx = makeFakeRpcSql([
+    const tx = makeFakeSql([
       [
         'get_analysis_overview',
-        {
-          stats: {
-            totalUsers: 10,
-            totalStreamers: 3,
-            totalCards: 20,
-            todayGacha: 5,
-            weekGacha: 30,
-            monthGacha: 80,
+        [
+          {
+            result: {
+              stats: {
+                totalUsers: 10,
+                totalStreamers: 3,
+                totalCards: 20,
+                todayGacha: 5,
+                weekGacha: 30,
+                monthGacha: 80,
+              },
+            },
           },
-        },
+        ],
       ],
-      ['get_analysis_users_summary', { totalCards: 40, usersWithTos: 8, usersWithCards: 6 }],
-      ['get_analysis_streamers_summary', { totalStreamers: 3, totalCards: 20 }],
+      [
+        'get_analysis_users_summary',
+        [{ result: { totalUsers: 10, totalCards: 40, usersWithTos: 8, usersWithCards: 6 } }],
+      ],
+      [
+        'get_analysis_streamers_summary',
+        [{ result: { totalStreamers: 3, totalCards: 20 } }],
+      ],
       [
         'get_analysis_gacha_summary',
-        {
-          totalGacha: 100,
-          uniqueUsers: 9,
-          rarityDistribution: [
-            { rarity: 'common', value: 70 },
-            { rarity: 'rare', value: 25 },
-          ],
-        },
+        [
+          {
+            result: {
+              totalGacha: 100,
+              uniqueUsers: 9,
+              rarityDistribution: [
+                { rarity: 'common', value: 70 },
+                { rarity: 'rare', value: 25 },
+              ],
+            },
+          },
+        ],
       ],
     ])
 
@@ -186,6 +319,7 @@ describe('fetchRpcAggregates', () => {
       weekGacha: 30,
       monthGacha: 80,
       rarityDistribution: { common: 70, rare: 25 },
+      usersSummaryTotalUsers: 10,
       streamersSummaryTotalStreamers: 3,
       streamersSummaryTotalCards: 20,
     })
@@ -194,14 +328,26 @@ describe('fetchRpcAggregates', () => {
   it('get_analysis_streamers_summary() がtotalStreamers/totalCardsを返さない場合はundefinedのまま伝播する', async () => {
     // diffAggregatesがこのundefinedを差分として検出することを保証するための前段テスト
     // （fetchRpcAggregates自身がundefinedを握りつぶしたり0埋めしたりしないことを固定する）。
-    const tx = makeFakeRpcSql([
+    const tx = makeFakeSql([
       [
         'get_analysis_overview',
-        { stats: { totalUsers: 1, totalStreamers: 1, totalCards: 1, todayGacha: 0, weekGacha: 0, monthGacha: 0 } },
+        [
+          {
+            result: {
+              stats: { totalUsers: 1, totalStreamers: 1, totalCards: 1, todayGacha: 0, weekGacha: 0, monthGacha: 0 },
+            },
+          },
+        ],
       ],
-      ['get_analysis_users_summary', { totalCards: 1, usersWithTos: 0, usersWithCards: 0 }],
-      ['get_analysis_streamers_summary', {}],
-      ['get_analysis_gacha_summary', { totalGacha: 0, uniqueUsers: 0, rarityDistribution: [] }],
+      [
+        'get_analysis_users_summary',
+        [{ result: { totalUsers: 1, totalCards: 1, usersWithTos: 0, usersWithCards: 0 } }],
+      ],
+      ['get_analysis_streamers_summary', [{ result: {} }]],
+      [
+        'get_analysis_gacha_summary',
+        [{ result: { totalGacha: 0, uniqueUsers: 0, rarityDistribution: [] } }],
+      ],
     ])
 
     const result = await fetchRpcAggregates(tx)

--- a/tests/unit/compare-analysis-dashboard-vs-sql.test.ts
+++ b/tests/unit/compare-analysis-dashboard-vs-sql.test.ts
@@ -1,48 +1,47 @@
 import { describe, expect, it } from 'vitest'
 import {
-  resolveConnectionString,
+  resolveDashboardDatabaseUrl,
   diffAggregates,
-} from '../../scripts/compare-analysis-dashboard-vs-sql.js'
+  fetchRpcAggregates,
+} from '../../scripts/compare-analysis-dashboard-vs-sql.mjs'
 
 /**
- * scripts/compare-analysis-dashboard-vs-sql.js の純粋関数に対する単体テスト (#1077)。
+ * scripts/compare-analysis-dashboard-vs-sql.mjs の純粋関数に対する単体テスト (#1077)。
  * DB接続は一切行わない。scripts/lib/db-migrate-core.test.ts と同じ流儀
  * （DB接続を伴わない純粋関数だけを対象に切り出してテストする）。
  */
 
-describe('resolveConnectionString', () => {
-  it('DASHBOARD_DATABASE_URL を最優先で使う', () => {
-    const url = resolveConnectionString({
-      DASHBOARD_DATABASE_URL: 'postgres://dashboard',
-      DATABASE_URL_PLANETSCALE: 'postgres://planetscale',
-      PLANETSCALE_DATABASE_URL: 'postgres://legacy',
-    })
-    expect(url).toBe('postgres://dashboard')
+describe('resolveDashboardDatabaseUrl', () => {
+  it('DASHBOARD_DATABASE_URL を返す', () => {
+    expect(resolveDashboardDatabaseUrl({ DASHBOARD_DATABASE_URL: 'postgres://dashboard' })).toBe(
+      'postgres://dashboard'
+    )
   })
 
-  it('DASHBOARD_DATABASE_URL が無い場合は DATABASE_URL_PLANETSCALE にフォールバックする', () => {
-    const url = resolveConnectionString({
-      DATABASE_URL_PLANETSCALE: 'postgres://planetscale',
-      PLANETSCALE_DATABASE_URL: 'postgres://legacy',
-    })
-    expect(url).toBe('postgres://planetscale')
+  it('前後の空白を除去する', () => {
+    expect(
+      resolveDashboardDatabaseUrl({ DASHBOARD_DATABASE_URL: '  postgres://dashboard  ' })
+    ).toBe('postgres://dashboard')
   })
 
-  it('前2つが無い場合は PLANETSCALE_DATABASE_URL にフォールバックする', () => {
-    const url = resolveConnectionString({ PLANETSCALE_DATABASE_URL: 'postgres://legacy' })
-    expect(url).toBe('postgres://legacy')
+  it('未設定なら空文字を返す（他の環境変数へフォールバックしない）', () => {
+    // #1077 PR初版レビュー【必須】指摘: DATABASE_URL_PLANETSCALE/PLANETSCALE_DATABASE_URL は
+    // それぞれ用途・権限が別の接続文字列であり、フォールバックすると誤って production の
+    // 管理接続でpreviewを検証したことになりうる。フォールバックしないことを固定する回帰テスト。
+    expect(
+      resolveDashboardDatabaseUrl({
+        DATABASE_URL_PLANETSCALE: 'postgres://planetscale',
+        PLANETSCALE_DATABASE_URL: 'postgres://legacy',
+      })
+    ).toBe('')
   })
 
-  it('空文字は未設定として扱う（前後空白のみの値でフォールバックを止めない）', () => {
-    const url = resolveConnectionString({
-      DASHBOARD_DATABASE_URL: '   ',
-      DATABASE_URL_PLANETSCALE: 'postgres://planetscale',
-    })
-    expect(url).toBe('postgres://planetscale')
+  it('空白のみの値は未設定として扱う', () => {
+    expect(resolveDashboardDatabaseUrl({ DASHBOARD_DATABASE_URL: '   ' })).toBe('')
   })
 
-  it('いずれも無い場合は空文字を返す', () => {
-    expect(resolveConnectionString({})).toBe('')
+  it('環境変数が何も無い場合は空文字を返す', () => {
+    expect(resolveDashboardDatabaseUrl({})).toBe('')
   })
 })
 
@@ -87,17 +86,32 @@ describe('diffAggregates', () => {
   it('get_analysis_streamers_summary() 由来のtotalStreamers/totalCardsの食い違いも検出する', () => {
     const rpc = { ...baseRpc, streamersSummaryTotalStreamers: 4 }
     const diffs = diffAggregates(baseBasic, rpc)
-    expect(diffs).toEqual([
-      { metric: 'streamersSummary.totalStreamers', expected: 3, actual: 4 },
-    ])
+    expect(diffs).toEqual([{ metric: 'streamersSummary.totalStreamers', expected: 3, actual: 4 }])
+  })
+
+  it('streamersSummaryの値がRPCから消えた場合(undefined)も差分として検出する', () => {
+    // #1077 PR初版レビュー【必須】指摘の回帰テスト: get_analysis_streamers_summary() が
+    // 将来totalStreamers/totalCardsキーを返さなくなる退行が「成功扱い」にならないことを
+    // 固定する（以前はrpc値がundefinedだとこの比較自体をスキップしていた）。
+    const rpc = {
+      ...baseRpc,
+      streamersSummaryTotalStreamers: undefined,
+      streamersSummaryTotalCards: undefined,
+    }
+    const diffs = diffAggregates(baseBasic, rpc)
+    expect(diffs).toEqual(
+      expect.arrayContaining([
+        { metric: 'streamersSummary.totalStreamers', expected: 3, actual: undefined },
+        { metric: 'streamersSummary.totalCards', expected: 20, actual: undefined },
+      ])
+    )
+    expect(diffs).toHaveLength(2)
   })
 
   it('rarityDistributionの不一致をrarityごとに報告する', () => {
     const rpc = { ...baseRpc, rarityDistribution: { common: 70, rare: 26, legendary: 5 } }
     const diffs = diffAggregates(baseBasic, rpc)
-    expect(diffs).toEqual([
-      { metric: 'rarityDistribution.rare', expected: 25, actual: 26 },
-    ])
+    expect(diffs).toEqual([{ metric: 'rarityDistribution.rare', expected: 25, actual: 26 }])
   })
 
   it('片方にしか無いrarityはもう片方を0として比較する', () => {
@@ -107,5 +121,92 @@ describe('diffAggregates', () => {
     }
     const diffs = diffAggregates(basic, baseRpc)
     expect(diffs).toEqual([{ metric: 'rarityDistribution.epic', expected: 2, actual: 0 }])
+  })
+})
+
+/**
+ * postgres.js のタグ付きテンプレート呼び出しを模す最小限のfake sql。
+ * fetchRpcAggregatesは`${}`によるfragment合成をしない単純な呼び出ししかしないため、
+ * クエリ文字列に含まれるRPC関数名で分岐して固定レスポンスを返すだけで十分
+ * （tests/unit/analysis-admin-db-driver.test.ts のfakeSqlTagより大幅に単純化できる）。
+ */
+function makeFakeRpcSql(responses: Array<[string, unknown]>) {
+  return (strings: readonly string[]) => {
+    const text = strings.join('')
+    for (const [marker, result] of responses) {
+      if (text.includes(marker)) return Promise.resolve([{ result }])
+    }
+    throw new Error(`makeFakeRpcSql: no matching response for query: ${text}`)
+  }
+}
+
+describe('fetchRpcAggregates', () => {
+  it('4つのRPCの戻り値を正しいキーへ写像する', async () => {
+    const tx = makeFakeRpcSql([
+      [
+        'get_analysis_overview',
+        {
+          stats: {
+            totalUsers: 10,
+            totalStreamers: 3,
+            totalCards: 20,
+            todayGacha: 5,
+            weekGacha: 30,
+            monthGacha: 80,
+          },
+        },
+      ],
+      ['get_analysis_users_summary', { totalCards: 40, usersWithTos: 8, usersWithCards: 6 }],
+      ['get_analysis_streamers_summary', { totalStreamers: 3, totalCards: 20 }],
+      [
+        'get_analysis_gacha_summary',
+        {
+          totalGacha: 100,
+          uniqueUsers: 9,
+          rarityDistribution: [
+            { rarity: 'common', value: 70 },
+            { rarity: 'rare', value: 25 },
+          ],
+        },
+      ],
+    ])
+
+    const result = await fetchRpcAggregates(tx)
+
+    expect(result).toEqual({
+      totalUsers: 10,
+      totalStreamers: 3,
+      totalCards: 20,
+      totalUserCards: 40,
+      usersWithTos: 8,
+      usersWithCards: 6,
+      totalGacha: 100,
+      uniqueUsers: 9,
+      todayGacha: 5,
+      weekGacha: 30,
+      monthGacha: 80,
+      rarityDistribution: { common: 70, rare: 25 },
+      streamersSummaryTotalStreamers: 3,
+      streamersSummaryTotalCards: 20,
+    })
+  })
+
+  it('get_analysis_streamers_summary() がtotalStreamers/totalCardsを返さない場合はundefinedのまま伝播する', async () => {
+    // diffAggregatesがこのundefinedを差分として検出することを保証するための前段テスト
+    // （fetchRpcAggregates自身がundefinedを握りつぶしたり0埋めしたりしないことを固定する）。
+    const tx = makeFakeRpcSql([
+      [
+        'get_analysis_overview',
+        { stats: { totalUsers: 1, totalStreamers: 1, totalCards: 1, todayGacha: 0, weekGacha: 0, monthGacha: 0 } },
+      ],
+      ['get_analysis_users_summary', { totalCards: 1, usersWithTos: 0, usersWithCards: 0 }],
+      ['get_analysis_streamers_summary', {}],
+      ['get_analysis_gacha_summary', { totalGacha: 0, uniqueUsers: 0, rarityDistribution: [] }],
+    ])
+
+    const result = await fetchRpcAggregates(tx)
+
+    expect(result.streamersSummaryTotalStreamers).toBeUndefined()
+    expect(result.streamersSummaryTotalCards).toBeUndefined()
   })
 })


### PR DESCRIPTION
## 対応するIssue
#1077 [preview-gate] preview: real-path-analysis-dashboard

## 問題

docs/QA.md の Preview 実経路ゲート #6「analysis dashboard の主要集計が PlanetScale の値と一致することを確認する」は、これまでダッシュボードをブラウザで開いて目視するだけの手動確認だった。ダッシュボードの表示値は `analysis/dev/adminApiPg.ts` 経由で `get_analysis_*()` RPC を呼んでいるだけなので、RPC自体にバグがあってもブラウザ目視では検出できない。#1077 が指摘するとおり、これを自動で突き合わせるworkflow/scriptは存在しなかった。

## 変更内容

- `scripts/compare-analysis-dashboard-vs-sql.js` を追加。`get_analysis_overview` / `get_analysis_users_summary` / `get_analysis_streamers_summary` / `get_analysis_gacha_summary` が返す users/streamers/cards、today/week/month/total gacha、unique users、rarity を、RPCを経由しない素朴な `COUNT`/`GROUP BY` と独立に突き合わせる。
- 接続文字列は `DASHBOARD_DATABASE_URL` → `DATABASE_URL_PLANETSCALE` → `PLANETSCALE_DATABASE_URL` の順で解決する（#1077 Issue本文が列挙した3変数と同じ優先順）。いずれも未設定なら安全側で exit 2（既存の `resolveDashboardDatabaseUrl` の「未設定は throw」方針と同じ)。
- `npm run check:analysis-dashboard-vs-sql` で実行できるようにし、`docs/analysis-dashboard-db-permissions.md`「確認手順」と `docs/QA.md` ゲート#6からこのスクリプトを参照するよう追記。
- `diffAggregates`/`resolveConnectionString` の純粋関数部分を DB 接続なしで単体テスト（`tests/unit/compare-analysis-dashboard-vs-sql.test.ts`、10 tests）。

## スコープ外（重要）

本PRは preview 用の限定read接続文字列を実行環境へ注入するものではない。ロールの払い出しと接続文字列の安全な注入は運用側の作業であり（`docs/analysis-dashboard-db-permissions.md` 既存記載どおり）、本PRのスコープ外。**そのため本PR単体では #1077 が指す「限定read接続が実行環境に無い」状態そのものは解消しない。** 実際にpreviewへ対して比較を実行するには、preview専用の限定readロール接続文字列を上記いずれかの環境変数に設定した実行環境が別途必要。

## 検証

- `npx tsc --noEmit` — エラーなし
- `npx eslint .` — 既存warningのみ（今回変更起因のerror/warningなし）
- `npx vitest run tests/unit` — 281 test files / 3671 tests すべてpass
- `node scripts/compare-analysis-dashboard-vs-sql.js`（環境変数未設定）→ 想定どおり exit 2 で安全に失敗することを確認

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018msbP2Nu5gkheaehPfxqDL)_