### PR TITLE
docs(db): live directory migration参照を修正 (#921)

### DIFF
--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -91,7 +91,7 @@ export const streamers = pgTable('streamers', {
   // 00035
   show_unowned_cards: boolean('show_unowned_cards').notNull().default(false),
   show_unowned_card_details: boolean('show_unowned_card_details').notNull().default(false),
-  // 00074 + 20260811120000: 配信掲載とランキング識別情報のオプトイン（両方OFF）
+  // 20260811000000: 配信掲載とランキング識別情報のオプトイン（両方OFF）
   publish_live_status: boolean('publish_live_status').notNull().default(false),
   publish_stats: boolean('publish_stats').notNull().default(false),
   // 00042: デフォルト無し・NULL 許容


### PR DESCRIPTION
## 概要

`src/lib/db/schema.ts` の配信掲載 / ランキング設定列コメントが、実在しない `00074` と誤った日時 `20260811120000` を参照していたため、実際に列を追加した `20260811000000_add_live_directory_settings.sql` の migration ID に揃えます。

## 変更範囲

- コメント1行のみ
- 実行コード、DB schema、migration、設定、依存関係の変更なし

Refs #921