### PR TITLE
test(eventsub): repo metadata validation前のhealth probeを固定

### DIFF
--- a/tests/unit/error-reporter-eventsub-health-repo-validation.test.ts
+++ b/tests/unit/error-reporter-eventsub-health-repo-validation.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import worker from '../../workers/error-reporter/src/index';
+
+// Issue #1226: repository metadata validation must not move ahead of the
+// EventSub health probe, otherwise a reporter-only configuration error can
+// silently suppress subscription-health monitoring.
+describe('error-reporter scheduled EventSub health before repository validation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ['GITHUB_REPO_OWNER', { GITHUB_REPO_OWNER: '', GITHUB_REPO_NAME: 'testrepo' }],
+    ['GITHUB_REPO_NAME', { GITHUB_REPO_OWNER: 'testowner', GITHUB_REPO_NAME: '' }],
+  ])('%s が未設定でも EventSub health を先に実行する', async (_missingKey, repository) => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        total: 2,
+        unhealthyCount: 0,
+        unhealthy: [],
+        checkedAt: '2026-08-27T00:00:00.000Z',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const env = {
+      HYPERDRIVE_PLANETSCALE: { connectionString: 'postgres://mock:mock@localhost:5432/mock' },
+      GITHUB_TOKEN: 'gh-token',
+      ...repository,
+      APP_BASE_URL_PROD: 'https://prod.example.com/',
+      EVENTSUB_HEALTH_SECRET_PROD: 'prod-health-secret',
+    } as unknown as Parameters<typeof worker.scheduled>[1];
+    const event = { cron: '*/5 * * * *' } as ScheduledController;
+    const ctx = { waitUntil: vi.fn() } as unknown as ExecutionContext;
+
+    await worker.scheduled(event, env, ctx);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://prod.example.com/api/admin/eventsub-health',
+      expect.objectContaining({
+        headers: { 'X-EventSub-Health-Secret': 'prod-health-secret' },
+      })
+    );
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Missing GITHUB_REPO_OWNER'));
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1226 の軽量フォローアップとして、error-reporter Worker の `scheduled()` が `GITHUB_REPO_OWNER` / `GITHUB_REPO_NAME` 欠落時でもEventSub subscription health probeを先に実行する契約を固定します。

- owner欠落 / repo name欠落の2ケースを `it.each` で検証
- production health endpointが1回呼ばれた後にrepository metadata validationで早期returnすることを固定
- 親PR #1225は `preview` へマージ済みで、最新 `preview` 上の差分はtest-only新規1ファイル
- 本番コード・Worker設定・DB・依存関係の変更なし

## 検証

- exact HEAD `29ab23f1`: CI成功
- 旧exact HEAD `9308115b`: 厳正レビューおよびClaude Auto Reviewで必須指摘なし
- 最新HEADのClaude実行はレビュー処理自体の基盤エラーで終了し、コード指摘・review artifactは生成されず
- Cloudflare Workers preview deployment成功

第1段のbinding/secret validationは親PR #1225で固定済みです。残る追加説明・配置・順序assertionは #1226 で継続追跡します。

Refs #1226 #1225