### PR TITLE
test(db-cutover): allowlist適用先の重複を固定

### DIFF
--- a/tests/unit/db-cutover-invariant-checks.test.ts
+++ b/tests/unit/db-cutover-invariant-checks.test.ts
@@ -68,6 +68,18 @@ describe('db cutover invariant checks', () => {
     expect(new Set(codes).size).toBe(codes.length)
   })
 
+  it('allowlistのappliesTo参照が重複しない', () => {
+    const targetKeys = ALLOWLIST.flatMap((entry) =>
+      entry.appliesTo.map((target) => {
+        if (target.layer === 'data') return `data:${target.table}`
+        if (target.layer === 'invariants') return `invariants:${target.invariantId}`
+        return `${target.layer}:${target.kind}:${target.key}`
+      }),
+    )
+
+    expect(new Set(targetKeys).size).toBe(targetKeys.length)
+  })
+
   it('finding識別に使うcheck codeが重複しない', () => {
     const codes = INVARIANTS.flatMap((invariant) =>
       invariant.checks.map((check) => check.code),


### PR DESCRIPTION
## 概要

Issue #1095 の軽量フォローアップとして、`ALLOWLIST[].appliesTo` の同一適用先が重複しないことを契約テストで固定します。

- data / invariants / schema targetを意味ベースのキーへ正規化
- 全entryを横断し、同じ適用先の重複を検出
- `findAllowlistEntry` の先頭一致で後続entryの根拠が失われる回帰を防止
- 本番コード・allowlistデータ・DB・設定・依存関係の変更なし

## 検証

- exact HEAD `fd0ad924`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）

新variant時のfail-loud、空集合ガード、理由コメントは #1095 で継続追跡します。

Refs #1095