### PR TITLE
docs(db): payer selectionの呼称を統一 (#1100)

### DIFF
--- a/docs/trade-migration-reference-notes.md
+++ b/docs/trade-migration-reference-notes.md
@@ -8,7 +8,9 @@ any byte changes the checksum and can block `apply`, `status`, `plan`, and
 
 When documentation or review notes need to refer to logic inside
 `accept_trade_offer`, use stable SQL identifiers and processing stages rather
-than line numbers:
+than line numbers. Use **payer selection** for the overall two-step operation;
+avoid positional labels such as **stage 2**, which can become ambiguous as the
+migration evolves:
 
 - **Payer selection — candidate locking:** the `PERFORM` first locks all
   eligible candidate `user_cards` rows in deterministic order. This


### PR DESCRIPTION
## 概要

Issue #1100 の軽量フォローアップです。

- `docs/trade-migration-reference-notes.md` で、2段構成の処理全体を **payer selection** と呼ぶことを明示
- 編集位置に依存する **stage 2** のような呼称を避ける方針を追加
- checksum 管理対象の migration 本体には触れない

## 変更範囲

- ドキュメント1ファイルのみ（+3 / -1）
- 実行コード・DB・設定・依存関係の変更なし

Refs #1100 #1099 #1013