### PR TITLE
test(r2): retry fixture不変条件を専用テストへ分離

### DIFF
--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -96,15 +96,6 @@ const RETRY_SUCCESS_ATTEMPTS = TRANSIENT_FAILURES_BEFORE_SUCCESS + 1
 const R2_INTERNAL_ERROR_MESSAGE = 'put: We encountered an internal error. Please try again. (10001)'
 
 function mockTransientFailuresThenSuccess(): void {
-  expect(
-    TRANSIENT_FAILURES_BEFORE_SUCCESS,
-    'リトライ成功fixtureには一時失敗を1回以上含めること',
-  ).toBeGreaterThanOrEqual(1)
-  expect(
-    TRANSIENT_FAILURES_BEFORE_SUCCESS,
-    'リトライ成功fixtureはMAX_RETRIES以内で成功へ到達できること',
-  ).toBeLessThanOrEqual(MAX_RETRIES)
-
   for (
     let transientFailureIndex = 0;
     transientFailureIndex < TRANSIENT_FAILURES_BEFORE_SUCCESS;
@@ -147,6 +138,17 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
     vi.unstubAllEnvs()
     // リトライ成功テストは fake timers を使うため、後続テストへ影響を残さない。
     vi.useRealTimers()
+  })
+
+  it('リトライ成功fixtureの一時失敗回数が有効範囲にある', () => {
+    expect(
+      TRANSIENT_FAILURES_BEFORE_SUCCESS,
+      'リトライ成功fixtureには一時失敗を1回以上含めること',
+    ).toBeGreaterThanOrEqual(1)
+    expect(
+      TRANSIENT_FAILURES_BEFORE_SUCCESS,
+      'リトライ成功fixtureはMAX_RETRIES以内で成功へ到達できること',
+    ).toBeLessThanOrEqual(MAX_RETRIES)
   })
 
   it('R2バインディング・環境変数がどちらも無い場合、実際のuploadToR2が投げる恒久エラーを1回の試行で返す', async () => {


### PR DESCRIPTION
## 概要

Issue #1103 のノンブロッキング項目から、`mockTransientFailuresThenSuccess` が持っていたfixture不変条件検証を専用テストへ分離します。

- helperはS3 mockの組み立てだけを担当
- `1 <= TRANSIENT_FAILURES_BEFORE_SUCCESS <= MAX_RETRIES` は独立した契約テストで固定
- 既存の診断メッセージとretry wiringの挙動は維持
- 本番コード・設定・依存関係は変更なし

## 検証

- CI: 成功
- Claude Auto Review: 成功（必須指摘なし）

Refs #1103