### PR TITLE
docs(ci): Discord mainマージ通知のWebhook運用を文書化 (#1027)

### DIFF
--- a/docs/discord-main-merge-notification.md
+++ b/docs/discord-main-merge-notification.md
@@ -1,0 +1,25 @@
+# Discord main マージ通知の運用
+
+`main` へマージされた PR は `.github/workflows/notify-discord-main-merge.yml` から Discord へ通知されます。
+
+## 必須 Repository Secret
+
+GitHub Actions の Repository Secret として `DISCORD_WEBHOOK_URL` を設定してください。
+
+1. GitHub リポジトリの **Settings → Secrets and variables → Actions** を開く。
+2. **New repository secret** を選ぶ。
+3. Name に `DISCORD_WEBHOOK_URL`、Secret に通知先 Discord チャンネルの Webhook URL を設定する。
+
+Webhook URL は認証情報として扱い、リポジトリ、Issue、PR、CI ログ、チャットへ値を貼り付けないでください。Workflow は Secret が未設定の場合、通知前の検証ステップで失敗します。
+
+## 通知の流れ
+
+- `main` 向け PR がマージされたときに通知します。
+- `preview → main` の昇格 PR では、PR 本文の最初の `## このリリースで変わること` セクションを通知本文として利用します。
+- `pull_request_target` を使うため、Secret を読む処理は信頼された base 側の workflow だけで実行します。PR head の checkout や実行をこの workflow に追加しないでください。
+
+## 運用確認
+
+Secret の値そのものは表示せず、Repository Secret に `DISCORD_WEBHOOK_URL` が存在することだけを確認します。次回の実際の `main` マージ後に Actions の通知 job が成功し、Discord に通知が 1 件だけ届くことを確認してください。
+
+Refs #1027


### PR DESCRIPTION
## 概要

Issue #1027 の軽量フォローアップとして、Discord mainマージ通知で必要な Repository Secret `DISCORD_WEBHOOK_URL` の運用手順を文書化します。

## 変更内容

- `docs/discord-main-merge-notification.md` を追加
- Repository Secret の設定場所と名前を明記
- Webhook URL を Issue / PR / CI ログ等へ出さない運用を明記
- `pull_request_target` で PR head を checkout / execute しない安全契約を記載
- 次回の実 `main` マージで通知が1件だけ届くことを確認する手順を記載

実行コード、workflow、Secret値、設定値には変更ありません。

Refs #1027