### PR TITLE
chore(test): unused logger warn mock を削除

### DIFF
--- a/tests/unit/post-redemption-notify-chat-retry.test.ts
+++ b/tests/unit/post-redemption-notify-chat-retry.test.ts
@@ -56,7 +56,6 @@ const mockRetry = vi.mocked(retryChatNotification)
 const mockMarkSent = vi.mocked(markChatNotificationSent)
 const mockDeadLetter = vi.mocked(deadLetterChatNotification)
 const mockReportError = vi.mocked(reportError)
-const mockLoggerWarn = vi.mocked(logger.warn)
 const mockLoggerInfo = vi.mocked(logger.info)
 
 // `{user}` / `{card}` だけのテンプレートにして補助DB参照を通さず、


### PR DESCRIPTION
## 概要

Issue #1037 の判断不要な軽量フォローアップとして、PR #1309 Auto Review から退避された未使用 `mockLoggerWarn` を削除します。

## 変更

- `tests/unit/post-redemption-notify-chat-retry.test.ts` の未使用 `mockLoggerWarn` 定義を削除
- fixture・assertion・本番コード・実行挙動は変更なし

## スコープ

#1037 の retry 滞留観測性、admin 経路の log level 再評価等は本PRの収束条件に含めません。

Refs #1037 #1309