### PR TITLE
chore(actions): ready-for-review時も昇格要約を検証

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -6,7 +6,7 @@ name: Notify Discord on main merge
 # `contents: read`; do not widen them without a reviewed workflow requirement.
 on:
   pull_request_target:
-    types: [opened, edited, synchronize, reopened, closed]
+    types: [opened, edited, synchronize, reopened, ready_for_review, closed]
     branches: [main]
 
 permissions:


### PR DESCRIPTION
## 概要

Issue #1113 の判断不要な軽量フォローアップとして、preview→main 昇格PRを draft から ready に戻した時にもリリース要約検証を再実行します。

## 変更

- `pull_request_target` の types に `ready_for_review` を追加
- 既存の `validate-promotion-summary` / Discord通知ロジック自体は変更なし
- 差分は workflow 1行のみ

## スコープ

#1113 の required status check 運用文書化、見出し正規化、埋め込みPython整理、Discord切り詰め改善などは本PRの収束条件に含めません。

Refs #1113 #1303