### PR TITLE
fix(channel-points): 追加引き換えのパック表示を更新後も維持

### DIFF
--- a/src/app/api/twitch/channel-point-bootstrap/route.ts
+++ b/src/app/api/twitch/channel-point-bootstrap/route.ts
@@ -144,13 +144,13 @@ async function getSubscriptionsByUserId(
  * Issue #690: getAdditionalRewards の pg 直結実装。
  *
  * - フル select（id, reward_id, reward_name, draw_count, is_raid_limited,
- *   created_at）を streamer_id で絞り込み created_at 昇順に取得する。
- * - draw_count・is_raid_limited は migration 00041 で追加されたため、rolling
- *   deploy の短い窓だけ SQLSTATE 42703 を検知して縮退クエリへ切り替える。
- *   任意の message 文字列ではなく SQLSTATE を根拠にし、接続障害や権限エラーを
- *   migration 遅延として握りつぶさない。
- * - フォールバック時は draw_count: 1 / is_raid_limited: false を補完する
- *   （streamerAdditionalGachaRewards schema の DEFAULT 値と一致）。
+ *   collection_name, created_at）を streamer_id で絞り込み created_at 昇順に取得する。
+ * - draw_count・is_raid_limited は migration 00041、collection_name は migration
+ *   00061 で追加されたため、rolling deploy の短い窓だけ SQLSTATE 42703 を検知して
+ *   縮退クエリへ切り替える。任意の message 文字列ではなく SQLSTATE を根拠にし、
+ *   接続障害や権限エラーを migration 遅延として握りつぶさない。
+ * - フォールバック時は draw_count: 1 / is_raid_limited: false /
+ *   collection_name: null を補完する（各列の未設定時の既存契約と一致）。
  * - withDbRetry 内で発生した例外はそのまま伝播させる（呼び出し元の
  *   GET ハンドラの try/catch が handleApiError で 500 を返す既存挙動を維持）。
  */
@@ -167,6 +167,7 @@ async function getAdditionalRewardsPg(streamerId: string) {
             reward_name: streamerAdditionalGachaRewardsTable.reward_name,
             draw_count: streamerAdditionalGachaRewardsTable.draw_count,
             is_raid_limited: streamerAdditionalGachaRewardsTable.is_raid_limited,
+            collection_name: streamerAdditionalGachaRewardsTable.collection_name,
             created_at: streamerAdditionalGachaRewardsTable.created_at,
           })
           .from(streamerAdditionalGachaRewardsTable)
@@ -181,9 +182,8 @@ async function getAdditionalRewardsPg(streamerId: string) {
     if (!isPgMissingColumnError(error)) {
       throw error;
     }
-    // デプロイ窓フォールバック（42703 undefined_column）: draw_count /
-    // is_raid_limited を含めない縮退クエリへ切り替え、PostgREST 版と同じ
-    // デフォルト値（draw_count: 1, is_raid_limited: false）を補って返す。
+    // デプロイ窓フォールバック（42703 undefined_column）: migration 00041/00061
+    // で追加された列を含めない縮退クエリへ切り替え、既存のデフォルト値を補う。
     return await withDbRetry(
       async () => {
         const { db } = await getDb();
@@ -201,6 +201,7 @@ async function getAdditionalRewardsPg(streamerId: string) {
           ...reward,
           draw_count: 1,
           is_raid_limited: false,
+          collection_name: null,
         }));
       },
       "getAdditionalRewards:raid-options-fallback",

--- a/tests/unit/channel-point-bootstrap-driver-parity.test.ts
+++ b/tests/unit/channel-point-bootstrap-driver-parity.test.ts
@@ -5,7 +5,7 @@
  *
  * 検証観点（tests/unit/announcements-driver-parity.test.ts と
  * tests/unit/overlay-events-api-pg.test.ts の確立パターンを踏襲）:
- *   1. フル select 経路の応答 JSON
+ *   1. フル select 経路の応答 JSON（collection_name を含む）
  *   2. raid 系カラムのスキーマドリフト時の縮退フォールバック経路
  *      (isPgMissingColumnError [42703])
  *   3. streamer 行なし(limit(1) → 空配列)で404 + STREAMER_NOT_FOUND
@@ -134,6 +134,7 @@ const FULL_REWARD_ROW = {
   reward_name: 'Extra Reward',
   draw_count: 2,
   is_raid_limited: true,
+  collection_name: 'pack-a',
   created_at: '2020-01-01T00:00:00.000+00:00',
 }
 
