### PR TITLE
test(sound): premium制限応答の表示を固定

### DIFF
--- a/tests/unit/components/gacha-sound-settings-premium-required.test.tsx
+++ b/tests/unit/components/gacha-sound-settings-premium-required.test.tsx
@@ -19,6 +19,8 @@ const rule: GachaSoundRule = {
   rewardName: null,
 };
 
+const premiumRequiredMessage = "複数効果音・ターゲット指定は助力プラン以上の機能です。";
+
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
@@ -26,16 +28,9 @@ afterEach(() => {
 });
 
 describe("GachaSoundSettings premium-required save response", () => {
-  it("gachaSoundRulesPremiumRequiredを受信すると制限メッセージを表示する", async () => {
+  it("gachaSoundRulesPremiumRequiredを受信すると制限メッセージを追加表示する", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
-
-      if (url.includes("/api/twitch/rewards")) {
-        return new Response(JSON.stringify([]), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        });
-      }
 
       if (url.includes("/api/streamer/settings")) {
         return new Response(
@@ -58,13 +53,11 @@ describe("GachaSoundSettings premium-required save response", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    // supportプランでは制限バナーが初期表示されないため、API応答で表示された
-    // premiumRequiredメッセージだけを独立して検証できる。
     render(
       <NextIntlClientProvider locale="ja" messages={jaMessages}>
         <GachaSoundSettings
           streamerId="streamer-1"
-          plan="support"
+          plan="basic"
           currentSoundUrl={null}
           currentSoundEnabled={false}
           currentSoundRules={[rule] as unknown as Json}
@@ -74,14 +67,9 @@ describe("GachaSoundSettings premium-required save response", () => {
       </NextIntlClientProvider>
     );
 
-    await waitFor(() => {
-      expect(
-        fetchMock.mock.calls.some(([input]) => String(input).includes("/api/twitch/rewards"))
-      ).toBe(true);
-    });
-    expect(
-      screen.queryByText("複数効果音・ターゲット指定は助力プラン以上の機能です。")
-    ).not.toBeInTheDocument();
+    // basicプランでは案内バナーが常時1件ある。保存応答のflagを受けた後に
+    // 同文言のエラーメッセージがもう1件増えることで、応答処理を区別して検証する。
+    expect(screen.getAllByText(premiumRequiredMessage)).toHaveLength(1);
 
     fireEvent.click(screen.getByLabelText("効果音を有効にする"));
 
@@ -89,9 +77,7 @@ describe("GachaSoundSettings premium-required save response", () => {
       expect(
         fetchMock.mock.calls.some(([input]) => String(input).includes("/api/streamer/settings"))
       ).toBe(true);
+      expect(screen.getAllByText(premiumRequiredMessage)).toHaveLength(2);
     });
-    expect(
-      await screen.findByText("複数効果音・ターゲット指定は助力プラン以上の機能です。")
-    ).toBeInTheDocument();
   });
 });

--- a/tests/unit/components/gacha-sound-settings-premium-required.test.tsx
+++ b/tests/unit/components/gacha-sound-settings-premium-required.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import GachaSoundSettings from "@/components/GachaSoundSettings";
+import jaMessages from "../../../messages/ja.json";
+import type { GachaSoundRule } from "@/lib/gacha-sound-rules";
+import type { Json } from "@/types/database";
+
+vi.mock("@/lib/logger");
+
+const rule: GachaSoundRule = {
+  id: "rule-1",
+  url: "https://example.com/sound.mp3",
+  enabled: true,
+  label: "効果音",
+  targetType: "all",
+  rarity: null,
+  rewardId: null,
+  rewardName: null,
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("GachaSoundSettings premium-required save response", () => {
+  it("gachaSoundRulesPremiumRequiredを受信すると制限メッセージを表示する", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.includes("/api/twitch/rewards")) {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      if (url.includes("/api/streamer/settings")) {
+        return new Response(
+          JSON.stringify({
+            success: true,
+            gachaSoundRules: [{ ...rule, enabled: false }],
+            gachaSoundRulesPremiumRequired: true,
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }
+        );
+      }
+
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // supportプランでは制限バナーが初期表示されないため、API応答で表示された
+    // premiumRequiredメッセージだけを独立して検証できる。
+    render(
+      <NextIntlClientProvider locale="ja" messages={jaMessages}>
+        <GachaSoundSettings
+          streamerId="streamer-1"
+          plan="support"
+          currentSoundUrl={null}
+          currentSoundEnabled={false}
+          currentSoundRules={[rule] as unknown as Json}
+          currentRewardId={null}
+          currentRewardName={null}
+        />
+      </NextIntlClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([input]) => String(input).includes("/api/twitch/rewards"))
+      ).toBe(true);
+    });
+    expect(
+      screen.queryByText("複数効果音・ターゲット指定は助力プラン以上の機能です。")
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("効果音を有効にする"));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([input]) => String(input).includes("/api/streamer/settings"))
+      ).toBe(true);
+    });
+    expect(
+      await screen.findByText("複数効果音・ターゲット指定は助力プラン以上の機能です。")
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

Issue #991 の軽量フォローアップとして、`GachaSoundSettings` が settings API の 200 応答で `gachaSoundRulesPremiumRequired` を受け取った際に、制限メッセージを表示する契約をコンポーネントテストで固定します。

- basicプランの常設案内バナーとは別に、API応答後のエラーメッセージが追加表示されることを検証
- `gachaSoundRulesPremiumRequired: true` の200応答経路だけを専用テストで固定
- 本番コード・DB・設定・既存fixtureは変更なし

## 検証

- 専用Vitestを追加。全体CIで型・lint・unit testを確認

Refs #991