### PR TITLE
docs(env): ALLOWED_SOUND_HOSTS の説明を効果音向けに訂正

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -114,7 +114,7 @@ NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 # MAINTENANCE_MESSAGE_KEY=xxx
 # MAINTENANCE_OPERATION_ID=xxx
 
-# カード画像 URL の外部ホスト許可リスト（カンマ区切り）
+# 効果音 URL の外部ホスト許可リスト（カンマ区切り）
 # ALLOWED_SOUND_HOSTS=xxx
 
 # その他


### PR DESCRIPTION
## 概要

Issue #1340 の判断不要なドキュメント修正です。

`.env.local.example` では `ALLOWED_SOUND_HOSTS` が「カード画像 URL の外部ホスト許可リスト」と説明されていましたが、実装ではガチャ効果音 URL の追加許可ホストとして使われています。

## 変更

- コメントを「効果音 URL の外部ホスト許可リスト（カンマ区切り）」へ訂正
- 環境変数名・runtime 挙動・許可判定ロジックは変更なし
- `preview` HEAD との差分は `.env.local.example` 1行のみ

Closes #1340
Refs #837