### PR TITLE
test(overlay): metadata待機値を名前付き定数へ整理

### DIFF
--- a/tests/unit/components/overlay-page-metadata-fallback.test.tsx
+++ b/tests/unit/components/overlay-page-metadata-fallback.test.tsx
@@ -8,6 +8,10 @@ const { subscribeMock, streamerIdRef } = vi.hoisted(() => ({
   streamerIdRef: { current: 'streamer-1' },
 }))
 
+// metadata callback が無応答のままでも表示が維持されることを見る観測窓。
+// 現行の 1.5 秒 probe timeout を少し越えて待つ意図を数値直書きから分離する。
+const METADATA_STALL_OBSERVATION_MS = 1_600
+
 vi.mock('next/navigation', () => ({
   useParams: () => ({ streamerId: streamerIdRef.current }),
 }))
@@ -136,7 +140,7 @@ describe('OverlayPage metadata fallback', () => {
 
     // load/errorは無応答のままでも、metadata期限に依存せず表示が維持される。
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(1600)
+      await vi.advanceTimersByTimeAsync(METADATA_STALL_OBSERVATION_MS)
     })
     expect(cardRoot).toHaveClass('opacity-100')
     expect(acknowledged).toBe(true)


### PR DESCRIPTION
## 概要

Issue #1178 の軽量フォローアップとして、metadata callback無応答テストの `1600ms` 直値を名前付き定数へ置き換えます。

- `METADATA_STALL_OBSERVATION_MS = 1_600` を追加
- 1.5秒のmetadata probe timeoutを少し越えて観測する意図を明文化
- 待機時間・fixture・assertion・本番overlayコード・DB・設定・依存関係の変更なし

## 検証

- exact HEAD `d35d562b`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）

実装定数からの導出や他suiteの直値整理は #1178 で継続追跡します。

Refs #1178