### PR TITLE
docs(twitch): emotesのtoken context根拠を明記 (#1088)

### DIFF
--- a/src/app/api/twitch/emotes/route.ts
+++ b/src/app/api/twitch/emotes/route.ts
@@ -116,6 +116,8 @@ export async function GET(request: Request) {
         { status: 401 }
       );
     }
+    // Token-manager refresh failures may wrap DB query/parameter details; report only the
+    // sanitized diagnostic fields exposed by the shared context helper at this API boundary.
     return handleApiError(error, "Twitch emotes fetch", twitchTokenErrorReportContext(error));
   }
 }


### PR DESCRIPTION
## Summary

- `/api/twitch/emotes` の token refresh 失敗時に `twitchTokenErrorReportContext(error)` を渡す理由をコメントで明文化
- DB query / parameter detail を含み得る元エラーを bug-report context へ直接流さず、共有helperのsanitized diagnosticだけを渡す安全境界であることを明記
- 実行ロジック・レスポンス・診断contextの値・設定・依存関係には変更なし

## Scope

Issue #1088 の「emotes ルートの `twitchTokenErrorReportContext(error)` 呼び出し付近へ、rewards / channel-point-bootstrap と同等の根拠コメントを追加する」項目のみを対象にします。401整理やcatch共通化、rate limit分離等は本PRの収束条件に含めません。

## Verification

- `preview` との差分は `src/app/api/twitch/emotes/route.ts` のコメント2行のみ
- GitHub CI / Auto Review で確認します

Refs #1088