### PR TITLE
test(r2): fixture不変条件の失敗理由を明確化 (#1103)

### DIFF
--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -95,8 +95,14 @@ const RETRY_SUCCESS_ATTEMPTS = TRANSIENT_FAILURES_BEFORE_SUCCESS + 1
 const R2_INTERNAL_ERROR_MESSAGE = 'put: We encountered an internal error. Please try again. (10001)'
 
 function mockTransientFailuresThenSuccess(): void {
-  expect(TRANSIENT_FAILURES_BEFORE_SUCCESS).toBeGreaterThanOrEqual(1)
-  expect(TRANSIENT_FAILURES_BEFORE_SUCCESS).toBeLessThanOrEqual(MAX_RETRIES)
+  expect(
+    TRANSIENT_FAILURES_BEFORE_SUCCESS,
+    'retry-success fixture must include at least one transient failure',
+  ).toBeGreaterThanOrEqual(1)
+  expect(
+    TRANSIENT_FAILURES_BEFORE_SUCCESS,
+    'retry-success fixture must remain reachable within MAX_RETRIES',
+  ).toBeLessThanOrEqual(MAX_RETRIES)
 
   for (
     let transientFailureIndex = 0;


### PR DESCRIPTION
## Summary

- `mockTransientFailuresThenSuccess` のfixture不変条件assertへ、下限・上限それぞれの意図が分かる失敗メッセージを追加
- 値・リトライ挙動・本番コード・設定・依存関係には変更なし

## Scope

Issue #1103 の「fixture不変条件assertへ理由が分かるメッセージを付ける」項目だけを対象にします。ヘルパ責務分離、上限assertの重複整理、ループ表現の再評価は本PRの収束条件に含めません。

## Verification

GitHub CI / Auto Review で確認します。

Refs #1103