### PR TITLE
test(live): status領域の空状態matcherを明確化 (#1126)

### DIFF
--- a/tests/unit/components/live-directory-settings.test.tsx
+++ b/tests/unit/components/live-directory-settings.test.tsx
@@ -61,7 +61,7 @@ describe("LiveDirectorySettings", () => {
 
     const status = screen.getByRole("status");
     expect(status).toHaveAttribute("aria-live", "polite");
-    expect(status.textContent).toBe("");
+    expect(status).toBeEmptyDOMElement();
 
     fireEvent.click(getLiveToggle());
 


### PR DESCRIPTION
## 概要

Issue #1126 のノンブロッキング項目から、`LiveDirectorySettings` の初期live regionが空であることの検証を意図が明確な matcher へ寄せます。

- `status.textContent === ""` の直接比較を `toBeEmptyDOMElement()` へ置換
- テストの意味・対象DOM・本番コードは変更しない
- a11y契約（status region常時マウント、同一ノード更新）はそのまま維持

## 確認

- 差分は `tests/unit/components/live-directory-settings.test.tsx` の1行のみ
- 本番コード・設定・依存関係には変更なし

Refs #1126