### PR TITLE
chore(overlay): OBS demo の Cookie 送信を明示する

### DIFF
--- a/src/components/OverlayPreview.tsx
+++ b/src/components/OverlayPreview.tsx
@@ -504,6 +504,7 @@ export default function OverlayPreview({
       const response = await fetch("/api/gacha/demo", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({
           streamerId,
           cardId: selectedCardId !== "random" ? selectedCardId : undefined,


### PR DESCRIPTION
## 概要

PR #1330 の CSRF 導入後フォローアップとして、OBS DEMO の `/api/gacha/demo` fetch に `credentials: "include"` を明示します。

同一オリジン fetch の現在の既定値でも Cookie は送信されるため、実質的な挙動変更ではありません。CSRF Cookie に依存する書き込み経路であることをコード上に明示し、直下の `triggerRealGacha` と方針を揃える保守性改善です。

## 変更

- `src/components/OverlayPreview.tsx` の OBS DEMO fetch に `credentials: "include"` を追加
- サーバー側の CSRF 判定、公開デモ経路、403 復旧 UX は変更しない

## レビュー

- exact HEAD `5417ca6ff894c8db50e20b663b7d297d271ee3ca` を手動で厳正レビューし、必須指摘0件
- Claude Auto Review #686 も必須指摘0件で合格
- 根拠コメント追加などの任意指摘は #1331 へ退避し、本PRの収束条件にはしない

## スコープ

#1331 の他の任意改善（403時の復旧導線、route コメント、fixture整理、rate limit検討など）は本PRへ混ぜず、フォローアップとして残します。

Refs #1331 #1330