### PR TITLE
test(a11y): live directoryのstatus領域常時マウントを固定 (#1126)

### DIFF
--- a/tests/unit/components/live-directory-settings.test.tsx
+++ b/tests/unit/components/live-directory-settings.test.tsx
@@ -169,12 +169,14 @@ describe("LiveDirectorySettings", () => {
       })
     );
     renderSettings({});
+    const status = screen.getByRole("status");
     const liveToggle = getLiveToggle();
     fireEvent.click(liveToggle);
 
     await waitFor(() => {
-      expect(screen.getByText("サーバーエラー")).toBeInTheDocument();
+      expect(status).toHaveTextContent("サーバーエラー");
     });
+    expect(screen.getByRole("status")).toBe(status);
     // 失敗時は楽観反映を巻き戻す
     expect(liveToggle).not.toBeChecked();
   });

--- a/tests/unit/components/live-directory-settings.test.tsx
+++ b/tests/unit/components/live-directory-settings.test.tsx
@@ -56,6 +56,21 @@ describe("LiveDirectorySettings", () => {
     expect(screen.getByRole("link", { name: "配信中ページ" })).toHaveAttribute("href", "/live");
   });
 
+  it("keeps the polite status region mounted before the first result and updates it in place", async () => {
+    renderSettings({});
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status.textContent).toBe("");
+
+    fireEvent.click(getLiveToggle());
+
+    await waitFor(() => {
+      expect(status).toHaveTextContent("配信中ページへの掲載設定をオンにしました");
+    });
+    expect(screen.getByRole("status")).toBe(status);
+  });
+
   it("defaults both independent toggles to off and keeps both operable", () => {
     renderSettings({});
 


### PR DESCRIPTION
## 概要

Issue #1126 の軽量フォローアップとして、`LiveDirectorySettings` の保存結果 live region が初回結果の前から常時マウントされ、保存成功・失敗時に同一DOMノードの内容だけが更新される契約を単体テストで固定します。

## 変更内容

- 初期表示で `role="status"` / `aria-live="polite"` の空 live region が存在することを確認
- 保存成功後、同じ status ノードに成功メッセージが入ることを確認
- 保存失敗時も同じ status ノードへエラーメッセージが入ることを確認
- 本番コード・API・DB・設定・依存関係の変更なし

Refs #1126