### PR TITLE
docs(db): trade設定のfail-closed契約を明記 (#1013)

### DIFF
--- a/src/lib/db/streamers-safe-columns.ts
+++ b/src/lib/db/streamers-safe-columns.ts
@@ -31,6 +31,10 @@ export const LIVE_DIRECTORY_SETTINGS_COLUMNS = [
 /**
  * デプロイ窓対象列を除いた streamers テーブルの明示的な列オブジェクト。
  * Drizzle の `.select({ ... })` にそのまま渡せる。
+ *
+ * trade_enabled / cross_channel_trade_enabled も意図的に含めないため、この安全列で再試行した
+ * 行では両設定値が undefined になりうる。消費側はデプロイ窓中の未定義値を有効扱いせず、
+ * `?? false` などで必ず fail-closed に扱うこと。
  */
 export const STREAMERS_SAFE_COLUMNS = {
   id: streamersTable.id,


### PR DESCRIPTION
## 概要

Issue #1013 の軽量フォローアップです。

- `STREAMERS_SAFE_COLUMNS` で再試行した行では trade 設定列が `undefined` になりうることを明記
- デプロイ窓中の未定義値を `?? false` 等で fail-closed に扱う契約をコメント化
- 実行コード・DB・設定・依存関係の変更なし

## 変更範囲

- `src/lib/db/streamers-safe-columns.ts` のコメントのみ

Refs #1013