### PR TITLE
docs(test): gacha sound SELECT側42703コメントを明確化

### DIFF
--- a/tests/unit/streamer-settings-driver-parity.test.ts
+++ b/tests/unit/streamer-settings-driver-parity.test.ts
@@ -348,7 +348,7 @@ describe("streamer/settings POST: PlanetScale契約 (#663)", () => {
         limit: 1,
       })
     );
-    // 42703 は basic プランの既存ルール取得だけで発生する。書込側の列欠落は
+    // 本ケースでは SELECT 側だけに 42703 を注入する。書込側の列欠落は
     // 直前の legacy fallback ケースが別途検証している。
     expect(pg.selectCalls[1]).toEqual({
       fields: { gacha_sound_rules: streamersTable.gacha_sound_rules },


### PR DESCRIPTION
## 概要

Issue #1279 の判断不要な軽量フォローアップとして、driver-parity test のコメントを実fixtureに合わせて明確化します。

- 42703 が「basicプランだから」ではなく、本ケースで SELECT 側だけに注入されることを明記
- assertion / fixture / test name / production code / behavior は変更なし
- Issue #1279 の他の任意改善（SELECT+UPDATE両方42703、skip flag assertion、fixture共通化、test name）は本PRの収束条件にしない

## 依存関係

- 元は PR #1273 の後続として作成
- #1273 の `preview` 反映後、最新 `preview` へ載せ直し済み
- 現在の差分はコメント1行のみ

## 変更分類

comment-only。実行コード、テスト挙動、DB、設定、依存関係には変更ありません。

Refs #1279 #1273