### PR TITLE
test(i18n): 静的翻訳キーの横断ガードを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ analysis/dist
 # and must never be tracked — they break Cloudflare Workers Builds' submodule clone.
 .codex-*/
 twica-maker-*/
+
+# Unit-test scratch repositories. May survive SIGKILL; never commit them.
+.tmp-i18n-static-keys-*/

--- a/scripts/check-i18n-static-keys.mjs
+++ b/scripts/check-i18n-static-keys.mjs
@@ -1,0 +1,196 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+/**
+ * Issue #1281 の静的 i18n ガード。
+ *
+ * next-intl の runtime lookup を全面的に再実装するのではなく、現在コードベースで多い
+ * `const t = useTranslations("namespace")` + `t("literal.key")` だけを保守的に検査する。
+ * 動的 namespace / 動的 key / `t.rich()` / server-side `getTranslations()` は意図的に
+ * 対象外としており、false positive を避ける代わりに一部の false negative を許容する。
+ * 対象拡張は Issue #1283 で別途追跡する。
+ */
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const srcDir = path.join(rootDir, "src");
+const messageFiles = {
+  en: path.join(rootDir, "messages", "en.json"),
+  ja: path.join(rootDir, "messages", "ja.json"),
+};
+
+const messages = Object.fromEntries(
+  await Promise.all(
+    Object.entries(messageFiles).map(async ([locale, filename]) => [
+      locale,
+      JSON.parse(await fs.readFile(filename, "utf8")),
+    ]),
+  ),
+);
+
+async function collectSourceFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map(async (entry) => {
+      const filename = path.join(dir, entry.name);
+      if (entry.isDirectory()) return collectSourceFiles(filename);
+      if (/\.[cm]?[jt]sx?$/.test(entry.name) && !entry.name.endsWith(".d.ts")) {
+        return [filename];
+      }
+      return [];
+    }),
+  );
+  return nested.flat().sort();
+}
+
+/**
+ * Message catalog は通常の JSON object として扱うが、`constructor` 等の継承 property を
+ * 翻訳キーと誤認しないよう各 segment を own-property として辿る。
+ */
+function hasMessage(root, namespace, key) {
+  const parts = [...namespace.split("."), ...key.split(".")];
+  let value = root;
+  for (const part of parts) {
+    if (
+      value === null ||
+      typeof value !== "object" ||
+      !Object.prototype.hasOwnProperty.call(value, part)
+    ) {
+      return false;
+    }
+    value = value[part];
+  }
+  return true;
+}
+
+function scriptKindFor(filename) {
+  if (filename.endsWith(".tsx")) return ts.ScriptKind.TSX;
+  if (filename.endsWith(".jsx")) return ts.ScriptKind.JSX;
+  if (filename.endsWith(".js") || filename.endsWith(".mjs") || filename.endsWith(".cjs")) {
+    return ts.ScriptKind.JS;
+  }
+  return ts.ScriptKind.TS;
+}
+
+function stringLiteralValue(node) {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return node.text;
+  }
+  return null;
+}
+
+function bindingNames(name, names = []) {
+  if (ts.isIdentifier(name)) {
+    names.push(name.text);
+    return names;
+  }
+  for (const element of name.elements) {
+    if (!ts.isOmittedExpression(element)) bindingNames(element.name, names);
+  }
+  return names;
+}
+
+/**
+ * namespace が静的に確定する `useTranslations("...")` だけを追跡する。
+ * 引数なし・変数引数・別 helper 経由は、誤った namespace を推測するより未検査に倒す。
+ */
+function translationNamespace(initializer) {
+  if (!initializer || !ts.isCallExpression(initializer)) return null;
+  if (!ts.isIdentifier(initializer.expression) || initializer.expression.text !== "useTranslations") {
+    return null;
+  }
+  if (initializer.arguments.length !== 1) return null;
+  return stringLiteralValue(initializer.arguments[0]);
+}
+
+function resolveBinding(scopes, name) {
+  for (let index = scopes.length - 1; index >= 0; index -= 1) {
+    if (scopes[index].has(name)) return scopes[index].get(name);
+  }
+  return null;
+}
+
+function inspectSource(filename, sourceText) {
+  const sourceFile = ts.createSourceFile(
+    filename,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindFor(filename),
+  );
+  const failures = [];
+
+  function visit(node, scopes) {
+    let activeScopes = scopes;
+
+    /**
+     * この walker は lexical shadowing を最低限再現するため、SourceFile / Block / function
+     * ごとに Map を積む。完全な TypeScript binder を再実装する目的ではないため、for/catch
+     * など細かな scope 境界は現時点では追跡しない（Issue #1283）。
+     */
+    if (ts.isSourceFile(node) || ts.isBlock(node)) {
+      activeScopes = [...scopes, new Map()];
+    } else if (ts.isFunctionLike(node)) {
+      const functionScope = new Map();
+      for (const parameter of node.parameters) {
+        // 引数名が外側の翻訳関数と同じ場合は null で shadow し、誤検査を防ぐ。
+        for (const name of bindingNames(parameter.name)) functionScope.set(name, null);
+      }
+      activeScopes = [...scopes, functionScope];
+    }
+
+    const currentScope = activeScopes[activeScopes.length - 1];
+
+    if (ts.isVariableDeclaration(node) && currentScope) {
+      const namespace = translationNamespace(node.initializer);
+      for (const name of bindingNames(node.name)) {
+        // 翻訳関数以外の同名変数も null で記録し、外側 binding を誤って参照しない。
+        currentScope.set(name, ts.isIdentifier(node.name) ? namespace : null);
+      }
+    } else if (
+      (ts.isFunctionDeclaration(node) || ts.isClassDeclaration(node)) &&
+      node.name &&
+      currentScope
+    ) {
+      currentScope.set(node.name.text, null);
+    }
+
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.arguments.length > 0) {
+      const namespace = resolveBinding(activeScopes, node.expression.text);
+      const key = stringLiteralValue(node.arguments[0]);
+      if (namespace && key !== null) {
+        for (const [locale, localeMessages] of Object.entries(messages)) {
+          if (!hasMessage(localeMessages, namespace, key)) {
+            const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+            failures.push({
+              fullKey: `${namespace}.${key}`,
+              locale,
+              location: `${path.relative(rootDir, filename)}:${line + 1}:${character + 1}`,
+            });
+          }
+        }
+      }
+    }
+
+    ts.forEachChild(node, (child) => visit(child, activeScopes));
+  }
+
+  visit(sourceFile, []);
+  return failures;
+}
+
+const sourceFiles = await collectSourceFiles(srcDir);
+const failures = [];
+for (const filename of sourceFiles) {
+  failures.push(...inspectSource(filename, await fs.readFile(filename, "utf8")));
+}
+
+if (failures.length > 0) {
+  console.error("Static i18n key check failed:\n");
+  for (const failure of failures) {
+    console.error(`- ${failure.location} ${failure.locale} missing ${failure.fullKey}`);
+  }
+  process.exitCode = 1;
+} else {
+  console.log(`Static i18n key check passed (${sourceFiles.length} source files scanned).`);
+}

