### PR TITLE
docs(test): rate-limit fallbackのfake timers理由を明記

### DIFF
--- a/tests/unit/rate-limit-kv-binding-fallback.test.ts
+++ b/tests/unit/rate-limit-kv-binding-fallback.test.ts
@@ -18,6 +18,8 @@ describe("rate-limit KV binding fallback", () => {
     // 各ケースを fresh module で開始して初回 binding 解決の契約だけを検証する。
     vi.resetModules();
     mocks.getKvBinding.mockReset();
+    // MemoryRateLimitStorage の module-scope cleanup interval を、
+    // vi.resetModules() ごとに実時間タイマーとして積み残さないため fake timers を使う。
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
   });


### PR DESCRIPTION
## 概要

Issue #1265 の軽量フォローアップとして、`rate-limit-kv-binding-fallback.test.ts` でfake timersを使う理由をコメントで明文化します。

- module scopeで生成される `MemoryRateLimitStorage` インスタンスのcleanup intervalを、`vi.resetModules()` ごとに実時間タイマーとして積み残さないためと記録
- fixture・assertion・実行コード・本番コード・設定・依存関係の変更なし
- comment-only

## 検証

- exact HEAD `5101fa9d`: CI成功
- 旧exact HEADの厳正レビューおよびClaude Auto Review: 必須指摘なし
- 最新HEADのClaude実行はレビュー処理自体の基盤エラーで2回失敗し、コード指摘・review artifactは生成されず
- 最新 `preview` 上の差分を手動再確認し、コメント2行のみ

残る任意改善は #1265 で継続追跡します。

Refs #1265 #1264