### PR TITLE
test(overlay): presence binding未設定時の503を固定

### DIFF
--- a/tests/unit/overlay-realtime-presence-binding.test.ts
+++ b/tests/unit/overlay-realtime-presence-binding.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import worker from '../../workers/overlay-realtime/src/index'
+
+describe('overlay realtime presence binding', () => {
+  it('returns 503 when OVERLAY_PRESENCE is not bound', async () => {
+    const env = {
+      OVERLAY_ROOMS: {} as Parameters<typeof worker.fetch>[1]['OVERLAY_ROOMS'],
+      OVERLAY_REALTIME_PUBLISH_SECRET: 'test-secret',
+      OVERLAY_REALTIME_MODE: 'do-primary',
+      OVERLAY_REALTIME_STREAMER_ALLOWLIST: '*',
+    } as Parameters<typeof worker.fetch>[1]
+
+    const response = await worker.fetch(
+      new Request('https://worker.example/presence'),
+      env,
+    )
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({ error: 'Presence unavailable' })
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1116 の軽量フォローアップとして、overlay realtime Worker の `OVERLAY_PRESENCE` 未バインド時の公開 `/presence` 契約を回帰テストで固定します。

- staged-rollout相当のenvで `/presence` を呼ぶ
- HTTP 503と `{ error: "Presence unavailable" }` を固定
- バインド不在を0件snapshotへ誤変換しない契約を保護
- 本番コード・Worker設定・DB・依存関係の変更なし

## 検証

- exact HEAD `3b9f37ac`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）

既存suiteへの統合、no-store header、fixture最小化は #1116 で継続追跡します。

Refs #1116