--- a/tests/unit/i18n-static-keys.test.ts
+++ b/tests/unit/i18n-static-keys.test.ts
@@ -1,0 +1,62 @@
+import { spawnSync } from "node:child_process";
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+function runStaticKeyCheck(cwd = process.cwd()) {
+  const result = spawnSync(process.execPath, ["scripts/check-i18n-static-keys.mjs"], {
+    cwd,
+    encoding: "utf8",
+  });
+  const details = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+  return { result, details };
+}
+
+describe("static i18n keys", () => {
+  it("keeps literal useTranslations keys present in both message catalogs", () => {
+    const { result, details } = runStaticKeyCheck();
+
+    expect(result.status, details || "static i18n key check did not exit cleanly").toBe(0);
+    expect(details).toMatch(/Static i18n key check passed \(([1-9]\d*) source files scanned\)\./);
+  });
+
+  it("fails when a scanned source references a missing literal key", async () => {
+    // Keep the fixture under the repository so the copied checker can resolve the repository's
+    // `typescript` package through normal Node module lookup. The prefix is ignored because a
+    // force-killed test process cannot run the cleanup below.
+    const tempRoot = await mkdtemp(path.join(process.cwd(), ".tmp-i18n-static-keys-"));
+
+    try {
+      await Promise.all([
+        mkdir(path.join(tempRoot, "scripts"), { recursive: true }),
+        mkdir(path.join(tempRoot, "src"), { recursive: true }),
+        mkdir(path.join(tempRoot, "messages"), { recursive: true }),
+      ]);
+      await Promise.all([
+        copyFile(
+          path.join(process.cwd(), "scripts", "check-i18n-static-keys.mjs"),
+          path.join(tempRoot, "scripts", "check-i18n-static-keys.mjs"),
+        ),
+        copyFile(path.join(process.cwd(), "messages", "en.json"), path.join(tempRoot, "messages", "en.json")),
+        copyFile(path.join(process.cwd(), "messages", "ja.json"), path.join(tempRoot, "messages", "ja.json")),
+        writeFile(
+          path.join(tempRoot, "src", "missing-key.ts"),
+          [
+            'declare const useTranslations: (namespace: string) => (key: string) => string;',
+            'const t = useTranslations("__i18nStaticKeysFixture");',
+            'export const missing = t("definitelyMissing");',
+            "",
+          ].join("\n"),
+          "utf8",
+        ),
+      ]);
+
+      const { result, details } = runStaticKeyCheck(tempRoot);
+
+      expect(result.status, details || "static i18n key check unexpectedly succeeded").toBe(1);
+      expect(details).toContain("__i18nStaticKeysFixture.definitelyMissing");
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## 概要

`useTranslations("namespace")` に束縛した翻訳関数のリテラル `t("key")` を、`messages/en.json` / `messages/ja.json` と突き合わせる静的ガードを追加します。

## 変更内容

- TypeScript ASTで `src` 配下を走査し、静的namespace・リテラルkeyの欠落をlocale別に検出
- 正常catalogで走査件数が0ではないことを固定
- 一時fixtureへ欠落キーを置き、実checkerが終了コード1と完全キーを返すことを固定
- force-killでfixtureが残っても誤コミットされないよう `.tmp-i18n-static-keys-*/` をignore
- PR #1280で欠落翻訳が解消済みのため、一時baselineは削除し既知例外なしで検査

## 検証

- exact HEAD `0dc0914c`: CI成功
- 旧exact HEAD `6bcdebcd` の厳正レビューおよびClaude Auto Review: 必須指摘なし
- 最新HEADは旧実装から一時baselineを削除して最新 `preview` へ載せ直したもの
- 最新HEADのClaude実行はレビュー処理自体の基盤エラーで2回失敗し、コード指摘・review artifactは生成されず
- 差分を手動再確認し、本番実行コード・翻訳catalog・DB・設定・依存関係の変更なし

動的namespace / 動的key、`t.rich()`、server-side `getTranslations()` 等の拡張は #1283 で継続追跡します。

Closes #1281
Refs #1283