### PR TITLE
test(gacha): 低レベルexecuteGachaの本番直呼びを防ぐ

### DIFF
--- a/tests/unit/gacha-public-entrypoint-contract.test.ts
+++ b/tests/unit/gacha-public-entrypoint-contract.test.ts
@@ -1,0 +1,53 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+function collectTypeScriptFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return collectTypeScriptFiles(path);
+    }
+    return /\.tsx?$/.test(entry.name) ? [path] : [];
+  });
+}
+
+function findExecuteGachaCalls(path: string): string[] {
+  const source = readFileSync(path, "utf8");
+  const sourceFile = ts.createSourceFile(
+    path,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    path.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  const calls: string[] = [];
+
+  function visit(node: ts.Node) {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === "executeGacha"
+    ) {
+      const position = sourceFile.getLineAndCharacterOfPosition(node.expression.name.getStart(sourceFile));
+      calls.push(`${relative(process.cwd(), path)}:${position.line + 1}`);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return calls;
+}
+
+describe("GachaService production entrypoints (#1301)", () => {
+  it("does not call the low-level executeGacha method outside GachaService", () => {
+    const srcRoot = resolve(process.cwd(), "src");
+    const servicePath = resolve(srcRoot, "lib/services/gacha.ts");
+    const directCallSites = collectTypeScriptFiles(srcRoot)
+      .filter((path) => path !== servicePath)
+      .flatMap(findExecuteGachaCalls);
+
+    expect(directCallSites).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1301 の判断不要な軽量フォローアップとして、低レベル `GachaService.executeGacha` を production code から直接呼ぶ経路が増えないことを source-contract test で固定します。

## 変更

- `src/` 配下の TypeScript / TSX を TypeScript AST で走査
- `src/lib/services/gacha.ts` 内部を除き、`.executeGacha(...)` の直接呼び出しが存在しないことを検証
- 既存の低レベル RPC/抽選テストはそのまま維持し、production entrypoint だけをガード
- 本番コード・runtime 挙動・DB は変更なし

## スコープ外

- `executeGacha` の位置引数を options object へ移行する大きめのリファクタ
- 低レベルメソッド自体の `private` 化（既存の低レベル RPC 契約テストが直接呼び出しているため、別途テスト構造と合わせて実施）
- 手動APIを `executeGachaDraws(..., 1)` へ統合する設計判断

これらは #1301 に残し、本PRの収束条件には含めません。

Refs #1301