### PR TITLE
docs(env): EventSub health注記の先頭行を短縮 (#1050)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -90,7 +90,7 @@ NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 
 # Cloudflare Workers / OpenNext デプロイ設定（Cloudflare Secrets で設定）
 # DB_HEALTH_SECRET=xxx            # /api/admin/db-health の共有シークレット
-# EVENTSUB_HEALTH_SECRET=xxx      # アプリ側 /api/admin/eventsub-health の共有シークレット
+# EVENTSUB_HEALTH_SECRET=xxx      # アプリ側 /api/admin/eventsub-health 用。Worker 側は別名
 #                                 # workers/error-reporter（twica-error-reporter）側は各環境のアプリと同じ値を、それぞれ
 #                                 # EVENTSUB_HEALTH_SECRET_PROD / EVENTSUB_HEALTH_SECRET_PREVIEW に設定
 #                                 # 詳細: docs/eventsub-subscription-health.md


### PR DESCRIPTION
## Summary

- `.env.local.example` の `EVENTSUB_HEALTH_SECRET` 先頭コメントを短縮
- Worker側は別名で設定することだけを先頭行に残し、具体的な変数名と詳細ドキュメントは既存の続き行へ委ねる
- 実行コード・実シークレット・デプロイ設定には変更なし

## Scope

Issue #1050 の任意改善3「コメント1行目の長さを抑える」のみを対象にします。他の EventSub 設定改善は本PRの収束条件に含めません。

## Verification

GitHub CI / Auto Review で確認します。

Refs #1050