### PR TITLE
docs(ci): fork判定用repository envの意図を明記 (#1091)

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -74,6 +74,7 @@ jobs:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       # PR/repository-derived strings stay in env and are consumed as data by Python/jq;
       # do not interpolate them directly into the shell script.
+      # Re-declare the runner default so the fork check's trusted base input is explicit.
       GITHUB_REPOSITORY: ${{ github.repository }}
       REPOSITORY_NAME: ${{ github.event.repository.name }}
       PR_TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## 概要

Issue #1091 の軽量フォローアップとして、Discord mainマージ通知workflowで `GITHUB_REPOSITORY` をjob envへ明示的に再宣言している理由をコメントで残します。

## 変更内容

- `notify` job の `GITHUB_REPOSITORY` 直上へ、runner既定値をあえて再宣言してfork判定の信頼済みbase入力をjob境界で明示している旨を1行追加
- trigger・permissions・env値・Secret・payload・通知処理の変更なし

Refs #1091