### PR TITLE
test(analysis): diff table fixtureの意図を明確化

### DIFF
--- a/tests/unit/compare-analysis-dashboard-vs-sql-table-layout.test.ts
+++ b/tests/unit/compare-analysis-dashboard-vs-sql-table-layout.test.ts
@@ -6,9 +6,11 @@ describe('printDiffTable separator layout', () => {
     vi.restoreAllMocks()
   })
 
-  it('区切り線の各列幅をヘッダーまたは最長データ幅へ揃える', () => {
+  it('ネスト名を含む実在メトリクスで区切り線の各列幅を固定する', () => {
     const log = vi.spyOn(console, 'log').mockImplementation(() => {})
 
+    // 平坦なメトリクス名も正当だが、実出力で使うネスト名を fixture へ含め、
+    // 「誤った名前の修正」ではなく列幅契約を実出力へ寄せる意図を明確にする。
     printDiffTable([
       { metric: 'usersSummary.totalUsers', expected: 10, actual: 11 },
       { metric: 'rarityDistribution.rare', expected: 25, actual: 26 },


### PR DESCRIPTION
## 概要

Issue #1143 の軽量フォローアップとして、`printDiffTable` の列幅テストでネスト名を含むfixtureを使う意図を明確化します。

- テスト名とコメントだけを変更
- 平坦なmetric名も正当だが、実出力に現れるネスト名を代表値として固定していることを記録
- assertion・fixture値・本番コード・DB・設定・依存関係の変更なし

## 検証

- exact HEAD `df6a61aa`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）

テスト名の追加改善、既存suiteへの統合、平坦名ケース追加は #1143 で継続追跡します。

Refs #1143