### PR TITLE
test: 503負例コメントに近傍regexを明記

### DIFF
--- a/tests/unit/error-handler.test.ts
+++ b/tests/unit/error-handler.test.ts
@@ -130,7 +130,7 @@ describe('error-handler', () => {
       'avatar-401.jpg',
       'asset-507-preview.png',
       'https://example.com/assets/503.png',
-      // 短いホスト名 `a` は `http` と `503` の距離を意図的に詰め、近傍regexへ戻した退行も検知する。
+      // 短いホスト名 `a` は `http` と `503` の距離を意図的に詰め、r2-client の `\D{0,10}` 近傍regexへ戻した退行も検知する。
       'PUT http://a/503 failed',
     ])('文脈のない数値をHTTP statusとして誤分類しない: %s', async (errorMessage) => {
       const response = await handleBlobError(new Error(errorMessage), 'blob');


### PR DESCRIPTION
## 概要

Issue #989 のノンブロッキング改善として、PR #1305 の Auto Review で任意指摘された「近傍regex」の参照先を具体化します。

## 変更

- `tests/unit/error-handler.test.ts` の既存コメントへ `r2-client` の `\D{0,10}` 近傍regexを明記
- fixture・assertion・本番コード・実行挙動は変更なし
- `preview` HEAD との差分は1ファイルのコメント1行置換のみ

## スコープ

#989 の残りの判定器統合、実R2ログ検証、境界値テスト等は本PRの収束条件に含めません。

Refs #989 #1305