### PR TITLE
test(db-cutover): Tier Bの違反0件時にdigestを実行しない契約を固定 (#1109)

### DIFF
--- a/tests/unit/db-cutover/layer-invariants.test.ts
+++ b/tests/unit/db-cutover/layer-invariants.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   INVARIANTS,
   TIER_A,
+  TIER_B,
 } from '../../../scripts/db-cutover/invariant-checks.mjs'
 import {
   evaluateInvariantsLayer,
@@ -66,6 +67,48 @@ describe('db cutover layer invariants', () => {
         side: 'source',
         invariantId: FIXTURE_INVARIANT.id,
         tablesOk: true,
+      }),
+    )
+  })
+
+  it('Tier B でも違反0件なら digest SQL を実行しない', async () => {
+    const tierBInvariant = {
+      ...FIXTURE_INVARIANT,
+      id: 'fixture-tier-b-invariant',
+      checks: [
+        {
+          ...FIXTURE_INVARIANT.checks[0],
+          tier: TIER_B,
+          digestSql: 'DIGEST_SQL',
+        },
+      ],
+    }
+    const unsafe = vi.fn(async (sql: string) => {
+      if (sql === 'COUNT_SQL') return [{ count: 0 }]
+      throw new Error(`unexpected SQL: ${sql}`)
+    })
+
+    const results = await readSideInvariants(
+      { unsafe } as never,
+      [tierBInvariant] as never,
+      'target',
+      (text: string) => text,
+      undefined,
+    )
+
+    expect(unsafe).toHaveBeenCalledTimes(1)
+    expect(unsafe).toHaveBeenCalledWith('COUNT_SQL')
+    expect(results.get(tierBInvariant.id)).toEqual(
+      expect.objectContaining({
+        tablesOk: true,
+        checks: [
+          expect.objectContaining({
+            tier: TIER_B,
+            violationCount: 0,
+            samples: [],
+            digest: null,
+          }),
+        ],
       }),
     )
   })


### PR DESCRIPTION
## 概要

Issue #1109 のノンブロッキング改善のうち、「違反0件なら digest SQL を実行しない」契約を、実際に `digestSql` を持つ Tier B fixture で固定します。

## 変更内容

- `TIER_B` の fixture を追加
- `violationCount = 0` の場合に `COUNT_SQL` 以外（sample / digest）が呼ばれないことを検証
- 戻り値でも Tier B / violationCount 0 / empty samples / digest null を確認

本番コード・DB・設定・依存関係の変更はありません。

Refs #1109