### PR TITLE
test(a11y): card visibilityの説明関連を固定

### DIFF
--- a/tests/unit/components/card-visibility-settings-maintenance.test.tsx
+++ b/tests/unit/components/card-visibility-settings-maintenance.test.tsx
@@ -10,13 +10,13 @@ vi.mock('@/lib/logger')
 
 // #694 Stage 6b: 「設定保存」カテゴリの代表として CardVisibilitySettings
 // (/api/streamer/settings への書き込み) を検証する。
-function renderSettings(status: MaintenanceStatusResponse) {
+function renderSettings(status: MaintenanceStatusResponse, currentShowUnowned = false) {
   return render(
     <NextIntlClientProvider locale="ja" messages={jaMessages}>
       <MaintenanceStatusContext.Provider value={status}>
         <CardVisibilitySettings
           streamerId="streamer-1"
-          currentShowUnowned={false}
+          currentShowUnowned={currentShowUnowned}
           currentShowUnownedDetails={false}
         />
       </MaintenanceStatusContext.Provider>
@@ -36,6 +36,34 @@ function getToggles() {
     }),
   ] as const
 }
+
+describe('CardVisibilitySettings accessible descriptions', () => {
+  it('未所持カード表示トグルを補足説明へ関連付ける', () => {
+    renderSettings({ mode: 'off' })
+    const [showUnownedToggle] = getToggles()
+
+    expect(showUnownedToggle).toHaveAccessibleDescription(
+      jaMessages.cardVisibilitySettings.form.showUnownedHelp
+    )
+  })
+
+  it('詳細トグルは未所持カード非表示時だけ前提条件も説明する', () => {
+    const { unmount } = renderSettings({ mode: 'off' })
+    const [, hiddenDetailsToggle] = getToggles()
+
+    expect(hiddenDetailsToggle).toHaveAccessibleDescription(
+      `${jaMessages.cardVisibilitySettings.form.showDetailsHelp} (${jaMessages.cardVisibilitySettings.form.requiresShowUnowned})`
+    )
+
+    unmount()
+    renderSettings({ mode: 'off' }, true)
+    const [, visibleDetailsToggle] = getToggles()
+
+    expect(visibleDetailsToggle).toHaveAccessibleDescription(
+      jaMessages.cardVisibilitySettings.form.showDetailsHelp
+    )
+  })
+})
 
 describe('CardVisibilitySettings maintenance integration', () => {
   afterEach(() => {


### PR DESCRIPTION
## 概要

Issue #1093 の軽量フォローアップとして、`CardVisibilitySettings` の `aria-describedby` 契約を既存コンポーネントテストで固定します。

- 未所持カード表示トグルは `showUnownedHelp` を説明として持つ
- 詳細トグルは未所持カード非表示時だけ `requiresShowUnowned` も説明へ含む
- 未所持カード表示済みでは通常ヘルプだけへ戻る
- 本番コード・DB・設定・依存関係の変更なし

## 検証

- exact HEAD `8e0384b5`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）
- Cloudflare Workers preview deployment成功

テスト配置・fixture options化など残る任意改善は #1093 で継続追跡します。

Refs #1093