### PR TITLE
fix(a11y): カード表示設定の補足説明をトグルへ関連付ける (#1093)

### DIFF
--- a/src/components/CardVisibilitySettings.tsx
+++ b/src/components/CardVisibilitySettings.tsx
@@ -164,6 +164,7 @@ export default function CardVisibilitySettings({
               checked={showUnowned}
               onChange={handleToggleShowUnowned}
               disabled={showUnownedDisabled}
+              aria-describedby="show-unowned-cards-help"
               className="peer sr-only"
             />
             <div className="h-6 w-11 rounded-full bg-gray-600 after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-purple-600 peer-checked:after:translate-x-full peer-checked:after:border-white peer-disabled:opacity-50" />
@@ -172,7 +173,7 @@ export default function CardVisibilitySettings({
             {t("form.showUnowned")}
           </label>
         </div>
-        <p className="-mt-2 ml-14 text-xs text-gray-500">
+        <p id="show-unowned-cards-help" className="-mt-2 ml-14 text-xs text-gray-500">
           {t("form.showUnownedHelp")}
         </p>
 
@@ -189,6 +190,11 @@ export default function CardVisibilitySettings({
               checked={showDetails}
               onChange={handleToggleShowDetails}
               disabled={detailsDisabled}
+              aria-describedby={
+                showUnowned
+                  ? "show-unowned-details-help"
+                  : "show-unowned-details-help show-unowned-details-requires"
+              }
               className="peer sr-only"
             />
             <div
@@ -206,12 +212,12 @@ export default function CardVisibilitySettings({
             {t("form.showDetails")}
           </label>
           {!showUnowned && (
-            <span className="text-xs text-gray-500">
+            <span id="show-unowned-details-requires" className="text-xs text-gray-500">
               ({t("form.requiresShowUnowned")})
             </span>
           )}
         </div>
-        <p className="-mt-2 ml-14 text-xs text-gray-500">
+        <p id="show-unowned-details-help" className="-mt-2 ml-14 text-xs text-gray-500">
           {t("form.showDetailsHelp")}
         </p>
 


### PR DESCRIPTION
## 概要

Issue #1093 の軽量フォローアップとして、`CardVisibilitySettings` の補足説明を各トグルのアクセシブル説明へ関連付けます。

- `showUnownedHelp` を「未所持カードを表示」checkbox の `aria-describedby` へ接続
- `showDetailsHelp` を「未所持カードの詳細を公開」checkbox の `aria-describedby` へ接続
- `showUnowned=false` のときだけ `requiresShowUnowned` も詳細トグルの説明へ追加
- 表示文言・保存ロジック・API・設定値には変更なし

## 変更範囲

- `src/components/CardVisibilitySettings.tsx` 1ファイルのみ
- a11y 属性と説明要素の `id` 追加のみ

Refs #1093