### PR TITLE
test(release): 昇格PRの確認済み行を固定

### DIFF
--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -17,6 +17,13 @@ const REQUIRED_TEMPLATE_HEADINGS = [
   "## main昇格条件",
 ] as const;
 
+const REQUIRED_CONFIRMATION_LINES = [
+  "- レビュー:",
+  "- CI:",
+  "- previewデプロイ:",
+  "- ブラウザー／実経路の確認: <!-- 対象外の場合は理由を記載 -->",
+] as const;
+
 function h2Headings(source: string): string[] {
   return source.split(/\r?\n/).filter((line) => line.startsWith("## "));
 }
@@ -51,6 +58,18 @@ describe("preview -> main release PR template contract", () => {
     );
 
     expect(requiredHeadings).toEqual([...REQUIRED_TEMPLATE_HEADINGS]);
+  });
+
+  it("keeps every required confirmation row in the confirmation section", () => {
+    const confirmationLines = h2Section(releaseTemplate, "## 確認済み")
+      .split(/\r?\n/)
+      .map((line) => line.trim());
+
+    // These rows are the promotion evidence slots documented in QA.md. Checking
+    // the complete row text catches template drift that a heading-only check misses.
+    for (const requiredLine of REQUIRED_CONFIRMATION_LINES) {
+      expect(confirmationLines).toContain(requiredLine);
+    }
   });
 
   it("keeps docs/QA.md aligned with the template responsibilities", () => {


### PR DESCRIPTION
## 概要

Issue #1371 の判断不要な軽量フォローアップとして、昇格PRテンプレートの `## 確認済み` 節にある必須4行を契約テストで直接固定します。

## 変更

- `レビュー` / `CI` / `previewデプロイ` / `ブラウザー／実経路の確認` の各行を完全な行テキストで検証
- 見出し・順序だけでは検知できないテンプレート内の証跡スロット欠落を回帰として検知
- production/runtime、release template 本文、`docs/QA.md` 本文、workflow は変更しない

## 重複回避

- open PR #1307 / #1318 / #1325 / #1330 / #1332 / #1333 / #1336 / #1338 の変更領域とは独立
- 進行中の通知 workflow 系PRには触れない
- #1371 の他の任意事項は本PRの収束条件に含めない

## レビュー・CI

exact HEAD `c6efcf3adb95f5e6c15b286eb6a289f31dc0189c`:

- CI #2614: completed / success
- Release PR template contract #4: completed / success
- Claude Auto Review #714: completed / success、必須指摘0件・任意指摘のみ
- 任意指摘（ラベルとヒント文の分離、前方一致化、確認行の順序・階層検証）は #1371 に退避済み
- 手動差分確認でも production/runtime 変更、秘密情報、既存PRとの変更ファイル重複、マージブロッカーは確認されず

Refs #1371 #1369 #1370