### PR TITLE
test(r2): fake timer helperの順序と復元責務を明確化

### DIFF
--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -95,6 +95,22 @@ const TRANSIENT_FAILURES_BEFORE_SUCCESS = 2
 const RETRY_SUCCESS_ATTEMPTS = TRANSIENT_FAILURES_BEFORE_SUCCESS + 1
 const R2_INTERNAL_ERROR_MESSAGE = 'put: We encountered an internal error. Please try again. (10001)'
 
+// fake timers を必要とするテスト基盤の責務を、R2 fixture の準備処理から分離する。
+async function runWithFakeTimers<T>(operation: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers()
+  try {
+    const pending = operation()
+    // pending を先に await すると、fake timer 上のバックオフ用 setTimeout が進まず、
+    // operation が解決しないまま Vitest の testTimeout まで停止し得る。先に登録済みの
+    // timer を全て進めてから、同じ operation の完了を待つ順序を維持する。
+    await vi.runAllTimersAsync()
+    return await pending
+  } finally {
+    // 呼び出し元やテスト成否にかかわらず、この helper が有効化した timer を自ら復元する。
+    vi.useRealTimers()
+  }
+}
+
 function mockTransientFailuresThenSuccess(): void {
   expect(
     TRANSIENT_FAILURES_BEFORE_SUCCESS,
@@ -113,13 +129,6 @@ function mockTransientFailuresThenSuccess(): void {
     sendMock.mockRejectedValueOnce(new Error(R2_INTERNAL_ERROR_MESSAGE))
   }
   sendMock.mockResolvedValueOnce({})
-}
-
-async function runWithFakeTimers<T>(operation: () => Promise<T>): Promise<T> {
-  vi.useFakeTimers()
-  const pending = operation()
-  await vi.runAllTimersAsync()
-  return pending
 }
 
 function expectAllAttemptsUsedConfig(expectedAttempts: number, expectedConfig: Record<string, unknown>): void {
@@ -152,7 +161,8 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
   afterEach(() => {
     // 環境変数はテストごとに vi.stubEnv で設定・削除し、ここで必ず元へ戻す。
     vi.unstubAllEnvs()
-    // リトライ成功テストは fake timers を使うため、後続テストへ影響を残さない。
+    // runWithFakeTimers は自己完結で復元するが、テスト途中の予期しない失敗や将来の
+    // 直接利用でも後続テストへ fake timers を残さないため、suite の安全網も維持する。
     vi.useRealTimers()
   })
 

--- a/tests/unit/r2-client-upload-retry-wiring.test.ts
+++ b/tests/unit/r2-client-upload-retry-wiring.test.ts
@@ -115,6 +115,13 @@ function mockTransientFailuresThenSuccess(): void {
   sendMock.mockResolvedValueOnce({})
 }
 
+async function runWithFakeTimers<T>(operation: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers()
+  const pending = operation()
+  await vi.runAllTimersAsync()
+  return pending
+}
+
 function expectAllAttemptsUsedConfig(expectedAttempts: number, expectedConfig: Record<string, unknown>): void {
   // PR #1030で呼び出し側にあった送信試行数のassertをこのヘルパへ集約したため、
   // 「期待回数だけ試行し、その各試行で期待configを使う」までを1つの契約として検証する。
@@ -182,11 +189,9 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
     mockTransientFailuresThenSuccess()
 
     const { uploadToR2WithRetry } = await import('@/lib/r2-client')
-    vi.useFakeTimers()
-    const pending = uploadToR2WithRetry('f.png', Buffer.from('img'), 'image/png', MAX_RETRIES)
-    // 保留中の指数バックオフを実時間で待たずに全て進める
-    await vi.runAllTimersAsync()
-    const result = await pending
+    const result = await runWithFakeTimers(() =>
+      uploadToR2WithRetry('f.png', Buffer.from('img'), 'image/png', MAX_RETRIES),
+    )
 
     expect(result).toEqual({ url: 'https://example.test/f.png' })
     // 全試行の入力が常に正しいことを確認する（リトライのたびに引数やbufferを
@@ -208,10 +213,9 @@ describe('uploadToR2WithRetry / uploadSoundToR2WithRetry の結線', () => {
     mockTransientFailuresThenSuccess()
 
     const { uploadSoundToR2WithRetry } = await import('@/lib/r2-client')
-    vi.useFakeTimers()
-    const pending = uploadSoundToR2WithRetry('f.mp3', Buffer.from('snd'), 'audio/mpeg', MAX_RETRIES)
-    await vi.runAllTimersAsync()
-    const result = await pending
+    const result = await runWithFakeTimers(() =>
+      uploadSoundToR2WithRetry('f.mp3', Buffer.from('snd'), 'audio/mpeg', MAX_RETRIES),
+    )
 
     expect(result).toEqual({ url: 'https://sounds.example.test/f.mp3' })
     for (const call of sendMock.mock.calls) {


### PR DESCRIPTION
Closes #1256

## 変更内容

- `runWithFakeTimers` をR2 fixture helper群からテスト基盤helperとして分離
- operationを開始してからtimerを進め、最後にpending Promiseを待つ順序制約をコメントで明記
- `try/finally` でhelper自身がreal timersへ復元し、`afterEach` はsuite全体の安全網として維持
- 親PR #1255のマージ後、差分がこのtest-only改善だけであることを確認

## 検証

- CI: 成功
- Claude Auto Review: 成功（必須指摘なし）
- 本番コード・設定・依存関係の変更なし