### PR TITLE
test(release): 昇格PRテンプレートとQA契約を固定

### DIFF
--- a/.github/workflows/release-template-contract.yml
+++ b/.github/workflows/release-template-contract.yml
@@ -1,0 +1,32 @@
+name: Release PR template contract
+
+on:
+  pull_request:
+    branches: [main, preview]
+    paths:
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'docs/QA.md'
+      - 'tests/unit/release-pr-template-contract.test.ts'
+      - '.github/workflows/release-template-contract.yml'
+  push:
+    branches: [main, preview]
+    paths:
+      - '.github/PULL_REQUEST_TEMPLATE/**'
+      - 'docs/QA.md'
+      - 'tests/unit/release-pr-template-contract.test.ts'
+      - '.github/workflows/release-template-contract.yml'
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci
+      - name: Verify release PR template contract
+        run: npx vitest run tests/unit/release-pr-template-contract.test.ts

--- a/.github/workflows/release-template-contract.yml
+++ b/.github/workflows/release-template-contract.yml
@@ -1,23 +1,41 @@
 name: Release PR template contract
 
 on:
-  pull_request:
-    branches: [main, preview]
-    paths:
-      - '.github/PULL_REQUEST_TEMPLATE/**'
-      - 'docs/QA.md'
-      - 'tests/unit/release-pr-template-contract.test.ts'
-      - '.github/workflows/release-template-contract.yml'
   push:
     branches: [main, preview]
-    paths:
-      - '.github/PULL_REQUEST_TEMPLATE/**'
-      - 'docs/QA.md'
-      - 'tests/unit/release-pr-template-contract.test.ts'
-      - '.github/workflows/release-template-contract.yml'
+  pull_request:
+    branches: [main, preview]
 
 jobs:
+  changes:
+    name: Detect release contract changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      contract: ${{ steps.filter.outputs.contract }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          base: ${{ github.ref }}
+          filters: |
+            contract:
+              - '.github/PULL_REQUEST_TEMPLATE/**'
+              - 'docs/QA.md'
+              - 'tests/unit/release-pr-template-contract.test.ts'
+              - '.github/workflows/release-template-contract.yml'
+
   contract:
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.result != 'success' ||
+       needs.changes.outputs.contract == 'true')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = process.cwd();
+const releaseTemplate = readFileSync(
+  join(repositoryRoot, ".github/PULL_REQUEST_TEMPLATE/release.md"),
+  "utf8"
+);
+const qaDocument = readFileSync(join(repositoryRoot, "docs/QA.md"), "utf8");
+
+const REQUIRED_TEMPLATE_HEADINGS = [
+  "## このリリースで変わること",
+  "## 対象PRと固定SHA",
+  "## 累積release-unit一覧",
+  "## 確認済み",
+  "## main昇格条件",
+] as const;
+
+function h2Headings(source: string): string[] {
+  return source.split(/\r?\n/).filter((line) => line.startsWith("## "));
+}
+
+describe("preview -> main release PR template contract", () => {
+  it("keeps the user-facing release summary as the first H2 heading", () => {
+    expect(h2Headings(releaseTemplate)[0]).toBe(REQUIRED_TEMPLATE_HEADINGS[0]);
+  });
+
+  it("keeps the required release sections in the documented order", () => {
+    const headings = h2Headings(releaseTemplate);
+    const requiredHeadings = headings.filter((heading) =>
+      REQUIRED_TEMPLATE_HEADINGS.includes(
+        heading as (typeof REQUIRED_TEMPLATE_HEADINGS)[number]
+      )
+    );
+
+    expect(requiredHeadings).toEqual([...REQUIRED_TEMPLATE_HEADINGS]);
+  });
+
+  it("keeps docs/QA.md aligned with the template responsibilities", () => {
+    expect(qaDocument).toContain("`## このリリースで変わること`");
+
+    for (const requiredTerm of [
+      "対象PRと固定SHA",
+      "累積release-unit一覧",
+      "レビュー",
+      "CI",
+      "previewデプロイ",
+      "ブラウザー／実経路の確認",
+      "main昇格条件",
+    ]) {
+      expect(qaDocument).toContain(requiredTerm);
+    }
+  });
+});

