### PR TITLE
test(analysis): diff table表示整形を固定 (#1082)

### DIFF
--- a/scripts/compare-analysis-dashboard-vs-sql.mjs
+++ b/scripts/compare-analysis-dashboard-vs-sql.mjs
@@ -433,4 +433,5 @@ export {
   fetchBasicAggregates,
   fetchRpcAggregates,
   diffAggregates,
+  printDiffTable,
 }

--- a/tests/unit/compare-analysis-dashboard-print-diff.test.ts
+++ b/tests/unit/compare-analysis-dashboard-print-diff.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { printDiffTable } from '../../scripts/compare-analysis-dashboard-vs-sql.mjs'
+
+/**
+ * Issue #1082 のフォローアップ。
+ * DB接続を伴わず、差分テーブルの列見出し・区切り・各差分行が欠落せず出力される契約を
+ * 固定する。値の比較自体は diffAggregates の既存テストが担うため、ここでは表示整形だけを
+ * 対象にし、console.log は spy へ閉じ込めてテストログを汚さない。
+ */
+describe('printDiffTable', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('見出し・区切り線・全差分行を順番どおり出力する', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    printDiffTable([
+      { metric: 'totalUsers', expected: 10, actual: 11 },
+      { metric: 'rarityDistribution.rare', expected: 25, actual: 26 },
+    ])
+
+    const lines = log.mock.calls.map(([line]) => String(line))
+
+    expect(lines).toHaveLength(4)
+    expect(lines[0]).toContain('METRIC')
+    expect(lines[0]).toContain('基礎集計SQL')
+    expect(lines[0]).toContain('get_analysis_* RPC')
+    expect(lines[1]).toMatch(/^-+\s{2}-+\s{2}-+$/)
+    expect(lines[2]).toMatch(/^totalUsers\s+10\s+11$/)
+    expect(lines[3]).toMatch(/^rarityDistribution\.rare\s+25\s+26$/)
+  })
+})

--- a/tests/unit/compare-analysis-dashboard-print-diff.test.ts
+++ b/tests/unit/compare-analysis-dashboard-print-diff.test.ts
@@ -21,7 +21,9 @@ describe('printDiffTable', () => {
       { metric: 'rarityDistribution.rare', expected: 25, actual: 26 },
     ])
 
-    const lines = log.mock.calls.map(([line]) => String(line))
+    // printDiffTable は列幅を揃えるため最終列も padEnd する。行末空白は表示上の意味を
+    // 持たないため除去し、列内容と順序の契約だけを検証する。
+    const lines = log.mock.calls.map(([line]) => String(line).trimEnd())
 
     expect(lines).toHaveLength(4)
     expect(lines[0]).toContain('METRIC')


### PR DESCRIPTION
## Summary

- analysis dashboard比較スクリプトの `printDiffTable` をDB接続なしで単体テスト可能にするためexport
- 見出し・区切り線・複数差分行が順番どおり出力されることを専用テストで固定
- 集計SQL・RPC・DB接続・実行時の表示内容そのものには変更なし

## Scope

Issue #1082 の任意改善4「`fetchBasicAggregates` / `printDiffTable` のテスト追加」のうち、現行previewですでに `fetchBasicAggregates` はテスト済みのため、未対応だった `printDiffTable` の表示整形だけを対象にします。ほかの任意改善は本PRの収束条件に含めません。

## Verification

GitHub CI / Auto Review で確認します。

Refs #1082