### PR TITLE
test(db): trade設定列のデプロイ窓フォールバックを固定

### DIFF
--- a/tests/unit/streamers-trade-column-fallback.test.ts
+++ b/tests/unit/streamers-trade-column-fallback.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest'
+import { withLiveDirectorySettingsColumnFallback } from '@/lib/db/streamers-safe-columns'
+
+function missingColumnError(column: string) {
+  return Object.assign(new Error(`column "${column}" does not exist`), {
+    code: '42703',
+  })
+}
+
+describe('streamers trade settings deploy-window fallback', () => {
+  it.each(['trade_enabled', 'cross_channel_trade_enabled'])(
+    '%s の 42703 で安全列集合へ再試行する',
+    async (column) => {
+      const attempt = vi
+        .fn()
+        .mockRejectedValueOnce(missingColumnError(column))
+        .mockResolvedValueOnce('safe-columns-result')
+
+      await expect(withLiveDirectorySettingsColumnFallback(attempt)).resolves.toBe(
+        'safe-columns-result'
+      )
+      expect(attempt).toHaveBeenNthCalledWith(1, false)
+      expect(attempt).toHaveBeenNthCalledWith(2, true)
+      expect(attempt).toHaveBeenCalledTimes(2)
+    }
+  )
+})


### PR DESCRIPTION
## 概要

Issue #1013 の軽量フォローアップ（項目9）として、`trade_enabled` / `cross_channel_trade_enabled` の列欠落時に streamers の安全列集合へ再試行する経路を直接回帰テストで固定します。

- SQLSTATE `42703` + `trade_enabled` で `false → true` の再試行を確認
- `cross_channel_trade_enabled` も同じ経路を確認
- 本番コード・DB・設定・依存関係は変更なし
- 既存の open PR と同一Issue・同一変更ファイルの重複がないことを確認済み

Refs #1013