### PR TITLE
fix(a11y): ランキング期間切替の操作領域と説明関連付けを改善

### DIFF
--- a/src/components/LiveDirectory.tsx
+++ b/src/components/LiveDirectory.tsx
@@ -237,7 +237,7 @@ export default function LiveDirectory({
           <>
             <div className="mb-6 flex flex-col gap-3 border-b border-gray-800 pb-5 sm:flex-row sm:items-end sm:justify-between">
               {view !== "cardCount" && (
-                <fieldset>
+                <fieldset aria-describedby="live-directory-ranking-period-help">
                   <legend className="mb-2 text-sm font-medium text-gray-300">
                     {t("period.label")}
                   </legend>
@@ -255,7 +255,7 @@ export default function LiveDirectory({
                           onChange={() => setRankingPeriod(period.id)}
                           className="peer sr-only"
                         />
-                        <span className="flex min-h-9 items-center justify-center px-4 text-sm font-medium text-gray-400 transition peer-checked:bg-gray-600 peer-checked:text-white peer-focus-visible:outline-none">
+                        <span className="flex min-h-11 items-center justify-center px-4 text-sm font-medium text-gray-400 transition peer-checked:bg-gray-600 peer-checked:text-white peer-focus-visible:outline-none">
                           {t(period.labelKey)}
                         </span>
                       </label>
@@ -263,7 +263,10 @@ export default function LiveDirectory({
                   </div>
                 </fieldset>
               )}
-              <p className="max-w-2xl text-xs leading-5 text-gray-400 sm:text-right">
+              <p
+                id="live-directory-ranking-period-help"
+                className="max-w-2xl text-xs leading-5 text-gray-400 sm:text-right"
+              >
                 {view === "cardCount"
                   ? t("period.cardCountHelp")
                   : t(`period.usageHelp.${rankingPeriod}`)}


### PR DESCRIPTION
## 概要

Issue #935 の軽量フォローアップとして、`/live` のランキング期間切替のアクセシビリティを改善します。

- 可視ラベルの操作領域を `min-h-11`（44px）へ拡大
- 期間選択fieldsetを既存の期間説明文へ `aria-describedby` で関連付け
- radio checked/onChange、ランキングデータ、翻訳、API、DBの挙動は変更なし

## 検証

- exact HEAD `216c167b`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）
- 変更は `src/components/LiveDirectory.tsx` のa11y markupのみ

動的説明の再通知、radio個別関連付け、幅下限、回帰テストは #935 で継続追跡します。

Refs #935