### PR TITLE
chore(ci): notify jobのrepository envを明示 (#1091)

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -74,6 +74,7 @@ jobs:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       # PR/repository-derived strings stay in env and are consumed as data by Python/jq;
       # do not interpolate them directly into the shell script.
+      GITHUB_REPOSITORY: ${{ github.repository }}
       REPOSITORY_NAME: ${{ github.event.repository.name }}
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_BODY: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
## 概要

Issue #1091 の軽量フォローアップです。

- `notify` job でも `GITHUB_REPOSITORY` を `${{ github.repository }}` から明示的に env 宣言
- `validate-promotion-summary` job と repository identity の読み口を揃える
- 実値は GitHub が既定で提供する同名envと同一で、通知ロジック・権限・Secret・payloadには変更なし

## 変更範囲

- `.github/workflows/notify-discord-main-merge.yml` の1行追加のみ

Refs #1091 #1121 #1155