### PR TITLE
test(db-cutover): Tier A fixtureを共有定数へ寄せる (#1109)

### DIFF
--- a/tests/unit/db-cutover/layer-invariants.test.ts
+++ b/tests/unit/db-cutover/layer-invariants.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { INVARIANTS } from '../../../scripts/db-cutover/invariant-checks.mjs'
+import {
+  INVARIANTS,
+  TIER_A,
+} from '../../../scripts/db-cutover/invariant-checks.mjs'
 import {
   evaluateInvariantsLayer,
   readSideInvariants,
@@ -13,7 +16,7 @@ const FIXTURE_INVARIANT = {
   checks: [
     {
       code: 'FIXTURE_CHECK',
-      tier: 'A',
+      tier: TIER_A,
       countSql: 'COUNT_SQL',
       sampleSql: 'SAMPLE_SQL',
       digestSql: null,
@@ -73,7 +76,7 @@ describe('db cutover layer invariants', () => {
       checks: [
         {
           code: 'FIXTURE_CHECK',
-          tier: 'A',
+          tier: TIER_A,
           violationCount: 0,
           samples: [],
           digest: null,


### PR DESCRIPTION
## Summary

- `tests/unit/db-cutover/layer-invariants.test.ts` の Tier A fixture で裸の `'A'` を使わず、`invariant-checks.mjs` が公開する `TIER_A` を利用
- Tier 定数側の変更時に、fixture が意図せず別Tier分岐へ落ちるドリフトを避ける
- 本番コード・DB・設定・依存関係には変更なし

## Scope

Issue #1109 の最初のノンブロッキング項目のみを対象にします。Tier B fixture、side取り違え、追加分岐カバレッジ等は本PRの収束条件に含めません。

## Verification

GitHub CI / Auto Review で確認します。

Refs #1109