@@ -151,7 +152,7 @@ const FALLBACK_REWARD_ROW = {
 
 const EXPECTED_FULL_ADDITIONAL_REWARDS = [FULL_REWARD_ROW]
 const EXPECTED_FALLBACK_ADDITIONAL_REWARDS = [
-  { ...FALLBACK_REWARD_ROW, draw_count: 1, is_raid_limited: false },
+  { ...FALLBACK_REWARD_ROW, draw_count: 1, is_raid_limited: false, collection_name: null },
 ]
 
 // ---------------------------------------------------------------------------
@@ -294,6 +295,9 @@ describe('GET /api/twitch/channel-point-bootstrap?diagnostics=1: フル select �
       eq(streamerAdditionalGachaRewardsTable.streamer_id, FULL_STREAMER_ROW.id)
     )
     expect(rewardsCall.orderByCondition).toEqual(asc(streamerAdditionalGachaRewardsTable.created_at))
+    // Issue #1324: refresh後のUIは bootstrap の additionalRewards を使うため、
+    // pack表示に必要な collection_name を full select で必ず返す。
+    expect(Object.keys(rewardsCall.fields)).toContain('collection_name')
   })
 })
 
@@ -328,7 +332,7 @@ describe('GET /api/twitch/channel-point-bootstrap?diagnostics=1: raid系カラ�
     expect(db.select).toHaveBeenCalledTimes(4)
   })
 
-  it('フォールバック時は縮退select(raid_gacha_draw_count/draw_count/is_raid_limitedを含まない)を発行する', async () => {
+  it('フォールバック時は縮退select(raid_gacha_draw_count/draw_count/is_raid_limited/collection_nameを含まない)を発行する', async () => {
     const { db } = await runPlanetscalePath(
       [
         {
@@ -355,13 +359,14 @@ describe('GET /api/twitch/channel-point-bootstrap?diagnostics=1: raid系カラ�
     expect(Object.keys(db.calls[0].fields)).toContain('raid_gacha_draw_count')
     // 2回目(streamers, フォールバック select)は raid_gacha_draw_count を含まない
     expect(Object.keys(db.calls[1].fields)).not.toContain('raid_gacha_draw_count')
-    // 3回目(rewards, フル select)は draw_count / is_raid_limited を含む
+    // 3回目(rewards, フル select)は draw_count / is_raid_limited / collection_name を含む
     expect(Object.keys(db.calls[2].fields)).toEqual(
-      expect.arrayContaining(['draw_count', 'is_raid_limited'])
+      expect.arrayContaining(['draw_count', 'is_raid_limited', 'collection_name'])
     )
-    // 4回目(rewards, フォールバック select)は draw_count / is_raid_limited を含まない
+    // 4回目(rewards, フォールバック select)は追加列を含まない
     expect(Object.keys(db.calls[3].fields)).not.toContain('draw_count')
     expect(Object.keys(db.calls[3].fields)).not.toContain('is_raid_limited')
+    expect(Object.keys(db.calls[3].fields)).not.toContain('collection_name')
   })
 
   it('42703以外の恒久的エラーはフォールバックせず500(handleApiError経由)になる', async () => {


### PR DESCRIPTION
## 概要

Issue #1324 の表示不整合を修正します。

追加のチャネルポイント引き換えにパックを紐付けた直後は正しく表示される一方、ブラウザ更新後は bootstrap API の `additionalRewards` に `collection_name` が含まれていなかったため、UI が「すべてのカード」と解釈していました。抽選側は別経路で保存済み `collection_name` を参照するため、実際の抽選対象だけは正しい状態でした。

## 変更

- `channel-point-bootstrap` の追加報酬 full select に `collection_name` を追加
- rolling deploy 用縮退経路では `collection_name: null` を明示
- driver parity test に `collection_name` の応答・select 契約を追加

## スコープ

問い合わせ内の「追加引き換え設定を後から変更するUI」は操作性改善の別件であり、本PRの収束条件に含めず #1326 へ退避しました。

Claude Auto Review #684 の任意改善（縮退契約の姉妹ルート統一、二重取得の整理、追加テスト、EOF改行、コミット衛生、Preview実画面確認）は #1327 へ退避し、本PRのマージブロッカーにはしません。

Closes #1324