### PR TITLE
docs(test): rate-limit reject fixtureの防御的意図を明記

### DIFF
--- a/tests/unit/rate-limit-kv-binding-fallback.test.ts
+++ b/tests/unit/rate-limit-kv-binding-fallback.test.ts
@@ -35,6 +35,8 @@ describe("rate-limit KV binding fallback", () => {
     },
     {
       label: "binding 解決が reject する",
+      // 現行 getKvBinding() は内部例外を null に畳むため、通常は到達しない防御的fixture。
+      // helper が将来 throw する実装へ変わっても rate-limit 側の fail-open を維持する契約を固定する。
       arrange: () => mocks.getKvBinding.mockRejectedValue(new Error("RATE_LIMIT_KV unavailable")),
     },
   ])("getKvBinding が $label 場合もメモリへfallbackしてカウントを継続する", async ({ arrange }) => {


### PR DESCRIPTION
## 概要

Issue #1265 の軽量フォローアップとして、`rate-limit-kv-binding-fallback.test.ts` のreject fixtureが防御的契約である理由をコメントで明文化します。

- 現行 `getKvBinding()` は内部例外を `null` に畳むため通常経路では到達しないことを記録
- helperが将来throwする実装へ変わっても、rate-limit側のfail-openを維持する契約を固定
- comment-onlyでfixture・assertion・本番コード・設定・依存関係の変更なし

## 検証

- exact HEAD `8a762d94`: CI成功
- 厳正レビュー: 必須指摘なし
- 最新Claude実行はレビュー基盤ステップでartifact生成前に失敗し、コード指摘なし

残るfixture配置や追加説明は実行契約を変えない任意改善のため、本PRの収束条件にしません。

Refs #1265