### PR TITLE
test(i18n): 静的キー検査subprocessに上限を追加

### DIFF
--- a/tests/unit/i18n-static-keys.test.ts
+++ b/tests/unit/i18n-static-keys.test.ts
@@ -3,10 +3,15 @@ import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
+const STATIC_KEY_CHECK_TIMEOUT_MS = 10_000;
+const STATIC_KEY_CHECK_MAX_BUFFER_BYTES = 1024 * 1024;
+
 function runStaticKeyCheck(cwd = process.cwd()) {
   const result = spawnSync(process.execPath, ["scripts/check-i18n-static-keys.mjs"], {
     cwd,
     encoding: "utf8",
+    timeout: STATIC_KEY_CHECK_TIMEOUT_MS,
+    maxBuffer: STATIC_KEY_CHECK_MAX_BUFFER_BYTES,
   });
   const details = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
   return { result, details };


### PR DESCRIPTION
## 概要

Issue #1283 の軽量フォローアップとして、静的i18nキーガードを実行するsubprocessに実行時間・出力サイズの上限を追加します。

- `spawnSync` に10秒のtimeoutを設定し、checker停止時のunit job固着を防止
- `maxBuffer: 1 MiB` を設定し、異常な大量出力にも親プロセス側で上限を設定
- 親PR #1282は `preview` へマージ済みで、最新 `preview` 上の差分はtest helperの定数2個とoptions2個だけ
- checker本体・catalog・検査対象・期待値・本番コードの変更なし

## 検証

- exact HEAD `c2d840e1`: CI成功
- 旧exact HEAD `e22d14d8`: 厳正レビューおよびClaude Auto Reviewで必須指摘なし
- 最新HEADのClaude実行はレビュー処理自体の基盤エラーで終了し、コード指摘・review artifactは生成されず
- Cloudflare Workers preview deployment成功

他のカバレッジ拡張・scope walker改善は #1283 で継続追跡します。

Refs #1283 #1282