### PR TITLE
test(db-cutover): 未使用callbackのundefined指定意図を明記 (#1109)

### DIFF
--- a/tests/unit/db-cutover/layer-invariants.test.ts
+++ b/tests/unit/db-cutover/layer-invariants.test.ts
@@ -93,6 +93,8 @@ describe('db cutover layer invariants', () => {
       [tierBInvariant] as never,
       'target',
       (text: string) => text,
+      // 型上は第5引数が必須なので、callbackを使わないことをundefinedで明示する。
+      undefined,
     )
 
     expect(unsafe).toHaveBeenCalledTimes(1)

--- a/tests/unit/db-cutover/layer-invariants.test.ts
+++ b/tests/unit/db-cutover/layer-invariants.test.ts
@@ -93,7 +93,6 @@ describe('db cutover layer invariants', () => {
       [tierBInvariant] as never,
       'target',
       (text: string) => text,
-      undefined,
     )
 
     expect(unsafe).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## 概要

Issue #1109 のノンブロッキング改善のうち、`readSideInvariants` の第5引数へ明示的に `undefined` を渡している理由を整理します。

初回は引数自体を省略しましたが、CI typecheck で `TS2554: Expected 5 arguments, but got 4` を確認しました。現行のJSDoc型では値として `undefined` を許容していても引数自体は必須扱いなので、省略ではなく「callbackを使わないことを明示するための `undefined`」という意図をコメントで残す形へ修正しています。

## 変更内容

- `tests/unit/db-cutover/layer-invariants.test.ts` の Tier B fixture で、明示的な `undefined` が型契約上必要であることを短いコメントで説明
- fixture・assertion・本番コード・DB・設定には変更なし

## CI対応

- 初回HEAD `ebd12b01` の CI #2208 は Typecheck で失敗
- 原因を特定して現HEADで修正・再push済み

Refs #1109