### PR TITLE
refactor(eventsub): 通知ラベル分岐を1箇所へ整理

### DIFF
--- a/src/lib/services/eventsub-redemption.ts
+++ b/src/lib/services/eventsub-redemption.ts
@@ -621,13 +621,15 @@ export async function postRedemptionNotify(
   // 加え、この「想定外throw」時にもreportErrorが機能する。
   for (const [i, result] of results.entries()) {
     if (result.status === 'rejected') {
-      const label = i === 0 ? 'broadcast' : 'chatAnnouncement';
-      logger.warn(`[postRedemptionNotify] ${i === 0 ? 'broadcast' : 'chat announcement'} failed`, {
+      const { contextLabel, displayLabel } = i === 0
+        ? { contextLabel: 'broadcast', displayLabel: 'broadcast' }
+        : { contextLabel: 'chatAnnouncement', displayLabel: 'chat announcement' };
+      logger.warn(`[postRedemptionNotify] ${displayLabel} failed`, {
         error: result.reason instanceof Error ? result.reason.message : String(result.reason),
         streamerId: data.streamer.id,
       });
       await reportNotificationError(result.reason, {
-        context: `eventsub:postRedemptionNotify:${label}`,
+        context: `eventsub:postRedemptionNotify:${contextLabel}`,
         streamerId: data.streamer.id,
         broadcasterTwitchUserId: data.broadcasterTwitchUserId,
       });


### PR DESCRIPTION
## 概要

Issue #1098 の軽量フォローアップとして、`postRedemptionNotify` の通知失敗ログに重複していた `i === 0` 判定を1箇所へ整理します。

- 人向けwarn表示は従来どおり `broadcast` / `chat announcement`
- 構造化error contextは従来どおり `broadcast` / `chatAnnouncement`
- `Promise.allSettled` の順序、reject判定、report timing、外部送信は変更なし

## 検証

- exact HEAD `44364853`: CI成功
- 厳正レビュー: 必須0件、任意0件
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）
- Cloudflare Workers preview deployment成功

タスクとラベルを構造体で結ぶ追加改善や外部監視設定確認は #1098 で継続追跡します。

Refs #1098