### PR TITLE
test(public): live directory導線テストを専用describeへ整理

### DIFF
--- a/tests/unit/public-help-pages.test.ts
+++ b/tests/unit/public-help-pages.test.ts
@@ -84,7 +84,9 @@ describe("FAQ page", () => {
     expect(source).toContain('href: "/privacy"');
     expect(source).toContain('href: "/releases"');
   });
+});
 
+describe("top page live-directory navigation", () => {
   it("places the live-directory link in content navigation instead of top bars", () => {
     const home = readSource("src/app/page.tsx");
     const dashboardNav = readSource("src/components/DashboardNav.tsx");


### PR DESCRIPTION
## 概要

Issue #932 のうち、判断を伴わないテスト整理だけを切り出します。

- `tests/unit/public-help-pages.test.ts` のトップページ `/live` 導線2テストを専用 `describe` へ分離
- assertion・日英文言・導線条件は変更しない
- 用語体系や完全一致／禁止語の契約判断は #932 に残す

## 検証

- exact HEAD `423c2a5c`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）
- 本番コード・翻訳・設定の変更なし

任意のassert精度改善は #1244 で継続追跡します。

Refs #932 #1244