### PR TITLE
test(db-cutover): invariant findingのside帰属を固定 (#1109)

### DIFF
--- a/tests/unit/db-cutover/layer-invariants-side-attribution.test.ts
+++ b/tests/unit/db-cutover/layer-invariants-side-attribution.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+
+import { TIER_A } from '../../../scripts/db-cutover/invariant-checks.mjs'
+import { evaluateInvariantsLayer } from '../../../scripts/db-cutover/layer-invariants.mjs'
+
+const FIXTURE_INVARIANT = {
+  id: 'fixture-side-attribution',
+  description: 'fixture side attribution invariant',
+  requiredTables: [],
+  checks: [
+    {
+      code: 'FIXTURE_SIDE_CHECK',
+      tier: TIER_A,
+      countSql: 'COUNT_SQL',
+      sampleSql: 'SAMPLE_SQL',
+      digestSql: null,
+    },
+  ],
+}
+
+function sideResult(violationCount: number) {
+  return {
+    tablesOk: true,
+    checks: [
+      {
+        code: 'FIXTURE_SIDE_CHECK',
+        tier: TIER_A,
+        violationCount,
+        samples: violationCount > 0 ? ['violator'] : [],
+        digest: null,
+        durationMs: 1,
+      },
+    ],
+    durationMs: 1,
+  }
+}
+
+describe('db cutover invariant finding side attribution', () => {
+  it.each([
+    { sourceViolationCount: 1, targetViolationCount: 0, expectedSide: 'source' },
+    { sourceViolationCount: 0, targetViolationCount: 1, expectedSide: 'target' },
+  ])(
+    '$expectedSide 側だけに違反がある場合、finding.side を取り違えない',
+    ({ sourceViolationCount, targetViolationCount, expectedSide }) => {
+      const source = sideResult(sourceViolationCount)
+      const target = sideResult(targetViolationCount)
+
+      expect(source).not.toBe(target)
+
+      const result = evaluateInvariantsLayer({
+        sourceResults: new Map([[FIXTURE_INVARIANT.id, source]]),
+        targetResults: new Map([[FIXTURE_INVARIANT.id, target]]),
+        invariantDefs: [FIXTURE_INVARIANT] as never,
+      })
+
+      expect(result.pass).toBe(false)
+      expect(result.findings).toEqual([
+        expect.objectContaining({
+          severity: 'fail',
+          code: 'FIXTURE_SIDE_CHECK',
+          side: expectedSide,
+        }),
+      ])
+      expect(result.invariants[0]).toMatchObject({
+        id: FIXTURE_INVARIANT.id,
+        pass: false,
+        checks: [
+          {
+            code: 'FIXTURE_SIDE_CHECK',
+            tier: TIER_A,
+            pass: false,
+            sideResults: {
+              source: { violationCount: sourceViolationCount },
+              target: { violationCount: targetViolationCount },
+            },
+          },
+        ],
+      })
+    },
+  )
+})


### PR DESCRIPTION
## 概要

Issue #1109 のノンブロッキング項目から、source / target の片側だけに Tier A violation がある場合の `finding.side` を単体テストで固定します。

- source / target に別オブジェクトを渡す
- source-only / target-only の両ケースを `it.each` で検証
- `finding.side` と `sideResults` の violation count を両方向で固定
- 本番コード・DB・設定・依存関係には変更なし

## 確認

- 変更は新規 unit test 1ファイルのみ
- `evaluateInvariantsLayer` の純粋判定経路だけを対象にし、DB接続は不要

Refs #1109