### PR TITLE
fix(gacha): demo broadcast を CSRF 保護する

### DIFF
--- a/src/app/api/gacha/demo/route.ts
+++ b/src/app/api/gacha/demo/route.ts
@@ -4,6 +4,7 @@ import { logger } from "@/lib/logger.server";
 import { getSession } from "@/lib/session";
 import { getStreamerIdByTwitchUserId } from "@/lib/user-data";
 import { ERROR_MESSAGES } from "@/lib/constants";
+import { validateCSRFToken } from "@/lib/csrf";
 import { checkRateLimit, rateLimits, getRateLimitIdentifier, retryAfterSeconds } from "@/lib/rate-limit";
 import type { ApiRateLimitResponse } from "@/types/api";
 import { eq, and } from "drizzle-orm";
@@ -213,6 +214,11 @@ export async function POST(request: NextRequest) {
     }
 
     if (broadcast && streamerId) {
+      const csrfValidation = await validateCSRFToken(request);
+      if (!csrfValidation.valid) {
+        return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 });
+      }
+
       const session = await getSession();
       if (!session) {
         return NextResponse.json({ error: ERROR_MESSAGES.UNAUTHORIZED }, { status: 401 });

--- a/tests/unit/api/gacha-demo-route.test.ts
+++ b/tests/unit/api/gacha-demo-route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server'
 import { POST } from '@/app/api/gacha/demo/route'
 import { getSession } from '@/lib/session'
 import { getStreamerIdByTwitchUserId } from '@/lib/user-data'
+import { validateCSRFToken } from '@/lib/csrf'
 import {
   createOverlayDemoEvent,
   storeOverlayDemoEvent,
@@ -18,6 +19,7 @@ vi.mock('@/lib/logger.server', () => ({
 }))
 vi.mock('@/lib/session')
 vi.mock('@/lib/user-data')
+vi.mock('@/lib/csrf')
 vi.mock('@/lib/overlay/demo-event-store', () => ({
   createOverlayDemoEvent: vi.fn(),
   storeOverlayDemoEvent: vi.fn(),
@@ -37,6 +39,7 @@ vi.mock('@/lib/rate-limit', () => ({
 
 const mockGetSession = vi.mocked(getSession)
 const mockGetStreamerIdByTwitchUserId = vi.mocked(getStreamerIdByTwitchUserId)
+const mockValidateCSRFToken = vi.mocked(validateCSRFToken)
 const mockCreateOverlayDemoEvent = vi.mocked(createOverlayDemoEvent)
 const mockStoreOverlayDemoEvent = vi.mocked(storeOverlayDemoEvent)
 const mockPublishOverlayDemoRealtimeEvent = vi.mocked(publishOverlayDemoRealtimeEvent)
@@ -72,6 +75,7 @@ function makeRequest(body: unknown) {
 describe('POST /api/gacha/demo: KV demo publication authorization', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockValidateCSRFToken.mockResolvedValue({ valid: true } as any)
     mockCreateOverlayDemoEvent.mockReturnValue(DEMO_EVENT)
     mockStoreOverlayDemoEvent.mockResolvedValue(undefined)
     mockPublishOverlayDemoRealtimeEvent.mockResolvedValue({
@@ -92,6 +96,20 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
 
   afterEach(() => {
     vi.unstubAllEnvs()
+  })
+
+  it('returns 403 before authentication or publication when broadcast CSRF validation fails', async () => {
+    mockValidateCSRFToken.mockResolvedValue({ valid: false, error: 'bad csrf' } as any)
+
+    const response = await POST(makeRequest({ streamerId: 'streamer-1', broadcast: true }))
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toEqual({ error: ERROR_MESSAGES.FORBIDDEN })
+    expect(mockGetSession).not.toHaveBeenCalled()
+    expect(mockGetStreamerIdByTwitchUserId).not.toHaveBeenCalled()
+    expect(mockCreateOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockStoreOverlayDemoEvent).not.toHaveBeenCalled()
+    expect(mockPublishOverlayDemoRealtimeEvent).not.toHaveBeenCalled()
   })
 
   it('returns 401 for unauthenticated publication', async () => {
@@ -274,6 +292,7 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
 
     expect(response.status).toBe(200)
     expect(body.card).toBeDefined()
+    expect(mockValidateCSRFToken).not.toHaveBeenCalled()
     expect(mockGetSession).not.toHaveBeenCalled()
     expect(mockCreateOverlayDemoEvent).not.toHaveBeenCalled()
     expect(mockStoreOverlayDemoEvent).not.toHaveBeenCalled()
@@ -289,6 +308,7 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
 
     expect(response.status).toBe(200)
     expect(body.card).toBeDefined()
+    expect(mockValidateCSRFToken).not.toHaveBeenCalled()
     expect(mockGetSession).not.toHaveBeenCalled()
     expect(mockCreateOverlayDemoEvent).not.toHaveBeenCalled()
     expect(mockStoreOverlayDemoEvent).not.toHaveBeenCalled()


### PR DESCRIPTION
## 概要

`POST /api/gacha/demo` は通常のデモカード取得を公開のまま維持しつつ、セッション Cookie を使って KV / Overlay Realtime へ状態変更する `broadcast=true && streamerId` 分岐だけ CSRF 検証を追加します。

## 変更

- broadcast 分岐で `validateCSRFToken` を session 取得より前に実行し、不正時は 403
- CSRF 失敗時に session / streamer lookup / publish へ到達しない回帰テストを追加
- 非 broadcast、および `streamerId` のない公開デモ経路では CSRF を呼ばないことを固定

## スコープ

公開デモ取得の認証・レートリミット・カード取得・配信処理は変更しません。

## レビュー収束

- exact HEAD `eab97e940098c61d6150087e0c6b8ce8b16ae958` で CI #2556 / Claude Auto Review #685 は success
- Auto Review のコード上の必須（マージブロッカー）指摘は 0 件
- 任意・ノンブロッキング改善は #1331 へ退避し、本PRの収束条件にはしない

## 未完了の Preview 実経路ゲート

本変更は OBS DEMO ボタンから利用者可視の overlay 表示へ至る経路に CSRF ゲートを追加するため、マージ前にログイン済み Preview セッションで OBS DEMO を複数回実行し、403 退行なく overlay 表示されることを確認・記録する。

現在の自動実行環境にはログイン済み Preview / OBS 操作環境がないため、この確認は未実施。証跡は捏造せず、マージ前ゲートとして残す。

Closes #1329
Follow-up of #736
Refs #1331