### PR TITLE
docs(next): Proxy移行の再検討条件を現行方針へ更新

### DIFF
--- a/docs/cloudflare-proxy-migration.md
+++ b/docs/cloudflare-proxy-migration.md
@@ -6,9 +6,12 @@ now because the current Cloudflare deployment path cannot build a Next.js Proxy.
 
 ## Current Decision
 
-- Keep `src/middleware.ts` on `preview` until the OpenNext Cloudflare adapter
-  supports Next.js Proxy output.
+- Keep `src/middleware.ts` on `preview` while the current `@opennextjs/cloudflare`
+  deployment path rejects Next.js Proxy / Node.js middleware.
 - Do not add `src/proxy.ts` yet.
+- Do not wait for `@opennextjs/cloudflare` itself to gain Proxy support. The
+  upstream direction is to handle Node.js middleware through the newer
+  `@opennextjs/adapters-api` architecture instead.
 - Accept the Next.js deprecated convention warning as the smaller operational
   risk while Cloudflare builds still require Edge Middleware output.
 
@@ -24,10 +27,15 @@ ERROR Node.js middleware is not currently supported. Consider switching to Edge 
 Next.js 16 rejects forcing Proxy back to Edge runtime, so the blocker is in the
 deployment compatibility layer rather than in TwiCa's middleware logic.
 
+The incompatibility remains observable upstream as
+[`opennextjs-cloudflare#1277`](https://github.com/opennextjs/opennextjs-cloudflare/issues/1277).
+
 ## Revisit Conditions
 
 Revisit this decision when either of these is true:
 
-- OpenNext Cloudflare documents support for Next.js Proxy / Node.js middleware.
+- Migrating TwiCa to `@opennextjs/adapters-api` (or another Cloudflare deployment
+  path with Next.js Proxy / Node.js middleware support) becomes practical and
+  `npm run workers:build` can be verified on that path.
 - TwiCa changes deployment architecture so request interception no longer needs
   to run in Cloudflare Workers middleware.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -162,7 +162,7 @@ export async function middleware(request: NextRequest) {
   // 継続発生させず、入力エラーとして400を返す。
   if (hasInvalidOverlayEventsStreamerId(pathname)) {
     const errorResponse = NextResponse.json(
-      { error: 'Invalid Streamer ID' },
+      { error: 'Invalid streamer ID' },
       { status: 400 }
     )
     return setSecurityHeaders(errorResponse, { pathname })

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -41,8 +41,10 @@ const MAINTENANCE_GUARDED_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 // using middleware.ts if it doesn't need Node.js-only APIs, which is exactly
 // what this file does.
 // This file intentionally stays on the deprecated middleware.ts convention
-// (with edge-compatible code only) until proxy.ts support ships in a
-// released @opennextjs/cloudflare version.
+// (with edge-compatible code only) while the current Cloudflare deployment
+// path rejects Next.js Proxy / Node.js middleware. Revisit this when TwiCa can
+// move to an Adapters API based (or other compatible) deployment path and
+// `npm run workers:build` succeeds there; see docs/cloudflare-proxy-migration.md.
 
 /**
  * Detect locale from request (cookie or Accept-Language header)
@@ -160,7 +162,7 @@ export async function middleware(request: NextRequest) {
   // 継続発生させず、入力エラーとして400を返す。
   if (hasInvalidOverlayEventsStreamerId(pathname)) {
     const errorResponse = NextResponse.json(
-      { error: 'Invalid streamer ID' },
+      { error: 'Invalid Streamer ID' },
       { status: 400 }
     )
     return setSecurityHeaders(errorResponse, { pathname })

--- a/tests/unit/cloudflare-proxy-migration.test.ts
+++ b/tests/unit/cloudflare-proxy-migration.test.ts
@@ -7,18 +7,18 @@ function readSource(path: string) {
 }
 
 describe("Cloudflare proxy migration policy", () => {
-  it("keeps Edge Middleware until OpenNext Cloudflare supports Next.js Proxy", () => {
+  it("keeps Edge Middleware while the current Cloudflare adapter rejects Next.js Proxy", () => {
     expect(existsSync(join(process.cwd(), "src/middleware.ts"))).toBe(true);
     expect(existsSync(join(process.cwd(), "src/proxy.ts"))).toBe(false);
   });
 
-  it("documents the deploy blocker and revisit condition", () => {
+  it("documents the deploy blocker and current revisit path", () => {
     const doc = readSource("docs/cloudflare-proxy-migration.md");
     const middleware = readSource("src/middleware.ts");
 
     expect(doc).toContain("Node.js middleware is not currently supported");
     expect(doc).toContain("Do not add `src/proxy.ts` yet");
-    expect(doc).toContain("OpenNext Cloudflare");
+    expect(doc).toContain("@opennextjs/adapters-api");
     expect(middleware).toContain("export async function middleware");
     expect(middleware).not.toContain("export async function proxy");
     expect(middleware).toContain("intentionally stays on the deprecated middleware.ts convention");


### PR DESCRIPTION
## 概要

Issue #417 のコメントで確定している軽量フォローアップです。Next.js 16 の `proxy.ts` 直接移行は現行 Cloudflare/OpenNext 経路を壊すため行わず、既存の暫定方針ドキュメントに残っていた古い再検討条件だけを更新します。

## 変更

- `@opennextjs/cloudflare` 自体の Proxy 対応を待つ、という旧表現を削除
- `@opennextjs/adapters-api` 等の Node.js middleware 対応デプロイ経路へ移行可能になった時点を再検討条件として明記
- 現在も再現している上流の Proxy 非対応 Issue `opennextjs-cloudflare#1277` を参照追加
- policy 回帰テストの名称と assertion を現行の追跡条件へ合わせる
- Auto Review #674 の必須指摘に従い、`src/middleware.ts` の方針コメントも同じ再検討条件へ同期

## 非スコープ

- `src/middleware.ts` → `src/proxy.ts` の移行
- Cloudflare デプロイアダプタ自体の変更
- deprecated warning の抑制
- Auto Review #674 の任意改善（Issue #1321 へ退避）

これらは現行 deployment path では安全に実施できないか、今回の必須修正とは独立した保守性改善のため、本PRの収束条件には含めません。

Refs #417 #1321