### PR TITLE
fix(storage): blob errorのHTTP status検知を文脈限定化 (#989)

### DIFF
--- a/src/lib/error-handler.ts
+++ b/src/lib/error-handler.ts
@@ -52,19 +52,41 @@ export async function handleDatabaseError(error: unknown, context: string): Prom
   return NextResponse.json({ error: 'Database error' }, { status: 500 })
 }
 
+const HTTP_STATUS_REASON_PHRASES = {
+  401: 'unauthorized',
+  503: 'service\\s+unavailable',
+  507: 'insufficient\\s+storage',
+} as const
+
+// Issue #989: 裸の `503` などを部分一致させると `photo-503.png` や URL 中の数値まで
+// HTTP status と誤認するため、明示的な status ラベルか標準的な status line だけを受理する。
+// `httpStatusCode` は識別子途中に `status` があるため `\bstatus` 枝では一致せず、専用枝が必要。
+// `503 Service Unavailable` のような数値先頭形式は理由句まで一致させ、文脈のない数値を除外する。
+// r2-client のリトライ判定は一時障害メッセージを拾う目的でより広い書式を許容する一方、
+// ここでは最終レスポンスの誤分類を避けるため `\D{0,10}` のような緩い範囲を意図的に使わない。
+// 両者の判定器統合・入力形の整理は Issue #989 の残フォローアップとして扱う。
+function hasHttpStatusContext(errorMessage: string, status: 401 | 503 | 507): boolean {
+  const reasonPhrase = HTTP_STATUS_REASON_PHRASES[status]
+  return new RegExp(
+    `(?:\\bhttp(?:\\/[0-9.]+)?\\s+${status}\\b|\\bstatus(?:\\s*code)?\\s*[:=]?\\s*${status}\\b|\\bhttpstatuscode\\s*[:=]?\\s*${status}\\b|(?:^|[\\s:(\\[])${status}\\s+${reasonPhrase}\\b)`,
+    'i'
+  ).test(errorMessage)
+}
+
 export async function handleBlobError(error: unknown, context: string, additionalInfo?: Record<string, unknown>): Promise<NextResponse> {
   const errorMessage = error instanceof Error ? error.message : String(error)
+  const normalizedErrorMessage = errorMessage.toLowerCase()
   await logAndRecordError(`${context}: ${errorMessage}`, error, additionalInfo)
 
-  if (errorMessage.includes('quota') || errorMessage.includes('limit') || errorMessage.includes('507')) {
+  if (normalizedErrorMessage.includes('quota') || normalizedErrorMessage.includes('limit') || hasHttpStatusContext(errorMessage, 507)) {
     return NextResponse.json({ error: 'Storage quota exceeded' }, { status: 507 })
   }
 
-  if (errorMessage.includes('authentication') || errorMessage.includes('unauthorized') || errorMessage.includes('401')) {
+  if (normalizedErrorMessage.includes('authentication') || normalizedErrorMessage.includes('unauthorized') || hasHttpStatusContext(errorMessage, 401)) {
     return NextResponse.json({ error: 'Storage authentication failed' }, { status: 503 })
   }
 
-  if (errorMessage.includes('service unavailable') || errorMessage.includes('503')) {
+  if (normalizedErrorMessage.includes('service unavailable') || hasHttpStatusContext(errorMessage, 503)) {
     return NextResponse.json({ error: 'Storage service temporarily unavailable' }, { status: 503 })
   }
 

--- a/tests/unit/error-handler.test.ts
+++ b/tests/unit/error-handler.test.ts
@@ -94,6 +94,47 @@ describe('error-handler', () => {
       expect(body.error).toBe('Storage service temporarily unavailable');
     });
 
+    it.each([
+      ['HTTP 503', 503, 'Storage service temporarily unavailable'],
+      ['HTTP/1.1 503 Service Unavailable', 503, 'Storage service temporarily unavailable'],
+      ['503 Service Unavailable', 503, 'Storage service temporarily unavailable'],
+      ['401 Unauthorized', 503, 'Storage authentication failed'],
+      ['507 Insufficient Storage', 507, 'Storage quota exceeded'],
+      ['status code: 401', 503, 'Storage authentication failed'],
+      ['statusCode=503', 503, 'Storage service temporarily unavailable'],
+      ['$metadata.httpStatusCode: 507', 507, 'Storage quota exceeded'],
+    ])('HTTP status文脈の数値を分類できる: %s', async (errorMessage, expectedStatus, expectedError) => {
+      const response = await handleBlobError(new Error(errorMessage), 'blob');
+      expect(response.status).toBe(expectedStatus);
+
+      const body = await response.json();
+      expect(body.error).toBe(expectedError);
+    });
+
+    it.each([
+      ['Unauthorized', 503, 'Storage authentication failed'],
+      ['Service Unavailable', 503, 'Storage service temporarily unavailable'],
+    ])('キーワードの大文字小文字に依存せず分類できる: %s', async (errorMessage, expectedStatus, expectedError) => {
+      const response = await handleBlobError(new Error(errorMessage), 'blob');
+      expect(response.status).toBe(expectedStatus);
+
+      const body = await response.json();
+      expect(body.error).toBe(expectedError);
+    });
+
+    it.each([
+      '401',
+      '503',
+      '507',
+      'photo-503.png',
+      'avatar-401.jpg',
+      'asset-507-preview.png',
+      'https://example.com/assets/503.png',
+    ])('文脈のない数値をHTTP statusとして誤分類しない: %s', async (errorMessage) => {
+      const response = await handleBlobError(new Error(errorMessage), 'blob');
+      expect(response.status).toBe(500);
+    });
+
     it('その他のエラーで 500 を返す', async () => {
       const response = await handleBlobError(new Error('unknown blob error'), 'blob');
       expect(response.status).toBe(500);


### PR DESCRIPTION
## 概要

Issue #989 のフォローアップ項目1として、`handleBlobError` に残っていた裸の `401` / `503` / `507` 部分一致を HTTP status 文脈に限定します。

- `HTTP 503`
- `status code: 401`
- `statusCode=503`
- `$metadata.httpStatusCode: 507`

のように status 文脈が明示されている場合だけ数値で分類します。裸の数値、`photo-503.png`、`https://example.com/assets/503.png` のようなファイル名・URL中の数値は 500 の通常エラーとして扱います。

## 対応範囲

今回の収束条件は Issue #989 の項目1（`src/lib/error-handler.ts` の修正漏れ）のみです。`src/lib/r2-client.ts` 側の既存regexに対する項目2 / 3 / 6、構造化フィールド利用の項目4、実ログ確認の項目5はノンブロッキングのまま本Issueに残します。

## テスト

`tests/unit/error-handler.test.ts` に `handleBlobError` の positive / negative 回帰ケースを追加しました。

Refs #989