### PR TITLE
test(db): safe columns差分をmap比較で読みやすくする (#1086)

### DIFF
--- a/tests/unit/streamers-safe-columns.test.ts
+++ b/tests/unit/streamers-safe-columns.test.ts
@@ -95,15 +95,15 @@ describe('streamers デプロイ窓の列集合契約', () => {
     // 対応する列オブジェクトを STREAMERS_SAFE_COLUMNS 側へ追加し、フォールバック時の返却行形状と
     // キー↔実SQL列の対応を維持する。
     const deployWindowColumnNames = new Set<string>(DEPLOY_WINDOW_COLUMNS)
-    const toProjectionPairs = (entries: [string, { name: string }][]) =>
-      entries.map(([key, column]) => `${key}=${column.name}`).sort()
-    const expectedSafeProjectionPairs = toProjectionPairs(
-      Object.entries(getTableColumns(streamersTable)).filter(
-        ([, column]) => !deployWindowColumnNames.has(column.name),
-      ),
+    const expectedSafeProjection = Object.fromEntries(
+      Object.entries(getTableColumns(streamersTable))
+        .filter(([, column]) => !deployWindowColumnNames.has(column.name))
+        .map(([key, column]) => [key, column.name]),
     )
-    const safeProjectionPairs = toProjectionPairs(Object.entries(STREAMERS_SAFE_COLUMNS))
+    const safeProjection = Object.fromEntries(
+      Object.entries(STREAMERS_SAFE_COLUMNS).map(([key, column]) => [key, column.name]),
+    )
 
-    expect(safeProjectionPairs).toEqual(expectedSafeProjectionPairs)
+    expect(safeProjection).toEqual(expectedSafeProjection)
   })
 })


### PR DESCRIPTION
## Summary

- `STREAMERS_SAFE_COLUMNS` と schema 由来の期待値を `key=column` 文字列配列ではなく key→SQL列名の object map として比較
- 契約自体は変えず、失敗時にどの投影キーの対応が違うかを Vitest の object diff で読みやすくする
- 本番コード・DB・設定・依存関係には変更なし

## Scope

Issue #1086 の「`${key}=${column.name}` の文字列化 + `.sort()` ではなく map 同士を比較し、失敗時の差分を読みやすくする」項目のみを対象にします。否定方向テストの統合やコメント簡略化など、残りの項目は本PRの収束条件に含めません。

## Verification

GitHub CI / Auto Review で確認します。

Refs #1086