### PR TITLE
feat: Discord main通知に更新内容を表示する

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -2,7 +2,8 @@ name: Notify Discord on main merge
 
 # Security contract: pull_request_target lets a merged PR notification read the
 # repository webhook secret from the trusted base context. Never checkout or
-# execute code from the PR head in this workflow.
+# execute code from the PR head in this workflow. GitHub API access below is
+# read-only and is used only to resolve merged preview PR metadata.
 on:
   pull_request_target:
     types: [closed]
@@ -10,18 +11,20 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   notify:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    # PR-controlled strings stay in env and are passed to jq via --arg below;
-    # do not interpolate them directly into the shell script.
+    # PR-controlled strings stay in env and are passed to jq / shell commands
+    # as quoted data; do not interpolate them directly into the shell script.
     env:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       REPOSITORY_NAME: ${{ github.event.repository.name }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_BODY: ${{ github.event.pull_request.body }}
       PR_URL: ${{ github.event.pull_request.html_url }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -35,24 +38,147 @@ jobs:
             exit 1
           fi
 
+      - name: Build release change list
+        id: changes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Current promotion PRs normally carry an `含めたPR:` line. Prefer it
+          # to avoid collecting unrelated references from QA notes. Older
+          # promotion formats fall back to scanning the whole PR body.
+          candidate_text=$(printf '%s\n' "$PR_BODY" | grep -E '含めたPR:.*#[0-9]+' || true)
+          if [[ -z "$candidate_text" ]]; then
+            candidate_text="$PR_BODY"
+          fi
+
+          candidate_numbers=$(
+            printf '%s\n' "$candidate_text" \
+              | grep -oE '#[0-9]+' \
+              | tr -d '#' \
+              | awk '!seen[$0]++' \
+              | head -n 30 \
+              || true
+          )
+
+          changes_json='[]'
+          for candidate in $candidate_numbers; do
+            # Do not accidentally list the promotion PR itself if its number is
+            # mentioned in the body.
+            if [[ "$candidate" == "$PR_NUMBER" ]]; then
+              continue
+            fi
+
+            response_file=$(mktemp)
+            if ! http_code=$(curl \
+              --silent \
+              --show-error \
+              --retry 2 \
+              --retry-delay 1 \
+              --output "$response_file" \
+              --write-out '%{http_code}' \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$candidate"); then
+              echo "::warning::Failed to fetch PR #$candidate while building the Discord change list."
+              rm -f "$response_file"
+              continue
+            fi
+
+            if [[ "$http_code" != "200" ]]; then
+              # Issue references and stale/non-PR numbers can legitimately be
+              # present in older promotion bodies, so they are ignored.
+              if [[ "$http_code" != "404" ]]; then
+                echo "::warning::GitHub API returned HTTP $http_code for PR #$candidate."
+              fi
+              rm -f "$response_file"
+              continue
+            fi
+
+            base_ref=$(jq -r '.base.ref // ""' "$response_file")
+            merged_at=$(jq -r '.merged_at // ""' "$response_file")
+            if [[ "$base_ref" != "preview" || -z "$merged_at" ]]; then
+              rm -f "$response_file"
+              continue
+            fi
+
+            title=$(jq -r '.title // ""' "$response_file" | tr '\n' ' ' | cut -c1-80)
+            url=$(jq -r '.html_url // ""' "$response_file")
+            rm -f "$response_file"
+
+            # Escape Discord Markdown control characters in PR-controlled
+            # titles while keeping the generated GitHub link clickable.
+            safe_title=$(TITLE="$title" python3 - <<'PY'
+import os
+import re
+
+value = os.environ["TITLE"]
+print(re.sub(r"([\\`*_~|>\[\]\(\)])", r"\\\1", value), end="")
+PY
+            )
+
+            changes_json=$(jq -c \
+              --arg number "$candidate" \
+              --arg title "$safe_title" \
+              --arg url "$url" \
+              '. + [{number: $number, title: $title, url: $url}]' \
+              <<<"$changes_json")
+          done
+
+          change_count=$(jq 'length' <<<"$changes_json")
+          if [[ "$change_count" -eq 0 ]]; then
+            # Keep the notification useful even if an old/custom promotion PR
+            # body does not expose its component PRs in a recognizable form.
+            safe_fallback_title=$(TITLE="$PR_TITLE" python3 - <<'PY'
+import os
+import re
+
+value = os.environ["TITLE"][:80]
+print(re.sub(r"([\\`*_~|>\[\]\(\)])", r"\\\1", value), end="")
+PY
+            )
+            change_count=1
+            change_list="- [#$PR_NUMBER $safe_fallback_title]($PR_URL)"
+          else
+            change_list=$(jq -r \
+              '.[:10][] | "- [#\(.number) \(.title)](\(.url))"' \
+              <<<"$changes_json")
+
+            if [[ "$change_count" -gt 10 ]]; then
+              change_list+=$'\n'"- ほか $((change_count - 10)) 件"
+            fi
+          fi
+
+          {
+            echo "count=$change_count"
+            echo 'change_list<<EOF'
+            printf '%s\n' "$change_list"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Send merge notification to Discord
         shell: bash
+        env:
+          CHANGE_COUNT: ${{ steps.changes.outputs.count }}
+          CHANGE_LIST: ${{ steps.changes.outputs.change_list }}
         run: |
           payload=$(jq -n \
             --arg repository "$REPOSITORY_NAME" \
-            --arg number "$PR_NUMBER" \
-            --arg title "$PR_TITLE" \
             --arg url "$PR_URL" \
             --arg author "$PR_AUTHOR" \
             --arg head_ref "$HEAD_REF" \
+            --arg change_count "$CHANGE_COUNT" \
+            --arg change_list "$CHANGE_LIST" \
             '{
               username: "twica GitHub",
               content: (
                 "🚀 **" + $repository + " が更新されました**\n\n" +
-                "**#" + $number + " " + $title + "**\n" +
+                "**今回の変更**\n" + $change_list + "\n\n" +
+                "**全" + $change_count + "件の変更**\n" +
                 "`" + $head_ref + " → main`\n" +
                 "by " + $author + "\n\n" +
-                "🔗 [Pull Requestを見る](" + $url + ")"
+                "🔗 [リリース内容を見る](" + $url + ")"
               ),
               allowed_mentions: {parse: []}
             }')

--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -68,27 +68,35 @@ jobs:
           }
 
           escape_title() {
-            TITLE="$1" python3 -c 'import os,re; value=os.environ["TITLE"][:80]; print(re.sub(r"([\\`*_~|\[\]])", r"\\\1", value), end="")'
+            # Normalize line breaks before the value can reach GITHUB_OUTPUT,
+            # truncate by Unicode characters (not bytes), then escape only
+            # Markdown controls that can affect link text rendering.
+            TITLE="$1" python3 -c 'import os,re; value=os.environ["TITLE"].replace("\r", " ").replace("\n", " ")[:80]; print(re.sub(r"([\\`*_~|\[\]])", r"\\\1", value), end="")'
           }
 
+          discovery_complete=true
           commit_shas=()
+          page_size=100
           max_pages=5
           for page in $(seq 1 "$max_pages"); do
             response_file=$(mktemp)
-            compare_url="https://api.github.com/repos/$GITHUB_REPOSITORY/compare/$BASE_SHA...$HEAD_SHA?per_page=100&page=$page"
+            compare_url="https://api.github.com/repos/$GITHUB_REPOSITORY/compare/$BASE_SHA...$HEAD_SHA?per_page=$page_size&page=$page"
             if ! http_code=$(api_get "$compare_url" "$response_file"); then
               echo "::warning::Failed to fetch release commit comparison from GitHub."
+              discovery_complete=false
               rm -f "$response_file"
               break
             fi
 
             if [[ "$http_code" != "200" ]]; then
               echo "::warning::GitHub compare API returned HTTP $http_code."
+              discovery_complete=false
               rm -f "$response_file"
               break
             fi
 
             page_count=$(jq '.commits | length' "$response_file")
+            total_commits=$(jq '.total_commits // 0' "$response_file")
             while IFS= read -r commit_sha; do
               if [[ -n "$commit_sha" ]]; then
                 commit_shas+=("$commit_sha")
@@ -96,12 +104,13 @@ jobs:
             done < <(jq -r '.commits[].sha' "$response_file")
             rm -f "$response_file"
 
-            if [[ "$page_count" -lt 100 ]]; then
+            if [[ "$page_count" -lt "$page_size" ]]; then
               break
             fi
 
-            if [[ "$page" -eq "$max_pages" ]]; then
-              echo "::warning::Release comparison exceeded $((max_pages * 100)) commits; Discord change discovery was truncated."
+            if [[ "$page" -eq "$max_pages" && "$total_commits" -gt $((max_pages * page_size)) ]]; then
+              echo "::warning::Release comparison exceeded $((max_pages * page_size)) commits; Discord change discovery was truncated."
+              discovery_complete=false
             fi
           done
 
@@ -112,12 +121,14 @@ jobs:
             pulls_url="https://api.github.com/repos/$GITHUB_REPOSITORY/commits/$commit_sha/pulls"
             if ! http_code=$(api_get "$pulls_url" "$response_file"); then
               echo "::warning::Failed to resolve PRs associated with commit $commit_sha."
+              discovery_complete=false
               rm -f "$response_file"
               continue
             fi
 
             if [[ "$http_code" != "200" ]]; then
               echo "::warning::GitHub commit-pulls API returned HTTP $http_code for $commit_sha."
+              discovery_complete=false
               rm -f "$response_file"
               continue
             fi
@@ -128,7 +139,7 @@ jobs:
                 continue
               fi
 
-              title=$(jq -r '.title // ""' <<<"$pr_json" | tr '\n' ' ')
+              title=$(jq -r '.title // ""' <<<"$pr_json")
               url=$(jq -r '.url // ""' <<<"$pr_json")
               safe_title=$(escape_title "$title")
 
@@ -146,12 +157,14 @@ jobs:
           done
 
           change_count=$(jq 'length' <<<"$changes_json")
-          if [[ "$change_count" -eq 0 ]]; then
-            # Direct-to-main PRs and API failures still get the previous useful
-            # notification rather than a misleading empty change list.
+          if [[ "$change_count" -eq 0 && "$discovery_complete" == "true" ]]; then
+            # A direct-to-main PR has no preview-origin PRs, so preserve the
+            # previous useful notification by showing the merged PR itself.
             safe_fallback_title=$(escape_title "$PR_TITLE")
             change_count=1
             change_list="- [#$PR_NUMBER $safe_fallback_title]($PR_URL)"
+          elif [[ "$change_count" -eq 0 ]]; then
+            change_list='- 更新内容をGitHubから完全には取得できませんでした'
           else
             change_list=$(jq -r \
               '.[:10][] | "- [#\(.number) \(.title)](\(.url))"' \
@@ -162,11 +175,15 @@ jobs:
             fi
           fi
 
+          # GitHub recommends a unique delimiter for multiline outputs when
+          # values can contain externally controlled text.
+          delimiter="EOF_$(python3 -c 'import uuid; print(uuid.uuid4().hex)')"
           {
             echo "count=$change_count"
-            echo 'change_list<<EOF'
+            echo "complete=$discovery_complete"
+            echo "change_list<<$delimiter"
             printf '%s\n' "$change_list"
-            echo 'EOF'
+            echo "$delimiter"
           } >> "$GITHUB_OUTPUT"
 
       - name: Send merge notification to Discord
@@ -174,20 +191,28 @@ jobs:
         env:
           CHANGE_COUNT: ${{ steps.changes.outputs.count }}
           CHANGE_LIST: ${{ steps.changes.outputs.change_list }}
+          DISCOVERY_COMPLETE: ${{ steps.changes.outputs.complete }}
         run: |
+          if [[ "$DISCOVERY_COMPLETE" == "true" ]]; then
+            change_heading="**今回の変更（全${CHANGE_COUNT}件）**"
+          elif [[ "$CHANGE_COUNT" -eq 0 ]]; then
+            change_heading='**今回の変更（取得失敗）**'
+          else
+            change_heading="**今回の変更（取得できた${CHANGE_COUNT}件・一部取得失敗）**"
+          fi
+
           payload=$(jq -n \
             --arg repository "$REPOSITORY_NAME" \
             --arg url "$PR_URL" \
             --arg author "$PR_AUTHOR" \
             --arg head_ref "$HEAD_REF" \
-            --arg change_count "$CHANGE_COUNT" \
+            --arg change_heading "$change_heading" \
             --arg change_list "$CHANGE_LIST" \
             '{
               username: "twica GitHub",
               content: (
                 "🚀 **" + $repository + " が更新されました**\n\n" +
-                "**今回の変更**\n" + $change_list + "\n\n" +
-                "**全" + $change_count + "件の変更**\n" +
+                $change_heading + "\n" + $change_list + "\n\n" +
                 "`" + $head_ref + " → main`\n" +
                 "by " + $author + "\n\n" +
                 "🔗 [リリース内容を見る](" + $url + ")"

--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -76,6 +76,7 @@ jobs:
 
           discovery_complete=true
           commit_shas=()
+          total_commits=0
           page_size=100
           max_pages=5
           for page in $(seq 1 "$max_pages"); do
@@ -95,13 +96,25 @@ jobs:
               break
             fi
 
-            page_count=$(jq '.commits | length' "$response_file")
-            total_commits=$(jq '.total_commits // 0' "$response_file")
+            if ! page_metadata=$(jq -r '[.commits | length, (.total_commits // 0)] | @tsv' "$response_file"); then
+              echo "::warning::Failed to parse release commit comparison metadata."
+              discovery_complete=false
+              rm -f "$response_file"
+              break
+            fi
+            IFS=$'\t' read -r page_count total_commits <<<"$page_metadata"
+
+            if ! page_commit_shas=$(jq -r '.commits[]?.sha' "$response_file"); then
+              echo "::warning::Failed to parse release commit SHAs."
+              discovery_complete=false
+              rm -f "$response_file"
+              break
+            fi
             while IFS= read -r commit_sha; do
               if [[ -n "$commit_sha" ]]; then
                 commit_shas+=("$commit_sha")
               fi
-            done < <(jq -r '.commits[].sha' "$response_file")
+            done <<<"$page_commit_shas"
             rm -f "$response_file"
 
             if [[ "$page_count" -lt "$page_size" ]]; then
@@ -113,6 +126,11 @@ jobs:
               discovery_complete=false
             fi
           done
+
+          if [[ "$discovery_complete" == "true" && ${#commit_shas[@]} -lt "$total_commits" ]]; then
+            echo "::warning::GitHub compare API returned ${#commit_shas[@]} of $total_commits commits; Discord change discovery is incomplete."
+            discovery_complete=false
+          fi
 
           changes_json='[]'
           seen_numbers=' '
@@ -201,22 +219,49 @@ jobs:
             change_heading="**今回の変更（取得できた${CHANGE_COUNT}件・一部取得失敗）**"
           fi
 
+          # Discord limits message content to 2000 UTF-16 code units. Keep the
+          # full count in the heading, but drop whole change-list lines if the
+          # rendered message would exceed that limit so the webhook still lands.
+          content=$(CHANGE_HEADING="$change_heading" python3 - <<'PY'
+          import os
+
+          limit = 2000
+          marker = "- 文字数上限のため一部省略"
+          lines = os.environ.get("CHANGE_LIST", "").splitlines()
+          if not lines:
+              lines = ["- 更新内容をGitHubから取得できませんでした"]
+
+          def build(change_lines):
+              return (
+                  f"🚀 **{os.environ['REPOSITORY_NAME']} が更新されました**\n\n"
+                  f"{os.environ['CHANGE_HEADING']}\n"
+                  f"{'\n'.join(change_lines)}\n\n"
+                  f"`{os.environ['HEAD_REF']} → main`\n"
+                  f"by {os.environ['PR_AUTHOR']}\n\n"
+                  f"🔗 [リリース内容を見る]({os.environ['PR_URL']})"
+              )
+
+          def discord_length(value):
+              return len(value.encode("utf-16-le")) // 2
+
+          content = build(lines)
+          if discord_length(content) > limit:
+              while lines and discord_length(build(lines + [marker])) > limit:
+                  lines.pop()
+              content = build(lines + [marker])
+
+          if discord_length(content) > limit:
+              raise SystemExit("Discord notification still exceeds 2000 characters after trimming")
+
+          print(content, end="")
+          PY
+          )
+
           payload=$(jq -n \
-            --arg repository "$REPOSITORY_NAME" \
-            --arg url "$PR_URL" \
-            --arg author "$PR_AUTHOR" \
-            --arg head_ref "$HEAD_REF" \
-            --arg change_heading "$change_heading" \
-            --arg change_list "$CHANGE_LIST" \
+            --arg content "$content" \
             '{
               username: "twica GitHub",
-              content: (
-                "🚀 **" + $repository + " が更新されました**\n\n" +
-                $change_heading + "\n" + $change_list + "\n\n" +
-                "`" + $head_ref + " → main`\n" +
-                "by " + $author + "\n\n" +
-                "🔗 [リリース内容を見る](" + $url + ")"
-              ),
+              content: $content,
               allowed_mentions: {parse: []}
             }')
 

--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -24,10 +24,11 @@ jobs:
       REPOSITORY_NAME: ${{ github.event.repository.name }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_TITLE: ${{ github.event.pull_request.title }}
-      PR_BODY: ${{ github.event.pull_request.body }}
       PR_URL: ${{ github.event.pull_request.html_url }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
 
     steps:
       - name: Validate webhook configuration
@@ -44,86 +45,111 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Current promotion PRs normally carry an `含めたPR:` line. Prefer it
-          # to avoid collecting unrelated references from QA notes. Older
-          # promotion formats fall back to scanning the whole PR body.
-          candidate_text=$(printf '%s\n' "$PR_BODY" | grep -E '含めたPR:.*#[0-9]+' || true)
-          if [[ -z "$candidate_text" ]]; then
-            candidate_text="$PR_BODY"
-          fi
-
-          candidate_numbers=$(
-            printf '%s\n' "$candidate_text" \
-              | grep -oE '#[0-9]+' \
-              | tr -d '#' \
-              | awk '!seen[$0]++' \
-              | head -n 30 \
-              || true
-          )
-
-          changes_json='[]'
-          for candidate in $candidate_numbers; do
-            # Do not accidentally list the promotion PR itself if its number is
-            # mentioned in the body.
-            if [[ "$candidate" == "$PR_NUMBER" ]]; then
-              continue
-            fi
-
-            response_file=$(mktemp)
-            if ! http_code=$(curl \
+          # Resolve the actual commits contained by the merged promotion PR,
+          # then ask GitHub which preview PR introduced each commit. This avoids
+          # trusting free-form promotion PR prose, which can mention unrelated
+          # historical PRs in QA/review notes.
+          api_get() {
+            local url="$1"
+            local output_file="$2"
+            curl \
               --silent \
               --show-error \
               --retry 2 \
               --retry-delay 1 \
-              --output "$response_file" \
+              --connect-timeout 5 \
+              --max-time 15 \
+              --output "$output_file" \
               --write-out '%{http_code}' \
               -H "Authorization: Bearer $GH_TOKEN" \
               -H 'Accept: application/vnd.github+json' \
               -H 'X-GitHub-Api-Version: 2022-11-28' \
-              "https://api.github.com/repos/$GITHUB_REPOSITORY/pulls/$candidate"); then
-              echo "::warning::Failed to fetch PR #$candidate while building the Discord change list."
+              "$url"
+          }
+
+          escape_title() {
+            TITLE="$1" python3 -c 'import os,re; value=os.environ["TITLE"][:80]; print(re.sub(r"([\\`*_~|\[\]])", r"\\\1", value), end="")'
+          }
+
+          commit_shas=()
+          max_pages=5
+          for page in $(seq 1 "$max_pages"); do
+            response_file=$(mktemp)
+            compare_url="https://api.github.com/repos/$GITHUB_REPOSITORY/compare/$BASE_SHA...$HEAD_SHA?per_page=100&page=$page"
+            if ! http_code=$(api_get "$compare_url" "$response_file"); then
+              echo "::warning::Failed to fetch release commit comparison from GitHub."
+              rm -f "$response_file"
+              break
+            fi
+
+            if [[ "$http_code" != "200" ]]; then
+              echo "::warning::GitHub compare API returned HTTP $http_code."
+              rm -f "$response_file"
+              break
+            fi
+
+            page_count=$(jq '.commits | length' "$response_file")
+            while IFS= read -r commit_sha; do
+              if [[ -n "$commit_sha" ]]; then
+                commit_shas+=("$commit_sha")
+              fi
+            done < <(jq -r '.commits[].sha' "$response_file")
+            rm -f "$response_file"
+
+            if [[ "$page_count" -lt 100 ]]; then
+              break
+            fi
+
+            if [[ "$page" -eq "$max_pages" ]]; then
+              echo "::warning::Release comparison exceeded $((max_pages * 100)) commits; Discord change discovery was truncated."
+            fi
+          done
+
+          changes_json='[]'
+          seen_numbers=' '
+          for commit_sha in "${commit_shas[@]}"; do
+            response_file=$(mktemp)
+            pulls_url="https://api.github.com/repos/$GITHUB_REPOSITORY/commits/$commit_sha/pulls"
+            if ! http_code=$(api_get "$pulls_url" "$response_file"); then
+              echo "::warning::Failed to resolve PRs associated with commit $commit_sha."
               rm -f "$response_file"
               continue
             fi
 
             if [[ "$http_code" != "200" ]]; then
-              # Issue references and stale/non-PR numbers can legitimately be
-              # present in older promotion bodies, so they are ignored.
-              if [[ "$http_code" != "404" ]]; then
-                echo "::warning::GitHub API returned HTTP $http_code for PR #$candidate."
+              echo "::warning::GitHub commit-pulls API returned HTTP $http_code for $commit_sha."
+              rm -f "$response_file"
+              continue
+            fi
+
+            while IFS= read -r pr_json; do
+              number=$(jq -r '.number | tostring' <<<"$pr_json")
+              if [[ "$seen_numbers" == *" $number "* ]]; then
+                continue
               fi
-              rm -f "$response_file"
-              continue
-            fi
 
-            base_ref=$(jq -r '.base.ref // ""' "$response_file")
-            merged_at=$(jq -r '.merged_at // ""' "$response_file")
-            if [[ "$base_ref" != "preview" || -z "$merged_at" ]]; then
-              rm -f "$response_file"
-              continue
-            fi
+              title=$(jq -r '.title // ""' <<<"$pr_json" | tr '\n' ' ')
+              url=$(jq -r '.url // ""' <<<"$pr_json")
+              safe_title=$(escape_title "$title")
 
-            title=$(jq -r '.title // ""' "$response_file" | tr '\n' ' ' | cut -c1-80)
-            url=$(jq -r '.html_url // ""' "$response_file")
+              changes_json=$(jq -c \
+                --arg number "$number" \
+                --arg title "$safe_title" \
+                --arg url "$url" \
+                '. + [{number: $number, title: $title, url: $url}]' \
+                <<<"$changes_json")
+              seen_numbers+="$number "
+            done < <(jq -c \
+              '.[] | select(.base.ref == "preview" and (.merged_at // "") != "") | {number, title, url: .html_url}' \
+              "$response_file")
             rm -f "$response_file"
-
-            # Escape Discord Markdown control characters in PR-controlled
-            # titles while keeping the generated GitHub link clickable.
-            safe_title=$(TITLE="$title" python3 -c 'import os,re; value=os.environ["TITLE"]; print(re.sub(r"([\\`*_~|>\[\]\(\)])", r"\\\1", value), end="")')
-
-            changes_json=$(jq -c \
-              --arg number "$candidate" \
-              --arg title "$safe_title" \
-              --arg url "$url" \
-              '. + [{number: $number, title: $title, url: $url}]' \
-              <<<"$changes_json")
           done
 
           change_count=$(jq 'length' <<<"$changes_json")
           if [[ "$change_count" -eq 0 ]]; then
-            # Keep the notification useful even if an old/custom promotion PR
-            # body does not expose its component PRs in a recognizable form.
-            safe_fallback_title=$(TITLE="$PR_TITLE" python3 -c 'import os,re; value=os.environ["TITLE"][:80]; print(re.sub(r"([\\`*_~|>\[\]\(\)])", r"\\\1", value), end="")')
+            # Direct-to-main PRs and API failures still get the previous useful
+            # notification rather than a misleading empty change list.
+            safe_fallback_title=$(escape_title "$PR_TITLE")
             change_count=1
             change_list="- [#$PR_NUMBER $safe_fallback_title]($PR_URL)"
           else

--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -109,14 +109,7 @@ jobs:
 
             # Escape Discord Markdown control characters in PR-controlled
             # titles while keeping the generated GitHub link clickable.
-            safe_title=$(TITLE="$title" python3 - <<'PY'
-import os
-import re
-
-value = os.environ["TITLE"]
-print(re.sub(r"([\\`*_~|>\[\]\(\)])", r"\\\1", value), end="")
-PY
-            )
+            safe_title=$(TITLE="$title" python3 -c 'import os,re; value=os.environ["TITLE"]; print(re.sub(r"([\\`*_~|>\[\]\(\)])", r"\\\1", value), end="")')
 
             changes_json=$(jq -c \
               --arg number "$candidate" \
@@ -130,14 +123,7 @@ PY
           if [[ "$change_count" -eq 0 ]]; then
             # Keep the notification useful even if an old/custom promotion PR
             # body does not expose its component PRs in a recognizable form.
-            safe_fallback_title=$(TITLE="$PR_TITLE" python3 - <<'PY'
-import os
-import re
-
-value = os.environ["TITLE"][:80]
-print(re.sub(r"([\\`*_~|>\[\]\(\)])", r"\\\1", value), end="")
-PY
-            )
+            safe_fallback_title=$(TITLE="$PR_TITLE" python3 -c 'import os,re; value=os.environ["TITLE"][:80]; print(re.sub(r"([\\`*_~|>\[\]\(\)])", r"\\\1", value), end="")')
             change_count=1
             change_list="- [#$PR_NUMBER $safe_fallback_title]($PR_URL)"
           else


### PR DESCRIPTION
## 概要

`main` マージ時のDiscord通知に、昇格PRへ実際に含まれる元PRのタイトル一覧を表示します。

## 変更内容

- 昇格PRの `base SHA ... head SHA` をGitHub Compare APIで取得
- 差分に含まれる各commitから、GitHubのcommit-associated PR APIで元PRを解決
- 実際に `preview` へマージ済みのPRだけを採用するため、PR本文中のQA・レビュー参照は混入しない
- 最大10件のPRタイトルを表示し、多い場合は `ほかN件`
- PRタイトルの分類（feat/fix/chore等による絵文字付与）は行わない
- PRタイトルはPythonで80文字単位に切り詰め、Discord Markdown制御文字をエスケープ
- 元PRを取得できない場合は従来どおり昇格PR自身のタイトルへフォールバック

## 通知例

```text
🚀 twica が更新されました

今回の変更
- #1097 ○○の不具合を修正
- #1094 ○○機能を追加
- #1090 ○○の動作を改善
- ほか 2 件

全5件の変更
preview → main
by azumag

🔗 リリース内容を見る
```

各PRタイトルと `リリース内容を見る` はGitHubへのリンクになります。

## セキュリティ

`pull_request_target` のPR headはcheckout・実行せず、GitHub APIはread-onlyで元PRメタデータを取得する用途に限定します。PR由来の値はshellへ直接展開せず、環境変数・quoted dataとして扱います。

## レビュー指摘対応

- 日本語タイトルを `cut` でバイト途中切断する問題を解消し、Pythonの文字単位スライスへ統一
- 自由記述のPR本文全体スキャンを廃止し、GitHub上の実際の差分commitとassociated PRからリリース構成を決定