### PR TITLE
fix(twitch): emotesのtoken診断Contextを引き継ぐ (#998)

### DIFF
--- a/src/app/api/twitch/emotes/route.ts
+++ b/src/app/api/twitch/emotes/route.ts
@@ -3,7 +3,7 @@ import { getSession, canUseStreamerFeatures } from "@/lib/session";
 import { handleApiError } from "@/lib/error-handler";
 import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
 import { ERROR_MESSAGES } from "@/lib/constants";
-import { getTwitchAccessToken } from "@/lib/twitch/token-manager";
+import { getTwitchAccessToken, twitchTokenErrorReportContext } from "@/lib/twitch/token-manager";
 
 const TWITCH_API_URL = "https://api.twitch.tv/helix";
 
@@ -116,6 +116,6 @@ export async function GET(request: Request) {
         { status: 401 }
       );
     }
-    return handleApiError(error, "Twitch emotes fetch");
+    return handleApiError(error, "Twitch emotes fetch", twitchTokenErrorReportContext(error));
   }
 }


### PR DESCRIPTION
## 概要

Issue #998 の判断不要な軽量フォローアップ（項目1）を反映します。

- `/api/twitch/emotes` の token refresh 失敗を `handleApiError` へ渡す際、`twitchTokenErrorReportContext(error)` も引き継ぐ
- rewards / channel-point-bootstrap と同様に、`refreshStatus` / `refreshErrorKind` 等の安全な診断情報を auto-generated error report の Context へ載せられるようにする

## 影響範囲

- `src/app/api/twitch/emotes/route.ts` 1ファイルのみ
- 正常系レスポンス、再認証判定、Twitch API 呼び出し自体の挙動変更なし

Refs #998