### PR TITLE
test(db-cutover): allowlist codeテスト名を実態に合わせる (#1095)

### DIFF
--- a/tests/unit/db-cutover-invariant-checks.test.ts
+++ b/tests/unit/db-cutover-invariant-checks.test.ts
@@ -62,7 +62,7 @@ describe('db cutover invariant checks', () => {
     }
   })
 
-  it('allowlist lookupの識別に使うcodeが重複しない', () => {
+  it('allowlist entryの追跡用codeが重複しない', () => {
     const codes = ALLOWLIST.map((entry) => entry.code)
 
     expect(new Set(codes).size).toBe(codes.length)


### PR DESCRIPTION
## 概要

Issue #1095 のノンブロッキング項目から、`ALLOWLIST[].code` 一意性テストの名前を実態へ合わせます。

- `code` は現在 lookup key ではなく、allowlist entry を人間が識別・追跡するためのID
- テスト名だけをその責務に合わせて変更
- assertion、fixture、本番コード、DB、設定、依存関係には変更なし

## 確認

- 差分は `tests/unit/db-cutover-invariant-checks.test.ts` のテスト名1行のみ
- `preview` の現行テスト契約・実行結果には影響しません

Refs #1095