### PR TITLE
docs(env): EventSub health secret注記を短くする (#1134)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -90,7 +90,7 @@ NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 
 # Cloudflare Workers / OpenNext デプロイ設定（Cloudflare Secrets で設定）
 # DB_HEALTH_SECRET=xxx            # アプリ側 /api/admin/db-health 用
-# EVENTSUB_HEALTH_SECRET=xxx      # アプリ側 /api/admin/eventsub-health 用
+# EVENTSUB_HEALTH_SECRET=xxx      # /api/admin/eventsub-health 用
 #                                 # workers/error-reporter（twica-error-reporter）側は各環境のアプリと同じ値を、それぞれ
 #                                 # EVENTSUB_HEALTH_SECRET_PROD / EVENTSUB_HEALTH_SECRET_PREVIEW に設定
 #                                 # 詳細: docs/eventsub-subscription-health.md


### PR DESCRIPTION
## 概要

Issue #1134 の軽量フォローアップです。

- `.env.local.example` の `EVENTSUB_HEALTH_SECRET` 先頭注記から重複する「アプリ側」を外し、表示幅を短縮
- Worker 側の変数名・各環境で同値にする説明・詳細ドキュメント参照は既存の継続行へ保持
- 実シークレット値、環境変数名、実行コード、CI、デプロイ設定には変更なし

## 変更範囲

- `.env.local.example` 1ファイル
- 1行変更のみ

Refs #1134