### PR TITLE
test(public): /live CTA styleをリンク要素に固定

### DIFF
--- a/tests/unit/top-page-live-directory-style.test.ts
+++ b/tests/unit/top-page-live-directory-style.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function readSource(path: string): string {
+  return readFileSync(join(process.cwd(), path), 'utf8')
+}
+
+describe('top page live-directory navigation', () => {
+  it('keeps the secondary style on the /live link itself', () => {
+    const home = readSource('src/app/page.tsx')
+    const liveLinkMatch = home.match(/<Link\s+href="\/live"[\s\S]*?<\/Link>/)
+
+    expect(liveLinkMatch, '/live Link should exist on the top page').not.toBeNull()
+    expect(liveLinkMatch?.[0] ?? '').toContain('border-gray-600 bg-gray-800')
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1244 の軽量フォローアップとして、トップページの `/live` CTAのsecondary style契約を対象リンクのブロックへ紐づけて回帰テスト化します。

- `src/app/page.tsx` から `href="/live"` の `<Link>` ブロックだけを抽出
- `border-gray-600 bg-gray-800` が同ブロックに含まれることを検証
- 親PR #1243は `preview` へマージ済み
- 本番コード・翻訳・ルーティング・設定・依存関係の変更なし

## 検証

- exact HEAD `b23d7adf`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）
- Cloudflare Workers preview deployment成功

開始タグだけへ限定する追加精度改善やfixture統合は #1244 で継続追跡します。

Refs #1244 #1243