### PR TITLE
test: emotes診断テスト名を契約に合わせる

### DIFF
--- a/tests/unit/twitch-emotes-error-reporting.test.ts
+++ b/tests/unit/twitch-emotes-error-reporting.test.ts
@@ -37,7 +37,7 @@ describe('GET /api/twitch/emotes error reporting', () => {
     })
   })
 
-  it('token refresh失敗時の安全な診断contextをhandleApiErrorへ渡す', async () => {
+  it('token refresh失敗時の診断contextをhandleApiErrorへ渡す', async () => {
     const tokenError = new Error('refresh failed')
     const reportContext = {
       refreshStatus: 503,


### PR DESCRIPTION
## 概要

Issue #1088 の判断不要な軽量フォローアップとして、emotes の結線回帰テスト名が実際の検証範囲を超えて「安全な診断context」と主張していた表現を正確化します。

## 変更

- `tests/unit/twitch-emotes-error-reporting.test.ts` のテスト名から「安全な」を削除
- token-manager helper 自体をモックしているため、このテストが検証するのは route から `handleApiError` への診断context結線まで
- fixture・assertion・実装コード・実行挙動は変更なし

## スコープ

#1088 の残りの共通化、実helperを通す強いテスト、rate limit整理等は本PRの収束条件に含めません。

Refs #1088 #1119