### PR TITLE
docs(live): presence unavailable境界のコメントを整理

### DIFF
--- a/src/lib/live-directory.ts
+++ b/src/lib/live-directory.ts
@@ -570,9 +570,10 @@ export async function getLiveDirectory(): Promise<LiveDirectoryEntry[]> {
  * The realtime Worker already coalesces room observations into one snapshot;
  * this second 60-second KV cache prevents every page request from waking the
  * registry. A missing binding or a failed snapshot is represented by null so
- * the UI can omit the estimate instead of claiming that zero channels are
- * live. Unavailable states are negative-cached for the same short TTL so a
- * staged Worker rollout cannot fan out one service call per public page view.
+ * callers can distinguish an unavailable estimate from a valid zero bucket
+ * instead of claiming that zero channels are live. Unavailable states are
+ * negative-cached for the same short TTL so a staged Worker rollout cannot fan
+ * out one service call per public page view.
  */
 export async function getLiveDirectoryPresence(): Promise<LiveDirectoryPresenceSnapshot | null> {
   const now = Date.now();


### PR DESCRIPTION
## 変更内容

- `getLiveDirectoryPresence()` のコメントを、`null` が「推定値を非表示にする」ことではなく、取得不能と有効な0 bucketを区別する戻り値契約だと分かる表現へ更新
- 呼び出し側の表示方針に依存しない説明とし、マージ済みPR #1200の「5件未満／不明」表示とも整合

## 検証

- exact HEAD `61a31b2c`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）
- 実行コード・API・キャッシュ・DB・設定・依存関係の変更なし

0 bucketの補足説明と回帰テストは #1201 の後続項目およびPR #1238で追跡します。

Refs #1201 #1200