### PR TITLE
chore(kv): 固定binding名の未使用引数を削除

### DIFF
--- a/src/lib/cloudflare-kv.ts
+++ b/src/lib/cloudflare-kv.ts
@@ -28,18 +28,23 @@ export interface KVNamespaceLike {
 }
 
 /**
+ * このヘルパーはアプリ共通の RATE_LIMIT_KV namespace 専用。呼び出し側が binding 名を
+ * 差し替える用途はなく、任意文字列を受け取る API にすると wrangler.toml の固定契約を
+ * 不要に汎用化してしまうため、binding 名はここで一元管理する。
+ */
+const KV_BINDING_NAME = "RATE_LIMIT_KV"
+
+/**
  * Workers 環境から KV バインディングを取得する。Workers 以外では null。
  * getCloudflareContext はビルド時に @opennextjs/cloudflare を解決しないよう
  * 動的 import する（r2-client.ts と同じ理由）。
  */
-export async function getKvBinding(
-  bindingName = "RATE_LIMIT_KV",
-): Promise<KVNamespaceLike | null> {
+export async function getKvBinding(): Promise<KVNamespaceLike | null> {
   try {
     const { getCloudflareContext } = await import("@opennextjs/cloudflare")
     const ctx = await getCloudflareContext({ async: true })
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const binding = (ctx.env as any)[bindingName] as KVNamespaceLike | undefined
+    const binding = (ctx.env as any)[KV_BINDING_NAME] as KVNamespaceLike | undefined
     return binding ?? null
   } catch {
     return null


### PR DESCRIPTION
## 概要

Issue #921 の任意フォローアップとして、`getKvBinding(bindingName = "RATE_LIMIT_KV")` の未使用な汎用化ポイントを削除します。

- `getKvBinding()` の引数を廃止し、このhelperが参照する `RATE_LIMIT_KV` binding名をローカル定数へ固定
- 既存の全呼び出し側は引数なしのため、利用方法・本番挙動は変更なし
- binding取得失敗時に `null` を返すfallback契約、設定、namespace、依存関係は変更なし

## 検証

- exact HEAD `4c45e18c`: CI成功
- Claude Auto Review成功（必須指摘なし、任意指摘のみ）
- 全呼び出し箇所が引数なしであることを確認

他の同名binding定義の集約や直接unit testは #921 の既存バックログで継続追跡します。

Refs #921