### PR TITLE
test(db): projection map比較の限界を明記 (#1086)

### DIFF
--- a/tests/unit/streamers-safe-columns.test.ts
+++ b/tests/unit/streamers-safe-columns.test.ts
@@ -23,6 +23,7 @@ function missingColumnError(column: string) {
 
 // 列オブジェクトを直接比較すると失敗時の差分が読みにくいため、
 // Drizzle の投影キーと実SQL列名だけの対応表へ落として比較する。
+// そのため、別テーブル由来でも同じSQL列名を持つ列オブジェクトへの差し替えまでは検知しない。
 function toProjectionMap(columns: Record<string, { name: string }>): Record<string, string> {
   return Object.fromEntries(
     Object.entries(columns).map(([key, column]) => [key, column.name]),


### PR DESCRIPTION
## 概要

Issue #1086 のノンブロッキング項目から、`toProjectionMap` の比較契約が保証しない範囲をコメントで明文化します。

- 投影キー ↔ 実SQL列名だけへ落として比較する既存方針は維持
- 別テーブル由来でも同じSQL列名を持つ列オブジェクトへの差し替えまでは検知しないことを明記
- テストロジック、本番コード、DB、設定、依存関係は変更なし

## 変更範囲

- `tests/unit/streamers-safe-columns.test.ts` のコメント1行のみ

Refs #1086