### PR TITLE
docs(a11y): live region常時マウントの意図を明記 (#1126)

### DIFF
--- a/src/components/LiveDirectorySettings.tsx
+++ b/src/components/LiveDirectorySettings.tsx
@@ -205,6 +205,7 @@ export default function LiveDirectorySettings({
           {t("form.publishStatsHelp")}
         </p>
 
+        {/* 初回の結果更新も読み上げ対象になるよう、空の live region を常時マウントする。 */}
         <p
           role="status"
           aria-live="polite"


### PR DESCRIPTION
## 概要

Issue #1126 の軽量フォローアップです。

- `LiveDirectorySettings` の保存結果用 `role="status"` を空のまま常時マウントしている理由をコメントで明記
- 初回の結果更新から支援技術が通知を拾えるようにする意図を、実装の直上に残す

## 変更範囲

- `src/components/LiveDirectorySettings.tsx` のコメント1行のみ
- 実行コード・UI構造・a11y属性・翻訳・設定・依存関係の変更なし

Refs #1126