### PR TITLE
docs(release): 昇格要約checkの必須運用を明記

### DIFF
--- a/docs/release-promotion-required-check.md
+++ b/docs/release-promotion-required-check.md
@@ -1,0 +1,12 @@
+# Preview→main 昇格時の required status check
+
+preview から main への昇格PRでは、`.github/workflows/notify-discord-main-merge.yml` の `validate-promotion-summary` を required status check として扱います。
+
+## 運用契約
+
+- repository rules / branch protection で `validate-promotion-summary` を required status check として登録・維持する。
+- 昇格PRの `validate-promotion-summary` が未実行、pending、failure、cancelled、skipped など `success` 以外の場合は main へマージしない。
+- workflow はリリース要約の検証ロジックと check run を提供する。required 化そのものは repository rules / branch protection 側の責務であり、workflow ファイルだけではマージ禁止を保証しない。
+- check 名を変更する場合は、workflow と repository rules / branch protection の required check 設定を同時に更新し、保護が外れる時間を作らない。
+
+この文書は運用契約の記録のみを目的とし、workflow・repository rules / branch protection・runtime の設定自体は変更しません。


### PR DESCRIPTION
## 概要

Issue #1359 の判断不要な軽量フォローアップです。

preview→main 昇格PRで `validate-promotion-summary` を required status check として扱う運用契約を独立文書に記録します。

## 変更

- `docs/release-promotion-required-check.md` を追加
- `validate-promotion-summary` が `success` でない場合は main 昇格を進めないことを明記
- workflow の check run と repository rules / branch protection の required 化の責務境界を明記
- check 名変更時は required check 設定も同時更新する運用を明記

## 重複回避

進行中 PR #1317 は `.github/workflows/notify-discord-main-merge.yml` の `ready_for_review` trigger のみを変更しています。本PRは新規 docs ファイル1個のみで、workflow・branch protection・runtime には触れません。

## レビュー・CI

- `preview` exact HEAD `c5f5caab0e7c7bc3cc3236048daeaad8b90568ed` から作成
- exact HEAD `eecc1078092e9e7f9650803141ad785a1eb16f24`
- 差分: 新規 docs 1ファイル、+12/-0
- CI #2580: completed / success
- exact HEAD を手動で厳正レビューし、必須・マージブロッカー0件を記録
- 現時点で Claude Auto Review run は生成されていないため、exact HEAD の手動厳正レビューで補完
- 追加確認で現行 `main` が未保護・required checks 未設定と判明。repository settings 側の実効化は判断を伴うため #1361 へ退避し、本PRの収束条件にはしない

Closes #1359
Follow-up of #1113
Refs #1317 #1361