### PR TITLE
test(db-cutover): Tier B fixtureのcode契約を固定

### DIFF
--- a/tests/unit/db-cutover/layer-invariants.test.ts
+++ b/tests/unit/db-cutover/layer-invariants.test.ts
@@ -104,6 +104,7 @@ describe('db cutover layer invariants', () => {
         tablesOk: true,
         checks: [
           expect.objectContaining({
+            code: 'FIXTURE_CHECK',
             tier: TIER_B,
             violationCount: 0,
             samples: [],


### PR DESCRIPTION
## 概要

Issue #1109 の軽量フォローアップとして、Tier B fixtureの結果でも `code` をassertし、fixtureのスプレッド元や返却形状が変わった際の回帰を検知します。

- 既存 `digestSql` 非null・違反0件ケースへ `code: "FIXTURE_CHECK"` の期待値を追加
- 本番コード・DB・設定・依存関係の変更なし
- test-onlyの1行追加

## 検証

- exact HEAD `c61fcae2`: CI成功
- 旧exact HEADの厳正レビュー: 必須指摘なし
- 最新HEADのClaude実行はレビュー処理自体の基盤エラーで2回失敗し、コード指摘・review artifactは生成されず
- 最新 `preview` 上の差分を手動再確認し、追加はTier B fixtureの `code` assertion 1行のみ

残るテスト網羅・配置・型安全性の任意改善は #1109 で継続追跡します。

Refs #1109