### PR TITLE
test(analysis): diff table区切り線の列幅契約を固定 (#1143)

### DIFF
--- a/tests/unit/compare-analysis-dashboard-vs-sql-table-layout.test.ts
+++ b/tests/unit/compare-analysis-dashboard-vs-sql-table-layout.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { printDiffTable } from '../../scripts/compare-analysis-dashboard-vs-sql.mjs'
+
+describe('printDiffTable separator layout', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('区切り線の各列幅をヘッダーまたは最長データ幅へ揃える', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    printDiffTable([
+      { metric: 'usersSummary.totalUsers', expected: 10, actual: 11 },
+      { metric: 'rarityDistribution.rare', expected: 25, actual: 26 },
+    ])
+
+    const lines = log.mock.calls.map(([line]) => String(line).trimEnd())
+    const expectedWidths = [
+      Math.max('METRIC'.length, 'usersSummary.totalUsers'.length, 'rarityDistribution.rare'.length),
+      Math.max('基礎集計SQL'.length, '10'.length, '25'.length),
+      Math.max('get_analysis_* RPC'.length, '11'.length, '26'.length),
+    ]
+
+    expect(lines[1]).toBe(
+      expectedWidths.map((width) => '-'.repeat(width)).join('  ')
+    )
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1143 の軽量フォローアップです。

- `printDiffTable` の区切り線について、3列それぞれのダッシュ長が「ヘッダー幅」と「fixture内の最長データ幅」の最大値に一致することを exact string で固定
- 1列目はデータ幅、2・3列目はヘッダー幅が支配するfixtureを使い、幅計算の両側を検証
- 本番コード・DB・設定・依存関係の変更なし

## 変更範囲

- テスト1ファイル追加のみ

Refs #1143 #1149