### PR TITLE
test(storage): message互換文字列の固定理由を明記

### DIFF
--- a/tests/unit/storage-status-api.test.ts
+++ b/tests/unit/storage-status-api.test.ts
@@ -37,6 +37,8 @@ async function getStorageStatus(overrides: Partial<StorageUsage> = {}) {
 }
 
 describe('GET /api/storage-status message compatibility', () => {
+  // 互換契約の退行を検知するため、production の定数を参照せず期待文字列をリテラルで固定する。
+  // 定数側の文言変更へテストも同時追従すると、未知クライアント向け message の意図しない変更を検知できない。
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetSession.mockResolvedValue({


### PR DESCRIPTION
## 概要

Issue #1352 の判断不要な軽量フォローアップとして、`storage-status` の互換 `message` をテストで定数参照せずリテラル固定している理由をコメントで明記します。

## 変更

- `tests/unit/storage-status-api.test.ts` に2行の設計コメントを追加
- production の `STORAGE_LIMIT_MESSAGES` を参照すると、文言変更時にテストも同時追従して互換性退行を検知できなくなることを明記
- runtime / API / テスト挙動は変更しない

## 重複回避

- open PR #1372 は release template 契約テストで、変更ファイルが異なる
- 既存の open PR 群に storage-status テスト変更はなく、同一Issueへの二重着手は避けている
- #1352 の他の任意事項は本PRの収束条件に含めない

## レビュー・CI

exact HEAD `7bc2557bd7965d934d58b2384093d61d3f43d0e6`:

- CI #2615: completed / success
- Release PR template contract #5: completed / success
- Claude Auto Review #715: completed / success、必須指摘0件・任意指摘のみ
- Auto Review の任意事項は #1352 へ退避済み
- production/runtime 変更なし、差分はテスト内コメント2行のみ

Refs #1352