### PR TITLE
chore(eventsub): chat announcement warnログ表記を統一 (#1037)

### DIFF
--- a/src/lib/services/eventsub-redemption.ts
+++ b/src/lib/services/eventsub-redemption.ts
@@ -622,7 +622,7 @@ export async function postRedemptionNotify(
   for (const [i, result] of results.entries()) {
     if (result.status === 'rejected') {
       const label = i === 0 ? 'broadcast' : 'chatAnnouncement';
-      logger.warn(`[postRedemptionNotify] ${label} failed`, {
+      logger.warn(`[postRedemptionNotify] ${i === 0 ? 'broadcast' : 'chat announcement'} failed`, {
         error: result.reason instanceof Error ? result.reason.message : String(result.reason),
         streamerId: data.streamer.id,
       });


### PR DESCRIPTION
## 対応
Issue #1037 の任意フォローアップ項目4「warnログの `chatAnnouncement` / `chat announcement` 表記揺れ」を処理します。

## 変更内容
- `postRedemptionNotify` の rejected 通知 warn ログだけを `chat announcement` 表記へ統一
- `reportError` の context (`eventsub:postRedemptionNotify:chatAnnouncement`) は既存契約を維持
- retry / DLQ のログ、制御フロー、判定、reportError の挙動は変更しない

既存の parity テスト契約を維持したまま、変更を1行に絞っています。

Refs #1037