### PR TITLE
test(rate-limit): no-opなstorage resetを削除

### DIFF
--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -154,8 +154,6 @@ describe("rate limit storage 切り替え", () => {
 
   beforeEach(() => {
     kv = makeKv();
-    // テスト間でモジュールレベルのストレージをメモリ実装へ戻す
-    setRateLimitStorage(getRateLimitStorage());
   });
 
   it("KVストレージ設定後はcheckRateLimitがKVを経由してカウントする", async () => {

--- a/tests/unit/rate-limit.test.ts
+++ b/tests/unit/rate-limit.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
   KVRateLimitStorage,
   checkRateLimit,
-  getRateLimitStorage,
   rateLimits,
   retryAfterSeconds,
   setRateLimitStorage,


### PR DESCRIPTION
## 概要

Issue #1265 の軽量フォローアップとして、`tests/unit/rate-limit.test.ts` の `beforeEach` に残っていた `setRateLimitStorage(getRateLimitStorage())` を削除します。

- 自分自身を再代入しているだけでメモリ実装へのリセットにはなっていなかった処理を除去
- 併せて不要になった `getRateLimitStorage` importを削除
- 各テストは `checkRateLimit` 前に新しい `KVRateLimitStorage` を明示設定するため、現在の配置ではこの処理は不要
- 親PR #1264のマージ後も別ファイルのtest-only差分

## 検証

- CI: 成功
- Claude Auto Review: 成功（必須指摘なし）
- テスト期待値・本番コード・設定・依存関係の変更なし

Refs #1265 #1264