### PR TITLE
test(db): safe columns否定方向ガードのコメントを簡潔化 (#1086)

### DIFF
--- a/tests/unit/streamers-safe-columns.test.ts
+++ b/tests/unit/streamers-safe-columns.test.ts
@@ -89,8 +89,7 @@ describe('streamers デプロイ窓の列集合契約', () => {
   })
 
   it('安全な列集合にはデプロイ窓で欠落しうる実SQL列を含めない', () => {
-    // 下の完全一致テストでも検知できるが、デプロイ窓列の混入時に原因を直接示す
-    // 診断用ガードとしてこの否定方向の契約も残す。
+    // 完全一致テストよりデプロイ窓列の混入原因を直接示せるため、この否定方向ガードも残す。
     const safeColumnNames = Object.values(STREAMERS_SAFE_COLUMNS).map((column) => column.name)
 
     for (const column of DEPLOY_WINDOW_COLUMNS) {


### PR DESCRIPTION
## 概要

Issue #1086 のノンブロッキング改善のうち、`STREAMERS_SAFE_COLUMNS` の否定方向ガードに付いた説明コメントを、現在のペア比較テスト導入後の役割に合わせて簡潔化します。

## 変更内容

- `tests/unit/streamers-safe-columns.test.ts` のコメント2行を1行へ整理
- 完全一致テストとは別に、デプロイ窓列の混入原因を直接示す診断用ガードとして残す意図を維持
- テストロジック・本番コード・DB・設定・依存関係は変更なし

Refs #1086