### PR TITLE
test(storage): uploadDisabled の OR 契約を固定

### DIFF
--- a/tests/unit/storage-status-upload-disabled.test.ts
+++ b/tests/unit/storage-status-upload-disabled.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GET } from '@/app/api/storage-status/route'
+import { getSession, canUseStreamerFeatures } from '@/lib/session'
+import { getStorageUsage, formatBytes, type StorageUsage } from '@/lib/storage-usage'
+import { sha256Prefix } from '@/lib/crypto-utils'
+
+vi.mock('@/lib/session')
+vi.mock('@/lib/storage-usage', () => ({
+  getStorageUsage: vi.fn(),
+  formatBytes: vi.fn(),
+}))
+vi.mock('@/lib/crypto-utils', () => ({
+  sha256Prefix: vi.fn(),
+}))
+
+const mockGetSession = vi.mocked(getSession)
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)
+const mockGetStorageUsage = vi.mocked(getStorageUsage)
+const mockFormatBytes = vi.mocked(formatBytes)
+const mockSha256Prefix = vi.mocked(sha256Prefix)
+
+const baseUsage: StorageUsage = {
+  userUsage: 1024,
+  globalUsage: 2048,
+  userLimitReached: false,
+  globalLimitReached: false,
+  userLimitBytes: 10 * 1024 * 1024,
+  globalLimitBytes: 50 * 1024 * 1024 * 1024,
+  planOverLimit: false,
+}
+
+type StorageStatusBody = Pick<
+  StorageUsage,
+  'userLimitReached' | 'globalLimitReached' | 'planOverLimit'
+> & {
+  uploadDisabled: boolean
+}
+
+async function getStorageStatus(
+  overrides: Partial<StorageUsage> = {}
+): Promise<StorageStatusBody> {
+  mockGetStorageUsage.mockResolvedValue({ ...baseUsage, ...overrides })
+  const response = await GET()
+  expect(response.status).toBe(200)
+  return response.json() as Promise<StorageStatusBody>
+}
+
+/**
+ * Issue #1352 の machine-readable 契約を route 境界で固定する。
+ * getStorageUsage の各制限フラグはここでは既に導出済みの入力として扱い、
+ * 上流の現在の相関に依存せず各 OR 項を独立に検証する。
+ */
+describe('GET /api/storage-status uploadDisabled contract (#1352)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSession.mockResolvedValue({
+      twitchUserId: 'test-user-id',
+      twitchUsername: 'test-user',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/avatar.jpg',
+      broadcasterType: 'affiliate',
+      expiresAt: 4_102_444_800_000,
+      version: 1,
+    })
+    mockCanUseStreamerFeatures.mockReturnValue(true)
+    mockSha256Prefix.mockResolvedValue('12345678')
+    mockFormatBytes.mockImplementation((bytes) => `${bytes} B`)
+  })
+
+  it('制限フラグがすべて false なら uploadDisabled は false', async () => {
+    const body = await getStorageStatus()
+
+    expect(body).toMatchObject({
+      userLimitReached: false,
+      globalLimitReached: false,
+      planOverLimit: false,
+      uploadDisabled: false,
+    })
+  })
+
+  it('userLimitReached が true なら uploadDisabled は true', async () => {
+    const body = await getStorageStatus({ userLimitReached: true })
+
+    expect(body).toMatchObject({
+      userLimitReached: true,
+      globalLimitReached: false,
+      planOverLimit: false,
+      uploadDisabled: true,
+    })
+  })
+
+  it('globalLimitReached が true なら uploadDisabled は true', async () => {
+    const body = await getStorageStatus({ globalLimitReached: true })
+
+    expect(body).toMatchObject({
+      userLimitReached: false,
+      globalLimitReached: true,
+      planOverLimit: false,
+      uploadDisabled: true,
+    })
+  })
+
+  it('planOverLimit が true なら uploadDisabled は true', async () => {
+    const body = await getStorageStatus({ planOverLimit: true })
+
+    expect(body).toMatchObject({
+      userLimitReached: false,
+      globalLimitReached: false,
+      planOverLimit: true,
+      uploadDisabled: true,
+    })
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1352 の判断不要な軽量フォローアップです。

`GET /api/storage-status` の machine-readable `uploadDisabled` が、`userLimitReached || globalLimitReached || planOverLimit` のいずれかで true になる現行契約を unit test で固定します。

## 変更

- 新規 `tests/unit/storage-status-upload-disabled.test.ts` を追加
- 制限なしでは `uploadDisabled: false` を検証
- `userLimitReached` / `globalLimitReached` / `planOverLimit` の各項を独立に true にし、`uploadDisabled: true` を検証
- runtime / API 実装は変更なし

## 重複回避

- PR #1351 は `tests/unit/storage-status-api.test.ts` の互換 `message` 契約
- PR #1355 は `tests/unit/storage-status-auth.test.ts` の401契約
- PR #1357 は `tests/unit/storage-status-error.test.ts` の例外委譲契約

本PRは新規 `storage-status-upload-disabled.test.ts` のみを追加し、進行中PRと変更ファイルを重ねません。

## スコープ外

#1352 に残る 401→403 の意味論変更、互換 `message` の設計変更、既存テストの整理・モック簡素化は本PRの収束条件に含めません。

Claude Auto Review #706 の任意指摘（到達可能な `planOverLimit` 実シナリオ、crypto 部分モック、引数配線、不要セットアップ整理等）も #1352 に退避済みです。

## 検証

- `preview` exact HEAD `c5f5caab0e7c7bc3cc3236048daeaad8b90568ed` から作成
- exact HEAD `a0c2fcb503fc3ee24206e41d6221cd6ac6149de0`
- 差分: 新規 unit test 1ファイルのみ
- CI #2579: success
  - Typecheck / Overlay Worker typecheck / Supabase shutdown independence / maintenance write-surface / unit tests / integration tests 成功
- Claude Auto Review #706: success / 必須指摘0件 / 任意指摘のみ
- Cloudflare Preview deployment: success
- exact HEAD を手動でも厳正レビューし、必須・マージブロッカー0件を確認

Refs #1352 #1351 #1355 #1357