### PR TITLE
docs(logging): params行の検閲境界を明文化

### DIFF
--- a/docs/log-sanitization-boundaries.md
+++ b/docs/log-sanitization-boundaries.md
@@ -1,0 +1,39 @@
+# Log sanitization boundaries
+
+`src/lib/log-sanitizer.ts` applies the same text sanitization policy to console logs and persisted error-reporting paths. This document records a deliberately conservative boundary that is easy to misread as Drizzle-specific behavior.
+
+## `params:` line handling
+
+`sanitizeErrorText()` treats a line whose first non-whitespace token is `params:` as the start of potentially sensitive bind-parameter output.
+
+The current matcher is equivalent to:
+
+```text
+(^|\r?\n)[whitespace]params:[whitespace]...
+```
+
+Once that marker is found, the sanitizer replaces everything after `params:` through the end of the string with `[REDACTED]`.
+
+This fail-closed behavior exists because `DrizzleQueryError.message` can contain database bind values after a `params:` line. Bind values themselves can contain newlines or text that looks like stack frames, so the sanitizer must not guess where a parameter list ends from its contents.
+
+## Intentional false-positive boundary
+
+The text sanitizer does not inspect the producer of the string. A non-Drizzle application log is therefore redacted in the same way when it contains a line beginning with `params:`.
+
+For example, diagnostic prose such as:
+
+```text
+request rejected
+params: harmless-example
+extra diagnostic text
+```
+
+is intentionally reduced to the prefix plus a redacted `params:` value; the trailing diagnostic text is not preserved.
+
+Do not rely on data after a line-leading `params:` marker remaining visible in logs. If such text is operationally important, avoid emitting it in this ambiguous free-form shape and prefer structured, explicitly named diagnostic fields that comply with the key-based redaction policy.
+
+## Known format dependency
+
+The current safeguard recognizes `params:` only at the start of the string or at the start of a new line, allowing indentation before the marker. A future Drizzle formatting change that flattens the marker into unrelated same-line prose would not match this boundary automatically. Changes to Drizzle error formatting should therefore be reviewed together with the sanitizer contract and its tests.
+
+This is a documentation-only description of the current policy; it does not broaden or relax redaction behavior.

--- a/src/lib/error-handler.ts
+++ b/src/lib/error-handler.ts
@@ -2,7 +2,7 @@ import 'server-only'
 
 import { NextResponse } from 'next/server'
 import { logErrorFromLogger } from './sentry/error-handler'
-import { sanitizeLogArg } from './log-sanitizer'
+import { sanitizeErrorText, sanitizeLogArg } from './log-sanitizer'
 import { ERROR_MESSAGES } from './constants'
 
 // Cloudflare Workers ではレスポンス返却後にバックグラウンド Promise が打ち切られるため、
@@ -10,7 +10,7 @@ import { ERROR_MESSAGES } from './constants'
 // logErrorFromLogger を直接使用することで、記録の確実性を担保する。
 //
 // Issue #401: console経路とPlanetScale経路で同一の機密情報マスキングを適用するため、
