### PR TITLE
test(storage): message互換契約を固定

### DIFF
--- a/tests/unit/storage-status-api.test.ts
+++ b/tests/unit/storage-status-api.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GET } from '@/app/api/storage-status/route'
+import { getSession, canUseStreamerFeatures } from '@/lib/session'
+import { getStorageUsage, formatBytes, type StorageUsage } from '@/lib/storage-usage'
+import { sha256Prefix } from '@/lib/crypto-utils'
+
+vi.mock('@/lib/session')
+vi.mock('@/lib/storage-usage', () => ({
+  getStorageUsage: vi.fn(),
+  formatBytes: vi.fn(),
+}))
+vi.mock('@/lib/crypto-utils', () => ({
+  sha256Prefix: vi.fn(),
+}))
+
+const mockGetSession = vi.mocked(getSession)
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)
+const mockGetStorageUsage = vi.mocked(getStorageUsage)
+const mockFormatBytes = vi.mocked(formatBytes)
+const mockSha256Prefix = vi.mocked(sha256Prefix)
+
+const baseUsage: StorageUsage = {
+  userUsage: 1024,
+  globalUsage: 2048,
+  userLimitReached: false,
+  globalLimitReached: false,
+  userLimitBytes: 10 * 1024 * 1024,
+  globalLimitBytes: 50 * 1024 * 1024 * 1024,
+  planOverLimit: false,
+}
+
+async function getStorageStatus(overrides: Partial<StorageUsage> = {}) {
+  mockGetStorageUsage.mockResolvedValue({ ...baseUsage, ...overrides })
+  const response = await GET()
+  expect(response.status).toBe(200)
+  return response.json() as Promise<{ message: string | null }>
+}
+
+describe('GET /api/storage-status message compatibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'test-user-id',
+      twitchUsername: 'test-user',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/avatar.jpg',
+      broadcasterType: 'affiliate',
+      expiresAt: Date.now() + 3600000,
+      version: 1,
+    })
+    mockCanUseStreamerFeatures.mockReturnValue(true)
+    mockSha256Prefix.mockResolvedValue('12345678')
+    mockFormatBytes.mockImplementation((bytes) => `${bytes} B`)
+  })
+
+  it('planOverLimit を最優先の互換 message として返す', async () => {
+    const body = await getStorageStatus({
+      planOverLimit: true,
+      globalLimitReached: true,
+      userLimitReached: true,
+    })
+
+    expect(body.message).toBe(
+      'ストレージ容量を超過しています。支援特典をアップグレードするか、画像を削除してください。'
+    )
+  })
+
+  it('globalLimitReached を userLimitReached より優先する', async () => {
+    const body = await getStorageStatus({
+      globalLimitReached: true,
+      userLimitReached: true,
+    })
+
+    expect(body.message).toBe('画像のアップロード上限に達しました。')
+  })
+
+  it('userLimitReached の互換 message を返す', async () => {
+    const body = await getStorageStatus({ userLimitReached: true })
+
+    expect(body.message).toBe(
+      '画像のアップロード上限は現在一アカウントにつき10MBです。上限を超える場合は、既存の画像を削除してから再度お試しください。'
+    )
+  })
+
+  it('制限に達していなければ message は null を返す', async () => {
+    const body = await getStorageStatus()
+
+    expect(body.message).toBeNull()
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1350 の判断不要な軽量フォローアップです。

`/api/storage-status` の後方互換 `message` について、現行値と優先順位を route の unit test で固定します。公式UIは構造化フラグから i18n 文言を解決するため、このPRでは runtime/API 実装には触れません。

## 変更

- `tests/unit/storage-status-api.test.ts` を追加
- `planOverLimit > globalLimitReached > userLimitReached` の message 優先順位を固定
- 制限なしでは `message: null` になることを固定
- 互換フィールドの現在の日本語文字列を直接検証

## 重複回避

進行中 PR #1347 は `src/app/api/storage-status/route.ts` のコメントのみを変更しています。本PRは新規 unit test ファイルだけで、変更ファイルは重複しません。

## スコープ外

- `message` の削除・deprecated 化
- `message` の多言語化
- 外部クライアント互換の廃止時期判断

## レビュー・CI

- exact HEAD: `d4d4a9df1e4fb3cac7eacab37a9296b7ecc73a46`
- 手動厳正レビュー: 必須・マージブロッカー0件
- CI #2575: success（Typecheck / Overlay Worker typecheck / Supabase shutdown independence / maintenance write surface / unit tests / integration tests）
- Claude Auto Review #702: success / 必須指摘0件
- Auto Review の任意・ノンブロッキング指摘は #1352 へ退避し、本PRの収束条件にはしない

Closes #1350
Refs #1345 #1347 #1352