### PR TITLE
fix(a11y): カード表示設定トグルにアクセシブルネームを追加 (#921)

### DIFF
--- a/src/components/CardVisibilitySettings.tsx
+++ b/src/components/CardVisibilitySettings.tsx
@@ -159,6 +159,7 @@ export default function CardVisibilitySettings({
           >
             <input
               type="checkbox"
+              aria-label={t("form.showUnowned")}
               checked={showUnowned}
               onChange={handleToggleShowUnowned}
               disabled={showUnownedDisabled}
@@ -182,6 +183,7 @@ export default function CardVisibilitySettings({
           >
             <input
               type="checkbox"
+              aria-label={t("form.showDetails")}
               checked={showDetails}
               onChange={handleToggleShowDetails}
               disabled={detailsDisabled}


### PR DESCRIPTION
## 概要

Issue #921 の任意フォローアップ項目17のみを小さく対応します。

- `CardVisibilitySettings` の2つの `sr-only` checkbox に `aria-label` を追加
- 既存の `cardVisibilitySettings.form.*` 翻訳をそのまま利用
- UI表示・保存処理・APIには変更なし

Refs #921