### PR TITLE
docs(live): 公開告知の本番URL方針を明文化 (#935)

### DIFF
--- a/docs/live-directory-announcement-url.md
+++ b/docs/live-directory-announcement-url.md
@@ -1,0 +1,11 @@
+# /live 公開告知のリンク先
+
+`db/planetscale/migrations/20260811140000_publish_live_directory_announcement.sql` の公開告知は、migration が preview 環境へ適用される場合も `https://twica.bluemoon.works/live` を案内する。
+
+これは意図した運用である。告知は preview 専用機能の案内ではなく、ダッシュボード利用者へ公開済みの「チャネル・ランキング」ページを知らせるユーザー向けメッセージであり、リンク先には安定した本番URLを使う。branch preview / commit preview のURLは検証用で寿命やURLが変更され得るため、告知本文の恒久的な遷移先にはしない。
+
+preview では、告知の表示、期限、`AutoLinkText` によるリンク化などを検証する。ただし検証のために告知本文を preview URL へ書き換えない。
+
+将来 preview 限定の告知が必要になった場合は、適用済みmigrationの本文を書き換えるのではなく、環境別の告知を明示的に分離する。適用済みmigrationはchecksum管理の対象になり得るため、既存ファイルのコメントだけを追記する目的でも編集しない。
+
+Refs: #740, #935, PR #934


### PR DESCRIPTION
## Summary

- `/live` 公開告知が preview へ適用される場合も本番URL `https://twica.bluemoon.works/live` を案内する意図を運用ドキュメントへ明記
- branch / commit preview URL は検証用で恒久リンクにしないことを記録
- preview では表示・期限・AutoLinkText を検証し、告知本文のリンク先自体は書き換えない方針を明記
- 適用済みmigrationをコメント目的で編集せず、将来preview専用告知が必要なら環境別に分離することを補足

## Scope

Issue #935 の「previewでも本番URLを案内する告知migrationの意図をコメントまたは運用ドキュメントへ残す」項目だけを対象にします。RPC fallback、a11y、期間URL反映、集計最適化など他の候補は本PRの収束条件に含めません。

## Verification

- `preview` との差分は新規ドキュメント1ファイル・11行のみ
- 適用済みmigration・実行コード・DB・設定・依存関係には変更なし
- GitHub CI / Auto Review で確認します

Refs #935 #740 #934