### PR TITLE
docs(db): trade取得日時の意味を明文化

### DIFF
--- a/docs/trade-migration-reference-notes.md
+++ b/docs/trade-migration-reference-notes.md
@@ -36,6 +36,13 @@ migration evolves:
   `trade_offers`, including completed rows. History retention is therefore
   scoped to card/card-copy cleanup; it does not promise retention after the
   offerer account or a referenced streamer is deleted.
+- **Ownership-transfer timestamp:** both transferred `user_cards` rows set
+  `obtained_at = now()` when `accept_trade_offer` moves ownership. This is
+  intentional: `obtained_at` represents when the current owner acquired that
+  copy, so `card_owner_stats.last_obtained_at` also reflects the trade time via
+  its `MAX(obtained_at)` refresh. The card copy's first-ever acquisition time is
+  not preserved in `user_cards`; completed trade history instead retains its
+  snapshots and `completed_at`.
 - **Chosen payment card:** references to the selected payment card should use
   `v_payer_user_card_id`, not migration line ranges.
 - **Lock-order contract:** describe the invariant as


### PR DESCRIPTION
## 概要

Issue #1013 の軽量フォローアップとして、trade成立時に `user_cards.obtained_at = now()` へ更新する意味を保守向け文書へ追記します。

- checksum管理対象の適用済みmigration本体は変更しない
- `obtained_at` は現在の所有者がそのcopyを取得した時刻
- `card_owner_stats.last_obtained_at` は `MAX(obtained_at)` によりtrade時刻へ追随
- 初回取得時刻は `user_cards` では保持せず、成立履歴はsnapshot / `completed_at` で追跡

## 検証

- exact HEAD `e651254d`: CI成功
- `accept_trade_offer` 実装と照合した厳正レビュー: 必須0件、任意0件
- Cloudflare Workers preview deployment成功
- docs-onlyで実行コード・DB・migration checksum・設定・依存関係の変更なし

Refs #1013