### PR TITLE
docs(security): 解消済みCSRF例外を削除

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,7 +45,6 @@ An unbounded decompression chain in HTTP responses on Node.js Fetch API via Cont
 - All API inputs are validated
 - Rate limiting prevents abuse
 - CSRF protection on all state-changing requests
-  （例外: `/api/twitch/eventsub/debug` の DELETE は #831 で追跡中）
 
 #### Rate Limiting
 - In-memory rate limiting for development
@@ -108,4 +107,4 @@ To automatically audit dependencies as part of CI/CD, consider adding to your wo
 
 ## Last Updated
 
-2026-08-12
+2026-09-01


### PR DESCRIPTION
## 概要

Issue #836 の SECURITY.md 乖離フォローアップとして、解消済みの `/api/twitch/eventsub/debug` DELETE を CSRF 例外として残している記述を削除します。

## 確認

- `src/app/api/twitch/eventsub/debug/route.ts` の DELETE は現在 `validateCSRFToken` を先頭で実行し、不正時 403 を返す
- 同ルートは rate limit も適用済み
- コード挙動は変更せず、SECURITY.md の現行実装との整合だけを取る
- `Last Updated` を 2026-09-01 に更新

## スコープ外

Issue #836 に残る CSP / Host allowlist 等の設計判断を伴う項目には触れません。

Refs #836