### PR TITLE
test(twitch): emotesのtoken error context結線を固定 (#1088)

### DIFF
--- a/tests/unit/twitch-emotes-error-reporting.test.ts
+++ b/tests/unit/twitch-emotes-error-reporting.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/session', () => ({
+  getSession: vi.fn(),
+  canUseStreamerFeatures: vi.fn(),
+}))
+
+vi.mock('@/lib/rate-limit', () => ({
+  getRateLimitIdentifier: vi.fn().mockResolvedValue('user:test'),
+  checkRateLimit: vi.fn(),
+  rateLimits: { twitchRewardsGet: { windowMs: 60_000, max: 30 } },
+}))
+
+vi.mock('@/lib/twitch/token-manager', () => ({
+  getTwitchAccessToken: vi.fn(),
+  twitchTokenErrorReportContext: vi.fn(),
+}))
+
+vi.mock('@/lib/error-handler', () => ({
+  handleApiError: vi.fn(),
+}))
+
+describe('GET /api/twitch/emotes error reporting', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    const { getSession, canUseStreamerFeatures } = await import('@/lib/session')
+    const { checkRateLimit } = await import('@/lib/rate-limit')
+
+    vi.mocked(getSession).mockResolvedValue({ twitchUserId: 'streamer-1' } as never)
+    vi.mocked(canUseStreamerFeatures).mockReturnValue(true)
+    vi.mocked(checkRateLimit).mockResolvedValue({
+      success: true,
+      limit: 30,
+      remaining: 29,
+      reset: Date.now() + 60_000,
+    })
+  })
+
+  it('token refresh失敗時の安全な診断contextをhandleApiErrorへ渡す', async () => {
+    const tokenError = new Error('refresh failed')
+    const reportContext = {
+      refreshStatus: 503,
+      refreshErrorKind: 'http',
+      refreshRetryable: true,
+    }
+
+    const { getTwitchAccessToken, twitchTokenErrorReportContext } =
+      await import('@/lib/twitch/token-manager')
+    const { handleApiError } = await import('@/lib/error-handler')
+
+    vi.mocked(getTwitchAccessToken).mockRejectedValue(tokenError)
+    vi.mocked(twitchTokenErrorReportContext).mockReturnValue(reportContext)
+    vi.mocked(handleApiError).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'handled' }), { status: 500 }) as never
+    )
+
+    const { GET } = await import('@/app/api/twitch/emotes/route')
+    const response = await GET(new Request('http://localhost:3000/api/twitch/emotes'))
+
+    expect(twitchTokenErrorReportContext).toHaveBeenCalledWith(tokenError)
+    expect(handleApiError).toHaveBeenCalledWith(
+      tokenError,
+      'Twitch emotes fetch',
+      reportContext
+    )
+    expect(response.status).toBe(500)
+  })
+})


### PR DESCRIPTION
## Summary

- `/api/twitch/emotes` で token refresh 失敗が発生した際、`twitchTokenErrorReportContext(error)` の安全な診断情報が `handleApiError` へ渡ることを単体テストで固定
- 本番コード・設定・依存関係には変更なし

## Scope

Issue #1088 の最初のノンブロッキング項目のみを対象にします。コメント追加、401/requiresReauth整理、catch共通化は本PRの収束条件に含めません。

## Verification

GitHub CI / Auto Review で確認します。

Refs #1088