### PR TITLE
docs(env): EventSub health secretのアプリ側用途を明記

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -90,7 +90,7 @@ NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 
 # Cloudflare Workers / OpenNext デプロイ設定（Cloudflare Secrets で設定）
 # DB_HEALTH_SECRET=xxx            # アプリ側 /api/admin/db-health 用
-# EVENTSUB_HEALTH_SECRET=xxx      # /api/admin/eventsub-health 用
+# EVENTSUB_HEALTH_SECRET=xxx      # アプリ側 /api/admin/eventsub-health 用
 #                                 # workers/error-reporter（twica-error-reporter）側は各環境のアプリと同じ値を、それぞれ
 #                                 # EVENTSUB_HEALTH_SECRET_PROD / EVENTSUB_HEALTH_SECRET_PREVIEW に設定
 #                                 # 詳細: docs/eventsub-subscription-health.md


### PR DESCRIPTION
## 概要

`.env.local.example` の `EVENTSUB_HEALTH_SECRET` コメントを、周辺の `DB_HEALTH_SECRET` / `EVENTSUB_REPLAY_SECRET` と同じ「アプリ側 ... 用」表現へ揃えます。

- アプリ側の変数であることを明示
- Worker側の `EVENTSUB_HEALTH_SECRET_PROD` / `EVENTSUB_HEALTH_SECRET_PREVIEW` と各環境で同値にする継続説明を維持
- 変数名・値・実行コード・デプロイ設定・Secretの扱いは変更なし
- コメント1行のみ

## 検証

- exact HEAD `c5ee33ab`: CI成功
- Claude Auto Review成功（指摘なし）
- 手動レビュー: 必須指摘なし

Refs #1050 #1134