### PR TITLE
fix(i18n): チャネルポイント作成中ラベルを追加

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -641,6 +641,7 @@
     },
     "buttons": {
       "createReward": "Create TwiCa Redemption (100 points)",
+      "creating": "Creating...",
       "saveEventSub": "Save & Register EventSub",
       "disconnect": "Disconnect",
       "disconnecting": "Disconnecting...",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -641,6 +641,7 @@
     },
     "buttons": {
       "createReward": "TwiCa用チャネルポイント引き換えを作成（100ポイント）",
+      "creating": "作成中...",
       "saveEventSub": "保存 & EventSub登録",
       "disconnect": "設定解除",
       "disconnecting": "解除中...",

--- a/tests/unit/i18n-channel-point-settings-creating.test.ts
+++ b/tests/unit/i18n-channel-point-settings-creating.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import enMessages from "../../messages/en.json";
+import jaMessages from "../../messages/ja.json";
+
+describe("channelPointSettings.buttons.creating", () => {
+  it("作成処理中ラベルを日本語・英語の双方で定義する", () => {
+    expect(jaMessages.channelPointSettings.buttons.creating).toBe("作成中...");
+    expect(enMessages.channelPointSettings.buttons.creating).toBe("Creating...");
+  });
+});


### PR DESCRIPTION
## 概要

チャネルポイント引き換えの作成処理中に参照される翻訳キーを日本語・英語へ追加し、`MISSING_MESSAGE` が表示されないようにします。

Closes #1276

## 変更内容

- `channelPointSettings.buttons.creating` を日本語・英語へ追加
- 専用の軽量i18n回帰テストで両言語のキーを固定
- 競合していた既存maintenance suiteへの変更は取り下げ、差分を翻訳2ファイル＋test-only 1ファイルへ限定

## 検証

- CI: 成功
- Claude Auto Review: 成功（必須指摘なし）
- 本番ロジック・API・DB・EventSub・ガチャ・overlay・Twitchチャット配送の変更なし

横断的なi18n検査改善は #1281 で追跡します。