### PR TITLE
test(rate-limit): KV自動初期化を固定

### DIFF
--- a/tests/unit/rate-limit-kv-auto-init.test.ts
+++ b/tests/unit/rate-limit-kv-auto-init.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { getKvBindingMock } = vi.hoisted(() => ({
+  getKvBindingMock: vi.fn(),
+}));
+
+vi.mock("@/lib/cloudflare-kv", () => ({
+  KV_MIN_EXPIRATION_TTL_SECONDS: 60,
+  getKvBinding: getKvBindingMock,
+}));
+
+describe("rate limit KV auto initialization", () => {
+  it("初回check時にRATE_LIMIT_KVへ自動切替し、以後同じbindingを再利用する", async () => {
+    const store = new Map<string, string>();
+    const kv = {
+      get: vi.fn(async (key: string, type?: "json") => {
+        const value = store.get(key);
+        if (value === undefined) return null;
+        return type === "json" ? JSON.parse(value) : value;
+      }),
+      put: vi.fn(
+        async (
+          key: string,
+          value: string,
+          _options?: { expirationTtl?: number },
+        ) => {
+          store.set(key, value);
+        },
+      ),
+      delete: vi.fn(async (key: string) => {
+        store.delete(key);
+      }),
+    };
+    getKvBindingMock.mockResolvedValue(kv);
+
+    const { checkRateLimit, rateLimits } = await import("@/lib/rate-limit");
+
+    const first = await checkRateLimit(rateLimits.authLogin, "user:auto-kv");
+    const second = await checkRateLimit(rateLimits.authLogin, "user:auto-kv");
+
+    expect(first.success).toBe(true);
+    expect(first.remaining).toBe(4);
+    expect(second.success).toBe(true);
+    expect(second.remaining).toBe(3);
+    expect(getKvBindingMock).toHaveBeenCalledTimes(1);
+    expect(kv.get).toHaveBeenCalledWith(
+      "ratelimit:authLogin:user:auto-kv",
+      "json",
+    );
+    expect(kv.put).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #728 の既存実装について、`checkRateLimit` の初回呼び出し時に `RATE_LIMIT_KV` bindingへ自動切替し、その後は同じbindingを再利用する契約をtest-onlyで固定します。

## 変更内容

- `getKvBinding()` が返すKVを使って初回 `checkRateLimit` が読み書きすることを確認
- 2回目の呼び出しで同じカウンタが増分されることを確認
- binding解決が1回だけであることを確認
- 本番コード・設定・依存関係の変更なし

## 検証

- CI: 成功
- Claude Auto Review: 成功（必須指摘なし）

任意改善は #1263 で追跡します。

Refs #728 #1263