### PR TITLE
test(r2): fixture assert診断を日本語化 (#1103)

### DIFF
--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -97,11 +97,11 @@ const R2_INTERNAL_ERROR_MESSAGE = 'put: We encountered an internal error. Please
 function mockTransientFailuresThenSuccess(): void {
   expect(
     TRANSIENT_FAILURES_BEFORE_SUCCESS,
-    'retry-success fixture must include at least one transient failure',
+    'リトライ成功fixtureには一時失敗を1回以上含めること',
   ).toBeGreaterThanOrEqual(1)
   expect(
     TRANSIENT_FAILURES_BEFORE_SUCCESS,
-    'retry-success fixture must remain reachable within MAX_RETRIES',
+    'リトライ成功fixtureはMAX_RETRIES以内で成功へ到達できること',
   ).toBeLessThanOrEqual(MAX_RETRIES)
 
   for (


### PR DESCRIPTION
## 概要

Issue #1103 の軽量フォローアップです。

- リトライ成功fixtureの不変条件assertに付けた失敗メッセージを、日本語主体の同テストファイルへ合わせて日本語化
- assert条件・fixture値・試行回数・本番コードは変更なし

## 変更範囲

- `tests/unit/r2-client-upload-retry-wiring.test.ts` の診断メッセージ2件のみ
- 本番コード・設定・依存関係の変更なし

Refs #1103 #1122