### PR TITLE
test(r2): retry fixture契約を明確化 (#1084)

### DIFF
--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -88,17 +88,20 @@ function stubSoundEnv(): void {
 const MAX_RETRIES = 3
 // 1回だけ試行 = リトライなし。
 const SINGLE_ATTEMPT_NO_RETRY = 1
-// 成功fixtureが実際に「リトライ後の成功」を通り、かつ到達可能であるため、
+// 成功fixtureが実際に「リトライ後の成功」を通り、かつ到達可能であるように、
 // 1 <= TRANSIENT_FAILURES_BEFORE_SUCCESS <= MAX_RETRIES を維持する。
 const TRANSIENT_FAILURES_BEFORE_SUCCESS = 2
 const RETRY_SUCCESS_ATTEMPTS = TRANSIENT_FAILURES_BEFORE_SUCCESS + 1
 const R2_INTERNAL_ERROR_MESSAGE = 'put: We encountered an internal error. Please try again. (10001)'
 
 function mockTransientFailuresThenSuccess(): void {
+  expect(TRANSIENT_FAILURES_BEFORE_SUCCESS).toBeGreaterThanOrEqual(1)
+  expect(TRANSIENT_FAILURES_BEFORE_SUCCESS).toBeLessThanOrEqual(MAX_RETRIES)
+
   for (
-    let transientFailure = 0;
-    transientFailure < TRANSIENT_FAILURES_BEFORE_SUCCESS;
-    transientFailure += 1
+    let transientFailureIndex = 0;
+    transientFailureIndex < TRANSIENT_FAILURES_BEFORE_SUCCESS;
+    transientFailureIndex += 1
   ) {
     sendMock.mockRejectedValueOnce(new Error(R2_INTERNAL_ERROR_MESSAGE))
   }


### PR DESCRIPTION
## 概要

Issue #1084 のノンブロッキング改善を、テスト1ファイルだけでまとめて対応します。

- 成功fixtureの不変条件コメントを自然な表現へ修正
- `TRANSIENT_FAILURES_BEFORE_SUCCESS` が 1 以上かつ `MAX_RETRIES` 以下であることを実assertで固定
- ループ変数を `transientFailureIndex` へ改名して役割を明確化

## 影響範囲

- `tests/unit/r2-client-upload-retry-wiring.test.ts` のみ
- 本番コード・設定・依存関係の変更なし

Closes #1084