### PR TITLE
docs(db): applied migration外へtrade参照メモを退避 (#1013)

### DIFF
--- a/docs/trade-migration-reference-notes.md
+++ b/docs/trade-migration-reference-notes.md
@@ -1,0 +1,14 @@
+# Card trading migration reference notes
+
+`db/planetscale/migrations/20260817100000_add_card_trading.sql` is an applied migration candidate whose checksum is tracked by `db-migrate`. Do not edit that migration after it has been registered, including comment-only edits; changing any byte changes the checksum and can block `apply`, `status`, `plan`, and `verify`.
+
+When documentation or review notes need to refer to logic inside `accept_trade_offer`, use stable SQL identifiers and processing stages rather than line numbers:
+
+- **Payer candidate locking:** the `PERFORM` immediately before payer selection locks all eligible candidate `user_cards` rows in deterministic order. The following stage-2 `SELECT ... INTO v_payer_user_card_id ... LIMIT 1` intentionally does not add `FOR UPDATE`; the two-stage pattern avoids the `LIMIT 1 + FOR UPDATE` candidate-selection problem while preserving the lock order.
+- **Offered-card ownership check:** the `SELECT ... INTO v_offered_card_owner_check ... FOR UPDATE` is the ownership/existence check for the offered card. Later logic may rely on that row already being locked.
+- **Payer selection:** references to the chosen payment card should use `v_payer_user_card_id`, not migration line ranges.
+- **Lock-order contract:** describe the invariant as `trade_offers row -> offered user_cards row -> payer candidate user_cards rows`, rather than pointing at specific line numbers.
+
+This file is the safe place for maintenance-oriented annotations that would otherwise require comment-only edits to an already tracked migration.
+
+Refs #1013, #1099


### PR DESCRIPTION
## 概要

Issue #1013 のノンブロッキング改善項目11について、適用済み migration を直接編集しない形へ修正しました。

- `db/planetscale/migrations/20260817100000_add_card_trading.sql` の変更は撤回
- checksum 管理対象の migration はコメントのみでも編集しない前提を明文化
- `accept_trade_offer` の保守向け参照を `docs/trade-migration-reference-notes.md` に移し、行番号ではなく `PERFORM` / `v_payer_user_card_id` / `v_offered_card_owner_check` / ロック順など安定した識別子で説明

## 影響範囲

- ドキュメント1ファイルのみ
- migration、SQL、DB状態、schema、実行コードの変更なし

Refs #1013

### レビュー対応

Claude Auto Review #277 の必須指摘「適用済み migration の checksum 不一致」を受け、migration の直接編集を完全に撤回しました。