-// console 出力前に args をサニタイズする。生の error / additionalInfo がそのまま
+// console 出力前に message / args をサニタイズする。生の error / additionalInfo がそのまま
 // Cloudflare Workers logs / wrangler tail に漏れないようにする。
 async function logAndRecordError(
   message: string,
@@ -18,8 +18,9 @@ async function logAndRecordError(
   additionalInfo?: Record<string, unknown>
 ): Promise<void> {
   const args: unknown[] = additionalInfo ? [error, additionalInfo] : [error]
-  console.error(`[ERROR] ${message}`, ...args.map(sanitizeLogArg))
-  await logErrorFromLogger(message, args)
+  const sanitizedMessage = sanitizeErrorText(message)
+  console.error(`[ERROR] ${sanitizedMessage}`, ...args.map(sanitizeLogArg))
+  await logErrorFromLogger(sanitizedMessage, args)
 }
 
 export async function handleApiError(
@@ -76,7 +77,8 @@ function hasHttpStatusContext(errorMessage: string, status: 401 | 503 | 507): bo
 export async function handleBlobError(error: unknown, context: string, additionalInfo?: Record<string, unknown>): Promise<NextResponse> {
   const errorMessage = error instanceof Error ? error.message : String(error)
   const normalizedErrorMessage = errorMessage.toLowerCase()
-  await logAndRecordError(`${context}: ${errorMessage}`, error, additionalInfo)
+  const sanitizedErrorMessage = sanitizeErrorText(errorMessage)
+  await logAndRecordError(`${context}: ${sanitizedErrorMessage}`, error, additionalInfo)
 
   if (normalizedErrorMessage.includes('quota') || normalizedErrorMessage.includes('limit') || hasHttpStatusContext(errorMessage, 507)) {
     return NextResponse.json({ error: 'Storage quota exceeded' }, { status: 507 })

--- a/src/lib/log-sanitizer.ts
+++ b/src/lib/log-sanitizer.ts
@@ -23,12 +23,13 @@ const PARTIAL_SENSITIVE_KEYS = [
   'csrf_token', 'xsrf_token',
 ]
 
-// Drizzle / postgres.js の error field は bind 値や failing row を保持し得るため、
-// 汎用名でも exact match で隠す。
-const EXACT_SENSITIVE_KEYS = [
-  'userid', 'username', 'email', 'ip_address',
-  'params', 'parameters', 'args', 'detail', 'where',
-]
+// DrizzleQueryError.params は bind 値（token 等）を保持し得るため、汎用名でも exact match で隠す。
+const EXACT_SENSITIVE_KEYS = ['userid', 'username', 'email', 'ip_address', 'params']
+
+// postgres.js の PostgresError はこれらを own enumerable field として持ち、
+// DETAIL / WHERE や debug bind 情報に行データ・token 等が含まれ得る。
+// 汎用 context の `detail` 等まで消さないよう、Error field を再構築する時だけ適用する。
+const ERROR_EXACT_SENSITIVE_KEYS = ['detail', 'where', 'parameters', 'args']
 
 const MAX_SANITIZE_DEPTH = 8
 const CIRCULAR_MARKER = '[Circular]'
@@ -46,6 +47,11 @@ export function isSensitiveKey(key: string): boolean {
   return false
 }
 
+function isSensitiveErrorKey(key: string): boolean {
+  const lowerKey = key.toLowerCase()
+  return isSensitiveKey(key) || ERROR_EXACT_SENSITIVE_KEYS.includes(lowerKey)
+}
+
 export function sanitizeErrorText(value: string): string {
   return value.replace(DRIZZLE_PARAMS_BLOCK, '$1[REDACTED]')
 }
@@ -58,10 +64,12 @@ function sanitizeRecord(
   obj: Record<string, unknown>,
   depth: number,
   seen: WeakSet<object>,
+  errorFields = false,
 ): Record<string, unknown> {
   const sanitized: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(obj)) {
-    sanitized[key] = isSensitiveKey(key)
+    const sensitive = errorFields ? isSensitiveErrorKey(key) : isSensitiveKey(key)
+    sanitized[key] = sensitive
       ? '[REDACTED]'
       : sanitizeValue(value, depth + 1, seen)
   }
@@ -78,10 +86,10 @@ function sanitizeErrorForLogInternal(
   if (error.stack) sanitized.stack = sanitizeErrorText(error.stack)
 
   // Error の custom enumerable fields（query / params / cause / code 等）も console 展開時に
-  // 見えるため、通常の context と同じキー名ベースのポリシーを適用する。
+  // 見えるため、Error 固有の機密fieldを含むキー名ベースのポリシーを適用する。
   Object.assign(
     sanitized,
-    sanitizeRecord(Object.fromEntries(Object.entries(error)), depth, seen),
+    sanitizeRecord(Object.fromEntries(Object.entries(error)), depth, seen, true),
   )
   return sanitized
 }

--- a/src/lib/log-sanitizer.ts
+++ b/src/lib/log-sanitizer.ts
@@ -56,7 +56,7 @@ export function sanitizeErrorText(value: string): string {
   return value.replace(DRIZZLE_PARAMS_TO_END, '$1$2[REDACTED]')
 }
 
-function sanitizeErrorStack(stack: string, name: string, message: string): string {
+export function sanitizeErrorStack(stack: string, name: string, message: string): string {
   // V8 / Node の標準形なら、信頼できる境界は stack 内の見た目ではなく Error.message
   // そのもの。bind 値中に `    at ...` があっても header 全体を exact length で置換し、
   // message の外側にある本物の stack frame だけを保持する。
@@ -117,14 +117,7 @@ function sanitizeValue(value: unknown, depth: number, seen: WeakSet<object>): un
   try {
     if (value instanceof Error) return sanitizeErrorForLogInternal(value, depth, seen)
     if (Array.isArray(value)) {
-      // 既存契約どおり配列は1段だけ処理し、ネスト配列の再帰化は別フォローアップに残す。
-      return value.map(item => {
-        if (item instanceof Error || isRecord(item)) {
-          return sanitizeValue(item, depth + 1, seen)
-        }
-        if (typeof item === 'string') return sanitizeErrorText(item)
-        return item
-      })
+      return value.map(item => sanitizeValue(item, depth + 1, seen))
     }
     return sanitizeRecord(value as Record<string, unknown>, depth, seen)
   } finally {
@@ -163,8 +156,8 @@ export function sanitizeContext(obj: Record<string, unknown>): Record<string, un
  *   fields are sanitized because library-generated errors may embed bind values.
  * - Primitives are passed through.
  *
- * Note: arrays of primitives pass through except string values, which still
- * receive the error-text redaction used for Drizzle-style `params:` lines.
+ * Arrays recurse through the same sanitizer so nested records, errors, strings,
+ * and arrays cannot bypass the key/text redaction policy.
  */
 export function sanitizeLogArg(arg: unknown): unknown {
   if (arg instanceof Error) return sanitizeErrorForLog(arg)
@@ -189,14 +182,15 @@ export function extractErrorMessage(error: unknown): string {
     }
     const seen = new WeakSet()
     try {
-      return sanitizeErrorText(JSON.stringify(error, (key, value) => {
+      return JSON.stringify(error, (key, value) => {
         if (key && isSensitiveKey(key)) return '[REDACTED]'
+        if (typeof value === 'string') return sanitizeErrorText(value)
         if (typeof value === 'object' && value !== null) {
           if (seen.has(value)) return '[Circular]'
           seen.add(value)
         }
         return value
-      }))
+      })
     } catch {
       return '[Unserializable object]'
     }

--- a/src/lib/log-sanitizer.ts
+++ b/src/lib/log-sanitizer.ts
@@ -96,7 +96,14 @@ function sanitizeValue(value: unknown, depth: number, seen: WeakSet<object>): un
   try {
     if (value instanceof Error) return sanitizeErrorForLogInternal(value, depth, seen)
     if (Array.isArray(value)) {
-      return value.map(item => sanitizeValue(item, depth + 1, seen))
+      // 既存契約どおり配列は1段だけ処理し、ネスト配列の再帰化は別フォローアップに残す。
+      return value.map(item => {
+        if (item instanceof Error || isRecord(item)) {
+          return sanitizeValue(item, depth + 1, seen)
+        }
+        if (typeof item === 'string') return sanitizeErrorText(item)
+        return item
+      })
     }
     return sanitizeRecord(value as Record<string, unknown>, depth, seen)
   } finally {

--- a/src/lib/log-sanitizer.ts
+++ b/src/lib/log-sanitizer.ts
@@ -23,8 +23,16 @@ const PARTIAL_SENSITIVE_KEYS = [
   'csrf_token', 'xsrf_token',
 ]
 
-// DrizzleQueryError.params は bind 値（token 等）を保持し得るため、汎用名でも exact match で隠す。
-const EXACT_SENSITIVE_KEYS = ['userid', 'username', 'email', 'ip_address', 'params']
+// Drizzle / postgres.js の error field は bind 値や failing row を保持し得るため、
+// 汎用名でも exact match で隠す。
+const EXACT_SENSITIVE_KEYS = [
+  'userid', 'username', 'email', 'ip_address',
+  'params', 'parameters', 'args', 'detail', 'where',
+]
+
+const MAX_SANITIZE_DEPTH = 8
+const CIRCULAR_MARKER = '[Circular]'
+const MAX_DEPTH_MARKER = '[MaxDepth]'
 
 // drizzle-orm の DrizzleQueryError は bind 値を `params:` 以降へ埋め込み得る。
 // bind 値自体に改行が含まれる場合もあるため、次の stack frame（`    at ...`）
@@ -46,15 +54,64 @@ function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v)
 }
 
-function sanitizeErrorForLog(error: Error): Error {
+function sanitizeRecord(
+  obj: Record<string, unknown>,
+  depth: number,
+  seen: WeakSet<object>,
+): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(obj)) {
+    sanitized[key] = isSensitiveKey(key)
+      ? '[REDACTED]'
+      : sanitizeValue(value, depth + 1, seen)
+  }
+  return sanitized
+}
+
+function sanitizeErrorForLogInternal(
+  error: Error,
+  depth: number,
+  seen: WeakSet<object>,
+): Error {
   const sanitized = new Error(sanitizeErrorText(error.message))
   sanitized.name = error.name
   if (error.stack) sanitized.stack = sanitizeErrorText(error.stack)
 
-  // Error の custom enumerable fields（query / params / code 等）も console 展開時に
+  // Error の custom enumerable fields（query / params / cause / code 等）も console 展開時に
   // 見えるため、通常の context と同じキー名ベースのポリシーを適用する。
-  Object.assign(sanitized, sanitizeContext(Object.fromEntries(Object.entries(error))))
+  Object.assign(
+    sanitized,
+    sanitizeRecord(Object.fromEntries(Object.entries(error)), depth, seen),
+  )
   return sanitized
+}
+
+function sanitizeValue(value: unknown, depth: number, seen: WeakSet<object>): unknown {
+  if (typeof value === 'string') return sanitizeErrorText(value)
+  if (typeof value !== 'object' || value === null) return value
+  if (depth >= MAX_SANITIZE_DEPTH) return MAX_DEPTH_MARKER
+  if (seen.has(value)) return CIRCULAR_MARKER
+
+  seen.add(value)
+  try {
+    if (value instanceof Error) return sanitizeErrorForLogInternal(value, depth, seen)
+    if (Array.isArray(value)) {
+      return value.map(item => sanitizeValue(item, depth + 1, seen))
+    }
+    return sanitizeRecord(value as Record<string, unknown>, depth, seen)
+  } finally {
+    seen.delete(value)
+  }
+}
+
+function sanitizeErrorForLog(error: Error): Error {
+  const seen = new WeakSet<object>()
+  seen.add(error)
+  try {
+    return sanitizeErrorForLogInternal(error, 0, seen)
+  } finally {
+    seen.delete(error)
+  }
 }
 
 /**
@@ -62,28 +119,13 @@ function sanitizeErrorForLog(error: Error): Error {
  * Pure function — input is not mutated.
  */
 export function sanitizeContext(obj: Record<string, unknown>): Record<string, unknown> {
-  const sanitized: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(obj)) {
-    if (isSensitiveKey(key)) {
-      sanitized[key] = '[REDACTED]'
-    } else if (Array.isArray(value)) {
-      sanitized[key] = value.map(item => {
-        if (item instanceof Error) return sanitizeErrorForLog(item)
-        if (isRecord(item)) return sanitizeContext(item)
-        if (typeof item === 'string') return sanitizeErrorText(item)
-        return item
-      })
-    } else if (value instanceof Error) {
-      sanitized[key] = sanitizeErrorForLog(value)
-    } else if (isRecord(value)) {
-      sanitized[key] = sanitizeContext(value)
-    } else if (typeof value === 'string') {
-      sanitized[key] = sanitizeErrorText(value)
-    } else {
-      sanitized[key] = value
-    }
+  const seen = new WeakSet<object>()
+  seen.add(obj)
+  try {
+    return sanitizeRecord(obj, 0, seen)
+  } finally {
+    seen.delete(obj)
   }
-  return sanitized
 }
 
 /**
@@ -98,14 +140,7 @@ export function sanitizeContext(obj: Record<string, unknown>): Record<string, un
  */
 export function sanitizeLogArg(arg: unknown): unknown {
   if (arg instanceof Error) return sanitizeErrorForLog(arg)
-  if (Array.isArray(arg)) {
-    return arg.map(item => {
-      if (item instanceof Error) return sanitizeErrorForLog(item)
-      if (isRecord(item)) return sanitizeContext(item)
-      if (typeof item === 'string') return sanitizeErrorText(item)
-      return item
-    })
-  }
+  if (Array.isArray(arg)) return sanitizeValue(arg, 0, new WeakSet<object>())
   if (isRecord(arg)) return sanitizeContext(arg)
   if (typeof arg === 'string') return sanitizeErrorText(arg)
   return arg

--- a/src/lib/log-sanitizer.ts
+++ b/src/lib/log-sanitizer.ts
@@ -9,8 +9,8 @@
  * Key categories follow OWASP Logging Cheat Sheet recommendations:
  * - PARTIAL_SENSITIVE_KEYS: substring match — always redact when the key
  *   contains one of these tokens (e.g. `twitch_access_token`, `csrf_token`).
- * - EXACT_SENSITIVE_KEYS: exact match only — redact bare PII keys without
- *   masking debug-friendly compound keys (e.g. `userId` is masked but
+ * - EXACT_SENSITIVE_KEYS: exact match only — redact bare sensitive/PII keys
+ *   without masking debug-friendly compound keys (e.g. `userId` is masked but
  *   `broadcasterUserId` / `twitchUsername` are kept for triage).
  */
 
@@ -23,7 +23,8 @@ const PARTIAL_SENSITIVE_KEYS = [
   'csrf_token', 'xsrf_token',
 ]
 
-const EXACT_SENSITIVE_KEYS = ['userid', 'username', 'email', 'ip_address']
+// DrizzleQueryError.params は bind 値（token 等）を保持し得るため、汎用名でも exact match で隠す。
+const EXACT_SENSITIVE_KEYS = ['userid', 'username', 'email', 'ip_address', 'params']
 
 export function isSensitiveKey(key: string): boolean {
   const lowerKey = key.toLowerCase()

--- a/src/lib/log-sanitizer.ts
+++ b/src/lib/log-sanitizer.ts
@@ -26,11 +26,19 @@ const PARTIAL_SENSITIVE_KEYS = [
 // DrizzleQueryError.params は bind 値（token 等）を保持し得るため、汎用名でも exact match で隠す。
 const EXACT_SENSITIVE_KEYS = ['userid', 'username', 'email', 'ip_address', 'params']
 
+// drizzle-orm の DrizzleQueryError は bind 値を `params:` 行として message / stack に
+// 埋め込み得る。キー名ベースのマスクだけでは防げないため、文字列経路も共通で検閲する。
+const DRIZZLE_PARAMS_LINE = /^(\s*params:\s*).*$/gim
+
 export function isSensitiveKey(key: string): boolean {
   const lowerKey = key.toLowerCase()
   if (EXACT_SENSITIVE_KEYS.some(k => lowerKey === k)) return true
   if (PARTIAL_SENSITIVE_KEYS.some(k => lowerKey.includes(k))) return true
   return false
+}
+
+export function sanitizeErrorText(value: string): string {
+  return value.replace(DRIZZLE_PARAMS_LINE, '$1[REDACTED]')
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -47,9 +55,15 @@ export function sanitizeContext(obj: Record<string, unknown>): Record<string, un
     if (isSensitiveKey(key)) {
       sanitized[key] = '[REDACTED]'
     } else if (Array.isArray(value)) {
-      sanitized[key] = value.map(item => isRecord(item) ? sanitizeContext(item) : item)
+      sanitized[key] = value.map(item => {
+        if (isRecord(item)) return sanitizeContext(item)
+        if (typeof item === 'string') return sanitizeErrorText(item)
+        return item
+      })
     } else if (isRecord(value)) {
       sanitized[key] = sanitizeContext(value)
+    } else if (typeof value === 'string') {
+      sanitized[key] = sanitizeErrorText(value)
     } else {
       sanitized[key] = value
     }
@@ -57,22 +71,38 @@ export function sanitizeContext(obj: Record<string, unknown>): Record<string, un
   return sanitized
 }
 
+function sanitizeErrorForLog(error: Error): Error {
+  const sanitized = new Error(sanitizeErrorText(error.message))
+  sanitized.name = error.name
+  if (error.stack) sanitized.stack = sanitizeErrorText(error.stack)
+
+  // Error の custom enumerable fields（query / params / code 等）も console 展開時に
+  // 見えるため、通常の context と同じキー名ベースのポリシーを適用する。
+  Object.assign(sanitized, sanitizeContext(Object.fromEntries(Object.entries(error))))
+  return sanitized
+}
+
 /**
  * Sanitize a single log argument for console output.
  * - Plain records are sanitized recursively.
- * - Error instances are passed through (their `.message` / `.stack` are
- *   developer-authored and assumed not to embed secrets).
+ * - Error instances keep their Error shape, but message / stack and enumerable
+ *   fields are sanitized because library-generated errors may embed bind values.
  * - Primitives are passed through.
  *
- * Note: arrays of primitives pass through unchanged; arrays of objects are
- * sanitized so structures like `[{ token: '...' }]` are still masked.
+ * Note: arrays of primitives pass through except string values, which still
+ * receive the error-text redaction used for Drizzle-style `params:` lines.
  */
 export function sanitizeLogArg(arg: unknown): unknown {
-  if (arg instanceof Error) return arg
+  if (arg instanceof Error) return sanitizeErrorForLog(arg)
   if (Array.isArray(arg)) {
-    return arg.map(item => isRecord(item) ? sanitizeContext(item) : item)
+    return arg.map(item => {
+      if (isRecord(item)) return sanitizeContext(item)
+      if (typeof item === 'string') return sanitizeErrorText(item)
+      return item
+    })
   }
   if (isRecord(arg)) return sanitizeContext(arg)
+  if (typeof arg === 'string') return sanitizeErrorText(arg)
   return arg
 }
 
@@ -87,21 +117,21 @@ export function sanitizeLogArg(arg: unknown): unknown {
 export function extractErrorMessage(error: unknown): string {
   if (error && typeof error === 'object') {
     if ('message' in error && typeof (error as { message: unknown }).message === 'string') {
-      return (error as { message: string }).message
+      return sanitizeErrorText((error as { message: string }).message)
     }
     const seen = new WeakSet()
     try {
-      return JSON.stringify(error, (key, value) => {
+      return sanitizeErrorText(JSON.stringify(error, (key, value) => {
         if (key && isSensitiveKey(key)) return '[REDACTED]'
         if (typeof value === 'object' && value !== null) {
           if (seen.has(value)) return '[Circular]'
           seen.add(value)
         }
         return value
-      })
+      }))
     } catch {
       return '[Unserializable object]'
     }
   }
-  return String(error)
+  return sanitizeErrorText(String(error))
 }

--- a/src/lib/log-sanitizer.ts
+++ b/src/lib/log-sanitizer.ts
@@ -26,10 +26,10 @@ const PARTIAL_SENSITIVE_KEYS = [
 // DrizzleQueryError.params は bind 値（token 等）を保持し得るため、汎用名でも exact match で隠す。
 const EXACT_SENSITIVE_KEYS = ['userid', 'username', 'email', 'ip_address', 'params']
 
-// drizzle-orm の DrizzleQueryError は bind 値を `params:` 行として message / stack に
-// 埋め込み得る。キー名ベースのマスクだけでは防げないため、文字列経路も共通で検閲する。
-// `\s` は改行も含むため使わず、必ず1行の `params:` だけを置換してstack frameを残す。
-const DRIZZLE_PARAMS_LINE = /^([^\S\r\n]*params:[^\S\r\n]*)[^\r\n]*$/gim
+// drizzle-orm の DrizzleQueryError は bind 値を `params:` 以降へ埋め込み得る。
+// bind 値自体に改行が含まれる場合もあるため、次の stack frame（`    at ...`）
+// または文字列末尾までを一括で置換し、stack frame だけを診断用に残す。
+const DRIZZLE_PARAMS_BLOCK = /^([^\S\r\n]*params:[^\S\r\n]*)(?:[^\r\n]*(?:\r?\n(?![^\S\r\n]+at\s)[^\r\n]*)*)/gim
 
 export function isSensitiveKey(key: string): boolean {
   const lowerKey = key.toLowerCase()
@@ -39,7 +39,7 @@ export function isSensitiveKey(key: string): boolean {
 }
 
 export function sanitizeErrorText(value: string): string {
-  return value.replace(DRIZZLE_PARAMS_LINE, '$1[REDACTED]')
+  return value.replace(DRIZZLE_PARAMS_BLOCK, '$1[REDACTED]')
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {

--- a/src/lib/log-sanitizer.ts
+++ b/src/lib/log-sanitizer.ts
@@ -28,7 +28,8 @@ const EXACT_SENSITIVE_KEYS = ['userid', 'username', 'email', 'ip_address', 'para
 
 // drizzle-orm の DrizzleQueryError は bind 値を `params:` 行として message / stack に
 // 埋め込み得る。キー名ベースのマスクだけでは防げないため、文字列経路も共通で検閲する。
-const DRIZZLE_PARAMS_LINE = /^(\s*params:\s*).*$/gim
+// `\s` は改行も含むため使わず、必ず1行の `params:` だけを置換してstack frameを残す。
+const DRIZZLE_PARAMS_LINE = /^([^\S\r\n]*params:[^\S\r\n]*)[^\r\n]*$/gim
 
 export function isSensitiveKey(key: string): boolean {
   const lowerKey = key.toLowerCase()

--- a/src/lib/log-sanitizer.ts
+++ b/src/lib/log-sanitizer.ts
@@ -35,10 +35,11 @@ const MAX_SANITIZE_DEPTH = 8
 const CIRCULAR_MARKER = '[Circular]'
 const MAX_DEPTH_MARKER = '[MaxDepth]'
 
-// drizzle-orm の DrizzleQueryError は bind 値を `params:` 以降へ埋め込み得る。
-// bind 値自体に改行が含まれる場合もあるため、次の stack frame（`    at ...`）
-// または文字列末尾までを一括で置換し、stack frame だけを診断用に残す。
-const DRIZZLE_PARAMS_BLOCK = /^([^\S\r\n]*params:[^\S\r\n]*)(?:[^\r\n]*(?:\r?\n(?![^\S\r\n]+at\s)[^\r\n]*)*)/gim
+// drizzle-orm の DrizzleQueryError.message は `params:` 以降が bind 値の文字列化。
+// bind 値自身に改行や `    at ...` のような stack-frame 風文字列を含められるため、
+// 終端を内容から推測せず `params:` 行から文字列末尾までを決定論的に検閲する。
+// stack 文字列へ適用した場合は診断用 frame も落ちるが、機密値を残すより安全側へ倒す。
+const DRIZZLE_PARAMS_TO_END = /(^|\r?\n)([^\S\r\n]*params:[^\S\r\n]*)[\s\S]*$/i
 
 export function isSensitiveKey(key: string): boolean {
   const lowerKey = key.toLowerCase()
@@ -53,7 +54,7 @@ function isSensitiveErrorKey(key: string): boolean {
 }
 
 export function sanitizeErrorText(value: string): string {
-  return value.replace(DRIZZLE_PARAMS_BLOCK, '$1[REDACTED]')
+  return value.replace(DRIZZLE_PARAMS_TO_END, '$1$2[REDACTED]')
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {

--- a/src/lib/log-sanitizer.ts
+++ b/src/lib/log-sanitizer.ts
@@ -46,6 +46,17 @@ function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v)
 }
 
+function sanitizeErrorForLog(error: Error): Error {
+  const sanitized = new Error(sanitizeErrorText(error.message))
+  sanitized.name = error.name
+  if (error.stack) sanitized.stack = sanitizeErrorText(error.stack)
+
+  // Error の custom enumerable fields（query / params / code 等）も console 展開時に
+  // 見えるため、通常の context と同じキー名ベースのポリシーを適用する。
+  Object.assign(sanitized, sanitizeContext(Object.fromEntries(Object.entries(error))))
+  return sanitized
+}
+
 /**
  * Recursively replace sensitive values with `[REDACTED]`.
  * Pure function — input is not mutated.
@@ -57,10 +68,13 @@ export function sanitizeContext(obj: Record<string, unknown>): Record<string, un
       sanitized[key] = '[REDACTED]'
     } else if (Array.isArray(value)) {
       sanitized[key] = value.map(item => {
+        if (item instanceof Error) return sanitizeErrorForLog(item)
         if (isRecord(item)) return sanitizeContext(item)
         if (typeof item === 'string') return sanitizeErrorText(item)
         return item
       })
+    } else if (value instanceof Error) {
+      sanitized[key] = sanitizeErrorForLog(value)
     } else if (isRecord(value)) {
       sanitized[key] = sanitizeContext(value)
     } else if (typeof value === 'string') {
@@ -69,17 +83,6 @@ export function sanitizeContext(obj: Record<string, unknown>): Record<string, un
       sanitized[key] = value
     }
   }
-  return sanitized
-}
-
-function sanitizeErrorForLog(error: Error): Error {
-  const sanitized = new Error(sanitizeErrorText(error.message))
-  sanitized.name = error.name
-  if (error.stack) sanitized.stack = sanitizeErrorText(error.stack)
-
-  // Error の custom enumerable fields（query / params / code 等）も console 展開時に
-  // 見えるため、通常の context と同じキー名ベースのポリシーを適用する。
-  Object.assign(sanitized, sanitizeContext(Object.fromEntries(Object.entries(error))))
   return sanitized
 }
 
@@ -97,6 +100,7 @@ export function sanitizeLogArg(arg: unknown): unknown {
   if (arg instanceof Error) return sanitizeErrorForLog(arg)
   if (Array.isArray(arg)) {
     return arg.map(item => {
+      if (item instanceof Error) return sanitizeErrorForLog(item)
       if (isRecord(item)) return sanitizeContext(item)
       if (typeof item === 'string') return sanitizeErrorText(item)
       return item

--- a/src/lib/log-sanitizer.ts
+++ b/src/lib/log-sanitizer.ts
@@ -38,7 +38,6 @@ const MAX_DEPTH_MARKER = '[MaxDepth]'
 // drizzle-orm の DrizzleQueryError.message は `params:` 以降が bind 値の文字列化。
 // bind 値自身に改行や `    at ...` のような stack-frame 風文字列を含められるため、
 // 終端を内容から推測せず `params:` 行から文字列末尾までを決定論的に検閲する。
-// stack 文字列へ適用した場合は診断用 frame も落ちるが、機密値を残すより安全側へ倒す。
 const DRIZZLE_PARAMS_TO_END = /(^|\r?\n)([^\S\r\n]*params:[^\S\r\n]*)[\s\S]*$/i
 
 export function isSensitiveKey(key: string): boolean {
@@ -55,6 +54,19 @@ function isSensitiveErrorKey(key: string): boolean {
 
 export function sanitizeErrorText(value: string): string {
   return value.replace(DRIZZLE_PARAMS_TO_END, '$1$2[REDACTED]')
+}
+
+function sanitizeErrorStack(stack: string, name: string, message: string): string {
+  // V8 / Node の標準形なら、信頼できる境界は stack 内の見た目ではなく Error.message
+  // そのもの。bind 値中に `    at ...` があっても header 全体を exact length で置換し、
+  // message の外側にある本物の stack frame だけを保持する。
+  const header = `${name}: ${message}`
+  if (stack.startsWith(header)) {
+    return `${name}: ${sanitizeErrorText(message)}${stack.slice(header.length)}`
+  }
+
+  // 非標準 stack は安全な message 境界を特定できないため、診断情報より漏洩防止を優先。
+  return sanitizeErrorText(stack)
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -84,7 +96,7 @@ function sanitizeErrorForLogInternal(
 ): Error {
   const sanitized = new Error(sanitizeErrorText(error.message))
   sanitized.name = error.name
-  if (error.stack) sanitized.stack = sanitizeErrorText(error.stack)
+  if (error.stack) sanitized.stack = sanitizeErrorStack(error.stack, error.name, error.message)
 
   // Error の custom enumerable fields（query / params / cause / code 等）も console 展開時に
   // 見えるため、Error 固有の機密fieldを含むキー名ベースのポリシーを適用する。

--- a/src/lib/logger.server.ts
+++ b/src/lib/logger.server.ts
@@ -1,6 +1,7 @@
 import 'server-only'
 
 import { logger as consoleLogger } from './logger'
+import { sanitizeLogArg } from './log-sanitizer'
 import { logErrorFromLogger } from './sentry/error-handler'
 
 /**
@@ -26,7 +27,9 @@ export const logger = {
   },
   error: (message: string, ...args: unknown[]): void => {
     consoleLogger.error(message, ...args)
-    // logErrorFromLoggerは内部で永続化失敗を捕捉し、呼び出し元へrejectを漏らさない。
-    void logErrorFromLogger(message, args)
+    // console側は共有logger内でサニタイズされる。DB永続化にはraw argsを渡さず、
+    // DrizzleQueryErrorのmessage/stackに含まれ得るbind paramsも同じ境界で落とす。
+    const sanitizedArgs = args.map(sanitizeLogArg)
+    void logErrorFromLogger(message, sanitizedArgs)
   },
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,4 +1,4 @@
-import { sanitizeLogArg } from './log-sanitizer'
+import { sanitizeErrorText, sanitizeLogArg } from './log-sanitizer'
 
 /**
  * ブラウザ・サーバー両方から利用できるconsole logger。
@@ -9,13 +9,14 @@ import { sanitizeLogArg } from './log-sanitizer'
  * `logger.server`はこのloggerへconsole出力を委譲するので、マスキング規則と出力形式は
  * 両runtimeで共通のまま維持される。
  *
- * 全consoleログ経路で同一の機密情報マスキングを適用するため、出力前にargsを
+ * 全consoleログ経路で同一の機密情報マスキングを適用するため、messageとargsを
  * サニタイズする。
  *
- * Sanitize args before they reach console.* so that Cloudflare Workers logs,
- * browser consoles, and server consoles all follow the same redaction policy.
- * Without this guard, raw context (OAuth codes, access tokens, cookies, session
- * identifiers, etc.) could leak via `console.log/warn/error`.
+ * Sanitize message and args before they reach console.* so that Cloudflare
+ * Workers logs, browser consoles, and server consoles all follow the same
+ * redaction policy. Without this guard, raw context (OAuth codes, access
+ * tokens, cookies, session identifiers, Drizzle bind params, etc.) could leak
+ * via `console.log/warn/error`.
  *
  * Error instances are also sanitized. Library-generated errors such as
  * DrizzleQueryError may embed bind params in `.message` / `.stack`, so Error
@@ -23,12 +24,12 @@ import { sanitizeLogArg } from './log-sanitizer'
  */
 export const logger = {
   info: (message: string, ...args: unknown[]) => {
-    console.log(`[INFO] ${message}`, ...args.map(sanitizeLogArg))
+    console.log(`[INFO] ${sanitizeErrorText(message)}`, ...args.map(sanitizeLogArg))
   },
   warn: (message: string, ...args: unknown[]) => {
-    console.warn(`[WARN] ${message}`, ...args.map(sanitizeLogArg))
+    console.warn(`[WARN] ${sanitizeErrorText(message)}`, ...args.map(sanitizeLogArg))
   },
   error: (message: string, ...args: unknown[]): void => {
-    console.error(`[ERROR] ${message}`, ...args.map(sanitizeLogArg))
+    console.error(`[ERROR] ${sanitizeErrorText(message)}`, ...args.map(sanitizeLogArg))
   },
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -17,8 +17,9 @@ import { sanitizeLogArg } from './log-sanitizer'
  * Without this guard, raw context (OAuth codes, access tokens, cookies, session
  * identifiers, etc.) could leak via `console.log/warn/error`.
  *
- * Error instances pass through untouched: their `.message` / `.stack` are
- * developer-authored strings and are assumed not to contain secrets.
+ * Error instances are also sanitized. Library-generated errors such as
+ * DrizzleQueryError may embed bind params in `.message` / `.stack`, so Error
+ * objects are not treated as inherently safe developer-authored strings.
  */
 export const logger = {
   info: (message: string, ...args: unknown[]) => {

--- a/src/lib/sentry/error-handler.ts
+++ b/src/lib/sentry/error-handler.ts
@@ -38,6 +38,7 @@ import 'server-only'
 
 import {
   sanitizeContext,
+  sanitizeErrorStack,
   sanitizeErrorText,
   sanitizeLogArg,
   extractErrorMessage,
@@ -52,7 +53,7 @@ function resolveErrorInfo(error: unknown): { message: string; stack: string | nu
   if (error instanceof Error) {
     return {
       message: sanitizeErrorText(error.message),
-      stack: error.stack ? sanitizeErrorText(error.stack) : null,
+      stack: error.stack ? sanitizeErrorStack(error.stack, error.name, error.message) : null,
       isErrorInstance: true,
     }
   }
@@ -157,10 +158,11 @@ async function persistErrorToDatabase(
     const environment = appUrl.includes('preview') ? 'preview' : 'production'
     const values = {
       error_type: errorType,
-      // DB / error-reporter への最終書き込み境界でも再度検閲し、呼び出し元が
-      // raw Error text を渡しても bind params が message / stack に残らないようにする。
+      // message/context は最終書き込み境界でも再検閲する。stack は Error 境界で
+      // sanitizeErrorStack() 済みで、再度 sanitizeErrorText() すると保持した実frameまで
+      // `params:` 以降として消してしまうため、ここでは長さ制限だけ適用する。
       message: sanitizeErrorText(message).slice(0, MAX_MESSAGE_LENGTH),
-      stack_trace: stackTrace ? sanitizeErrorText(stackTrace).slice(0, MAX_STACK_LENGTH) : null,
+      stack_trace: stackTrace ? stackTrace.slice(0, MAX_STACK_LENGTH) : null,
       // 機密情報（userId, token 等）を除外してから記録
       context: persistedContext(context),
       environment,
@@ -282,7 +284,7 @@ export async function logErrorFromLogger(message: string, args: unknown[]): Prom
         // 最初の Error を採用（原因エラーは通常先頭に渡される）
         if (!errorDetail) {
           errorDetail = sanitizeErrorText(arg.message)
-          stack = arg.stack ? sanitizeErrorText(arg.stack) : null
+          stack = arg.stack ? sanitizeErrorStack(arg.stack, arg.name, arg.message) : null
         }
       } else if (arg && typeof arg === 'object') {
         const obj = arg as Record<string, unknown>
@@ -290,7 +292,9 @@ export async function logErrorFromLogger(message: string, args: unknown[]): Prom
         if ('error' in obj && obj.error != null && !errorDetail) {
           if (obj.error instanceof Error) {
             errorDetail = sanitizeErrorText(obj.error.message)
-            stack = obj.error.stack ? sanitizeErrorText(obj.error.stack) : null
+            stack = obj.error.stack
+              ? sanitizeErrorStack(obj.error.stack, obj.error.name, obj.error.message)
+              : null
           } else {
             errorDetail = extractErrorMessage(obj.error)
           }

--- a/src/lib/sentry/error-handler.ts
+++ b/src/lib/sentry/error-handler.ts
@@ -29,14 +29,19 @@ import 'server-only'
  * - db/retry.ts → logger.server.ts → 本moduleの循環を初期評価時に作らない
  *
  * 機密情報マスキング:
- * - sanitizeContext / extractErrorMessage は log-sanitizer.ts に集約
+ * - sanitizeContext / extractErrorMessage / sanitizeErrorText は log-sanitizer.ts に集約
  * - 同じユーティリティを logger.ts も使用しており、console 経路 / DB 記録経路で
  *   同一ポリシーが適用される（Issue #401）
  * - Sensitive-info masking lives in log-sanitizer so both the console pipeline
  *   (logger) and the database pipeline use the same redaction policy.
  */
 
-import { sanitizeContext, extractErrorMessage } from '@/lib/log-sanitizer'
+import {
+  sanitizeContext,
+  sanitizeErrorText,
+  sanitizeLogArg,
+  extractErrorMessage,
+} from '@/lib/log-sanitizer'
 import type { Json } from '@/types/database'
 
 /**
@@ -45,7 +50,11 @@ import type { Json } from '@/types/database'
  */
 function resolveErrorInfo(error: unknown): { message: string; stack: string | null; isErrorInstance: boolean } {
   if (error instanceof Error) {
-    return { message: error.message, stack: error.stack || null, isErrorInstance: true }
+    return {
+      message: sanitizeErrorText(error.message),
+      stack: error.stack ? sanitizeErrorText(error.stack) : null,
+      isErrorInstance: true,
+    }
   }
   return { message: extractErrorMessage(error), stack: null, isErrorInstance: false }
 }
@@ -116,7 +125,10 @@ async function logErrorToDatabase(
       // （ガードが無い＝保険が効かないだけで、通常運用では #711 の不変条件により
       // そもそも再帰は起きないため実害は無い）。
       reentryGuardPromise = undefined
-      console.warn('[Error Tracking] Failed to load reentry guard, proceeding without it:', err)
+      console.warn(
+        '[Error Tracking] Failed to load reentry guard, proceeding without it:',
+        sanitizeLogArg(err),
+      )
       return persistErrorToDatabase(errorType, message, stackTrace, context)
     }
 
@@ -124,7 +136,7 @@ async function logErrorToDatabase(
       // 真の再帰を検知。DBへは書き込まず console.warn のみ（この関数自身を
       // 再度呼ぶと同じ分岐を無限に辿るため、ここは再帰防止の末端でなければ
       // ならない）。
-      console.warn('[Error Tracking] Reentrant error logging suppressed:', message)
+      console.warn('[Error Tracking] Reentrant error logging suppressed:', sanitizeErrorText(message))
       return
     }
     return guard.run(true, () => persistErrorToDatabase(errorType, message, stackTrace, context))
@@ -145,8 +157,10 @@ async function persistErrorToDatabase(
     const environment = appUrl.includes('preview') ? 'preview' : 'production'
     const values = {
       error_type: errorType,
-      message: message.slice(0, MAX_MESSAGE_LENGTH),
-      stack_trace: stackTrace?.slice(0, MAX_STACK_LENGTH) || null,
+      // DB / error-reporter への最終書き込み境界でも再度検閲し、呼び出し元が
+      // raw Error text を渡しても bind params が message / stack に残らないようにする。
+      message: sanitizeErrorText(message).slice(0, MAX_MESSAGE_LENGTH),
+      stack_trace: stackTrace ? sanitizeErrorText(stackTrace).slice(0, MAX_STACK_LENGTH) : null,
       // 機密情報（userId, token 等）を除外してから記録
       context: persistedContext(context),
       environment,
@@ -188,7 +202,7 @@ async function persistErrorToDatabase(
     // 二重の防御になる）。同一isolate内の別requestで同じエラーが並行発生しても
     // 観測データを誤って捨てないことは AsyncLocalStorage ガード側で担保される
     // （上記コメント参照）。
-    console.warn('[Error Tracking] Failed to persist error:', err)
+    console.warn('[Error Tracking] Failed to persist error:', sanitizeLogArg(err))
   }
 }
 
@@ -267,25 +281,25 @@ export async function logErrorFromLogger(message: string, args: unknown[]): Prom
       if (arg instanceof Error) {
         // 最初の Error を採用（原因エラーは通常先頭に渡される）
         if (!errorDetail) {
-          errorDetail = arg.message
-          stack = arg.stack || null
+          errorDetail = sanitizeErrorText(arg.message)
+          stack = arg.stack ? sanitizeErrorText(arg.stack) : null
         }
       } else if (arg && typeof arg === 'object') {
         const obj = arg as Record<string, unknown>
         // { error: ... } パターンからエラー詳細を抽出
         if ('error' in obj && obj.error != null && !errorDetail) {
           if (obj.error instanceof Error) {
-            errorDetail = (obj.error as Error).message
-            stack = (obj.error as Error).stack || null
+            errorDetail = sanitizeErrorText(obj.error.message)
+            stack = obj.error.stack ? sanitizeErrorText(obj.error.stack) : null
           } else {
             errorDetail = extractErrorMessage(obj.error)
           }
         } else if (!errorDetail && 'message' in obj && typeof obj.message === 'string' && obj.message !== '') {
           // error プロパティがない場合、オブジェクト自体が PostgrestError 等のエラーと判定
           // See: https://github.com/azumag/twica/issues/262
-          errorDetail = obj.message
+          errorDetail = sanitizeErrorText(obj.message)
         }
-        Object.assign(context, obj)
+        Object.assign(context, sanitizeContext(obj))
       }
     }
 

--- a/src/lib/twitch/token-manager.ts
+++ b/src/lib/twitch/token-manager.ts
@@ -18,10 +18,12 @@ import {
 } from '@/lib/db/schema';
 
 export class TwitchTokenError extends Error {
+  public readonly originalError?: Error;
+
   constructor(
     message: string,
     public readonly code: 'NO_TOKEN' | 'REFRESH_FAILED' | 'DATABASE_ERROR' | 'USER_NOT_FOUND',
-    public readonly originalError?: Error,
+    originalError?: Error,
     // Issue #653/#670/#654/#655: TwitchTokenRefreshErrorのstatus/kind/retryable
     // (安全な要約値のみ)をAPI境界(handleApiError)まで橋渡しするための追加フィールド。
     // 生のoriginalErrorをここに載せない理由はtwitchTokenRefreshFailureContextの
@@ -32,6 +34,9 @@ export class TwitchTokenError extends Error {
   ) {
     super(message);
     this.name = 'TwitchTokenError';
+    // Issue #998: DrizzleQueryError の params には token 実値が含まれ得るため、
+    // DATABASE_ERROR では生の DB error を将来の診断経路へ持ち越さない。
+    this.originalError = code === 'DATABASE_ERROR' ? undefined : originalError;
   }
 }
 

--- a/tests/unit/error-handler.test.ts
+++ b/tests/unit/error-handler.test.ts
@@ -135,6 +135,25 @@ describe('error-handler', () => {
       expect(response.status).toBe(500);
     });
 
+    it('Drizzle bind paramsをconsole / DB loggerへ渡す前にmessageから検閲する', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const error = new Error(
+        'Failed query: SELECT * FROM cards LIMIT 1\nparams: sensitive-token-value'
+      );
+
+      await handleBlobError(error, 'blob context');
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[ERROR] blob context: Failed query: SELECT * FROM cards LIMIT 1\nparams: [REDACTED]',
+        expect.any(Error)
+      );
+      expect(logErrorFromLogger).toHaveBeenCalledWith(
+        'blob context: Failed query: SELECT * FROM cards LIMIT 1\nparams: [REDACTED]',
+        [error]
+      );
+      consoleSpy.mockRestore();
+    });
+
     it('その他のエラーで 500 を返す', async () => {
       const response = await handleBlobError(new Error('unknown blob error'), 'blob');
       expect(response.status).toBe(500);

--- a/tests/unit/log-sanitizer.test.ts
+++ b/tests/unit/log-sanitizer.test.ts
@@ -29,19 +29,12 @@ describe('log-sanitizer', () => {
       expect(isSensitiveKey(key)).toBe(true)
     })
 
-    it.each([
-      'userId',
-      'username',
-      'email',
-      'ip_address',
-      'params',
-      'parameters',
-      'args',
-      'detail',
-      'where',
-    ])('redacts exact match key %s', (key) => {
-      expect(isSensitiveKey(key)).toBe(true)
-    })
+    it.each(['userId', 'username', 'email', 'ip_address', 'params'])(
+      'redacts exact match key %s',
+      (key) => {
+        expect(isSensitiveKey(key)).toBe(true)
+      }
+    )
 
     it.each(['broadcasterUserId', 'twitchUsername', 'streamerId', 'safeName', 'queryParams'])(
       'keeps debug-friendly compound key %s',

--- a/tests/unit/log-sanitizer.test.ts
+++ b/tests/unit/log-sanitizer.test.ts
@@ -29,12 +29,19 @@ describe('log-sanitizer', () => {
       expect(isSensitiveKey(key)).toBe(true)
     })
 
-    it.each(['userId', 'username', 'email', 'ip_address', 'params'])(
-      'redacts exact match key %s',
-      (key) => {
-        expect(isSensitiveKey(key)).toBe(true)
-      }
-    )
+    it.each([
+      'userId',
+      'username',
+      'email',
+      'ip_address',
+      'params',
+      'parameters',
+      'args',
+      'detail',
+      'where',
+    ])('redacts exact match key %s', (key) => {
+      expect(isSensitiveKey(key)).toBe(true)
+    })
 
     it.each(['broadcasterUserId', 'twitchUsername', 'streamerId', 'safeName', 'queryParams'])(
       'keeps debug-friendly compound key %s',
@@ -127,6 +134,18 @@ describe('log-sanitizer', () => {
       expect(nested.query).toBe('UPDATE users SET twitch_access_token = $1')
       expect(nested.cause).toEqual({ code: '42703' })
     })
+
+    it('stops recursive records at a bounded depth', () => {
+      let nested: Record<string, unknown> = { leaf: 'safe' }
+      for (let i = 0; i < 12; i += 1) nested = { next: nested }
+
+      let cursor: unknown = sanitizeContext({ nested }).nested
+      for (let i = 0; i < 20 && cursor && typeof cursor === 'object'; i += 1) {
+        cursor = (cursor as Record<string, unknown>).next
+      }
+
+      expect(cursor).toBe('[MaxDepth]')
+    })
   })
 
   describe('sanitizeLogArg', () => {
@@ -161,6 +180,51 @@ describe('log-sanitizer', () => {
       expect(out.query).toBe('UPDATE users SET twitch_access_token = $1')
       expect(out.params).toBe('[REDACTED]')
       expect(err.message).toContain('sensitive-token-value')
+    })
+
+    it('redacts postgres.js fields on an enumerable Drizzle cause', () => {
+      const cause = Object.assign(new Error('duplicate key value violates unique constraint'), {
+        code: '23505',
+        detail: 'Key (twitch_access_token)=(sensitive-token-value) already exists.',
+        where: 'SQL statement with sensitive-token-value',
+        parameters: ['sensitive-token-value'],
+        args: ['sensitive-token-value'],
+      })
+      cause.name = 'PostgresError'
+
+      const err = Object.assign(new Error('Failed query: UPDATE users SET twitch_access_token = $1'), {
+        query: 'UPDATE users SET twitch_access_token = $1',
+        params: ['sensitive-token-value'],
+        cause,
+      })
+      err.name = 'DrizzleQueryError'
+
+      const out = sanitizeLogArg(err) as Error & {
+        cause: Error & {
+          code: string
+          detail: unknown
+          where: unknown
+          parameters: unknown
+          args: unknown
+        }
+      }
+
+      expect(out.cause).toBeInstanceOf(Error)
+      expect(out.cause.code).toBe('23505')
+      expect(out.cause.detail).toBe('[REDACTED]')
+      expect(out.cause.where).toBe('[REDACTED]')
+      expect(out.cause.parameters).toBe('[REDACTED]')
+      expect(out.cause.args).toBe('[REDACTED]')
+      expect(JSON.stringify(out.cause)).not.toContain('sensitive-token-value')
+    })
+
+    it('stops circular Error cause chains', () => {
+      const err = new Error('database failure') as Error & { cause?: unknown }
+      err.cause = err
+
+      const out = sanitizeLogArg(err) as Error & { cause: unknown }
+
+      expect(out.cause).toBe('[Circular]')
     })
 
     it.each([null, undefined, 42, 'plain', true])(

--- a/tests/unit/log-sanitizer.test.ts
+++ b/tests/unit/log-sanitizer.test.ts
@@ -63,6 +63,14 @@ describe('log-sanitizer', () => {
       ).toEqual({ items: [{ password: '[REDACTED]' }, { name: 'n' }] })
     })
 
+    it('redacts Drizzle-style bind params stored as a context string', () => {
+      expect(sanitizeContext({
+        error: 'Failed query: UPDATE users SET twitch_access_token = $1\nparams: sensitive-token-value',
+      })).toEqual({
+        error: 'Failed query: UPDATE users SET twitch_access_token = $1\nparams: [REDACTED]',
+      })
+    })
+
     it('redacts Drizzle-style bind params nested in a log context', () => {
       const dbError = Object.assign(new Error('database query failed'), {
         query: 'UPDATE users SET twitch_access_token = $1',
@@ -89,9 +97,29 @@ describe('log-sanitizer', () => {
       })
     })
 
-    it('passes Error instances through untouched (preserves stack)', () => {
-      const err = new Error('boom')
-      expect(sanitizeLogArg(err)).toBe(err)
+    it('sanitizes Error message / stack and enumerable params without mutating the original', () => {
+      const err = Object.assign(
+        new Error('Failed query: UPDATE users SET twitch_access_token = $1\nparams: sensitive-token-value'),
+        {
+          query: 'UPDATE users SET twitch_access_token = $1',
+          params: ['sensitive-token-value'],
+        },
+      )
+      err.name = 'DrizzleQueryError'
+      err.stack = 'DrizzleQueryError: Failed query: UPDATE users SET twitch_access_token = $1\nparams: sensitive-token-value\n    at query.ts:1:1'
+
+      const out = sanitizeLogArg(err) as Error & { query: string; params: unknown }
+
+      expect(out).toBeInstanceOf(Error)
+      expect(out).not.toBe(err)
+      expect(out.name).toBe('DrizzleQueryError')
+      expect(out.message).toContain('params: [REDACTED]')
+      expect(out.message).not.toContain('sensitive-token-value')
+      expect(out.stack).toContain('params: [REDACTED]')
+      expect(out.stack).not.toContain('sensitive-token-value')
+      expect(out.query).toBe('UPDATE users SET twitch_access_token = $1')
+      expect(out.params).toBe('[REDACTED]')
+      expect(err.message).toContain('sensitive-token-value')
     })
 
     it.each([null, undefined, 42, 'plain', true])(
@@ -114,6 +142,12 @@ describe('log-sanitizer', () => {
       expect(
         extractErrorMessage({ code: '23505', message: 'duplicate key' })
       ).toBe('duplicate key')
+    })
+
+    it('redacts Drizzle-style params from message fields', () => {
+      expect(extractErrorMessage({
+        message: 'Failed query: UPDATE users SET twitch_access_token = $1\nparams: sensitive-token-value',
+      })).toBe('Failed query: UPDATE users SET twitch_access_token = $1\nparams: [REDACTED]')
     })
 
     it('falls back to JSON.stringify with redacted secrets when message is missing', () => {

--- a/tests/unit/log-sanitizer.test.ts
+++ b/tests/unit/log-sanitizer.test.ts
@@ -28,14 +28,14 @@ describe('log-sanitizer', () => {
       expect(isSensitiveKey(key)).toBe(true)
     })
 
-    it.each(['userId', 'username', 'email', 'ip_address'])(
+    it.each(['userId', 'username', 'email', 'ip_address', 'params'])(
       'redacts exact match key %s',
       (key) => {
         expect(isSensitiveKey(key)).toBe(true)
       }
     )
 
-    it.each(['broadcasterUserId', 'twitchUsername', 'streamerId', 'safeName'])(
+    it.each(['broadcasterUserId', 'twitchUsername', 'streamerId', 'safeName', 'queryParams'])(
       'keeps debug-friendly compound key %s',
       (key) => {
         expect(isSensitiveKey(key)).toBe(false)
@@ -61,6 +61,23 @@ describe('log-sanitizer', () => {
       expect(
         sanitizeContext({ items: [{ password: 'p' }, { name: 'n' }] })
       ).toEqual({ items: [{ password: '[REDACTED]' }, { name: 'n' }] })
+    })
+
+    it('redacts Drizzle-style bind params nested in a log context', () => {
+      const dbError = Object.assign(new Error('database query failed'), {
+        query: 'UPDATE users SET twitch_access_token = $1',
+        params: ['sensitive-token-value'],
+        cause: { code: '42703' },
+      })
+
+      expect(sanitizeContext({ twitchUserId: 'user-1', error: dbError })).toEqual({
+        twitchUserId: 'user-1',
+        error: {
+          query: 'UPDATE users SET twitch_access_token = $1',
+          params: '[REDACTED]',
+          cause: { code: '42703' },
+        },
+      })
     })
   })
 

--- a/tests/unit/log-sanitizer.test.ts
+++ b/tests/unit/log-sanitizer.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   isSensitiveKey,
   sanitizeContext,
+  sanitizeErrorText,
   sanitizeLogArg,
   extractErrorMessage,
 } from '@/lib/log-sanitizer'
@@ -41,6 +42,32 @@ describe('log-sanitizer', () => {
         expect(isSensitiveKey(key)).toBe(false)
       }
     )
+  })
+
+  describe('sanitizeErrorText', () => {
+    it('redacts multiline Drizzle bind params through the end of a message', () => {
+      expect(sanitizeErrorText(
+        'Failed query: INSERT INTO support_messages (body, token) VALUES ($1, $2)\n' +
+        'params: first line\nsecond line,sensitive-token-value'
+      )).toBe(
+        'Failed query: INSERT INTO support_messages (body, token) VALUES ($1, $2)\n' +
+        'params: [REDACTED]'
+      )
+    })
+
+    it('preserves stack frames after redacting multiline Drizzle bind params', () => {
+      expect(sanitizeErrorText(
+        'DrizzleQueryError: Failed query: INSERT INTO support_messages (body) VALUES ($1)\n' +
+        'params: first line\nsecond line\n' +
+        '    at query.ts:10:20\n' +
+        '    at route.ts:30:40'
+      )).toBe(
+        'DrizzleQueryError: Failed query: INSERT INTO support_messages (body) VALUES ($1)\n' +
+        'params: [REDACTED]\n' +
+        '    at query.ts:10:20\n' +
+        '    at route.ts:30:40'
+      )
+    })
   })
 
   describe('sanitizeContext', () => {

--- a/tests/unit/log-sanitizer.test.ts
+++ b/tests/unit/log-sanitizer.test.ts
@@ -87,6 +87,12 @@ describe('log-sanitizer', () => {
       ).toEqual({ items: [{ password: '[REDACTED]' }, { name: 'n' }] })
     })
 
+    it('sanitizes sensitive records inside nested arrays', () => {
+      expect(
+        sanitizeContext({ items: [[{ twitch_access_token: 'secret' }]] })
+      ).toEqual({ items: [[{ twitch_access_token: '[REDACTED]' }]] })
+    })
+
     it('redacts Drizzle-style bind params stored as a context string', () => {
       expect(sanitizeContext({
         error: 'Failed query: UPDATE users SET twitch_access_token = $1\nparams: sensitive-token-value',
@@ -249,6 +255,15 @@ describe('log-sanitizer', () => {
       expect(out).toContain('"code":500')
       expect(out).toContain('[REDACTED]')
       expect(out).not.toContain('secret')
+    })
+
+    it('redacts Drizzle-style params inside JSON fallback string values', () => {
+      const out = extractErrorMessage({
+        code: 500,
+        detail: 'Failed query: UPDATE users SET twitch_access_token = $1\nparams: sensitive-token-value',
+      })
+      expect(out).toContain('params: [REDACTED]')
+      expect(out).not.toContain('sensitive-token-value')
     })
 
     it('handles circular references safely', () => {

--- a/tests/unit/log-sanitizer.test.ts
+++ b/tests/unit/log-sanitizer.test.ts
@@ -55,17 +55,14 @@ describe('log-sanitizer', () => {
       )
     })
 
-    it('preserves stack frames after redacting multiline Drizzle bind params', () => {
+    it('does not trust stack-frame-like text inside bind values as a redaction boundary', () => {
       expect(sanitizeErrorText(
-        'DrizzleQueryError: Failed query: INSERT INTO support_messages (body) VALUES ($1)\n' +
-        'params: first line\nsecond line\n' +
-        '    at query.ts:10:20\n' +
-        '    at route.ts:30:40'
+        'DrizzleQueryError: Failed query: INSERT INTO support_messages (body, token) VALUES ($1, $2)\n' +
+        'params: hello\n    at attacker,sensitive-token-value\n' +
+        '    at query.ts:10:20'
       )).toBe(
-        'DrizzleQueryError: Failed query: INSERT INTO support_messages (body) VALUES ($1)\n' +
-        'params: [REDACTED]\n' +
-        '    at query.ts:10:20\n' +
-        '    at route.ts:30:40'
+        'DrizzleQueryError: Failed query: INSERT INTO support_messages (body, token) VALUES ($1, $2)\n' +
+        'params: [REDACTED]'
       )
     })
   })
@@ -122,7 +119,7 @@ describe('log-sanitizer', () => {
       expect(nested.message).toContain('params: [REDACTED]')
       expect(nested.message).not.toContain('sensitive-token-value')
       expect(nested.stack).toContain('params: [REDACTED]')
-      expect(nested.stack).toContain('at query.ts:1:1')
+      expect(nested.stack).not.toContain('sensitive-token-value')
       expect(nested.params).toBe('[REDACTED]')
       expect(nested.query).toBe('UPDATE users SET twitch_access_token = $1')
       expect(nested.cause).toEqual({ code: '42703' })
@@ -168,7 +165,6 @@ describe('log-sanitizer', () => {
       expect(out.message).toContain('params: [REDACTED]')
       expect(out.message).not.toContain('sensitive-token-value')
       expect(out.stack).toContain('params: [REDACTED]')
-      expect(out.stack).toContain('at query.ts:1:1')
       expect(out.stack).not.toContain('sensitive-token-value')
       expect(out.query).toBe('UPDATE users SET twitch_access_token = $1')
       expect(out.params).toBe('[REDACTED]')

--- a/tests/unit/log-sanitizer.test.ts
+++ b/tests/unit/log-sanitizer.test.ts
@@ -71,21 +71,34 @@ describe('log-sanitizer', () => {
       })
     })
 
-    it('redacts Drizzle-style bind params nested in a log context', () => {
-      const dbError = Object.assign(new Error('database query failed'), {
-        query: 'UPDATE users SET twitch_access_token = $1',
-        params: ['sensitive-token-value'],
-        cause: { code: '42703' },
-      })
-
-      expect(sanitizeContext({ twitchUserId: 'user-1', error: dbError })).toEqual({
-        twitchUserId: 'user-1',
-        error: {
+    it('preserves a nested Error while redacting its message / stack / params', () => {
+      const dbError = Object.assign(
+        new Error('Failed query: UPDATE users SET twitch_access_token = $1\nparams: sensitive-token-value'),
+        {
           query: 'UPDATE users SET twitch_access_token = $1',
-          params: '[REDACTED]',
+          params: ['sensitive-token-value'],
           cause: { code: '42703' },
         },
-      })
+      )
+      dbError.name = 'DrizzleQueryError'
+      dbError.stack = 'DrizzleQueryError: Failed query: UPDATE users SET twitch_access_token = $1\nparams: sensitive-token-value\n    at query.ts:1:1'
+
+      const sanitized = sanitizeContext({ twitchUserId: 'user-1', error: dbError })
+      const nested = sanitized.error as Error & {
+        query: string
+        params: unknown
+        cause: { code: string }
+      }
+
+      expect(sanitized.twitchUserId).toBe('user-1')
+      expect(nested).toBeInstanceOf(Error)
+      expect(nested.message).toContain('params: [REDACTED]')
+      expect(nested.message).not.toContain('sensitive-token-value')
+      expect(nested.stack).toContain('params: [REDACTED]')
+      expect(nested.stack).toContain('at query.ts:1:1')
+      expect(nested.params).toBe('[REDACTED]')
+      expect(nested.query).toBe('UPDATE users SET twitch_access_token = $1')
+      expect(nested.cause).toEqual({ code: '42703' })
     })
   })
 
@@ -116,6 +129,7 @@ describe('log-sanitizer', () => {
       expect(out.message).toContain('params: [REDACTED]')
       expect(out.message).not.toContain('sensitive-token-value')
       expect(out.stack).toContain('params: [REDACTED]')
+      expect(out.stack).toContain('at query.ts:1:1')
       expect(out.stack).not.toContain('sensitive-token-value')
       expect(out.query).toBe('UPDATE users SET twitch_access_token = $1')
       expect(out.params).toBe('[REDACTED]')

--- a/tests/unit/logger-server.test.ts
+++ b/tests/unit/logger-server.test.ts
@@ -33,14 +33,36 @@ describe('server-only logger boundary', () => {
     expect(mockLogErrorFromLogger).not.toHaveBeenCalled()
   })
 
-  it('errorは共有console loggerへ出力後、server側だけでDB永続化を開始する', () => {
+  it('errorはconsole委譲後、サニタイズ済みargsだけをDB永続化へ渡す', () => {
     const context = { operation: 'query', access_token: 'secret' }
 
     logger.error('database failed', context)
 
-    // console側のredactionは共有logger、DB側のredactionはerror-handlerが担当する。
-    // server logger自身で変形しないことで両実装の責務と既存契約を維持する。
+    // console側のredactionは共有loggerに委譲するため、server境界ではraw引数をそのまま渡す。
     expect(consoleLogger.error).toHaveBeenCalledWith('database failed', context)
-    expect(mockLogErrorFromLogger).toHaveBeenCalledWith('database failed', [context])
+    // DB永続化側は共有sanitizerを先に通し、raw secretをerror-handlerへ渡さない。
+    expect(mockLogErrorFromLogger).toHaveBeenCalledWith('database failed', [
+      { operation: 'query', access_token: '[REDACTED]' },
+    ])
+  })
+
+  it('Drizzle-style Errorのmessage / stack / paramsをDB永続化前に検閲する', () => {
+    const dbError = Object.assign(
+      new Error('Failed query: UPDATE users SET twitch_access_token = $1\nparams: sensitive-token-value'),
+      { params: ['sensitive-token-value'] },
+    )
+    dbError.name = 'DrizzleQueryError'
+    dbError.stack = 'DrizzleQueryError: Failed query: UPDATE users SET twitch_access_token = $1\nparams: sensitive-token-value\n    at query.ts:1:1'
+
+    logger.error('token save failed', dbError)
+
+    expect(consoleLogger.error).toHaveBeenCalledWith('token save failed', dbError)
+    const persisted = mockLogErrorFromLogger.mock.calls[0][1][0] as Error & { params: unknown }
+    expect(persisted).toBeInstanceOf(Error)
+    expect(persisted.message).toContain('params: [REDACTED]')
+    expect(persisted.message).not.toContain('sensitive-token-value')
+    expect(persisted.stack).toContain('params: [REDACTED]')
+    expect(persisted.stack).not.toContain('sensitive-token-value')
+    expect(persisted.params).toBe('[REDACTED]')
   })
 })

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -34,10 +34,14 @@ describe('logger', () => {
       expect(consoleWarnMock).toHaveBeenCalledWith('[WARN] warning message')
     })
 
-    it('passes Error instances through untouched', () => {
+    it('keeps Error shape while sanitizing Error arguments', () => {
       const error = new Error('test error')
       logger.warn('warning message', error)
-      expect(consoleWarnMock).toHaveBeenCalledWith('[WARN] warning message', error)
+
+      const loggedError = consoleWarnMock.mock.calls[0]?.[1]
+      expect(loggedError).toBeInstanceOf(Error)
+      expect(loggedError).not.toBe(error)
+      expect((loggedError as Error).message).toBe('test error')
     })
   })
 
@@ -91,10 +95,24 @@ describe('logger', () => {
       })
     })
 
-    it('keeps Error instances untouched so stack traces remain available', () => {
-      const err = new Error('boom')
+    it('redacts Drizzle params embedded in the log message', () => {
+      logger.error('query failed\nparams: secret-bind-value')
+      expect(consoleErrorMock).toHaveBeenCalledWith('[ERROR] query failed\nparams: [REDACTED]')
+    })
+
+    it('preserves Error diagnostics while redacting Drizzle params', () => {
+      const err = new Error('query failed\nparams: secret-bind-value')
+      err.stack = 'Error: query failed\nparams: secret-bind-value\n    at test-callsite'
+
       logger.error('failure', err)
-      expect(consoleErrorMock).toHaveBeenCalledWith('[ERROR] failure', err)
+
+      const loggedError = consoleErrorMock.mock.calls[0]?.[1]
+      expect(loggedError).toBeInstanceOf(Error)
+      expect(loggedError).not.toBe(err)
+      expect((loggedError as Error).message).toBe('query failed\nparams: [REDACTED]')
+      expect((loggedError as Error).stack).toContain('params: [REDACTED]')
+      expect((loggedError as Error).stack).toContain('at test-callsite')
+      expect((loggedError as Error).stack).not.toContain('secret-bind-value')
     })
   })
 })

--- a/tests/unit/sentry-error-redaction.test.ts
+++ b/tests/unit/sentry-error-redaction.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDb } from '@/lib/db/client'
+import { logErrorFromLogger, reportError } from '@/lib/sentry/error-handler'
+
+vi.mock('@/lib/db/client', () => ({
+  getDb: vi.fn(),
+}))
+
+const mockValues = vi.fn().mockResolvedValue(undefined)
+const mockInsert = vi.fn().mockReturnValue({ values: mockValues })
+
+function drizzleStyleError(): Error & { params: string[] } {
+  const error = Object.assign(
+    new Error('Failed query: UPDATE users SET twitch_access_token = $1\nparams: sensitive-token-value'),
+    { params: ['sensitive-token-value'] },
+  )
+  error.name = 'DrizzleQueryError'
+  error.stack = 'DrizzleQueryError: Failed query: UPDATE users SET twitch_access_token = $1\nparams: sensitive-token-value\n    at query.ts:1:1'
+  return error
+}
+
+describe('sentry error persistence redaction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('NEXT_RUNTIME', 'nodejs')
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.mocked(getDb).mockResolvedValue({
+      db: { insert: mockInsert } as never,
+      sql: {} as never,
+    })
+  })
+
+  it('reportErrorはDrizzle message / stackのbind paramsをDBへ保存しない', async () => {
+    await reportError(drizzleStyleError())
+
+    const values = mockValues.mock.calls[0][0]
+    expect(values.message).toContain('params: [REDACTED]')
+    expect(values.message).not.toContain('sensitive-token-value')
+    expect(values.stack_trace).toContain('params: [REDACTED]')
+    expect(values.stack_trace).toContain('at query.ts:1:1')
+    expect(values.stack_trace).not.toContain('sensitive-token-value')
+  })
+
+  it('logErrorFromLoggerへraw Errorを直接渡してもbind paramsをDBへ保存しない', async () => {
+    await logErrorFromLogger('token save failed', [drizzleStyleError()])
+
+    const values = mockValues.mock.calls[0][0]
+    expect(values.message).toContain('token save failed Failed query:')
+    expect(values.message).toContain('params: [REDACTED]')
+    expect(values.message).not.toContain('sensitive-token-value')
+    expect(values.stack_trace).toContain('params: [REDACTED]')
+    expect(values.stack_trace).not.toContain('sensitive-token-value')
+  })
+})

--- a/tests/unit/twitch-token-error-original-error.test.ts
+++ b/tests/unit/twitch-token-error-original-error.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { TwitchTokenError } from '@/lib/twitch/token-manager'
+
+describe('TwitchTokenError originalError policy', () => {
+  it('DATABASE_ERRORでは生のDBエラーを保持しない', () => {
+    const originalError = Object.assign(new Error('database query failed'), {
+      params: ['sensitive-token-value'],
+    })
+
+    const error = new TwitchTokenError(
+      'Failed to fetch user tokens from database',
+      'DATABASE_ERROR',
+      originalError,
+    )
+
+    expect(error.originalError).toBeUndefined()
+  })
+
+  it('DATABASE_ERROR以外では既存のoriginalError契約を維持する', () => {
+    const originalError = new Error('refresh failed')
+
+    const error = new TwitchTokenError(
+      'Failed to refresh Twitch access token',
+      'REFRESH_FAILED',
+      originalError,
+    )
+
+    expect(error.originalError).toBe(originalError)
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1242 の判断不要な項目として、一般ログ文字列でも行頭 `params:` 以降がfail-closedで検閲される現在の境界をドキュメント化します。

- `sanitizeErrorText()` がproducerを判別せず、行頭（空白許容）の `params:` を機密bind値の開始として扱うことを明記
- `params:` 以降を文字列末尾まで検閲する理由を記録
- Drizzle以外の自由形式ログでも同形なら偽陽性で末尾が落ちることを明文化
- 現matcherが行頭書式に依存し、将来Drizzleが同一行へ平坦化した場合は契約・テストの再確認が必要と記録
- 親PR #1241のマージ後、増分はdocs-onlyの新規1ファイル

## 検証

- exact HEAD `dd298226`: CI成功
- Claude Auto Review成功（必須指摘なし）
- 実行コード、sanitizer、ログ出力、DB、設定、依存関係の変更なし

Refs #1242 #1241