### PR TITLE
docs(env): ALLOWED_SOUND_HOSTS の追加許可セマンティクスを明記

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -115,8 +115,8 @@ NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 # MAINTENANCE_OPERATION_ID=xxx
 
 # 効果音 URL の追加許可ホスト（カンマ区切り）。
-# R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL 由来ホストとの和集合で判定する。
-# すべて未設定なら後方互換で HTTPS URL を許可し、同一オリジンは常に許可する。
+# HTTPS は常に必須。R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL 由来ホストとの和集合で判定する。
+# 許可ホストがすべて未設定なら任意の HTTPS URL を許可し、設定時も HTTPS の同一オリジンは許可する。
 # ALLOWED_SOUND_HOSTS=cdn.example.com,media.example.com
 
 # その他

--- a/.env.local.example
+++ b/.env.local.example
@@ -114,8 +114,10 @@ NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 # MAINTENANCE_MESSAGE_KEY=xxx
 # MAINTENANCE_OPERATION_ID=xxx
 
-# 効果音 URL の外部ホスト許可リスト（カンマ区切り）
-# ALLOWED_SOUND_HOSTS=xxx
+# 効果音 URL の追加許可ホスト（カンマ区切り）。
+# R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL 由来ホストとの和集合で判定する。
+# すべて未設定なら後方互換で HTTPS URL を許可し、同一オリジンは常に許可する。
+# ALLOWED_SOUND_HOSTS=cdn.example.com,media.example.com
 
 # その他
 # NEXT_PUBLIC_CF_IMAGES_ENABLED=false


### PR DESCRIPTION
## 概要

Issue #1342 の判断不要な軽量フォローアップです。

`.env.local.example` の `ALLOWED_SOUND_HOSTS` 説明を、現行 `src/lib/gacha-sound-rules.ts` の実装契約と同期します。

## 変更

- `ALLOWED_SOUND_HOSTS` が単独の完全 allowlist ではなく「追加許可ホスト」であることを明記
- HTTPS 必須であることを明記
- `R2_SOUND_PUBLIC_URL` / `R2_PUBLIC_URL` 由来ホストとの和集合で判定することを明記
- 許可ホストがすべて未設定の場合は任意の HTTPS URL を許可し、設定時も HTTPS の同一オリジンを許可することを明記
- `xxx` を `cdn.example.com,media.example.com` の形式例へ置換
- runtime / URL 判定ロジック / 環境変数名は変更しない

## 重複回避

- 前提 PR #1341 は既に `preview` へマージ済み
- 現在の open PR で `.env.local.example` を対象にしたものは検索上確認されず、進行中PRとの同一箇所二重着手を避けている

## レビュー・CI

exact HEAD `4f595083ceca17f5f9649e9b77c1d1218d320d11`:

- 手動厳正レビュー: 必須・マージブロッカー0件
- 初稿の same-origin 表現が HTTPS 必須条件を迂回するようにも読めたため、自主レビューで修正・再push済み
- CI #2617: completed / success
- Release PR template contract #7: completed / success
- Claude Auto Review #717: completed / success、必須指摘0件・任意指摘のみ
- Auto Review の任意事項（same-origin 分岐の実効性、HTTPS fallback の運用説明、hostname 完全一致仕様など）は #1375 へ退避済み

Closes #1342
Refs #1341 #837 #1375