### PR TITLE
test(analysis): CLI未設定時の終了コードを固定

### DIFF
--- a/tests/unit/compare-analysis-dashboard-cli.test.ts
+++ b/tests/unit/compare-analysis-dashboard-cli.test.ts
@@ -1,0 +1,32 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const scriptPath = path.join(repoRoot, "scripts/compare-analysis-dashboard-vs-sql.mjs");
+
+describe("compare-analysis-dashboard-vs-sql CLI", () => {
+  it("DASHBOARD_DATABASE_URL が未設定なら DB へ接続せず終了コード2を返す", () => {
+    const env = {
+      ...process.env,
+      // 旧接続変数が存在しても DASHBOARD_DATABASE_URL へフォールバックしないことを
+      // CLI 経路でも固定する。
+      DATABASE_URL_PLANETSCALE: "postgres://must-not-be-used",
+      PLANETSCALE_DATABASE_URL: "postgres://must-not-be-used",
+    };
+    delete env.DASHBOARD_DATABASE_URL;
+
+    const result = spawnSync(process.execPath, [scriptPath], {
+      cwd: repoRoot,
+      env,
+      encoding: "utf8",
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("DASHBOARD_DATABASE_URL の設定が必要です。");
+  });
+});

--- a/tests/unit/compare-analysis-dashboard-cli.test.ts
+++ b/tests/unit/compare-analysis-dashboard-cli.test.ts
@@ -8,7 +8,7 @@ const scriptPath = path.join(repoRoot, "scripts/compare-analysis-dashboard-vs-sq
 
 describe("compare-analysis-dashboard-vs-sql CLI", () => {
   it("DASHBOARD_DATABASE_URL が未設定なら DB へ接続せず終了コード2を返す", () => {
-    const env = {
+    const env: NodeJS.ProcessEnv = {
       ...process.env,
       // 旧接続変数が存在しても DASHBOARD_DATABASE_URL へフォールバックしないことを
       // CLI 経路でも固定する。


### PR DESCRIPTION
## 概要

Issue #1082 の軽量フォローアップとして、analysis dashboard比較CLIの未設定時終了契約を固定します。

- `DASHBOARD_DATABASE_URL` 未設定ならDBへ接続せず終了コード2
- stdoutは空、stderrには設定案内
- 旧接続変数が存在してもフォールバックしないことを実CLI subprocessで確認
- 本番コード・DB・設定・依存関係の変更なし

## 検証

- exact HEAD `0b8250c7`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）

subprocess timeout・最小env・説明コメントは #1082 で継続追跡します。

Refs #1082