### PR TITLE
test(db-cutover): digest skipテスト名を分岐条件へ揃える (#1109)

### DIFF
--- a/tests/unit/db-cutover/layer-invariants.test.ts
+++ b/tests/unit/db-cutover/layer-invariants.test.ts
@@ -71,7 +71,7 @@ describe('db cutover layer invariants', () => {
     )
   })
 
-  it('Tier B でも違反0件なら digest SQL を実行しない', async () => {
+  it('digestSql があっても違反0件なら digest SQL を実行しない', async () => {
     const tierBInvariant = {
       ...FIXTURE_INVARIANT,
       id: 'fixture-tier-b-invariant',


### PR DESCRIPTION
## 概要

Issue #1109 の軽量フォローアップです。

- `readSideInvariants` の違反0件時 digest skip テスト名を、fixture の Tier ではなく実際の分岐条件 `digestSql` を主語に変更
- テスト本体・fixture・assertion・本番コードには変更なし

## 変更範囲

- `tests/unit/db-cutover/layer-invariants.test.ts` のテスト名1行のみ
- 本番コード・DB・設定・依存関係の変更なし

Refs #1109 #1151