### PR TITLE
test(db-cutover): invariant identifier列契約を固定 (#1095)

### DIFF
--- a/tests/unit/db-cutover-invariant-identifier-contract.test.ts
+++ b/tests/unit/db-cutover-invariant-identifier-contract.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import { INVARIANTS } from '../../scripts/db-cutover/invariant-checks.mjs'
+
+const COUNT_SQL_PREFIX = 'WITH violators AS (\n'
+const COUNT_SQL_SUFFIX = '\n)\nSELECT COUNT(*)::int AS count FROM violators'
+
+function extractViolatorsCte(countSql: string): string {
+  if (!countSql.startsWith(COUNT_SQL_PREFIX) || !countSql.endsWith(COUNT_SQL_SUFFIX)) {
+    throw new Error('unexpected invariant count SQL shape')
+  }
+
+  return countSql.slice(COUNT_SQL_PREFIX.length, -COUNT_SQL_SUFFIX.length)
+}
+
+describe('db cutover invariant identifier contract', () => {
+  it('各checkのviolators CTEがidentifier列をちょうど1つ定義する', () => {
+    const invalidChecks = INVARIANTS.flatMap((invariant) =>
+      invariant.checks.flatMap((check) => {
+        const violatorsCte = extractViolatorsCte(check.countSql)
+        const identifierAliases = violatorsCte.match(/\bAS identifier\b/g) ?? []
+
+        return identifierAliases.length === 1
+          ? []
+          : [`${invariant.id}/${check.code}`]
+      }),
+    )
+
+    expect(invalidChecks).toEqual([])
+  })
+})


### PR DESCRIPTION
## 対応するIssue
#1095 のフォローアップ候補「各 check の `violatorsCte` が `identifier` 列を返す設計規約をテストで固定する」に対応します。

## 変更内容
- `INVARIANTS` の全 check について、生成済み `countSql` から `violators` CTE を取り出す
- 各 CTE が `AS identifier` をちょうど1つ定義していることを一括検証する
- 本番コード・DB・設定・依存関係には変更なし

## 意図
`buildViolationSampleSql` / `buildViolationDigestSql` は共通の `identifier` 列契約に依存しています。新しい invariant を追加した際に alias の付け忘れや複数定義を早い段階で検知できるようにします。

## 検証
CI / Auto Review で確認します。