### PR TITLE
test(eventsub): health監視のscheduled配線を固定

### DIFF
--- a/tests/unit/error-reporter-eventsub-health-scheduled.test.ts
+++ b/tests/unit/error-reporter-eventsub-health-scheduled.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import worker from '../../workers/error-reporter/src/index';
+
+describe('error-reporter scheduled EventSub health wiring', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('reporter用binding/secretsが未設定でもEventSub healthを先に実行する', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        total: 2,
+        unhealthyCount: 0,
+        unhealthy: [],
+        checkedAt: '2026-08-25T00:00:00.000Z',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const env = {
+      GITHUB_TOKEN: '',
+      GITHUB_REPO_OWNER: 'testowner',
+      GITHUB_REPO_NAME: 'testrepo',
+      APP_BASE_URL_PROD: 'https://prod.example.com/',
+      EVENTSUB_HEALTH_SECRET_PROD: 'prod-health-secret',
+    };
+    const event = { cron: '*/5 * * * *' } as ScheduledController;
+    const ctx = { waitUntil: vi.fn() } as unknown as ExecutionContext;
+
+    await worker.scheduled(event, env, ctx);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://prod.example.com/api/admin/eventsub-health',
+      expect.objectContaining({
+        headers: { 'X-EventSub-Health-Secret': 'prod-health-secret' },
+      })
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Missing required binding/secrets')
+    );
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1010 の項目4として、error-reporter Worker の `scheduled()` が EventSub subscription health checkを既存reporter用binding/secretsのバリデーションより前に実行する契約を固定します。

- `HYPERDRIVE_PLANETSCALE` 未設定・`GITHUB_TOKEN` 空でもproduction health endpointを先にfetch
- health check後にreporter用環境変数バリデーションで安全に早期return
- 本番コード・Worker設定・DB・依存関係の変更なし

## 検証

- exact HEAD `21dde041`: CI成功
- 旧exact HEADの厳正レビューおよびClaude Auto Review: 必須指摘なし
- 最新HEADのClaude実行はレビュー処理自体の基盤エラーで2回失敗し、コード指摘・review artifactは生成されず
- 最新 `preview` 上の差分を手動再確認し、既存と同内容のtest-only新規1ファイル

コメント・配置・追加ケースの任意改善は #1226 で継続追跡します。

Refs #1010 #1226