### PR TITLE
test(a11y): カード表示トグルを名前で取得 (#1093)

### DIFF
--- a/tests/unit/components/card-visibility-settings-maintenance.test.tsx
+++ b/tests/unit/components/card-visibility-settings-maintenance.test.tsx
@@ -28,8 +28,12 @@ function renderSettings(status: MaintenanceStatusResponse) {
 // label/htmlFor の関連付けが壊れた場合も既存maintenanceテストで回帰検知する。
 function getToggles() {
   return [
-    screen.getByRole('checkbox', { name: '未所持カードを表示' }),
-    screen.getByRole('checkbox', { name: '未所持カードの詳細を公開' }),
+    screen.getByRole('checkbox', {
+      name: jaMessages.cardVisibilitySettings.form.showUnowned,
+    }),
+    screen.getByRole('checkbox', {
+      name: jaMessages.cardVisibilitySettings.form.showDetails,
+    }),
   ] as const
 }
 

--- a/tests/unit/components/card-visibility-settings-maintenance.test.tsx
+++ b/tests/unit/components/card-visibility-settings-maintenance.test.tsx
@@ -24,11 +24,13 @@ function renderSettings(status: MaintenanceStatusResponse) {
   )
 }
 
-// トグルには可視ラベル由来のアクセシブルネームが付くが、このmaintenanceテストは
-// 両トグル共通のdisable挙動をまとめて検証するため表示順で取得する。
-// アクセシブルネーム指定へ寄せる追加改善は Issue #1093 で別途追跡する。
+// #1093: DOM順ではなく可視ラベル由来のアクセシブルネームで取得し、
+// label/htmlFor の関連付けが壊れた場合も既存maintenanceテストで回帰検知する。
 function getToggles() {
-  return screen.getAllByRole('checkbox')
+  return [
+    screen.getByRole('checkbox', { name: '未所持カードを表示' }),
+    screen.getByRole('checkbox', { name: '未所持カードの詳細を公開' }),
+  ] as const
 }
 
 describe('CardVisibilitySettings maintenance integration', () => {


### PR DESCRIPTION
## 概要

Issue #1093 の軽量フォローアップです。

- `CardVisibilitySettings` の2トグルを DOM 順ではなく、可視ラベル由来のアクセシブルネームで取得
- `label` / `htmlFor` の関連付けが壊れた場合に既存 maintenance テストで回帰検知
- 本番コード・表示・翻訳・設定・依存関係の変更なし

## 変更範囲

- `tests/unit/components/card-visibility-settings-maintenance.test.tsx` のみ

Refs #1093 #1118