### PR TITLE
fix(a11y): 保存結果をstatusで通知 (#1126)

### DIFF
--- a/src/components/LiveDirectorySettings.tsx
+++ b/src/components/LiveDirectorySettings.tsx
@@ -206,7 +206,11 @@ export default function LiveDirectorySettings({
         </p>
 
         {message && (
-          <p className={`text-sm ${isError ? "text-red-400" : "text-green-400"}`}>
+          <p
+            role="status"
+            aria-live="polite"
+            className={`text-sm ${isError ? "text-red-400" : "text-green-400"}`}
+          >
             {message}
           </p>
         )}

--- a/src/components/LiveDirectorySettings.tsx
+++ b/src/components/LiveDirectorySettings.tsx
@@ -205,15 +205,13 @@ export default function LiveDirectorySettings({
           {t("form.publishStatsHelp")}
         </p>
 
-        {message && (
-          <p
-            role="status"
-            aria-live="polite"
-            className={`text-sm ${isError ? "text-red-400" : "text-green-400"}`}
-          >
-            {message}
-          </p>
-        )}
+        <p
+          role="status"
+          aria-live="polite"
+          className={`text-sm ${isError ? "text-red-400" : "text-green-400"}`}
+        >
+          {message}
+        </p>
         {saving && (
           <p className="text-sm text-gray-400">{t("messages.saving")}</p>
         )}


### PR DESCRIPTION
## 概要

Issue #1126 の軽量フォローアップとして、`LiveDirectorySettings` の保存成功・失敗メッセージを支援技術へ通知できるようにします。

## 変更内容

- 保存結果メッセージへ `role="status"` を追加
- `aria-live="polite"` を明示し、トグル操作後の成功・失敗結果を割り込みすぎず読み上げる

## 変更範囲

- `src/components/LiveDirectorySettings.tsx` 1ファイルのみ
- 保存API、状態更新、DB、設定、依存関係には変更なし

Refs #1126