### PR TITLE
docs(twitch): rewards refresh診断コメントを統一

### DIFF
--- a/src/app/api/twitch/rewards/route.ts
+++ b/src/app/api/twitch/rewards/route.ts
@@ -80,8 +80,8 @@ export async function GET(request: Request) {
         { status: 401 }
       );
     }
-    // Issue #653: refresh失敗(REFRESH_FAILED)の場合、diagnostics(status/kind)を
-    // auto-generated bug reportのContextへ載せる(twitchTokenErrorReportContext参照)。
+    // token-manager側はrefresh障害を二重報告しない。永続化責任はAPI境界のhandleApiErrorにあり、
+    // ここで安全なrefresh診断だけをadditionalInfoへ明示的に橋渡しする。
     return handleApiError(error, "Twitch rewards fetch", twitchTokenErrorReportContext(error));
   }
 }
@@ -155,6 +155,8 @@ export async function POST(request: Request) {
         { status: 401 }
       );
     }
+    // token-manager側はrefresh障害を二重報告しない。永続化責任はAPI境界のhandleApiErrorにあり、
+    // ここで安全なrefresh診断だけをadditionalInfoへ明示的に橋渡しする。
     return handleApiError(error, "Twitch reward creation", twitchTokenErrorReportContext(error));
   }
 }


### PR DESCRIPTION
## 概要

Issue #1088 の軽量フォローアップとして、rewards routeのtoken refresh診断コメントをemotes routeと同じ責務説明へ揃えます。

- GET / POSTの両catchで、token-managerはrefresh障害を二重報告しないことを明記
- 永続化責任はAPI境界の `handleApiError` にあることを明記
- `twitchTokenErrorReportContext(error)` は安全なrefresh診断だけをadditionalInfoへ橋渡しすることを明記
- 実行コード・レスポンス・エラー処理・DB・設定・依存関係の変更なし

## 検証

- exact HEAD `28a71eec`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）
- Cloudflare Workers preview deployment成功

他routeのコメント統一は #1088 で継続追跡します。

Refs #1088