### PR TITLE
test(live): deploy-window status領域を固定

### DIFF
--- a/tests/unit/components/live-directory-settings-deploy-window-status.test.tsx
+++ b/tests/unit/components/live-directory-settings-deploy-window-status.test.tsx
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import LiveDirectorySettings from "@/components/LiveDirectorySettings";
+import { MaintenanceStatusContext } from "@/components/MaintenanceStatusProvider";
+import jaMessages from "../../../messages/ja.json";
+
+vi.mock("@/lib/logger");
+
+describe("LiveDirectorySettings deploy-window status", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ success: true, liveDirectorySettingsSkippedDeployWindow: true }),
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the deploy-window error in the existing status region", async () => {
+    render(
+      <NextIntlClientProvider locale="ja" messages={jaMessages}>
+        <MaintenanceStatusContext.Provider value={{ mode: "off" }}>
+          <LiveDirectorySettings
+            streamerId="streamer-1"
+            currentPublishLiveStatus={false}
+            currentPublishStats={false}
+          />
+        </MaintenanceStatusContext.Provider>
+      </NextIntlClientProvider>
+    );
+
+    const status = screen.getByRole("status");
+    expect(status).toBeEmptyDOMElement();
+
+    const liveToggle = screen.getByRole("checkbox", { name: "配信中を公表する" });
+    fireEvent.click(liveToggle);
+
+    await waitFor(() => {
+      expect(status).toHaveTextContent(
+        "配信中ページの設定を現在保存できません。しばらくしてから再度お試しください。"
+      );
+    });
+    expect(screen.getByRole("status")).toBe(status);
+    expect(liveToggle).not.toBeChecked();
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1126 の軽量フォローアップとして、deploy-window skip時のエラーメッセージも既存の `role="status"` live region内で更新される契約を固定します。

- 初期status regionが空で常時マウント
- skip応答後も同じDOMノードへエラー文言を表示
- 楽観反映したトグルをfalseへ巻き戻す既存挙動を維持
- 本番コード・DB・設定・依存関係の変更なし

## 検証

- exact HEAD `5224647e`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）
- Cloudflare Workers preview deployment成功

既存suiteへの統合・fixture整理は #1126 で継続追跡します。

Refs #1126