### PR TITLE
ci: Discord webhook secretを必要stepへ限定

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -71,7 +71,6 @@ jobs:
     if: github.event.action == 'closed' && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     env:
-      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
       # PR/repository-derived strings stay in env and are consumed as data by Python/jq;
       # do not interpolate them directly into the shell script.
       # Re-declare the runner default so the fork check's trusted base input is explicit.
@@ -88,6 +87,8 @@ jobs:
     steps:
       - name: Validate webhook configuration
         shell: bash
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
           if [[ -z "$DISCORD_WEBHOOK_URL" ]]; then
             echo "::error::Repository secret DISCORD_WEBHOOK_URL is not configured."
@@ -96,6 +97,8 @@ jobs:
 
       - name: Send merge notification to Discord
         shell: bash
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
           # Promotion PRs keep the human-facing release summary in the first
           # `## このリリースで変わること` section. Reuse that text directly


### PR DESCRIPTION
## 概要

Discord mainマージ通知workflowで、`DISCORD_WEBHOOK_URL` をjob-level envから外し、実際に参照する2つのstepだけへ限定します。

- 設定検証stepとDiscord送信stepだけへSecretを渡す
- 後段のfailure stepやPR由来データ処理へは渡さない
- webhook未設定時のfail-fast、payload、retry、permissions、triggerは変更なし

## 検証

- exact HEAD `d4c6eb08`: CI成功（actionlintを含む）
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）
- Cloudflare Workers preview deployment成功

Secret注記や設定検証stepとの統合は #1027 で継続追跡します。

Refs #1027