### PR TITLE
test(storage): storage-status の500エラー委譲契約を固定

### DIFF
--- a/tests/unit/storage-status-error.test.ts
+++ b/tests/unit/storage-status-error.test.ts
@@ -1,0 +1,72 @@
+/**
+ * #1356: GET /api/storage-status の例外委譲契約を固定する。
+ *
+ * storage usage の取得失敗を route 内で成功扱いへ握りつぶすと、監視記録と利用者への
+ * 500 応答が同時に失われる。error reporter 自体の副作用はこの unit test では起動せず、
+ * API 境界が共通の handleApiError へ元の例外と context を渡し、その Response を返す
+ * ところだけを独立して検証する。
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { GET } from '@/app/api/storage-status/route';
+import { getSession, canUseStreamerFeatures } from '@/lib/session';
+import { getStorageUsage } from '@/lib/storage-usage';
+import { sha256Prefix } from '@/lib/crypto-utils';
+import { handleApiError } from '@/lib/error-handler';
+import type { SessionPayload } from '@/lib/session-cookie';
+
+vi.mock('@/lib/session');
+vi.mock('@/lib/storage-usage', () => ({
+  getStorageUsage: vi.fn(),
+  formatBytes: vi.fn(),
+}));
+vi.mock('@/lib/crypto-utils', () => ({
+  sha256Prefix: vi.fn(),
+}));
+vi.mock('@/lib/error-handler', () => ({
+  handleApiError: vi.fn(),
+}));
+
+const mockGetSession = vi.mocked(getSession);
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures);
+const mockGetStorageUsage = vi.mocked(getStorageUsage);
+const mockSha256Prefix = vi.mocked(sha256Prefix);
+const mockHandleApiError = vi.mocked(handleApiError);
+
+const SESSION: SessionPayload = {
+  twitchUserId: 'storage-error-user',
+  twitchUsername: 'storage-error-user',
+  twitchDisplayName: 'Storage Error User',
+  twitchProfileImageUrl: '',
+  broadcasterType: 'affiliate',
+  expiresAt: 4_102_444_800_000,
+  version: 1,
+};
+
+describe('GET /api/storage-status: error delegation (#1356)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(SESSION);
+    mockCanUseStreamerFeatures.mockReturnValue(true);
+    mockSha256Prefix.mockResolvedValue('storage-error-prefix');
+    mockHandleApiError.mockResolvedValue(
+      NextResponse.json({ error: 'handled-storage-error' }, { status: 500 })
+    );
+  });
+
+  it('storage usage 取得失敗を共通ハンドラへ委譲し、その応答を返す', async () => {
+    const error = new Error('storage unavailable');
+    mockGetStorageUsage.mockRejectedValue(error);
+
+    const response = await GET();
+
+    expect(mockGetStorageUsage).toHaveBeenCalledWith(
+      'storage-error-prefix',
+      SESSION.twitchUserId
+    );
+    expect(mockHandleApiError).toHaveBeenCalledTimes(1);
+    expect(mockHandleApiError).toHaveBeenCalledWith(error, 'Storage Status API');
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: 'handled-storage-error' });
+  });
+});


### PR DESCRIPTION
## 概要

Issue #1356 の判断不要な軽量フォローアップです。

`GET /api/storage-status` で storage usage 取得が例外になった場合、route が例外を握りつぶさず共通 `handleApiError(error, 'Storage Status API')` へ委譲し、その Response を返す契約を unit test で固定します。

## 変更

- 新規 `tests/unit/storage-status-error.test.ts` を追加
- 有効な配信者セッションから storage usage 取得失敗を再現
- 元例外と context が `handleApiError` へ渡ることを固定
- 共通ハンドラの 500 Response がそのまま返ることを固定
- runtime / API 実装は変更なし

## 重複回避

- PR #1355 は `tests/unit/storage-status-auth.test.ts` の401契約
- PR #1351 は `tests/unit/storage-status-api.test.ts` の正常系 message 互換契約

本PRは新規 error delegation test 1ファイルだけを追加し、変更ファイルを重ねません。

## スコープ外

401→403 の意味論変更、互換 `message` の設計変更、#1352 の他の任意改善は本PRの収束条件に含めません。Claude Auto Review #705 の任意・ノンブロッキング指摘も #1352 へ退避済みです。

## 検証

- `preview` exact HEAD `c5f5caab0e7c7bc3cc3236048daeaad8b90568ed` から作成
- exact HEAD `f5ada9b4b74ca57c3f0d63ed66799accae948cbd`
- 差分: 新規 unit test 1ファイルのみ
- 手動厳正レビュー: 必須・マージブロッカー0件
- Claude Auto Review #705: success / 必須指摘0件 / 任意指摘のみ
- CI #2578: success（Typecheck / Overlay Worker typecheck / Supabase shutdown independence / maintenance write-surface / unit tests / integration tests を含む）
- Cloudflare Preview deployment: success

Closes #1356
Refs #1352 #1355