### PR TITLE
test: 503 URL負例fixtureの意図を明文化

### DIFF
--- a/tests/unit/error-handler.test.ts
+++ b/tests/unit/error-handler.test.ts
@@ -130,6 +130,7 @@ describe('error-handler', () => {
       'avatar-401.jpg',
       'asset-507-preview.png',
       'https://example.com/assets/503.png',
+      // 短いホスト名 `a` は `http` と `503` の距離を意図的に詰め、近傍regexへ戻した退行も検知する。
       'PUT http://a/503 failed',
     ])('文脈のない数値をHTTP statusとして誤分類しない: %s', async (errorMessage) => {
       const response = await handleBlobError(new Error(errorMessage), 'blob');


### PR DESCRIPTION
## 概要

Issue #989 のノンブロッキング改善から、`PUT http://a/503 failed` という負例で短いホスト名 `a` を使っている理由をテスト内コメントで明文化します。

## 変更

- `tests/unit/error-handler.test.ts` の既存fixture直前に1行コメントを追加
- `http` と `503` の距離を意図的に短くし、将来近傍regexへ戻した退行も検知するfixtureであることを記録
- 本番コード、fixture値、assertion、挙動は変更なし

## スコープ

#989 の他の文字列判定統合・R2実ログ検証・境界値テスト等は本PRの収束条件にしません。

Refs #989