### PR TITLE
test(storage): storage-status の401認証契約を固定

### DIFF
--- a/tests/unit/storage-status-auth.test.ts
+++ b/tests/unit/storage-status-auth.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GET } from '@/app/api/storage-status/route'
+import { getSession, canUseStreamerFeatures } from '@/lib/session'
+import { getStorageUsage } from '@/lib/storage-usage'
+import { sha256Prefix } from '@/lib/crypto-utils'
+import { ERROR_MESSAGES } from '@/lib/constants'
+
+vi.mock('@/lib/session')
+vi.mock('@/lib/storage-usage')
+vi.mock('@/lib/crypto-utils')
+
+const SESSION = {
+  twitchUserId: 'viewer-twitch-id',
+  twitchUsername: 'viewer',
+  twitchDisplayName: 'Viewer',
+  twitchProfileImageUrl: '',
+  broadcasterType: '',
+  expiresAt: Date.now() + 100_000,
+  version: 1 as const,
+}
+
+describe('GET /api/storage-status auth contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(getSession).mockResolvedValue(SESSION)
+    vi.mocked(canUseStreamerFeatures).mockReturnValue(true)
+  })
+
+  it('未認証なら 401 を返し storage 読み取りへ進まない', async () => {
+    vi.mocked(getSession).mockResolvedValue(null)
+
+    const response = await GET()
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: ERROR_MESSAGES.UNAUTHORIZED })
+    expect(canUseStreamerFeatures).not.toHaveBeenCalled()
+    expect(sha256Prefix).not.toHaveBeenCalled()
+    expect(getStorageUsage).not.toHaveBeenCalled()
+  })
+
+  it('配信者機能を使えないセッションでも 401 を返し storage 読み取りへ進まない', async () => {
+    vi.mocked(canUseStreamerFeatures).mockReturnValue(false)
+
+    const response = await GET()
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: ERROR_MESSAGES.UNAUTHORIZED })
+    expect(canUseStreamerFeatures).toHaveBeenCalledWith(SESSION)
+    expect(sha256Prefix).not.toHaveBeenCalled()
+    expect(getStorageUsage).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1352 の判断不要な軽量フォローアップとして、`GET /api/storage-status` の認証拒否契約だけを unit test で固定します。

## 変更

- 未認証（`getSession() === null`）で 401 + `UNAUTHORIZED` を返すことを検証
- セッションはあるが `canUseStreamerFeatures=false` の場合も 401 + `UNAUTHORIZED` を返すことを検証
- どちらも `sha256Prefix` / `getStorageUsage` へ進まないことを固定
- runtime/API 実装は変更なし

## 重複回避

- PR #1351 は `tests/unit/storage-status-api.test.ts` の message 互換契約
- PR #1347 は `src/app/api/storage-status/route.ts` の互換コメント

本PRは新規 `tests/unit/storage-status-auth.test.ts` だけを追加し、変更ファイルを重ねません。

## スコープ外

#1352 の他の任意項目は本PRの収束条件に含めません。Auto Review #704 の任意・ノンブロッキング指摘も #1352 へ退避済みです。

## 検証

- `preview` exact HEAD `c5f5caab0e7c7bc3cc3236048daeaad8b90568ed` から作成
- exact HEAD `df0962d76db62d5a56481ff601d43037ebb0e0ba`
- 差分: 新規 unit test 1ファイルのみ
- 手動厳正レビュー: 必須・マージブロッカー0件
- CI #2577: success
- Claude Auto Review #704: success / 必須指摘0件 / 任意指摘のみ
- Cloudflare Preview deployment: success

Refs #1352 #1351 #1347