--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -21,6 +21,22 @@ function h2Headings(source: string): string[] {
   return source.split(/\r?\n/).filter((line) => line.startsWith("## "));
 }
 
+function h2Section(source: string, heading: string): string {
+  const lines = source.split(/\r?\n/);
+  const start = lines.findIndex((line) => line === heading);
+  if (start === -1) return "";
+
+  const next = lines.findIndex(
+    (line, index) => index > start && line.startsWith("## ")
+  );
+  return lines.slice(start, next === -1 ? undefined : next).join("\n");
+}
+
+const qaReleaseContract = h2Section(
+  qaDocument,
+  "## Preview→main昇格PRのタイトル・本文契約"
+);
+
 describe("preview -> main release PR template contract", () => {
   it("keeps the user-facing release summary as the first H2 heading", () => {
     expect(h2Headings(releaseTemplate)[0]).toBe(REQUIRED_TEMPLATE_HEADINGS[0]);
@@ -38,7 +54,11 @@ describe("preview -> main release PR template contract", () => {
   });
 
   it("keeps docs/QA.md aligned with the template responsibilities", () => {
-    expect(qaDocument).toContain("`## このリリースで変わること`");
+    expect(qaReleaseContract).not.toBe("");
+    expect(qaReleaseContract).toContain("`## このリリースで変わること`");
+    expect(qaReleaseContract).toContain(
+      ".github/PULL_REQUEST_TEMPLATE/release.md"
+    );
 
     for (const requiredTerm of [
       "対象PRと固定SHA",
@@ -49,7 +69,7 @@ describe("preview -> main release PR template contract", () => {
       "ブラウザー／実経路の確認",
       "main昇格条件",
     ]) {
-      expect(qaDocument).toContain(requiredTerm);
+      expect(qaReleaseContract).toContain(requiredTerm);
     }
   });
 });


### PR DESCRIPTION
## 概要

Issue #1369 の判断不要な回帰ガードを追加します。

現行 `preview` では `.github/PULL_REQUEST_TEMPLATE/release.md` と `docs/QA.md` の昇格PR契約は既に一致していますが、片側だけの編集でドリフトすることを防ぐテストがありませんでした。本PRでは現行契約を unit test で固定し、template / QA 文書だけの変更でもそのテストが確実に実行される専用 workflow を追加します。

## 変更

- release template の最初の H2 が `## このリリースで変わること` であることを固定
- 必須セクションの順序を固定
- `docs/QA.md` の `Preview→main昇格PRのタイトル・本文契約` 節に同じ昇格PR責務が記載されていることを固定
- `.github/workflows/release-template-contract.yml` を追加し、template / `docs/QA.md` / 契約テスト / workflow 自身の変更時だけ契約テストを実行
- 変更検出失敗時はテストを skip せず実行する fail-safe とし、既存 CI と同じ job 単位 paths-filter 方針に合わせる

## レビュー対応

Claude Auto Review #711 の必須指摘「template / `docs/QA.md` だけを変更した場合に通常CIの test job が起動せず、契約テストが実行されない」を修正済みです。

exact HEAD `da2105a7969df80abebfcd5802ba430760b0abaa` では Claude Auto Review #713 が success / 必須指摘0件です。任意・ノンブロッキング指摘は #1371 へ退避し、本PRの収束条件にはしていません。required check の repository 設定については既存 #1361 と重複させず参照しています。

## 重複回避

- PR #1317 の通知 workflow には触れません
- PR #1360 / #1368 の docs には触れません
- release template 本文 / `docs/QA.md` 本文 / runtime は変更しません

## 検証

exact HEAD `da2105a7969df80abebfcd5802ba430760b0abaa`:

- CI #2588: completed / success
- Release PR template contract #2: completed / success
- Claude Auto Review #713: completed / success、必須指摘0件
- 手動の厳正レビュー: 必須・マージブロッカー0件

## 影響範囲

`静的/CI検証` に分類します。変更はテストとCIのみに限定され、EventSub、gacha、状態更新、outbox、chat、overlay、uploadの利用者向け引き換え経路には到達しません。そのため実チャネルポイント引き換えは不要です。

Closes #1369

Refs #1113 #1361 #1371
