### PR TITLE
test(rate-limit): KV binding の既定参照を固定

### DIFF
--- a/tests/unit/rate-limit-kv-auto-init.test.ts
+++ b/tests/unit/rate-limit-kv-auto-init.test.ts
@@ -43,6 +43,7 @@ describe("rate limit KV auto initialization", () => {
     expect(second.success).toBe(true);
     expect(second.remaining).toBe(3);
     expect(getKvBindingMock).toHaveBeenCalledTimes(1);
+    expect(getKvBindingMock).toHaveBeenCalledWith();
     expect(kv.get).toHaveBeenCalledWith(
       "ratelimit:authLogin:user:auto-kv",
       "json",


### PR DESCRIPTION
## 取り下げ

Issue #1263 が既に closed であることを最終照合で確認したため、このPRは重複・不要作業として未マージのままクローズします。

差分は既存テストへの assertion 1行のみで、`preview` には取り込みません。

Refs #1263 #728