### PR TITLE
docs(twitch): emotes診断コメントにIssue参照を追加 (#1088)

### DIFF
--- a/src/app/api/twitch/emotes/route.ts
+++ b/src/app/api/twitch/emotes/route.ts
@@ -117,7 +117,7 @@ export async function GET(request: Request) {
       );
     }
     // token-manager側ではrefresh障害を二重Issue化しないため、route境界で安全な
-    // refresh診断だけをadditionalInfoへ明示的に橋渡しする。
+    // refresh診断だけをadditionalInfoへ明示的に橋渡しする（#1088）。
     return handleApiError(error, "Twitch emotes fetch", twitchTokenErrorReportContext(error));
   }
 }


### PR DESCRIPTION
## 概要

Issue #1088 の軽量フォローアップです。

- `/api/twitch/emotes` の token refresh 診断コメントへ追跡先 `#1088` を明記
- `twitchTokenErrorReportContext(error)` の呼び出し・エラー処理・レスポンス挙動は変更なし

## 変更範囲

- `src/app/api/twitch/emotes/route.ts` のコメント1行のみ
- 本番コード・設定・依存関係の変更なし

Refs #1088 #1150 #1119