### PR TITLE
test(r2): 500/503数値列の誤検知回帰を固定

### DIFF
--- a/tests/unit/r2-client-transient-error.test.ts
+++ b/tests/unit/r2-client-transient-error.test.ts
@@ -36,12 +36,15 @@ describe('isTransientR2Error', () => {
     expect(isTransientR2Error('put: status: 503, please retry later')).toBe(true)
   })
 
-  // 【Issue #984】裸の'503'部分文字列マッチは、キー名やリクエストIDに偶然'503'を含む
-  // 恒久エラーを誤って一時障害と判定するリスクがあった。'http'/'status'という文脈語が
-  // 近傍に無い'503'は一時障害として扱わないことを確認する回帰テスト。
-  it('キー名にたまたま503を含む恒久エラーは一時障害として扱わない (Issue #984)', () => {
-    expect(isTransientR2Error("AccessDenied: key 'photo-503.png' is not permitted")).toBe(false)
-  })
+  // 【Issue #984】裸の'500'/'503'部分文字列マッチは、キー名やリクエストIDに偶然数字列を含む
+  // 恒久エラーを誤って一時障害と判定するリスクがあった。HTTP statusの文脈が無い数字列は
+  // 一時障害として扱わないことを両方の代表値で固定する。
+  it.each(['500', '503'])(
+    'キー名にたまたま%sを含む恒久エラーは一時障害として扱わない (Issue #984)',
+    (status) => {
+      expect(isTransientR2Error(`AccessDenied: key 'photo-${status}.png' is not permitted`)).toBe(false)
+    },
+  )
 
   // r2-retry-policy.tsのCLOUDFLARE_R2_TRANSIENT_MARKERSをここから直接importして
   // 全要素をループ検証する。ハードコピーした文字列リテラルではなく実際にimportした


### PR DESCRIPTION
## 概要

Issue #984 の軽量フォローアップとして、R2一時障害判定がキー名中の裸の `500` / `503` を HTTP status と誤認しない契約を回帰テストで固定します。

- 既存の `photo-503.png` 負例を `it.each(['500', '503'])` へ拡張
- `500` / `503` のどちらも HTTP status の文脈が無い場合は恒久エラーとして扱うことを固定
- 現行 `preview` の実装ロジック、本番コード、設定、依存関係には変更なし

現在の実装では `503` は `http` / `status` 文脈付きの正規表現に限定され、裸の `500` パターンも存在しません。本PRは Issue #984 の両数値について再発防止テストを揃える test-only 変更です。

Refs #984