### PR TITLE
test(storage): usage引数の配線を固定

### DIFF
--- a/tests/unit/storage-status-usage-args.test.ts
+++ b/tests/unit/storage-status-usage-args.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GET } from '@/app/api/storage-status/route'
+import { getSession, canUseStreamerFeatures } from '@/lib/session'
+import { getStorageUsage, formatBytes, type StorageUsage } from '@/lib/storage-usage'
+import { sha256Prefix } from '@/lib/crypto-utils'
+
+vi.mock('@/lib/session')
+vi.mock('@/lib/storage-usage', () => ({
+  getStorageUsage: vi.fn(),
+  formatBytes: vi.fn(),
+}))
+vi.mock('@/lib/crypto-utils', () => ({
+  sha256Prefix: vi.fn(),
+}))
+
+const mockGetSession = vi.mocked(getSession)
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)
+const mockGetStorageUsage = vi.mocked(getStorageUsage)
+const mockFormatBytes = vi.mocked(formatBytes)
+const mockSha256Prefix = vi.mocked(sha256Prefix)
+
+const usage: StorageUsage = {
+  userUsage: 1024,
+  globalUsage: 2048,
+  userLimitReached: false,
+  globalLimitReached: false,
+  userLimitBytes: 10 * 1024 * 1024,
+  globalLimitBytes: 50 * 1024 * 1024 * 1024,
+  planOverLimit: false,
+}
+
+describe('GET /api/storage-status usage argument wiring (#1352)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSession.mockResolvedValue({
+      twitchUserId: '987654321',
+      twitchUsername: 'test-user',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/avatar.jpg',
+      broadcasterType: 'affiliate',
+      expiresAt: 4_102_444_800_000,
+      version: 1,
+    })
+    mockCanUseStreamerFeatures.mockReturnValue(true)
+    mockSha256Prefix.mockResolvedValue('cafebabe')
+    mockGetStorageUsage.mockResolvedValue(usage)
+    mockFormatBytes.mockImplementation((bytes) => `${bytes} B`)
+  })
+
+  it('sessionのTwitch IDからprefixを生成し、prefixと同じTwitch IDをusage取得へ渡す', async () => {
+    const response = await GET()
+
+    expect(response.status).toBe(200)
+    expect(mockSha256Prefix).toHaveBeenCalledTimes(1)
+    expect(mockSha256Prefix).toHaveBeenCalledWith('987654321')
+    expect(mockGetStorageUsage).toHaveBeenCalledTimes(1)
+    expect(mockGetStorageUsage).toHaveBeenCalledWith('cafebabe', '987654321')
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1352 に残っている判断不要な軽量フォローアップとして、`GET /api/storage-status` から `getStorageUsage` への引数配線を unit test で固定します。

## 変更

- 新規 `tests/unit/storage-status-usage-args.test.ts` を追加
- session の `twitchUserId` が `sha256Prefix` に渡ることを固定
- 生成された prefix と同じ `twitchUserId` が `getStorageUsage(prefix, twitchUserId)` に渡ることを固定
- runtime / API 実装は変更なし

## 重複回避

進行中の storage-status 系PRはそれぞれ別の新規テストファイルを扱っています。

- #1351: `storage-status-api.test.ts`（互換 message）
- #1355: `storage-status-auth.test.ts`（401）
- #1357: `storage-status-error.test.ts`（500委譲）
- #1358: `storage-status-upload-disabled.test.ts`（OR契約）

本PRは新規 `storage-status-usage-args.test.ts` のみで、変更ファイルを重ねません。

## スコープ外

#1352 のモック簡素化、401→403、互換 message の設計変更、既存テスト統合は本PRの収束条件に含めません。

## レビュー・CI

- exact HEAD `f47fac81ce680cce55ced9b37fa27fdc493b1f06`
- 手動厳正レビュー: 必須・マージブロッカー0件
- CI #2581: completed / success
- Claude Auto Review #707: completed / success / 必須指摘0件 / 任意指摘のみ
- Cloudflare Preview deployment: success
- Auto Review の任意事項は #1352 に退避済み。401 / `uploadDisabled` / `message` は #1355 / #1358 / #1351 で既に独立対応中のため二重着手しない

Refs #1352