### PR TITLE
docs(ci): Discord通知workflowの安全条件を明記 (#1027)

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -1,5 +1,8 @@
 name: Notify Discord on main merge
 
+# Security contract: pull_request_target lets a merged PR notification read the
+# repository webhook secret from the trusted base context. Never checkout or
+# execute code from the PR head in this workflow.
 on:
   pull_request_target:
     types: [closed]
@@ -12,6 +15,8 @@ jobs:
   notify:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    # PR-controlled strings stay in env and are passed to jq via --arg below;
+    # do not interpolate them directly into the shell script.
     env:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       REPOSITORY_NAME: ${{ github.event.repository.name }}


### PR DESCRIPTION
## 概要

Issue #1027 の判断不要な軽量フォローアップとして、Discord mainマージ通知workflowの既存セキュリティ契約をコメントで明文化します。

- `pull_request_target` を使う理由（trusted base context から Repository Secret を参照するため）を記録
- このworkflowで PR head の checkout / 実行を行わない制約を明記
- PR由来の文字列は `env` 経由で受け、`jq --arg` に渡し、shellへ直接式展開しない方針を明記

## 影響範囲

- `.github/workflows/notify-discord-main-merge.yml` のコメント5行のみ
- trigger、権限、Discord payload、curl挙動、Secret設定には変更なし

Refs #1027