### PR TITLE
perf(cache): sound-settings GETを短TTLでcacheable化

### DIFF
--- a/src/app/api/streamer/[streamerId]/sound-settings/route.ts
+++ b/src/app/api/streamer/[streamerId]/sound-settings/route.ts
@@ -20,6 +20,13 @@ interface RouteParams {
   params: Promise<{ streamerId: string }>;
 }
 
+// #675: Workers Cache の公開GETパイロット。
+// settings POST 側の Cache-Tag purge はまだ結線していないため、まずは 1 秒だけ
+// edge cache し、同時リクエストの request collapsing を有効にする。長TTL化は
+// tag purge と同時に行い、設定変更直後の古い値が長時間残る退行を作らない。
+const SOUND_SETTINGS_CACHE_CONTROL = "public, max-age=0, s-maxage=1";
+const NO_STORE_CACHE_CONTROL = "private, no-store";
+
 interface SoundSettingsRow {
   gacha_sound_url: string | null;
   gacha_sound_enabled: boolean | null;
@@ -134,17 +141,23 @@ export async function GET(
     if (!streamerId) {
       return NextResponse.json(
         { error: ERROR_MESSAGES.STREAMER_ID_REQUIRED },
-        { status: 400 }
+        {
+          status: 400,
+          headers: { "Cache-Control": NO_STORE_CACHE_CONTROL },
+        }
       );
     }
 
     const lookup = await getSoundSettings(streamerId);
 
     if (lookup.kind === "degraded") {
-      return NextResponse.json({
-        soundUrl: null,
-        soundEnabled: false,
-      });
+      return NextResponse.json(
+        {
+          soundUrl: null,
+          soundEnabled: false,
+        },
+        { headers: { "Cache-Control": NO_STORE_CACHE_CONTROL } }
+      );
     }
 
     const streamer = lookup.streamer;
@@ -152,7 +165,10 @@ export async function GET(
     if (!streamer) {
       return NextResponse.json(
         { error: ERROR_MESSAGES.STREAMER_NOT_FOUND },
-        { status: 404 }
+        {
+          status: 404,
+          headers: { "Cache-Control": NO_STORE_CACHE_CONTROL },
+        }
       );
     }
 
@@ -162,13 +178,24 @@ export async function GET(
       streamer.gacha_sound_enabled ?? true,
     );
 
-    // 効果音設定を返す
-    return NextResponse.json({
-      soundUrl: streamer.gacha_sound_url,
-      soundEnabled: streamer.gacha_sound_enabled ?? true, // デフォルトはtrue
-      soundRules: soundRules.length > 0 ? soundRules : legacyRules,
-    });
+    // 効果音設定を返す。streamerId は DB の PK として取得成功した値だけがここへ
+    // 到達するため、そのまま Cache-Tag のスコープキーとして使用できる。
+    return NextResponse.json(
+      {
+        soundUrl: streamer.gacha_sound_url,
+        soundEnabled: streamer.gacha_sound_enabled ?? true, // デフォルトはtrue
+        soundRules: soundRules.length > 0 ? soundRules : legacyRules,
+      },
+      {
+        headers: {
+          "Cache-Control": SOUND_SETTINGS_CACHE_CONTROL,
+          "Cache-Tag": `sound-settings-${streamerId}`,
+        },
+      }
+    );
   } catch (error) {
-    return handleApiError(error, "Streamer Sound Settings API");
+    const response = handleApiError(error, "Streamer Sound Settings API");
+    response.headers.set("Cache-Control", NO_STORE_CACHE_CONTROL);
+    return response;
   }
 }

--- a/src/app/api/streamer/[streamerId]/sound-settings/route.ts
+++ b/src/app/api/streamer/[streamerId]/sound-settings/route.ts
@@ -194,7 +194,7 @@ export async function GET(
       }
     );
   } catch (error) {
-    const response = handleApiError(error, "Streamer Sound Settings API");
+    const response = await handleApiError(error, "Streamer Sound Settings API");
     response.headers.set("Cache-Control", NO_STORE_CACHE_CONTROL);
     return response;
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -101,7 +101,11 @@ const RATE_LIMIT_EXCLUDED_PATHS = [
 // 警告: ここへ HTML を返すパスを追加してはならない。エッジキャッシュに nonce 付き
 // CSP が焼き付き、キャッシュ HIT 中の全スクリプトが nonce 不一致でブロックされる
 // （現状の対象は JSON のみで無害）。
-const CACHEABLE_PUBLIC_PATHS = ['/api/maintenance-status']
+const CACHEABLE_PUBLIC_PATHS = [
+  /^\/api\/maintenance-status$/,
+  /^\/api\/streamer\/[^/]+\/sound-settings$/,
+  /^\/api\/overlay\/[^/]+\/realtime-config$/,
+]
 
 /**
  * #694 Stage 3: maintenance mode (off 以外) のとき、/api 配下の write メソッド
@@ -209,10 +213,9 @@ export async function middleware(request: NextRequest) {
   // 明示する意図的な短 TTL キャッシュ対象（オーバーレイのバージョン確認）。
   // 警告: ここも HTML を返すパスを追加してはならない（CACHEABLE_PUBLIC_PATHS と
   // 同じ理由で nonce がエッジキャッシュに焼き付く）。
-  const isCacheablePublicPath =
-    CACHEABLE_PUBLIC_PATHS.some((path) => pathname.startsWith(path)) ||
-    (pathname.startsWith('/api/overlay/') &&
-      pathname.endsWith('/realtime-config'))
+  const isCacheablePublicPath = CACHEABLE_PUBLIC_PATHS.some((pathPattern) =>
+    pathPattern.test(pathname)
+  )
   if (!isCacheablePublicPath) {
     response.headers.set('Cache-Control', 'private, no-store')
   }

--- a/tests/unit/middleware-cache-control.test.ts
+++ b/tests/unit/middleware-cache-control.test.ts
@@ -60,6 +60,11 @@ describe('middleware fail-closed Cache-Control (issue #906)', () => {
     expect(response.headers.get('Cache-Control')).toBeNull()
   })
 
+  it('キャッシュ許可パス（sound-settings）にも no-store を付与しない', async () => {
+    const response = await middleware(makeRequest('/api/streamer/123e4567-e89b-42d3-a456-426614174000/sound-settings'))
+    expect(response.headers.get('Cache-Control')).toBeNull()
+  })
+
   it('キャッシュ許可パス（/api/overlay/ 配下の realtime-config）にも no-store を付与しない', async () => {
     const response = await middleware(makeRequest('/api/overlay/123e4567-e89b-42d3-a456-426614174000/realtime-config'))
     expect(response.headers.get('Cache-Control')).toBeNull()

--- a/tests/unit/sound-settings-api.test.ts
+++ b/tests/unit/sound-settings-api.test.ts
@@ -67,6 +67,8 @@ describe("GET /api/streamer/[streamerId]/sound-settings", () => {
     });
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("public, max-age=0, s-maxage=1");
+    expect(response.headers.get("Cache-Tag")).toBe("sound-settings-streamer-1");
     await expect(response.json()).resolves.toEqual({
       soundUrl: "https://cdn.example.com/sound.mp3",
       soundEnabled: true,
@@ -81,7 +83,7 @@ describe("GET /api/streamer/[streamerId]/sound-settings", () => {
     expect(pg.select).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps streamer-not-found as a 404", async () => {
+  it("keeps streamer-not-found as a non-cacheable 404", async () => {
     primeSoundSettingsDb({});
 
     const response = await GET(request(), {
@@ -89,10 +91,12 @@ describe("GET /api/streamer/[streamerId]/sound-settings", () => {
     });
 
     expect(response.status).toBe(404);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Cache-Tag")).toBeNull();
     await expect(response.json()).resolves.toEqual({ error: "Streamer not found" });
   });
 
-  it("falls back to disabled sound settings when PlanetScale returns a transient connection error", async () => {
+  it("falls back to non-cacheable disabled sound settings when PlanetScale returns a transient connection error", async () => {
     primeSoundSettingsDb({
       error: { code: "08006", message: "connection failure" },
     });
@@ -102,6 +106,8 @@ describe("GET /api/streamer/[streamerId]/sound-settings", () => {
     });
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Cache-Tag")).toBeNull();
     await expect(response.json()).resolves.toEqual({
       soundUrl: null,
       soundEnabled: false,


### PR DESCRIPTION
## 概要

Issue #675 の Workers Cache Phase 1 を、小さく安全側で開始します。

- `GET /api/streamer/[streamerId]/sound-settings` の正常 200 応答だけを `public, max-age=0, s-maxage=1` にする
- 正常応答に `Cache-Tag: sound-settings-${streamerId}` を付与する
- 404 / DB縮退応答 / 例外応答は明示的に `private, no-store` のままにする
- 成功・404・縮退応答の cache header 契約を unit test で固定する
- middleware の fail-closed キャッシュ許可インベントリにも sound-settings を endpoint 単位で登録し、回帰テストを追加する

## レビュー対応

Claude Auto Review #688 で、route 側の `public` 設定と `src/middleware.ts` の `CACHEABLE_PUBLIC_PATHS` が同期していない点が必須指摘となったため修正済みです。既存の realtime-config も含め、キャッシュ許可対象を endpoint 単位の正規表現インベントリへ統一し、広すぎる prefix 許可を作らない形にしています。

任意・ノンブロッキング事項（TTLの実効性測定、Cache-Tag purge、UUID正規化、Set-Cookie方針、追加 no-store テスト、定数共通化）は #1334 に退避しています。

## TTLを1秒に留める理由

#675 の最終案は 30 秒 TTL + 設定更新時の tag purge ですが、writer 側の purge を同時に入れず 30 秒化すると、設定変更直後に古い効果音設定が残る時間を新たに作ります。今回は request collapsing / ごく短い edge cache を先行検証するパイロットとして 1 秒に限定し、長TTL化は tag purge 結線と Preview 実測を #1334 へ退避します。

## 確認対象

- CI / unit tests
- Preview で `Cache-Control` / `Cache-Tag` / `Cf-Cache-Status` が意図どおりになること

Refs #675 #1334