### PR TITLE
test(analysis): diff table fixtureを実メトリクス名へ合わせる (#1143)

### DIFF
--- a/tests/unit/compare-analysis-dashboard-vs-sql.test.ts
+++ b/tests/unit/compare-analysis-dashboard-vs-sql.test.ts
@@ -381,7 +381,7 @@ describe('printDiffTable', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {})
 
     printDiffTable([
-      { metric: 'totalUsers', expected: 10, actual: 11 },
+      { metric: 'usersSummary.totalUsers', expected: 10, actual: 11 },
       { metric: 'rarityDistribution.rare', expected: 25, actual: 26 },
     ])
 
@@ -393,7 +393,7 @@ describe('printDiffTable', () => {
     expect(lines).toHaveLength(4)
     expect(lines[0]).toMatch(/^METRIC\s+基礎集計SQL\s+get_analysis_\* RPC$/)
     expect(lines[1]).toMatch(/^-+\s{2}-+\s{2}-+$/)
-    expect(lines[2]).toMatch(/^totalUsers\s+10\s+11$/)
+    expect(lines[2]).toMatch(/^usersSummary\.totalUsers\s+10\s+11$/)
     expect(lines[3]).toMatch(/^rarityDistribution\.rare\s+25\s+26$/)
   })
 })


### PR DESCRIPTION
## 概要

Issue #1143 の軽量フォローアップとして、`printDiffTable` の表示fixtureを `diffAggregates` が実際に生成するメトリクス名へ揃えます。

- `totalUsers` → `usersSummary.totalUsers`
- 期待する出力行も同じ実メトリクス名へ更新

## 変更範囲

- `tests/unit/compare-analysis-dashboard-vs-sql.test.ts` の2箇所のみ
- 実行コード、DB、設定、依存関係には変更なし

## 対応範囲

今回は Issue #1143 の先頭項目のみを収束条件とします。区切り線の幅計算をより厳密に固定する案は同Issueの残件として残します。

Refs #1143