### PR TITLE
docs(storage): message互換フィールドの意図を明記

### DIFF
--- a/src/app/api/storage-status/route.ts
+++ b/src/app/api/storage-status/route.ts
@@ -35,6 +35,8 @@ export async function GET() {
       // planOverLimitの場合もアップロードを無効化
       uploadDisabled: usage.userLimitReached || usage.globalLimitReached || usage.planOverLimit,
       planOverLimit: usage.planOverLimit,
+      // 後方互換用の message。公式UIは上記フラグを見て t() で文言を解決するため、
+      // ここは未知・外部クライアント向けフォールバックとして維持する（#835, #1345）。
       message: usage.planOverLimit
         ? ERROR_MESSAGES.PLAN_OVER_LIMIT
         : usage.globalLimitReached


### PR DESCRIPTION
## 概要

Issue #1345 のうち、判断不要な軽量フォローアップとして `storage-status.message` を現状維持する理由を route 近傍へ明記します。

## 変更

- `/api/storage-status` の `message` が後方互換用フォールバックであることを2行コメントで記録
- 公式UIは `userLimitReached` / `globalLimitReached` / `planOverLimit` の構造化フラグから i18n 文言を解決する、という既存契約を明示
- runtime、レスポンス形、定数値、API互換性は一切変更しない

## スコープ外

- `message` フィールド自体の削除可否（外部クライアント互換性判断が必要）
- `STORAGE_LIMIT_MESSAGES` の削除・文言変更

## 検証

- exact HEAD `679df2afd8d7f35d2c01e096972c48819318a42a` を手動レビュー: 必須・マージブロッカー0件
- CI #2572: success
- Claude Auto Review #701: success / 必須指摘0件 / 任意指摘のみ
- Auto Review の任意指摘は #1345 に退避済み

Refs #1345 #835