### PR TITLE
perf(live): ヘッダー用データをdirectory取得と並列化

### DIFF
--- a/src/app/live/page.tsx
+++ b/src/app/live/page.tsx
@@ -39,12 +39,28 @@ export async function generateMetadata(): Promise<Metadata> {
  * 伴う警告だからだ（Header/DashboardNav自体はそれらに依存しない）。
  */
 export default async function LivePage() {
-  const [session, entries, presence, rankings, t] = await Promise.all([
-    getSession(),
-    getLiveDirectory(),
-    getLiveDirectoryPresence(),
-    getLiveDirectoryRankings(),
-    getTranslations("livePage"),
+  // sessionだけはヘッダー分岐に必要だが、directory系と翻訳は先に開始する。
+  // ログイン済みならsession解決直後にplan / unreadも開始し、遅いdirectory取得の
+  // 完了後までヘッダー用DB照会を直列化しない（Issue #1130）。
+  const sessionPromise = getSession();
+  const entriesPromise = getLiveDirectory();
+  const presencePromise = getLiveDirectoryPresence();
+  const rankingsPromise = getLiveDirectoryRankings();
+  const translationsPromise = getTranslations("livePage");
+
+  const session = await sessionPromise;
+  const authenticatedHeaderPromise = session
+    ? Promise.all([
+        getUserPlanSnapshot(session.twitchUserId),
+        getUnreadAnnouncements(session.twitchUserId),
+      ])
+    : undefined;
+
+  const [entries, presence, rankings, t] = await Promise.all([
+    entriesPromise,
+    presencePromise,
+    rankingsPromise,
+    translationsPromise,
   ]);
 
   // Serverで基準時刻を1回だけ確定し、Client ComponentのSSR/hydration間で
@@ -83,7 +99,7 @@ export default async function LivePage() {
     </>
   );
 
-  if (!session) {
+  if (!session || !authenticatedHeaderPromise) {
     return (
       <div className="min-h-screen bg-gray-900">
         <header className="border-b border-gray-800">
@@ -117,12 +133,9 @@ export default async function LivePage() {
   // ダッシュボードレイアウトと同じHeader+DashboardNavの組み合わせ。
   // 未読数・プラン判定はダッシュボードレイアウトと同じReact cache付き関数で、
   // 失敗時は basic / 0件 へ縮退する（公開ページを500にしない）。
-  // ただし/liveにはダッシュボードlayoutが無いため、ログイン済み訪問1回あたり
-  // この2クエリが純増する（cacheは同一リクエスト内の重複排除であり初回は走る）。
-  const [plan, unreadAnnouncements] = await Promise.all([
-    getUserPlanSnapshot(session.twitchUserId),
-    getUnreadAnnouncements(session.twitchUserId),
-  ]);
+  // /liveにはダッシュボードlayoutが無いためログイン済み訪問1回あたり2クエリは
+  // 純増するが、上でdirectory系と並列に開始してレスポンス待ち時間へ直列加算しない。
+  const [plan, unreadAnnouncements] = await authenticatedHeaderPromise;
 
   return (
     <div className="min-h-screen bg-gray-900">

--- a/tests/unit/live-page-data-concurrency.test.tsx
+++ b/tests/unit/live-page-data-concurrency.test.tsx
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSession: vi.fn(),
+  canUseStreamerFeatures: vi.fn(),
+  getLiveDirectory: vi.fn(),
+  getLiveDirectoryPresence: vi.fn(),
+  getLiveDirectoryRankings: vi.fn(),
+  getTranslations: vi.fn(),
+  getUnreadAnnouncements: vi.fn(),
+  getUserPlanSnapshot: vi.fn(),
+}));
+
+vi.mock("@/lib/session", () => ({
+  getSession: mocks.getSession,
+  canUseStreamerFeatures: mocks.canUseStreamerFeatures,
+}));
+vi.mock("@/lib/live-directory", () => ({
+  getLiveDirectory: mocks.getLiveDirectory,
+  getLiveDirectoryPresence: mocks.getLiveDirectoryPresence,
+  getLiveDirectoryRankings: mocks.getLiveDirectoryRankings,
+}));
+vi.mock("@/lib/announcements", () => ({
+  getUnreadAnnouncements: mocks.getUnreadAnnouncements,
+}));
+vi.mock("@/lib/plan", () => ({
+  getUserPlanSnapshot: mocks.getUserPlanSnapshot,
+}));
+vi.mock("next-intl/server", () => ({
+  getTranslations: mocks.getTranslations,
+}));
+vi.mock("@/components/LiveDirectory", () => ({ default: () => null }));
+vi.mock("@/components/Header", () => ({ default: () => null }));
+vi.mock("@/components/DashboardNav", () => ({ default: () => null }));
+vi.mock("@/components/PublicFooter", () => ({ default: () => null }));
+
+import LivePage from "@/app/live/page";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
+describe("LivePage data concurrency", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSession.mockResolvedValue({ twitchUserId: "user-1" });
+    mocks.canUseStreamerFeatures.mockReturnValue(false);
+    mocks.getLiveDirectoryPresence.mockResolvedValue(null);
+    mocks.getLiveDirectoryRankings.mockResolvedValue({ last7Days: [], allTime: [] });
+    mocks.getTranslations.mockResolvedValue((key: string) => key);
+    mocks.getUnreadAnnouncements.mockResolvedValue([]);
+    mocks.getUserPlanSnapshot.mockResolvedValue("basic");
+  });
+
+  it("starts authenticated header queries before a slow directory request finishes", async () => {
+    const directory = deferred<unknown[]>();
+    mocks.getLiveDirectory.mockReturnValue(directory.promise);
+
+    const pagePromise = LivePage();
+
+    // getSession() の解決だけを進め、directory promise は未解決のまま維持する。
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.getUserPlanSnapshot).toHaveBeenCalledWith("user-1");
+    expect(mocks.getUnreadAnnouncements).toHaveBeenCalledWith("user-1");
+
+    directory.resolve([]);
+    await expect(pagePromise).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1130 のうち、ログイン済み `/live` でdirectory取得完了後までplan／未読取得が直列化されていた点を解消します。

- session・directory・presence・rankings・翻訳を同時に開始
- session解決直後にplanと未読お知らせの取得を開始
- directoryが遅い場合もヘッダー用DB照会を先行させる
- 未ログイン時はplan／未読を呼ばない既存契約を維持
- 遅延directoryを未解決のまま、plan／未読が開始される回帰テストを追加

## 影響範囲

データ取得の開始順序だけを変更します。表示、API、DBクエリ内容、キャッシュ、翻訳、依存関係には変更ありません。

LIVE ring / badge分岐の共通化やi18nキー改名は挙動不変の任意リファクタなので、本PRには含めません。

Refs #1130