### PR TITLE
test(r2): 数字fixture引数の役割を明確化

### DIFF
--- a/tests/unit/r2-client-transient-error.test.ts
+++ b/tests/unit/r2-client-transient-error.test.ts
@@ -41,8 +41,8 @@ describe('isTransientR2Error', () => {
   // 一時障害として扱わないことを両方の代表値で固定する。
   it.each(['500', '503'])(
     'キー名にたまたま%sを含む恒久エラーは一時障害として扱わない (Issue #984)',
-    (status) => {
-      expect(isTransientR2Error(`AccessDenied: key 'photo-${status}.png' is not permitted`)).toBe(false)
+    (numericToken) => {
+      expect(isTransientR2Error(`AccessDenied: key 'photo-${numericToken}.png' is not permitted`)).toBe(false)
     },
   )
 


### PR DESCRIPTION
## 概要

R2 500/503 負例のtable-driven test引数名を `status` から `numericToken` へ変更します。

- 値はHTTP statusそのものではなく、キー名中に現れる単なる数字列であることを変数名で明確化
- テスト入力・期待値・本番コード・設定・依存関係は変更なし
- 親PR #1251のマージ後、差分は変数名2箇所だけ

## 検証

- exact HEAD `8d96b1e6`: CI成功
- Claude Auto Review成功（必須指摘なし）
- Cloudflare Workers preview deployment成功

HTTP 500 retry方針など判断を伴う残件は #1252 で継続追跡します。

Refs #1252 #1251