### PR TITLE
ci: reopened 昇格PRを再検証する

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -6,7 +6,7 @@ name: Notify Discord on main merge
 # `contents: read`; do not widen them without a reviewed workflow requirement.
 on:
   pull_request_target:
-    types: [opened, edited, synchronize, closed]
+    types: [opened, edited, synchronize, reopened, closed]
     branches: [main]
 
 permissions:


### PR DESCRIPTION
## 概要

`preview -> main` の昇格PRを再オープンしたときにも `validate-promotion-summary` が再実行されるよう、`pull_request_target` の対象 action に `reopened` を追加します。

Refs #1113

## 変更内容

- `.github/workflows/notify-discord-main-merge.yml` の `pull_request_target.types` に `reopened` を追加
- validation / notify ロジック自体は変更しない
- `ready_for_review` など #1113 の他の任意項目は本PRの収束条件に含めない

## 確認観点

- 再オープンされた `preview -> main` PRで validation job が起動する
- `closed` 時の Discord 通知条件には影響しない
- workflow 権限・secret 取扱いは変更しない
