### PR TITLE
test(a11y): maintenance文言を翻訳参照へ統一 (#1093)

### DIFF
--- a/tests/unit/components/card-visibility-settings-maintenance.test.tsx
+++ b/tests/unit/components/card-visibility-settings-maintenance.test.tsx
@@ -93,7 +93,7 @@ describe('CardVisibilitySettings maintenance integration', () => {
 
   it('mode!=off でもshowDetailsトグルは元々のshowUnowned依存disableと重複してdisableされる', () => {
     renderSettings({ mode: 'read-only' })
-    const [, showDetailsToggle] = getTogles()
+    const [, showDetailsToggle] = getToggles()
     expect(showDetailsToggle).toBeDisabled()
   })
 })

--- a/tests/unit/components/card-visibility-settings-maintenance.test.tsx
+++ b/tests/unit/components/card-visibility-settings-maintenance.test.tsx
@@ -46,14 +46,14 @@ describe('CardVisibilitySettings maintenance integration', () => {
     renderSettings({ mode: 'off' })
     const [showUnownedToggle] = getToggles()
     expect(showUnownedToggle).not.toBeDisabled()
-    expect(screen.queryByText('メンテナンス中は操作できません')).not.toBeInTheDocument()
+    expect(screen.queryByText(jaMessages.maintenance.writeDisabled)).not.toBeInTheDocument()
   })
 
   it('mode!=off のときはトグルがdisableされ、案内文言が表示される（事前disable）', () => {
     renderSettings({ mode: 'read-only' })
     const [showUnownedToggle] = getToggles()
     expect(showUnownedToggle).toBeDisabled()
-    expect(screen.getByText('メンテナンス中は操作できません')).toBeInTheDocument()
+    expect(screen.getByText(jaMessages.maintenance.writeDisabled)).toBeInTheDocument()
   })
 
   it('incident-read-only でも同様にdisableされる', () => {
@@ -93,7 +93,7 @@ describe('CardVisibilitySettings maintenance integration', () => {
 
   it('mode!=off でもshowDetailsトグルは元々のshowUnowned依存disableと重複してdisableされる', () => {
     renderSettings({ mode: 'read-only' })
-    const [, showDetailsToggle] = getToggles()
+    const [, showDetailsToggle] = getTogles()
     expect(showDetailsToggle).toBeDisabled()
   })
 })


### PR DESCRIPTION
## 概要

Issue #1093 の軽量フォローアップとして、`CardVisibilitySettings` の maintenance 統合テストに残っていた固定日本語文言を既存の `jaMessages.maintenance.writeDisabled` 参照へ寄せます。

## 変更内容

- `メンテナンス中は操作できません` の直書き2箇所を翻訳JSON参照へ置換
- テストの判定内容・本番コード・設定・依存関係の変更なし

## 確認

- 最新 `preview` (`d4bdb1fd`) から作成
- 差分はテスト1ファイル・+2/-2のみ

Refs #1093