### PR TITLE
test(overlay): middlewareの不正streamerId応答を固定

### DIFF
--- a/tests/unit/middleware-overlay-events-validation.test.ts
+++ b/tests/unit/middleware-overlay-events-validation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+import { middleware } from '@/middleware'
+
+vi.mock('@/lib/logger', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+
+describe('middleware overlay events validation', () => {
+  it('不正なstreamerIdを400の固定JSON本文で拒否する', async () => {
+    const response = await middleware(
+      new NextRequest('https://example.com/api/overlay/not-a-uuid/events')
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Invalid streamer ID',
+    })
+  })
+})


### PR DESCRIPTION
## 概要

Refs #1321

`/api/overlay/:streamerId/events` に不正な `streamerId` が来た場合、middleware が返す 400 JSON 本文 `{ "error": "Invalid streamer ID" }` を回帰テストで固定します。

## 変更内容

- middleware の不正 `streamerId` 早期 return を直接呼ぶ unit test を追加
- status=400 と現行 JSON body を検証
- 本番コード・runtime 挙動は変更なし

## スコープ外

- route handler 側のエラースキーマとの統一は別判断とし、本PRでは扱いません
- #1321 の他の任意・ノンブロッキング項目も本PRの収束条件にしません
- 進行中の #1320 が触る production/docs には触れず、テスト追加のみに限定しています
