### PR TITLE
docs(db): trade履歴の削除境界を明文化 (#1013)

### DIFF
--- a/docs/trade-migration-reference-notes.md
+++ b/docs/trade-migration-reference-notes.md
@@ -27,6 +27,15 @@ migration evolves:
   offered card exists and is still owned by the offerer, while locking that row
   for the later transfer. Prefer this role-based name in prose; use
   `v_offered_card_owner_check` when the exact result variable matters.
+- **Deletion-history boundary:** card-definition references use `ON DELETE SET
+  NULL`, while card-copy identifiers intentionally have no foreign key, so
+  completed trade rows can keep using their snapshots after cards or
+  `user_cards` rows are deleted. By contrast, `offerer_user_id`,
+  `offered_streamer_id`, and `wanted_streamer_id` use `ON DELETE CASCADE`, so
+  deleting the referenced user or streamer also deletes related
+  `trade_offers`, including completed rows. History retention is therefore
+  scoped to card/card-copy cleanup; it does not promise retention after an
+  account or streamer is deleted.
 - **Chosen payment card:** references to the selected payment card should use
   `v_payer_user_card_id`, not migration line ranges.
 - **Lock-order contract:** describe the invariant as

--- a/docs/trade-migration-reference-notes.md
+++ b/docs/trade-migration-reference-notes.md
@@ -32,10 +32,10 @@ migration evolves:
   completed trade rows can keep using their snapshots after cards or
   `user_cards` rows are deleted. By contrast, `offerer_user_id`,
   `offered_streamer_id`, and `wanted_streamer_id` use `ON DELETE CASCADE`, so
-  deleting the referenced user or streamer also deletes related
+  deleting the offerer user or either referenced streamer also deletes related
   `trade_offers`, including completed rows. History retention is therefore
-  scoped to card/card-copy cleanup; it does not promise retention after an
-  account or streamer is deleted.
+  scoped to card/card-copy cleanup; it does not promise retention after the
+  offerer account or a referenced streamer is deleted.
 - **Chosen payment card:** references to the selected payment card should use
   `v_payer_user_card_id`, not migration line ranges.
 - **Lock-order contract:** describe the invariant as


### PR DESCRIPTION
## 概要

Issue #1013 のノンブロッキング項目6を、checksum管理済みmigration本体を変更せず保守向け参照メモへ反映します。

- card / `user_cards` 削除ではスナップショットを使ってcompleted履歴を残す境界を明記
- user / streamer の `ON DELETE CASCADE` では関連 `trade_offers`（completed含む）が削除される非対称性を明記
- 「履歴保全」がアカウント／streamer削除まで保証するものではないことを明確化

実行コード、DB schema、migration、設定、依存関係には変更ありません。

Refs #1013