### PR TITLE
chore(discord): promotion branch判定を定数化

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -110,6 +110,10 @@ jobs:
 
           limit = 2000
           section_heading = "## このリリースで変わること"
+          # Only the canonical preview -> main path is a release promotion.
+          # Keep the branch names explicit here so direct-to-main merges use the title fallback.
+          promotion_source_ref = "preview"
+          promotion_target_ref = "main"
           body = os.environ.get("PR_BODY", "").replace("\r\n", "\n").replace("\r", "\n")
           # Only same-repository promotion text is trusted as notification input.
           # Fork PRs fall back to a sanitized title below.
@@ -150,8 +154,8 @@ jobs:
           release_text = strip_markdown_links(chr(10).join(release_lines)).strip()
           if not release_text or not re.search("[0-9A-Za-zぁ-んァ-ヶ一-龠]", release_text):
               is_promotion = (
-                  os.environ.get("BASE_REF") == "main"
-                  and os.environ.get("HEAD_REF") == "preview"
+                  os.environ.get("BASE_REF") == promotion_target_ref
+                  and os.environ.get("HEAD_REF") == promotion_source_ref
                   and os.environ.get("HEAD_REPOSITORY") == os.environ.get("GITHUB_REPOSITORY")
               )
               if is_promotion:


### PR DESCRIPTION
## 概要

Issue #1107 の軽量フォローアップとして、Discord main更新通知のpromotion判定に残る `preview` / `main` をPythonブロック内のローカル定数へ寄せます。

- canonical release pathが `preview -> main` であることを明文化
- `promotion_source_ref` / `promotion_target_ref` を使って判定
- direct-to-main mergeは従来どおりtitle fallback
- trigger・permissions・Secret・payload・送信処理は変更なし

## 検証

- exact HEAD `0764e2d8`: CI成功（actionlint含む）
- 旧HEADを含む厳正レビュー: 必須指摘なし、任意指摘のみ
- 最新Claude実行はレビュー基盤ステップでartifact生成前に失敗し、コード指摘なし

YAML条件側との完全な単一正本化はGitHub Actionsの評価境界上できず、通知表示文言まで定数へ寄せる追加抽象化も実益が小さいため、本PRの収束条件にしません。

Refs #1107 #1211