### PR TITLE
test(settings): authorization_revokedバナーの復旧導線を固定

### DIFF
--- a/tests/unit/components/channel-point-settings-authorization-revoked.test.tsx
+++ b/tests/unit/components/channel-point-settings-authorization-revoked.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import ChannelPointSettings from "@/components/ChannelPointSettings";
+import { MaintenanceStatusContext } from "@/components/MaintenanceStatusProvider";
+import jaMessages from "../../../messages/ja.json";
+
+vi.mock("@/lib/logger");
+
+const AUTHORIZATION_REVOKED_RETRY_GUIDANCE =
+  "そのうえで「保存 & EventSub登録」ボタンで登録し直してください";
+
+function renderComponent() {
+  return render(
+    <NextIntlClientProvider locale="ja" messages={jaMessages}>
+      <MaintenanceStatusContext.Provider value={{ mode: "off" }}>
+        <ChannelPointSettings
+          streamerId="streamer-1"
+          currentRewardId="reward-1"
+          currentRewardName="Reward1"
+        />
+      </MaintenanceStatusContext.Provider>
+    </NextIntlClientProvider>
+  );
+}
+
+describe("ChannelPointSettings authorization_revoked banner", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("再連携CTAとEventSub再登録案内を同じバナー内に表示する（Issue #1019）", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+
+      if (url.includes("/api/cards/collections")) {
+        return new Response(JSON.stringify({ collections: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.includes("/api/twitch/channel-point-bootstrap")) {
+        return new Response(
+          JSON.stringify({
+            hasRequiredScope: true,
+            rewards: [{ id: "reward-1", title: "Reward1", cost: 100, is_enabled: true }],
+            subscriptions: [
+              {
+                id: "sub-1",
+                status: "authorization_revoked",
+                type: "channel.channel_points_custom_reward_redemption.add",
+                condition: { broadcaster_user_id: "user-1", reward_id: "reward-1" },
+                transport: { callback: "https://example.com/api/twitch/eventsub" },
+              },
+            ],
+            additionalRewards: [],
+            eventSubStatus: "error",
+            raidEventSubStatus: "active",
+            raidGiftDrawCount: 0,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } }
+        );
+      }
+
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    renderComponent();
+
+    const bannerTitle = await screen.findByText("認証が取り消されました");
+    const banner = bannerTitle.closest("div");
+    expect(banner).not.toBeNull();
+
+    const revokedBanner = within(banner as HTMLElement);
+    expect(revokedBanner.getByText(AUTHORIZATION_REVOKED_RETRY_GUIDANCE)).toBeInTheDocument();
+    expect(
+      revokedBanner.getByRole("button", { name: "チャネルポイント連携を有効化" })
+    ).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1019 の既存実装に対する軽量フォローアップとして、`authorization_revoked` バナーの復旧導線を test-only で固定します。

- 再連携 CTA が単に画面上に存在するだけでなく、`authorization_revoked` バナー内に存在することを検証
- 再認証後に「保存 & EventSub登録」で再登録する案内も同じバナー内に表示されることを検証
- 本番コード・翻訳・API・DB・設定・依存関係は変更なし

既存の open PR に Issue #1019 の進行中作業はなく、`ChannelPointSettings` を対象にした open PR もないことを確認してから着手しています。

Refs #1019