### PR TITLE
test(error-handler): URL中の503をstatus誤認しない回帰を追加

### DIFF
--- a/tests/unit/error-handler.test.ts
+++ b/tests/unit/error-handler.test.ts
@@ -130,6 +130,7 @@ describe('error-handler', () => {
       'avatar-401.jpg',
       'asset-507-preview.png',
       'https://example.com/assets/503.png',
+      'PUT http://a/503 failed',
     ])('文脈のない数値をHTTP statusとして誤分類しない: %s', async (errorMessage) => {
       const response = await handleBlobError(new Error(errorMessage), 'blob');
       expect(response.status).toBe(500);


### PR DESCRIPTION
## 概要

Issue #989 の軽量フォローアップとして、URLパス中の `503` をHTTP statusと誤分類しない契約を `handleBlobError` の既存負例へ追加します。

- `PUT http://a/503 failed` でもレスポンスは500のまま
- 明示的なstatus文脈や標準status lineでないURL内数字を503扱いへ倒さない
- 本番コード・DB・設定・依存関係の変更なし

## 検証

- exact HEAD `68b45a16`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）

`r2-client` 側の意図的に広い一時障害判定、fixture説明、ブロック名整理は #989 で継続追跡します。

Refs #989