### PR TITLE
test(storage): formatBytes の引数配線を固定

### DIFF
--- a/tests/unit/storage-status-format-bytes.test.ts
+++ b/tests/unit/storage-status-format-bytes.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GET } from '@/app/api/storage-status/route'
+import { getSession, canUseStreamerFeatures } from '@/lib/session'
+import { getStorageUsage, formatBytes, type StorageUsage } from '@/lib/storage-usage'
+import { sha256Prefix } from '@/lib/crypto-utils'
+
+vi.mock('@/lib/session')
+vi.mock('@/lib/storage-usage', () => ({
+  getStorageUsage: vi.fn(),
+  formatBytes: vi.fn(),
+}))
+vi.mock('@/lib/crypto-utils', () => ({
+  sha256Prefix: vi.fn(),
+}))
+
+const mockGetSession = vi.mocked(getSession)
+const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)
+const mockGetStorageUsage = vi.mocked(getStorageUsage)
+const mockFormatBytes = vi.mocked(formatBytes)
+const mockSha256Prefix = vi.mocked(sha256Prefix)
+
+const usage: StorageUsage = {
+  userUsage: 111,
+  globalUsage: 222,
+  userLimitReached: false,
+  globalLimitReached: false,
+  userLimitBytes: 333,
+  globalLimitBytes: 444,
+  planOverLimit: false,
+}
+
+describe('GET /api/storage-status formatBytes wiring (#1363)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSession.mockResolvedValue({
+      twitchUserId: '987654321',
+      twitchUsername: 'test-user',
+      twitchDisplayName: 'Test User',
+      twitchProfileImageUrl: 'https://example.com/avatar.jpg',
+      broadcasterType: 'affiliate',
+      expiresAt: 4_102_444_800_000,
+      version: 1,
+    })
+    mockCanUseStreamerFeatures.mockReturnValue(true)
+    mockSha256Prefix.mockResolvedValue('cafebabe')
+    mockGetStorageUsage.mockResolvedValue(usage)
+    mockFormatBytes.mockImplementation((bytes) => `formatted:${bytes}`)
+  })
+
+  it('usageとlimitの4値を対応するformattedフィールドへ配線する', async () => {
+    const response = await GET()
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(mockFormatBytes.mock.calls).toEqual([
+      [111],
+      [222],
+      [333],
+      [444],
+    ])
+    expect(body).toMatchObject({
+      userUsageFormatted: 'formatted:111',
+      globalUsageFormatted: 'formatted:222',
+      userLimitFormatted: 'formatted:333',
+      globalLimitFormatted: 'formatted:444',
+    })
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1363 の判断不要な軽量フォローアップとして、`GET /api/storage-status` の `formatBytes` 引数配線を unit test で固定します。

## 変更

- 新規 `tests/unit/storage-status-format-bytes.test.ts` を追加
- `userUsage` / `globalUsage` / `userLimitBytes` / `globalLimitBytes` がそれぞれ `formatBytes` に渡ることを固定
- 4つの formatted response field が対応する整形結果を返すことを固定
- runtime / API 実装は変更なし

## 重複回避

- #1351: message 契約
- #1355: 401 契約
- #1357: 500 委譲
- #1358: uploadDisabled OR 契約
- #1362: `getStorageUsage(prefix, twitchUserId)` 引数配線

本PRは新規 `storage-status-format-bytes.test.ts` のみで、既存PRの変更ファイルと重複しません。

## スコープ外

#1352 に残るモック簡素化、401→403、互換 message の設計変更、既存テスト統合は本PRの収束条件に含めません。

## レビュー・CI

- exact HEAD `6561705be93047f2bb1d6603f036ad9b19e1c104`
- 手動厳正レビュー: 必須・マージブロッカー0件
- CI #2582: completed / success
- Claude Auto Review #708: completed / success / 必須指摘0件 / 任意指摘のみ
- Cloudflare Preview deployment: success
- Auto Review #708 の任意事項（呼び出し順への過剰結合、`formatBytes` 本体境界値、モック理由コメント、`crypto-utils` 部分モック化）は #1352 へ退避済み。`uploadDisabled` / `message` は #1358 / #1351 で既に対応中のため二重着手しない

Closes #1363
Refs #1352 #1362