### PR TITLE
fix(a11y): カード表示設定の可視ラベルをトグルへ関連付け (#1093)

### DIFF
--- a/src/components/CardVisibilitySettings.tsx
+++ b/src/components/CardVisibilitySettings.tsx
@@ -154,12 +154,13 @@ export default function CardVisibilitySettings({
         {/* 未所持カードを表示 */}
         <div className="flex items-center gap-3">
           <label
+            htmlFor="show-unowned-cards-toggle"
             className="relative inline-flex cursor-pointer items-center"
             title={isMaintenanceBlocked ? tMaintenance("writeDisabled") : undefined}
           >
             <input
+              id="show-unowned-cards-toggle"
               type="checkbox"
-              aria-label={t("form.showUnowned")}
               checked={showUnowned}
               onChange={handleToggleShowUnowned}
               disabled={showUnownedDisabled}
@@ -167,9 +168,9 @@ export default function CardVisibilitySettings({
             />
             <div className="h-6 w-11 rounded-full bg-gray-600 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-purple-600 peer-checked:after:translate-x-full peer-checked:after:border-white peer-disabled:opacity-50" />
           </label>
-          <span className="text-sm text-gray-300">
+          <label htmlFor="show-unowned-cards-toggle" className="cursor-pointer text-sm text-gray-300">
             {t("form.showUnowned")}
-          </span>
+          </label>
         </div>
         <p className="-mt-2 ml-14 text-xs text-gray-500">
           {t("form.showUnownedHelp")}
@@ -178,12 +179,13 @@ export default function CardVisibilitySettings({
         {/* 未所持カードの詳細を公開 */}
         <div className="flex items-center gap-3">
           <label
+            htmlFor="show-unowned-details-toggle"
             className="relative inline-flex cursor-pointer items-center"
             title={isMaintenanceBlocked ? tMaintenance("writeDisabled") : undefined}
           >
             <input
+              id="show-unowned-details-toggle"
               type="checkbox"
-              aria-label={t("form.showDetails")}
               checked={showDetails}
               onChange={handleToggleShowDetails}
               disabled={detailsDisabled}
@@ -195,13 +197,14 @@ export default function CardVisibilitySettings({
               }`}
             />
           </label>
-          <span
-            className={`text-sm ${
+          <label
+            htmlFor="show-unowned-details-toggle"
+            className={`cursor-pointer text-sm ${
               showUnowned ? "text-gray-300" : "text-gray-500"
             }`}
           >
             {t("form.showDetails")}
-          </span>
+          </label>
           {!showUnowned && (
             <span className="text-xs text-gray-500">
               ({t("form.requiresShowUnowned")})

--- a/tests/unit/components/card-visibility-settings-maintenance.test.tsx
+++ b/tests/unit/components/card-visibility-settings-maintenance.test.tsx
@@ -24,10 +24,9 @@ function renderSettings(status: MaintenanceStatusResponse) {
   )
 }
 
-// トグルのラベルテキストは<label>要素の外側（兄弟<span>）にあり、アクセシブルネームが
-// 付いていない既存マークアップのため、name指定では拾えない。表示順が固定
-// （0: 未所持カードを表示する, 1: 未所持カードの詳細を公開する）であることを
-// 前提にインデックスで取得する。
+// トグルには可視ラベル由来のアクセシブルネームが付くが、このmaintenanceテストは
+// 両トグル共通のdisable挙動をまとめて検証するため表示順で取得する。
+// アクセシブルネーム指定へ寄せる追加改善は Issue #1093 で別途追跡する。
 function getToggles() {
   return screen.getAllByRole('checkbox')
 }


### PR DESCRIPTION
## Summary

- `CardVisibilitySettings` の2つのcheckboxへ安定した `id` を付与
- 可視テキストを `label htmlFor` で対応付け、`aria-label` の二重管理を解消
- 可視ラベル自体をクリックしてもトグルを操作できるようにする

## Scope

Issue #1093 の最初のノンブロッキング項目のみを対象にしています。`aria-describedby` や disabled 理由の追加伝達など、残りのa11y改善は本PRの収束条件に含めません。

## Verification

GitHub CI / Auto Review で確認します。

Refs #1093