### PR TITLE
docs(twitch): emotesのtoken error context橋渡し理由を明記 (#1088)

### DIFF
--- a/src/app/api/twitch/emotes/route.ts
+++ b/src/app/api/twitch/emotes/route.ts
@@ -116,6 +116,8 @@ export async function GET(request: Request) {
         { status: 401 }
       );
     }
+    // token-manager側ではrefresh障害を二重Issue化しないため、route境界で安全な
+    // refresh診断だけをadditionalInfoへ明示的に橋渡しする。
     return handleApiError(error, "Twitch emotes fetch", twitchTokenErrorReportContext(error));
   }
 }


### PR DESCRIPTION
## Summary

- `/api/twitch/emotes` の catch で `twitchTokenErrorReportContext(error)` を `handleApiError` へ渡す理由をコメントで明文化
- token-manager 側で refresh 障害を二重Issue化せず、route 境界で安全な診断情報だけを橋渡しする設計意図を残す
- 実行コード・API契約・設定・依存関係には変更なし

## Scope

Issue #1088 の「emotes ルートの `twitchTokenErrorReportContext(error)` 呼び出し付近へ根拠コメントを追加する」項目のみを対象にします。PR #1119 は既に `preview` へマージ済みで、結線回帰テストはそちらで対応済みです。401/requiresReauth 整理、catch共通化、コメント表現のさらなる統一は本PRの収束条件に含めず #1088 へ退避します。

## Verification

最新 `preview` (`99dc5f7a`) へ載せ直し済み。差分はコメント2行のみです。GitHub CI / Auto Review で確認します。

Refs #1088