### PR TITLE
docs(test): EventSub health scheduled回帰テストの根拠を明記

### DIFF
--- a/tests/unit/error-reporter-eventsub-health-scheduled.test.ts
+++ b/tests/unit/error-reporter-eventsub-health-scheduled.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import worker from '../../workers/error-reporter/src/index';
 
+// workers/error-reporter/src/index.ts の scheduled() が説明する通り、EventSub health は
+// reporter 用 binding/secrets の設定ミスに巻き込まれず動く必要がある。このテストは、
+// その監視を既存 reporter の環境変数バリデーションより前に実行する順序契約を固定する。
 describe('error-reporter scheduled EventSub health wiring', () => {
   afterEach(() => {
     vi.unstubAllGlobals();


### PR DESCRIPTION
## 概要

Issue #1226 の軽量フォローアップとして、`tests/unit/error-reporter-eventsub-health-scheduled.test.ts` に回帰テストの根拠コメントを追加します。

- `workers/error-reporter/src/index.ts` の `scheduled()` が持つ順序契約へ直接つながる説明を追加
- EventSub health 監視が reporter 用 binding/secrets の設定ミスに巻き込まれて停止しないことが、このテストの目的だと明文化
- comment-onlyで fixture・assertion・本番コード・設定・依存関係の変更なし

## 検証

- `preview` との差分は1ファイル・+3行のみ
- 実行挙動は変更しないため、既存CIで回帰がないことを確認する

Issue #1226 のその他の任意改善は本PRの収束条件に含めません。

Refs #1226 #1225 #1010