### PR TITLE
test(twitch): KV書き込み失敗時もapp token継続を固定

### DIFF
--- a/tests/unit/twitch-app-token.test.ts
+++ b/tests/unit/twitch-app-token.test.ts
@@ -206,6 +206,18 @@ describe("Twitch app access token", () => {
     });
   });
 
+  it("KV 書き込みが例外を投げても発行済みトークンを返し reportError で通知する", async () => {
+    kv.put.mockRejectedValue(new Error("kv write failed"));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(tokenResponse() as never);
+
+    const token = await getTwitchAppAccessToken();
+
+    expect(token).toBe("token-1");
+    expect(reportError).toHaveBeenCalledWith(expect.any(Error), {
+      context: "twitchAppToken:kvWrite",
+    });
+  });
+
   it("expirationTtl は Cloudflare KV の最小値60秒を下回らない", async () => {
     // expires_in 30秒（0.8倍で24秒 < 60秒）でも TTL は60秒になる
     vi.spyOn(globalThis, "fetch").mockResolvedValue(


### PR DESCRIPTION
## 概要

Issue #921 の軽量フォローアップとして、`getTwitchAppAccessToken()` のKV write failure契約を固定します。

- token endpointで発行済みのapp tokenはKV `put` 失敗でも返す
- `twitchAppToken:kvWrite` contextで `reportError` へ通知
- 本番コード・設定・依存関係の変更なし

## 検証

- exact HEAD `429ab5bd`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）

reportErrorの厳密化・2回目取得のメモリ継続・KV delete経路は #1215 および後続PR #1230で追跡します。

Refs #921 #1215