### PR TITLE
docs(eventsub): pending再試行の通報境界を明記

### DIFF
--- a/docs/eventsub-notification-log-contract.md
+++ b/docs/eventsub-notification-log-contract.md
@@ -5,12 +5,12 @@
 - warn 表示は `broadcast` / `chat announcement` を使う。ログ本文からソースを grep しやすいよう、表示ラベルはリテラルのまま維持する。
 - `reportError` の context は `eventsub:postRedemptionNotify:broadcast` / `eventsub:postRedemptionNotify:chatAnnouncement` を使う。`chatAnnouncement` は既存の監視・テストとの互換性を保つため camelCase のまま変更しない。
 
-## pending 再試行時の通報境界
+## pending 状態と通報境界
 
 chat 通知が `pending` に戻る場合でも、通報契約は経路によって異なる。
 
 - `sendChatAnnouncement` が retryable outcome を返した通常の再試行経路は、`chat announcement retry scheduled` の warn を残して正常終了し、`reportError` へは到達しない。
-- `sendChatAnnouncement` 自体が予期せず throw した catch 経路は、delivery state が未確定なら outbox を再試行可能な状態へ戻したうえで例外を rethrow する。この場合は呼び出し元の失敗処理を通って `reportError` の対象になり得る。
+- `sendChatAnnouncement` 自体が予期せず throw した catch 経路は、delivery state が未確定なら `retryChatNotification` を呼ぶ。これは試行回数や lease 状態に応じて `pending` / `dead` / `lost-lease` になり得るが、その結果にかかわらず元の例外を rethrow するため、呼び出し元の失敗処理を通って `reportError` の対象になり得る。
 
 したがって、outbox の最終状態が `pending` であることだけを根拠に「`reportError` されない」と判断してはならない。通常の retryable outcome と unexpected throw は別の経路として扱う。
 

--- a/docs/eventsub-notification-log-contract.md
+++ b/docs/eventsub-notification-log-contract.md
@@ -5,10 +5,19 @@
 - warn 表示は `broadcast` / `chat announcement` を使う。ログ本文からソースを grep しやすいよう、表示ラベルはリテラルのまま維持する。
 - `reportError` の context は `eventsub:postRedemptionNotify:broadcast` / `eventsub:postRedemptionNotify:chatAnnouncement` を使う。`chatAnnouncement` は既存の監視・テストとの互換性を保つため camelCase のまま変更しない。
 
+## pending 再試行時の通報境界
+
+chat 通知が `pending` に戻る場合でも、通報契約は経路によって異なる。
+
+- `sendChatAnnouncement` が retryable outcome を返した通常の再試行経路は、`chat announcement retry scheduled` の warn を残して正常終了し、`reportError` へは到達しない。
+- `sendChatAnnouncement` 自体が予期せず throw した catch 経路は、delivery state が未確定なら outbox を再試行可能な状態へ戻したうえで例外を rethrow する。この場合は呼び出し元の失敗処理を通って `reportError` の対象になり得る。
+
+したがって、outbox の最終状態が `pending` であることだけを根拠に「`reportError` されない」と判断してはならない。通常の retryable outcome と unexpected throw は別の経路として扱う。
+
 したがって、表示文言を整える目的で `chatAnnouncement` context を `chat announcement` へ変更してはならない。逆に、人向け warn 表示を context に合わせて camelCase へ戻す必要もない。
 
 リポジトリ外の Cloudflare Observability 等で文字列監視を追加・変更する場合は、旧表示文字列 `chatAnnouncement failed` を前提にせず、可能なら構造化 context を利用する。既存の外部監視条件があるかどうかはリポジトリだけでは確認できないため、監視設定を変更する際に別途確認する。
 
 この文書化は既存ログ契約の説明だけで実行コードを変更しないため、専用の Preview 実経路ゲートは不要とする。通常の CI とレビューで文書と現行実装の整合を確認する。
 
-Refs #1098 #1097
+Refs #1098 #1097 #1037 #1348


### PR DESCRIPTION
## 概要

Issue #1348 の判断不要な文書化フォローアップです。

`postRedemptionNotify` の chat 通知では、outbox が `pending` になり得る場合でも、通常の retryable outcome と unexpected throw で `reportError` への到達可否が異なります。現行実装・既存テストに沿って、その境界を既存のログ契約ドキュメントへ明記します。

## 変更

- retryable outcome は warn を残して正常終了し、`reportError` しないことを明記
- unexpected throw は delivery state 未確定なら `retryChatNotification` を呼び、`pending` / `dead` / `lost-lease` のいずれになっても元例外を rethrow するため `reportError` 対象になり得ることを明記
- `pending` という最終状態だけで通報有無を判断しない旨を追加
- runtime、ログ文字列、retry 判定、テストコードは変更なし

## 重複回避

進行中の PR #1316 は `tests/unit/post-redemption-notify-chat-retry.test.ts` の未使用 mock 削除だけを扱っているため、本PRは同ファイルに触れず docs 1ファイルに限定しています。

## 検証

- `preview` exact HEAD `c5f5caab0e7c7bc3cc3236048daeaad8b90568ed` から作成
- exact HEAD `078ded196813ec33ce86870cb9d6bc3d113b3aa5`
- 差分: `docs/eventsub-notification-log-contract.md` のみ
- 実装コードの `retryable -> warn + return` と `unexpected throw -> retryChatNotification + rethrow` を照合済み
- 自己レビューで `retryChatNotification` が試行上限時に `dead`、lease競合時に `lost-lease` になり得る点を拾い、初稿の「再試行可能状態へ戻す」という過剰な表現を修正済み
- 厳正レビュー: 必須・マージブロッカー0件
- CI #2574: success
- このPRでは Auto Review のチェックが生成されていないため、exact HEAD の厳正レビューで補完

Closes #1348
Refs #1037 #1316