### PR TITLE
fix(gacha): NULL redeemed_atを最新履歴から除外

### DIFF
--- a/src/lib/services/gacha.ts
+++ b/src/lib/services/gacha.ts
@@ -14,7 +14,7 @@ import {
   isPgFunctionNotFoundError,
   isPgMissingNamedColumnError,
 } from '@/lib/db/errors'
-import { and, count, desc, eq, inArray, isNull } from 'drizzle-orm'
+import { and, count, desc, eq, inArray, isNotNull, isNull } from 'drizzle-orm'
 import {
   cards as cardsTable,
   gachaHistory,
@@ -837,7 +837,10 @@ export class GachaService {
         const { db } = await getDb()
         return db.select({ card_id: gachaHistory.card_id })
           .from(gachaHistory)
-          .where(eq(gachaHistory.streamer_id, streamerId))
+          .where(and(
+            eq(gachaHistory.streamer_id, streamerId),
+            isNotNull(gachaHistory.redeemed_at),
+          ))
           .orderBy(desc(gachaHistory.redeemed_at), desc(gachaHistory.id))
           .limit(1)
       }, 'gacha:getLatestCardIdForStreamer', { idempotent: true })


### PR DESCRIPTION
## 概要
Issue #1300 の独立した NULL 耐性フォローアップです。

- `getLatestCardIdForStreamer` の履歴条件へ `redeemed_at IS NOT NULL` を追加
- PostgreSQL の `DESC` が既定で NULL を先頭に置くため、legacy の NULL 行が「最新」として固定されるケースを回避
- 既存の `redeemed_at DESC, id DESC` の順序、covering index、エラー時フォールバックは変更しない

## 対象外
`EXPLAIN (ANALYZE, BUFFERS)`、latency 計測、`id DESC` の必要性評価、読み取り回数/並列化など #1300 の残りの性能検証はこのPRの収束条件にしません。

## テスト
CI の Typecheck / unit tests で確認します。

Refs #1300