### PR TITLE
test(r2): fake timer実行をhelperへ集約

### DIFF
--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -115,6 +115,13 @@ function mockTransientFailuresThenSuccess(): void {
   sendMock.mockResolvedValueOnce({})
 }
 
+async function runWithFakeTimers<T>(operation: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers()
+  const pending = operation()
+  await vi.runAllTimersAsync()
+  return pending
+}
+
 function expectAllAttemptsUsedConfig(expectedAttempts: number, expectedConfig: Record<string, unknown>): void {
   // PR #1030で呼び出し側にあった送信試行数のassertをこのヘルパへ集約したため、
   // 「期待回数だけ試行し、その各試行で期待configを使う」までを1つの契約として検証する。
@@ -182,11 +189,9 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
     mockTransientFailuresThenSuccess()
 
     const { uploadToR2WithRetry } = await import('@/lib/r2-client')
-    vi.useFakeTimers()
-    const pending = uploadToR2WithRetry('f.png', Buffer.from('img'), 'image/png', MAX_RETRIES)
-    // 保留中の指数バックオフを実時間で待たずに全て進める
-    await vi.runAllTimersAsync()
-    const result = await pending
+    const result = await runWithFakeTimers(() =>
+      uploadToR2WithRetry('f.png', Buffer.from('img'), 'image/png', MAX_RETRIES),
+    )
 
     expect(result).toEqual({ url: 'https://example.test/f.png' })
     // 全試行の入力が常に正しいことを確認する（リトライのたびに引数やbufferを
@@ -208,10 +213,9 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
     mockTransientFailuresThenSuccess()
 
     const { uploadSoundToR2WithRetry } = await import('@/lib/r2-client')
-    vi.useFakeTimers()
-    const pending = uploadSoundToR2WithRetry('f.mp3', Buffer.from('snd'), 'audio/mpeg', MAX_RETRIES)
-    await vi.runAllTimersAsync()
-    const result = await pending
+    const result = await runWithFakeTimers(() =>
+      uploadSoundToR2WithRetry('f.mp3', Buffer.from('snd'), 'audio/mpeg', MAX_RETRIES),
+    )
 
     expect(result).toEqual({ url: 'https://sounds.example.test/f.mp3' })
     for (const call of sendMock.mock.calls) {


### PR DESCRIPTION
## 概要

Issue #1029 のノンブロッキング項目3として、retry wiringテストのfake timers実行定型を小さなhelperへ集約します。

- `runWithFakeTimers` で `useFakeTimers` → operation開始 → `runAllTimersAsync` → 結果待機の順序を1箇所に固定
- 画像 / 効果音のretry success 2ケースをhelper経由へ変更
- retry回数、S3入力、credentials、期待URLなど既存assertionは維持
- 本番コード・設定・依存関係の変更なし
- 同一ファイルのPR #1213マージ後も変更ハンクが独立していることを確認

## 検証

- CI: 成功
- Claude Auto Review: 成功（必須指摘なし）

Refs #1029