### PR TITLE
test(streamers): safe columnsを投影キー基準で検証 (#1072)

### DIFF
--- a/tests/unit/streamers-safe-columns.test.ts
+++ b/tests/unit/streamers-safe-columns.test.ts
@@ -89,16 +89,21 @@ describe('streamers デプロイ窓の列集合契約', () => {
     }
   })
 
-  it('安全な列集合は streamers 全列からデプロイ窓対象だけを除いた投影キーと一致する', () => {
+  it('安全な列集合は streamers 全列からデプロイ窓対象だけを除いた投影キーと実SQL列の対応に一致する', () => {
     // schema に新列を追加してこのテストが失敗した場合は、その実SQL列が未デプロイの窓を
-    // 持つなら *_SETTINGS_COLUMNS 側へ、既にデプロイ済みの通常列なら Drizzle の投影キーを
-    // STREAMERS_SAFE_COLUMNS 側へ追加し、フォールバック時の返却行形状を維持する。
+    // 持つなら *_SETTINGS_COLUMNS 側へ、既にデプロイ済みの通常列なら Drizzle の投影キーと
+    // 対応する列オブジェクトを STREAMERS_SAFE_COLUMNS 側へ追加し、フォールバック時の返却行形状と
+    // キー↔実SQL列の対応を維持する。
     const deployWindowColumnNames = new Set<string>(DEPLOY_WINDOW_COLUMNS)
-    const expectedSafeProjectionKeys = Object.entries(getTableColumns(streamersTable))
-      .filter(([, column]) => !deployWindowColumnNames.has(column.name))
-      .map(([key]) => key)
-    const safeProjectionKeys = Object.keys(STREAMERS_SAFE_COLUMNS)
+    const toProjectionPairs = (entries: [string, { name: string }][]) =>
+      entries.map(([key, column]) => `${key}=${column.name}`).sort()
+    const expectedSafeProjectionPairs = toProjectionPairs(
+      Object.entries(getTableColumns(streamersTable)).filter(
+        ([, column]) => !deployWindowColumnNames.has(column.name),
+      ),
+    )
+    const safeProjectionPairs = toProjectionPairs(Object.entries(STREAMERS_SAFE_COLUMNS))
 
-    expect(safeProjectionKeys.sort()).toEqual(expectedSafeProjectionKeys.sort())
+    expect(safeProjectionPairs).toEqual(expectedSafeProjectionPairs)
   })
 })

--- a/tests/unit/streamers-safe-columns.test.ts
+++ b/tests/unit/streamers-safe-columns.test.ts
@@ -67,7 +67,8 @@ describe('streamers デプロイ窓の列集合契約', () => {
 
   it('デプロイ窓の対象列集合を明示的に固定する', () => {
     // 各列の検知経路自体は上の it.each で直接検証している。
-    // ここでは対象列の追加・削除を意図せず見落とさないよう列集合そのものを固定する。
+    // `cross_channel_trade_enabled` は `trade_enabled` を部分文字列として含むため、
+    // 検知テストだけでは前者の登録漏れを見逃しうる。ここで列集合そのものを固定する。
     expect(LIVE_DIRECTORY_SETTINGS_COLUMNS).toEqual([
       'publish_live_status',
       'publish_stats',
@@ -76,14 +77,6 @@ describe('streamers デプロイ窓の列集合契約', () => {
       'trade_enabled',
       'cross_channel_trade_enabled',
     ])
-  })
-
-  it('安全な列集合の投影キーと実SQL列名が一致する', () => {
-    const mismatches = Object.entries(STREAMERS_SAFE_COLUMNS)
-      .filter(([key, column]) => key !== column.name)
-      .map(([key, column]) => [key, column.name])
-
-    expect(mismatches).toEqual([])
   })
 
   it('安全な列集合にはデプロイ窓で欠落しうる実SQL列を含めない', () => {
@@ -96,17 +89,16 @@ describe('streamers デプロイ窓の列集合契約', () => {
     }
   })
 
-  it('安全な列集合は streamers 全列からデプロイ窓対象だけを除いた集合と一致する', () => {
-    // schema に新列を追加してこのテストが失敗した場合は、その列が未デプロイの窓を
-    // 持つなら *_SETTINGS_COLUMNS 側へ、既にデプロイ済みの通常列なら
-    // STREAMERS_SAFE_COLUMNS 側へ追加し、フォールバック時の投影漏れを防ぐ。
+  it('安全な列集合は streamers 全列からデプロイ窓対象だけを除いた投影キーと一致する', () => {
+    // schema に新列を追加してこのテストが失敗した場合は、その実SQL列が未デプロイの窓を
+    // 持つなら *_SETTINGS_COLUMNS 側へ、既にデプロイ済みの通常列なら Drizzle の投影キーを
+    // STREAMERS_SAFE_COLUMNS 側へ追加し、フォールバック時の返却行形状を維持する。
     const deployWindowColumnNames = new Set<string>(DEPLOY_WINDOW_COLUMNS)
-    const allColumnNames = Object.values(getTableColumns(streamersTable)).map((column) => column.name)
-    const expectedSafeColumnNames = allColumnNames.filter(
-      (column) => !deployWindowColumnNames.has(column),
-    )
-    const safeColumnNames = Object.values(STREAMERS_SAFE_COLUMNS).map((column) => column.name)
+    const expectedSafeProjectionKeys = Object.entries(getTableColumns(streamersTable))
+      .filter(([, column]) => !deployWindowColumnNames.has(column.name))
+      .map(([key]) => key)
+    const safeProjectionKeys = Object.keys(STREAMERS_SAFE_COLUMNS)
 
-    expect(safeColumnNames.sort()).toEqual(expectedSafeColumnNames.sort())
+    expect(safeProjectionKeys.sort()).toEqual(expectedSafeProjectionKeys.sort())
   })
 })


### PR DESCRIPTION
## 概要

Issue #1072 の判断不要なノンブロッキング改善を反映します。

- `cross_channel_trade_enabled` が `trade_enabled` を部分文字列として含むため、検知テストだけでは登録漏れを見逃しうる点をコメントで明示
- `STREAMERS_SAFE_COLUMNS` の完全一致契約を実SQL列名ではなく Drizzle の投影キー基準へ変更
- 将来プロパティ名とSQL列名が異なる列が追加されても、フォールバック時の返却行形状を正しく固定できるよう整理
- 投影キーと実SQL列名の一致を強制していた重複テストを削除

## 影響範囲

- テスト1ファイルのみ
- 本番コード、設定、依存関係の変更なし

Closes #1072