### PR TITLE
docs(ci): Discord通知workflowの最小権限契約を明記 (#1091)

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -2,7 +2,8 @@ name: Notify Discord on main merge
 
 # Security contract: pull_request_target lets a merged PR notification read the
 # repository webhook secret from the trusted base context. Never checkout or
-# execute code from the PR head in this workflow.
+# execute code from the PR head in this workflow. Keep permissions at
+# `contents: read`; do not widen them without a reviewed workflow requirement.
 on:
   pull_request_target:
     types: [opened, edited, synchronize, closed]


### PR DESCRIPTION
## 概要

Issue #1091 の軽量フォローアップとして、`pull_request_target` の安全契約コメントへ `permissions: contents: read` を不用意に広げない前提を追記します。

## 変更内容

- PR head を checkout / execute しない既存制約は維持
- workflow 権限を `contents: read` の最小権限に保つ前提をコメントで明文化
- trigger / permissions 値 / Secret / payload / 通知処理は変更なし

変更は `.github/workflows/notify-discord-main-merge.yml` のコメントのみです。

Refs #1091