### PR TITLE
docs(eventsub): 通知失敗ログのラベル契約を明文化 (#1098)

### DIFF
--- a/docs/eventsub-notification-log-contract.md
+++ b/docs/eventsub-notification-log-contract.md
@@ -1,0 +1,14 @@
+# EventSub 通知失敗ログのラベル契約
+
+`postRedemptionNotify` の通知失敗ログでは、人が読む warn 表示と `reportError` の構造化 context でラベル表記を意図的に分ける。
+
+- warn 表示は `broadcast` / `chat announcement` を使う。ログ本文からソースを grep しやすいよう、表示ラベルはリテラルのまま維持する。
+- `reportError` の context は `eventsub:postRedemptionNotify:broadcast` / `eventsub:postRedemptionNotify:chatAnnouncement` を使う。`chatAnnouncement` は既存の監視・テストとの互換性を保つため camelCase のまま変更しない。
+
+したがって、表示文言を整える目的で `chatAnnouncement` context を `chat announcement` へ変更してはならない。逆に、人向け warn 表示を context に合わせて camelCase へ戻す必要もない。
+
+リポジトリ外の Cloudflare Observability 等で文字列監視を追加・変更する場合は、旧表示文字列 `chatAnnouncement failed` を前提にせず、可能なら構造化 context を利用する。既存の外部監視条件があるかどうかはリポジトリだけでは確認できないため、監視設定を変更する際に別途確認する。
+
+この文書化は既存ログ契約の説明だけで実行コードを変更しないため、専用の Preview 実経路ゲートは不要とする。通常の CI とレビューで文書と現行実装の整合を確認する。
+
+Refs #1098 #1097


### PR DESCRIPTION
## 概要

Issue #1098 の軽量フォローアップとして、`postRedemptionNotify` の通知失敗ログで意図的に使い分けている表示ラベルと構造化 context の契約を運用ドキュメントへ明記します。

- warn 表示は `broadcast` / `chat announcement` の人向けリテラルを維持
- `reportError` context は監視・テスト互換のため `broadcast` / `chatAnnouncement` を維持
- 外部監視では旧表示文字列 `chatAnnouncement failed` を前提にしない方針を記載
- 実行コードは変更せず、専用 Preview 実経路ゲート不要の判断も記録

## 変更範囲

- `docs/eventsub-notification-log-contract.md` の新規追加のみ
- 実行コード・設定・依存関係の変更なし

Refs #1098 #1097