### PR TITLE
test(db): projection map helperの意図を補足 (#1086)

### DIFF
--- a/tests/unit/streamers-safe-columns.test.ts
+++ b/tests/unit/streamers-safe-columns.test.ts
@@ -21,7 +21,8 @@ function missingColumnError(column: string) {
   })
 }
 
-// Drizzle の投影キーと実SQL列名の対応表を作る。
+// 列オブジェクトを直接比較すると失敗時の差分が読みにくいため、
+// Drizzle の投影キーと実SQL列名だけの対応表へ落として比較する。
 function toProjectionMap(columns: Record<string, { name: string }>): Record<string, string> {
   return Object.fromEntries(
     Object.entries(columns).map(([key, column]) => [key, column.name]),


### PR DESCRIPTION
## 概要

Issue #1086 のノンブロッキング項目から、`toProjectionMap` のコメントを What だけでなく Why まで明確化します。

- 列オブジェクトを直接比較すると失敗時の差分が読みにくいことを明記
- Drizzle の投影キーと実SQL列名だけの対応表へ落として比較する意図を明記
- テストロジック、本番コード、DB、設定、依存関係には変更なし

## 確認

- 差分は `tests/unit/streamers-safe-columns.test.ts` のコメントのみ
- `preview` の現行実装・テスト契約には影響しません

Refs #1086