### PR TITLE
test(db): safe columns投影map変換を共通化 (#1086)

### DIFF
--- a/tests/unit/streamers-safe-columns.test.ts
+++ b/tests/unit/streamers-safe-columns.test.ts
@@ -21,6 +21,12 @@ function missingColumnError(column: string) {
   })
 }
 
+function toProjectionMap(columns: Record<string, { name: string }>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(columns).map(([key, column]) => [key, column.name]),
+  )
+}
+
 describe('withLiveDirectorySettingsColumnFallback', () => {
   it.each(DEPLOY_WINDOW_COLUMNS)(
     '%s の未デプロイを検知すると安全な列集合で再試行する',
@@ -95,14 +101,13 @@ describe('streamers デプロイ窓の列集合契約', () => {
     // 対応する列オブジェクトを STREAMERS_SAFE_COLUMNS 側へ追加し、フォールバック時の返却行形状と
     // キー↔実SQL列の対応を維持する。
     const deployWindowColumnNames = new Set<string>(DEPLOY_WINDOW_COLUMNS)
-    const expectedSafeProjection = Object.fromEntries(
-      Object.entries(getTableColumns(streamersTable))
-        .filter(([, column]) => !deployWindowColumnNames.has(column.name))
-        .map(([key, column]) => [key, column.name]),
+    const expectedSafeColumns = Object.fromEntries(
+      Object.entries(getTableColumns(streamersTable)).filter(
+        ([, column]) => !deployWindowColumnNames.has(column.name),
+      ),
     )
-    const safeProjection = Object.fromEntries(
-      Object.entries(STREAMERS_SAFE_COLUMNS).map(([key, column]) => [key, column.name]),
-    )
+    const expectedSafeProjection = toProjectionMap(expectedSafeColumns)
+    const safeProjection = toProjectionMap(STREAMERS_SAFE_COLUMNS)
 
     expect(safeProjection).toEqual(expectedSafeProjection)
   })


### PR DESCRIPTION
## 概要

Issue #1086 の軽量フォローアップです。

- `STREAMERS_SAFE_COLUMNS` と期待値側で重複していた `Object.fromEntries(Object.entries(...).map(...))` を `toProjectionMap` へ共通化
- helper の戻り値を `Record<string, string>` として明示し、比較対象の型契約を維持
- デプロイ窓列の除外、投影キー↔実SQL列対応の検証内容は変更なし

## 変更範囲

- `tests/unit/streamers-safe-columns.test.ts` のみ
- 本番コード・DB・設定・依存関係の変更なし

Refs #1086