### PR TITLE
docs(env): replay secretの運用スクリプト利用を明記 (#1134)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -95,6 +95,7 @@ NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 #                                 # EVENTSUB_HEALTH_SECRET_PROD / EVENTSUB_HEALTH_SECRET_PREVIEW に設定
 #                                 # 詳細: docs/eventsub-subscription-health.md
 # EVENTSUB_REPLAY_SECRET=xxx      # アプリ側 /api/admin/eventsub-replay 用
+#                                 # scripts/replay-maintenance-eventsub.js からも対象環境のアプリ側と同じ値を使用
 #                                 # workers/error-reporter（twica-error-reporter）側は各環境のアプリと同じ値を、それぞれ
 #                                 # EVENTSUB_REPLAY_SECRET_PROD / EVENTSUB_REPLAY_SECRET_PREVIEW に設定
 # SESSION_COOKIE_SECRET は上記参照（本番は wrangler secret put で設定）


### PR DESCRIPTION
## 概要

Issue #1134 の軽量フォローアップです。

- `.env.local.example` の `EVENTSUB_REPLAY_SECRET` 注記へ、`scripts/replay-maintenance-eventsub.js` も対象環境のアプリ側と同じ値を使用することを追記
- 実シークレット値、環境変数名、実行コード、Worker設定には変更なし

## 確認

- `scripts/replay-maintenance-eventsub.js` は `EVENTSUB_REPLAY_SECRET` を環境変数から読み、`/api/admin/eventsub-replay` の `X-Replay-Secret` に使用する既存実装
- コメント1行のみの変更

Refs #1134