### PR TITLE
test(chat): retry fixtureのDB非依存意図を明記

### DIFF
--- a/tests/unit/post-redemption-notify-chat-retry.test.ts
+++ b/tests/unit/post-redemption-notify-chat-retry.test.ts
@@ -58,6 +58,8 @@ const mockDeadLetter = vi.mocked(deadLetterChatNotification)
 const mockReportError = vi.mocked(reportError)
 const mockLoggerWarn = vi.mocked(logger.warn)
 
+// `{user}` / `{card}` だけのテンプレートにして補助DB参照を通さず、
+// retryState と reportError の契約だけを隔離して検証する。
 const streamer = {
   id: 'streamer-1',
   chat_announcement_enabled: true,


### PR DESCRIPTION
## 概要

Issue #1037 の軽量フォローアップとして、`post-redemption-notify-chat-retry.test.ts` のfixture直上にDB非依存の前提を明記します。

- `{user}` / `{card}` だけのtemplateで補助DB参照を避ける
- retryStateとreportErrorの契約だけを隔離する意図を記録
- 実行コード・mock構成・assertion・DB・設定・依存関係の変更なし

## 検証

- exact HEAD `5f7b3754`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）

DB非呼び出しの機械的assertionや説明集約は #1217 で継続追跡します。

Refs #1037 #1217