### PR TITLE
test(storage): formatBytes の現行境界値を固定

### DIFF
--- a/tests/unit/storage-usage.test.ts
+++ b/tests/unit/storage-usage.test.ts
@@ -227,3 +227,21 @@ describe('getStorageUsage', () => {
     expect(result.planOverLimit).toBe(false)
   })
 })
+
+describe('formatBytes', () => {
+  // 現行の実利用は非負の B〜GB 範囲なので、その契約だけを直接固定する。
+  // 負数や TB 以上をどう表現するかは別途仕様判断が必要なため、このテストでは既存挙動を固定しない。
+  it.each([
+    { bytes: 0, expected: '0 B' },
+    { bytes: 1023, expected: '1023 B' },
+    { bytes: 1024, expected: '1 KB' },
+    { bytes: 1536, expected: '1.5 KB' },
+    { bytes: 1024 ** 2, expected: '1 MB' },
+    { bytes: 1024 ** 3, expected: '1 GB' },
+    { bytes: 50 * 1024 ** 3, expected: '50 GB' },
+  ])('formats $bytes bytes as $expected', async ({ bytes, expected }) => {
+    const { formatBytes } = await import('@/lib/storage-usage')
+
+    expect(formatBytes(bytes)).toBe(expected)
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1365 の判断不要な軽量フォローアップとして、`formatBytes` 実装そのものの現行 B / KB / MB / GB 境界を既存 unit test に追加して固定します。

## 変更

- `tests/unit/storage-usage.test.ts` に `formatBytes` の直接テストを追加
- `0 B`、B→KB 境界、KB 小数、MB、GB、現行 global limit 相当の 50GB を検証
- production/runtime コード変更なし

## スコープ外

負数や TB 以上の扱いは現行実利用範囲外で、望ましい契約の判断が必要なため本PRでは固定しません。Auto Review #709 で確認された現行の配列外挙動を含め、必要な改善は #1352 へ退避済みです。

## 重複回避

PR #1364 は新規 `storage-status-format-bytes.test.ts` で route から `formatBytes` への配線だけを固定しています。本PRは既存 `storage-usage.test.ts` で実 `formatBytes` の出力を直接検証するため、変更ファイルも検証責務も重複しません。

## レビュー・CI

- exact HEAD `efe9baf0e94e66be0374ccf87e96a0c264716698`
- 手動厳正レビュー: 必須・マージブロッカー0件
- CI #2583: completed / success
- Claude Auto Review #709: completed / success / 必須指摘0件 / 合格（任意指摘のみ）
- Auto Review の任意事項（動的 import 簡素化、負数/TB以上の契約、analysis側の同一実装コピー）は #1352 に退避済み

Closes #1365
Refs #1352 #1364