### PR TITLE
docs(discord): fork判定の信頼境界を明記

### DIFF
--- a/docs/discord-main-merge-notification.md
+++ b/docs/discord-main-merge-notification.md
@@ -17,6 +17,7 @@ Webhook URL は認証情報として扱い、リポジトリ、Issue、PR、CI �
 - `main` 向け PR がマージされたときに通知します。
 - `preview → main` の昇格 PR では、PR 本文の最初の `## このリリースで変わること` セクションを通知本文として利用します。
 - fork からの PR では PR 本文を通知本文として採用せず、サニタイズした PR タイトルへフォールバックします。
+- fork 判定は、信頼された base context の `GITHUB_REPOSITORY` と PR head 由来の `HEAD_REPOSITORY` を比較して行います。`HEAD_REPOSITORY` は非信頼入力として扱い、信頼側の基準値には使用しません。
 - `pull_request_target` を使うため、Secret を読む処理は信頼された base 側の workflow だけで実行します。PR head の checkout や実行をこの workflow に追加しないでください。
 
 ## 運用確認


### PR DESCRIPTION
## 概要

Issue #1091 の軽量フォローアップとして、Discord mainマージ通知のfork判定で使う入力の信頼境界を運用ドキュメントへ明記します。

- `GITHUB_REPOSITORY` は信頼されたbase contextの基準値
- `HEAD_REPOSITORY` はPR head由来の非信頼入力
- fork判定は両者を比較して行い、`HEAD_REPOSITORY` を信頼側の基準値には使わない

## 検証

- exact HEAD `b571c36e`: CI成功
- 現行workflowと照合した厳正レビュー: 必須0件、任意0件
- Cloudflare Workers preview deployment成功
- docs-onlyで実行コード・workflow・trigger・権限・Secret・通知payloadの変更なし

Refs #1091 #1027