### PR TITLE
fix(cache): overlay events の不正ID 400をno-store化

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -241,7 +241,6 @@ export async function middleware(request: NextRequest) {
     if (!isExcludedPath) {
       const ip = getClientIp(request)
       const identifier = `global:${ip}`
-
       const rateLimitResult = await checkRateLimit(
         rateLimits.global,
         identifier

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -163,6 +163,9 @@ export async function middleware(request: NextRequest) {
       { error: 'Invalid streamer ID' },
       { status: 400 }
     )
+    // 早期 return は後段の fail-closed Cache-Control を通らないため、
+    // エラー応答側でも明示的に保存禁止を宣言する（#1337）。
+    errorResponse.headers.set('Cache-Control', 'private, no-store')
     return setSecurityHeaders(errorResponse, { pathname })
   }
 
@@ -199,8 +202,8 @@ export async function middleware(request: NextRequest) {
   // 明示的にキャッシュを許可した公開パス以外には private, no-store を付与する。
   // キャッシュ許可パスはルート側で Cache-Control: public を設定する（この middleware は
   // ルートより先に実行されるため、ルートが最終的にヘッダーを上書きできる）。
-  // 400/429/503 等のエラーレスポンスは Workers Cache のヒューリスティック対象外のため、
-  // 早期 return 経路では Cache-Control を設定しない。
+  // 400/429/503 等は Workers Cache のヒューリスティック対象外だが、早期 return でも
+  // fail-closed 契約が必要な経路は個別に private, no-store を明示する。
   // /api/overlay/ 配下は prefix ではなくエンドポイント単位で判定する。
   // events は OBS オーバーレイの 3 秒間隔ポーリングだが Cache-Control を設定
   // しないため、prefix 許可だと Workers Caching のヒューリスティック TTL
@@ -238,6 +241,7 @@ export async function middleware(request: NextRequest) {
     if (!isExcludedPath) {
       const ip = getClientIp(request)
       const identifier = `global:${ip}`
+
       const rateLimitResult = await checkRateLimit(
         rateLimits.global,
         identifier

--- a/tests/unit/middleware-cache-control.test.ts
+++ b/tests/unit/middleware-cache-control.test.ts
@@ -73,6 +73,16 @@ describe('middleware fail-closed Cache-Control (issue #906)', () => {
     expect(response.headers.get('Cache-Control')).toBe('private, no-store')
   })
 
+  it('不正 streamerId の overlay events 400 にも private, no-store を付与する', async () => {
+    const response = await middleware(makeRequest('/api/overlay/not-a-uuid/events'))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid streamer ID' })
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
+    // DB/session I/O より前の早期拒否契約も維持する。
+    expect(updateSessionMock).not.toHaveBeenCalled()
+  })
+
   it('overlay demo-events にも private, no-store を付与する（ルート側 no-store と二重防御）', async () => {
     const response = await middleware(makeRequest('/api/overlay/123e4567-e89b-42d3-a456-426614174000/demo-events'))
     expect(response.headers.get('Cache-Control')).toBe('private, no-store')


### PR DESCRIPTION
## 概要

Issue #1337 の判断不要な軽量フォローアップです。

`/api/overlay/<invalid>/events` は middleware で不正 `streamerId` を早期 400 return するため、通常レスポンスに適用される fail-closed `Cache-Control: private, no-store` より前に終了していました。

## 変更

- 不正 streamerId の `/api/overlay/:streamerId/events` 400へ `Cache-Control: private, no-store` を明示
- 早期 return でも fail-closed を維持する理由コメントを追加
- middleware のエラーキャッシュ方針コメントを実装と矛盾しない表現へ更新
- unit test で status / body / cache header / session I/O 前の早期拒否を固定
- 正常 events の既存 `private, no-store` 契約は維持

## レビュー

- exact HEAD `480d99f521fc44af12f74dab90e3de335c0dd204` を手動で厳正レビューし、必須・マージブロッカー指摘0件
- Claude Auto Review #693 は同HEADで success、必須指摘0件・任意指摘のみ
- 任意事項（早期returnのno-store基準整理、defense-in-depth意図コメント、Preview QA証跡等）は #1337 へ退避し、本PRのコード収束条件にはしない
- Auto Review が挙げた realtime-config 400 は進行中 PR #1336 が既に対応済みのため重複着手しない

## CI

CI #2564 は exact HEAD `480d99f521fc44af12f74dab90e3de335c0dd204` で completed / success。Typecheck / Overlay Worker typecheck / Supabase shutdown independence / maintenance write-surface / unit tests / integration tests / i18n lint / Supabase変数なし Application build を含めて成功済み。

## スコープ

PR #1336 の realtime-config 実装ファイルには触れず、同PRとの重複作業を避けています。#1336 の残りの任意事項は #1337 に残します。

Refs #1337 #1336 #675