### PR TITLE
fix(cache): realtime-configの400をno-store化

### DIFF
--- a/src/app/api/overlay/[streamerId]/realtime-config/route.ts
+++ b/src/app/api/overlay/[streamerId]/realtime-config/route.ts
@@ -32,7 +32,15 @@ export async function GET(
 ): Promise<NextResponse> {
   const { streamerId } = await params
   if (!isValidStreamerId(streamerId)) {
-    return NextResponse.json({ error: 'Invalid streamer ID' }, { status: 400 })
+    return NextResponse.json(
+      { error: 'Invalid streamer ID' },
+      {
+        status: 400,
+        headers: {
+          'Cache-Control': 'private, no-store',
+        },
+      }
+    )
   }
 
   const overlayVersion = process.env.NEXT_PUBLIC_OVERLAY_VERSION ?? 'dev'

--- a/tests/unit/overlay-realtime-config-route.test.ts
+++ b/tests/unit/overlay-realtime-config-route.test.ts
@@ -23,7 +23,9 @@ describe('overlay realtime runtime config', () => {
     expect(response.status).toBe(200)
     expect(body.mode).toBe('polling-only')
     expect(JSON.stringify(body)).not.toContain('must-never-leak')
-    expect(response.headers.get('cache-control')).toContain('max-age=15')
+    expect(response.headers.get('cache-control')).toBe(
+      'public, max-age=15, stale-while-revalidate=15'
+    )
   })
 
   it('enables only an allowlisted room with a secure WebSocket endpoint', async () => {
@@ -56,11 +58,12 @@ describe('overlay realtime runtime config', () => {
     expect(body).not.toHaveProperty('overlayVersion')
   })
 
-  it('rejects an invalid public room ID', async () => {
+  it('rejects an invalid public room ID without making the error cacheable', async () => {
     const response = await GET(
       new Request('https://app.example/config'),
       params('not-a-uuid')
     )
     expect(response.status).toBe(400)
+    expect(response.headers.get('cache-control')).toBe('private, no-store')
   })
 })


### PR DESCRIPTION
Closes #1335

## 概要

`/api/overlay/[streamerId]/realtime-config` の不正な `streamerId` による400応答へ、`Cache-Control: private, no-store` を明示します。正常な200応答の短TTL公開キャッシュ契約は維持します。

## 変更内容

- 不正IDの400応答に `private, no-store` を付与
- 正常200の `public, max-age=15, stale-while-revalidate=15` を維持
- 400/200双方のcache header契約をunit testで固定

## 変更分類

`実引き換え必須（現行 docs/QA.md の overlay 対応表）`。差分自体はrealtime-configの400応答のHTTPヘッダーとテストだけですが、現行のQA対応表はoverlayが取得するruntime応答・キャッシュ挙動をoverlay経路として扱い、項目1〜5（実チャネルポイント引き換え複数回、overlay順序、chat、EventSub direct、WebSocket再接続／polling gap recovery）を必須としています。unit/CIは成功済みですが、固定Preview URLでの実経路証跡は未確認のため、Previewマージとmain昇格は保留です。認証情報の取得・保存・入力は行いません。

## 現在のゲート

- Auto Review（exact HEAD `77ec2febb22830389c13c4486d90c01b1ea19695`）でコード上の必須指摘はありません。
- 現行QA表に基づくoverlay実経路ゲートは未達です。Twitchの対象報酬を実際に交換できる既存セッションと、固定Preview overlay／OBSを同じ観測で操作するユーザー側の手順が必要です。
- 実経路証跡が揃うまで、このPRをマージせず、Issue #1335も完了扱いにしません。

## 検証

- `npx vitest run --cache=false tests/unit/overlay-realtime-config-route.test.ts` — 4 tests passed
- `npx tsc --noEmit` — passed
- `npx eslint 'src/app/api/overlay/[streamerId]/realtime-config/route.ts' tests/unit/overlay-realtime-config-route.test.ts` — passed
- `git diff --check` — passed
- PR CI / Workers Builds: `77ec2febb22830389c13c4486d90c01b1ea19695` で成功済み

## 関連

Refs #1333
