### PR TITLE
test(db-cutover): layer invariant契約を固定 (#1095)

### DIFF
--- a/tests/unit/db-cutover/layer-invariants.test.ts
+++ b/tests/unit/db-cutover/layer-invariants.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { INVARIANTS } from '../../../scripts/db-cutover/invariant-checks.mjs'
+import {
+  evaluateInvariantsLayer,
+  readSideInvariants,
+} from '../../../scripts/db-cutover/layer-invariants.mjs'
+
+const FIXTURE_INVARIANT = {
+  id: 'fixture-invariant',
+  description: 'fixture invariant',
+  requiredTables: [],
+  checks: [
+    {
+      code: 'FIXTURE_CHECK',
+      tier: 'A',
+      countSql: 'COUNT_SQL',
+      sampleSql: 'SAMPLE_SQL',
+      digestSql: null,
+    },
+  ],
+}
+
+describe('db cutover layer invariants', () => {
+  it('invariant id が重複しない', () => {
+    const ids = INVARIANTS.map((invariant) => invariant.id)
+
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('違反0件なら sample / digest SQL を実行せず side 結果を返す', async () => {
+    const unsafe = vi.fn(async (sql: string) => {
+      if (sql === 'COUNT_SQL') return [{ count: 0 }]
+      throw new Error(`unexpected SQL: ${sql}`)
+    })
+    const onInvariantChecked = vi.fn()
+
+    const results = await readSideInvariants(
+      { unsafe } as never,
+      [FIXTURE_INVARIANT] as never,
+      'source',
+      (text: string) => text,
+      onInvariantChecked,
+    )
+
+    expect(unsafe).toHaveBeenCalledTimes(1)
+    expect(unsafe).toHaveBeenCalledWith('COUNT_SQL')
+    expect(results.get(FIXTURE_INVARIANT.id)).toEqual(
+      expect.objectContaining({
+        tablesOk: true,
+        checks: [
+          expect.objectContaining({
+            code: 'FIXTURE_CHECK',
+            violationCount: 0,
+            samples: [],
+            digest: null,
+          }),
+        ],
+      }),
+    )
+    expect(onInvariantChecked).toHaveBeenCalledWith(
+      expect.objectContaining({
+        side: 'source',
+        invariantId: FIXTURE_INVARIANT.id,
+        tablesOk: true,
+      }),
+    )
+  })
+
+  it('Tier A が両側0件なら layer を pass にする', () => {
+    const sideResult = {
+      tablesOk: true,
+      checks: [
+        {
+          code: 'FIXTURE_CHECK',
+          tier: 'A',
+          violationCount: 0,
+          samples: [],
+          digest: null,
+          durationMs: 1,
+        },
+      ],
+      durationMs: 1,
+    }
+
+    const result = evaluateInvariantsLayer({
+      sourceResults: new Map([[FIXTURE_INVARIANT.id, sideResult]]),
+      targetResults: new Map([[FIXTURE_INVARIANT.id, sideResult]]),
+      invariantDefs: [FIXTURE_INVARIANT] as never,
+    })
+
+    expect(result).toMatchObject({
+      layer: 'invariants',
+      pass: true,
+      findings: [],
+      invariants: [
+        {
+          id: FIXTURE_INVARIANT.id,
+          pass: true,
+          allowlisted: false,
+        },
+      ],
+    })
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1095 の判断不要なテスト追加を小さく切り出します。

## 変更内容

- `INVARIANTS` の `invariant.id` 一意性を固定
- `readSideInvariants` で違反0件時に sample / digest SQL を実行しない契約を固定
- `evaluateInvariantsLayer` の Tier A 両側0件正常系を固定
- `layer-invariants.mjs` 内で参照されていた `tests/unit/db-cutover/layer-invariants.test.ts` を実在するテストとして追加

## 影響範囲

- テストファイル1件の追加のみ
- 本番コード、DB、設定、依存関係の変更なし

Refs #1095