### PR TITLE
docs(twitch): refresh診断の永続化境界を明記 (#1088)

### DIFF
--- a/src/app/api/twitch/emotes/route.ts
+++ b/src/app/api/twitch/emotes/route.ts
@@ -116,8 +116,8 @@ export async function GET(request: Request) {
         { status: 401 }
       );
     }
-    // token-manager側ではrefresh障害を二重Issue化しないため、route境界で安全な
-    // refresh診断だけをadditionalInfoへ明示的に橋渡しする（#1088）。
+    // token-manager側はrefresh障害を二重報告しない。永続化責任はAPI境界のhandleApiErrorにあり、
+    // ここで安全なrefresh診断だけをadditionalInfoへ明示的に橋渡しする。
     return handleApiError(error, "Twitch emotes fetch", twitchTokenErrorReportContext(error));
   }
 }


### PR DESCRIPTION
## 概要

Issue #1088 のノンブロッキング項目から、emotes route の token refresh 失敗時に診断情報を `handleApiError` へ渡す理由を、責務境界が分かる表現へ整理します。

- token-manager 側では refresh 障害を二重報告しないことを明記
- 診断情報の永続化責任が API 境界の `handleApiError` にあることを明記
- `twitchTokenErrorReportContext(error)` の結線、本番挙動、設定、依存関係は変更なし

## 変更範囲

- `src/app/api/twitch/emotes/route.ts` のコメントのみ（+2 / -2）

Refs #1088