### PR TITLE
test(live): 通常loginのLIVE ring陽性対照を固定

### DIFF
--- a/tests/unit/components/live-directory-normal-login-ring.test.tsx
+++ b/tests/unit/components/live-directory-normal-login-ring.test.tsx
@@ -1,0 +1,62 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { describe, expect, it } from "vitest";
+import LiveDirectory from "@/components/LiveDirectory";
+import type {
+  LiveDirectoryEntry,
+  LiveDirectoryRankingEntry,
+} from "@/lib/live-directory";
+import jaMessages from "../../../messages/ja.json";
+
+const normalLoginEntry: LiveDirectoryEntry = {
+  streamerId: "normal-login-streamer",
+  twitchUserId: "twitch-normal-login-streamer",
+  twitchLogin: "normal-login-streamer",
+  displayName: "Normal Login Streamer",
+  profileImageUrl: "https://example.com/normal-login-streamer-profile.png",
+  title: "normal login stream",
+  gameName: "Game",
+  viewerCount: 1,
+  startedAt: "2026-08-11T02:00:00Z",
+  thumbnailUrl: "https://example.com/normal-login-streamer-thumbnail.jpg",
+};
+
+const normalLoginRanking: LiveDirectoryRankingEntry = {
+  identity: {
+    twitchLogin: normalLoginEntry.twitchLogin,
+    displayName: normalLoginEntry.displayName,
+    profileImageUrl: normalLoginEntry.profileImageUrl,
+  },
+  cardCount: 1,
+  redemptionCount: 1,
+  totalPoints: 100,
+  rankedMetrics: ["cardCount", "redemptionCount", "totalPoints"],
+};
+
+describe("live directory normal-login positive control (#1277)", () => {
+  it("keeps the LIVE ring on the matching normal-login avatar", () => {
+    render(
+      <NextIntlClientProvider locale="ja" messages={jaMessages}>
+        <LiveDirectory
+          entries={[normalLoginEntry]}
+          rankings={{
+            last7Days: [normalLoginRanking],
+            allTime: [normalLoginRanking],
+          }}
+          referenceTime="2026-08-11T03:00:00Z"
+        />
+      </NextIntlClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "チャネルポイントランキング" }));
+
+    const normalRankingLink = screen.getByRole("link", {
+      name: /Normal Login StreamerをTwitchで見る/,
+    });
+    const avatar = normalRankingLink.querySelector("img");
+
+    expect(normalRankingLink).toHaveTextContent("LIVE");
+    expect(normalRankingLink).toHaveTextContent("現在配信中");
+    expect(normalRankingLink.querySelector(".ring-red-600")).toBe(avatar);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1277 の判断不要な軽量フォローアップとして、通常loginが一致するランキング行でLIVE ringが画像avatarへ付く契約を独立した回帰テストで固定します。

- 通常loginのランキング行が `LIVE` / `現在配信中` を表示することを確認
- `.ring-red-600` がリンク内の `img` avatarそのものへ付くことを確認
- 親PR #1271 のマージ後、最新 `preview` 上へ新規test-only 1ファイルだけを載せ直し
- 本番コード・翻訳・DB・設定・依存関係には変更なし

## スコープ外

Issue #1277 のfixture factory化など、残る任意改善は別の小粒対応として追跡します。

Refs #1277 #1271