### PR TITLE
test(r2): retry fixture契約を明確化 (#1074)

### DIFF
--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -88,13 +88,18 @@ function stubSoundEnv(): void {
 const MAX_RETRIES = 3
 // 1回だけ試行 = リトライなし。
 const SINGLE_ATTEMPT_NO_RETRY = 1
+// 成功fixtureが実際に「リトライ後の成功」を通り、かつ到達可能であるため、
+// 1 <= TRANSIENT_FAILURES_BEFORE_SUCCESS <= MAX_RETRIES を維持する。
 const TRANSIENT_FAILURES_BEFORE_SUCCESS = 2
 const RETRY_SUCCESS_ATTEMPTS = TRANSIENT_FAILURES_BEFORE_SUCCESS + 1
-// 成功fixtureを到達可能に保つため、値を変える場合も TRANSIENT_FAILURES_BEFORE_SUCCESS <= MAX_RETRIES を維持する。
 const R2_INTERNAL_ERROR_MESSAGE = 'put: We encountered an internal error. Please try again. (10001)'
 
 function mockTransientFailuresThenSuccess(): void {
-  for (let i = 0; i < TRANSIENT_FAILURES_BEFORE_SUCCESS; i += 1) {
+  for (
+    let transientFailure = 0;
+    transientFailure < TRANSIENT_FAILURES_BEFORE_SUCCESS;
+    transientFailure += 1
+  ) {
     sendMock.mockRejectedValueOnce(new Error(R2_INTERNAL_ERROR_MESSAGE))
   }
   sendMock.mockResolvedValueOnce({})


### PR DESCRIPTION
## 概要

Issue #1074 の判断不要なノンブロッキング改善を反映します。

- `TRANSIENT_FAILURES_BEFORE_SUCCESS` の直上へfixture不変条件コメントを移動
- `1 <= TRANSIENT_FAILURES_BEFORE_SUCCESS <= MAX_RETRIES` を明示し、0回失敗で「リトライ成功」テストが形骸化するのを防ぐ意図を記録
- fixtureループ変数を `i` から `transientFailure` へ改名

## 影響範囲

- テスト1ファイルのみ
- 本番コード、設定、依存関係の変更なし

Closes #1074