### PR TITLE
test(db): projection map helperの意図を明記 (#1086)

### DIFF
--- a/tests/unit/streamers-safe-columns.test.ts
+++ b/tests/unit/streamers-safe-columns.test.ts
@@ -21,6 +21,7 @@ function missingColumnError(column: string) {
   })
 }
 
+// Drizzle の投影キーと実SQL列名の対応表を作る。
 function toProjectionMap(columns: Record<string, { name: string }>): Record<string, string> {
   return Object.fromEntries(
     Object.entries(columns).map(([key, column]) => [key, column.name]),


### PR DESCRIPTION
## 概要

Issue #1086 の軽量フォローアップとして、`toProjectionMap` が Drizzle の投影キーと実SQL列名の対応表を作るヘルパであることを短いコメントで明記します。

## 変更内容

- `tests/unit/streamers-safe-columns.test.ts` に意図コメントを1行追加
- テストロジック・本番コード・DB・設定・依存関係の変更なし

## 確認

- `preview` 最新HEADから作成
- 差分は1ファイル・+1行のみ

Refs #1086