### PR TITLE
docs(storage): 互換フォールバックコメントを両制限へ共通化

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -434,12 +434,12 @@ export const PLAN_CONFIG = {
   FANBOX_ID_MAX_LENGTH: 100,
 } as const
 
+// API互換用の日本語フォールバック文言。公式UIは upload の code /
+// storage-status の構造化フラグを使って t() で表示文言を解決するため、
+// ここでは外部・未知クライアント向けの互換文字列を維持する（#835 / #1345）。
 export const STORAGE_LIMIT_MESSAGES = {
   // User limit message: increased to 10MB
   // ユーザー制限メッセージ: 10MBに増加
   USER_LIMIT_REACHED: '画像のアップロード上限は現在一アカウントにつき10MBです。上限を超える場合は、既存の画像を削除してから再度お試しください。',
-  // 後方互換のため維持。クライアントは code フィールドで t() 解決するため、この文言は
-  // サーバーフォールバック（未知のクライアント等）でしか表示されない
-  // （#835: 英語ロケールでも制限理由を表示できるよう、APIの error 文言は最終手段）。
   GLOBAL_LIMIT_REACHED: '画像のアップロード上限に達しました。',
 } as const


### PR DESCRIPTION
## 概要

Issue #1345 の判断不要な軽量フォローアップです。

`STORAGE_LIMIT_MESSAGES` の互換目的コメントが `GLOBAL_LIMIT_REACHED` だけに付いていたため、`USER_LIMIT_REACHED` / `GLOBAL_LIMIT_REACHED` の両方に共通する契約として定数ブロック直前へ移します。

## 変更

- 公式UIは upload の `code` / storage-status の構造化フラグから `t()` で表示文言を解決することを共通コメントで明記
- 2つの日本語文字列は外部・未知クライアント向けの互換フォールバックとして維持することを明記
- 定数値、APIレスポンス、runtime 挙動は変更しない

## 重複回避

進行中 PR #1347 は `src/app/api/storage-status/route.ts`、PR #1351 は `tests/unit/storage-status-api.test.ts` を変更しています。本PRは `src/lib/constants.ts` のコメントだけで、変更ファイルは重複しません。

## スコープ外

- `storage-status.message` の削除・deprecated 化
- 互換フィールドの廃止時期判断
- 文言の多言語化

これらは #1345 / #1352 に残し、本PRの収束条件には含めません。

## レビュー・CI

- exact HEAD: `59180712a72610c9f1c81a0d6a24a9a9c596bb17`
- 手動厳正レビュー: 必須・マージブロッカー0件
- Claude Auto Review #703: success / 必須指摘0件 / 任意指摘のみ
- Auto Review の任意事項（固定10MB文言と実効上限の乖離、履歴コメント整理）は #1354 へ退避し、本PRの収束条件にはしない
- CI #2576: success（Typecheck / Overlay Worker typecheck / Supabase shutdown independence / maintenance write-surface / unit tests / integration tests / i18n lint / Application build を含む）

Refs #1345 #835 #1347 #1351 #1354