### PR TITLE
docs(next): Adapters API の表現をリポジトリ基準にする

### DIFF
--- a/docs/cloudflare-proxy-migration.md
+++ b/docs/cloudflare-proxy-migration.md
@@ -10,8 +10,8 @@ now because the current Cloudflare deployment path cannot build a Next.js Proxy.
   deployment path rejects Next.js Proxy / Node.js middleware.
 - Do not add `src/proxy.ts` yet.
 - Do not wait for `@opennextjs/cloudflare` itself to gain Proxy support. The
-  upstream direction is to handle Node.js middleware through the newer
-  `@opennextjs/adapters-api` architecture instead.
+  upstream direction is to handle Node.js middleware through the newer Next.js
+  Adapters API architecture tracked in the `opennextjs/adapters-api` repository.
 - Accept the Next.js deprecated convention warning as the smaller operational
   risk while Cloudflare builds still require Edge Middleware output.
 
@@ -34,8 +34,9 @@ The incompatibility remains observable upstream as
 
 Revisit this decision when either of these is true:
 
-- Migrating TwiCa to `@opennextjs/adapters-api` (or another Cloudflare deployment
-  path with Next.js Proxy / Node.js middleware support) becomes practical and
+- Migrating TwiCa to the Next.js Adapters API path from
+  `opennextjs/adapters-api` (or another Cloudflare deployment path with Next.js
+  Proxy / Node.js middleware support) becomes practical and
   `npm run workers:build` can be verified on that path.
 - TwiCa changes deployment architecture so request interception no longer needs
   to run in Cloudflare Workers middleware.

--- a/tests/unit/cloudflare-proxy-migration.test.ts
+++ b/tests/unit/cloudflare-proxy-migration.test.ts
@@ -18,7 +18,9 @@ describe("Cloudflare proxy migration policy", () => {
 
     expect(doc).toContain("Node.js middleware is not currently supported");
     expect(doc).toContain("Do not add `src/proxy.ts` yet");
-    expect(doc).toContain("@opennextjs/adapters-api");
+    expect(doc).toContain("Next.js Adapters API");
+    expect(doc).toContain("opennextjs/adapters-api");
+    expect(doc).not.toContain("@opennextjs/adapters-api");
     expect(middleware).toContain("export async function middleware");
     expect(middleware).not.toContain("export async function proxy");
     expect(middleware).toContain("intentionally stays on the deprecated middleware.ts convention");


### PR DESCRIPTION
## 概要

Issue #1321 の判断不要な軽量フォローアップです。

Proxy 移行方針ドキュメントで `@opennextjs/adapters-api` を公開済み npm package のように読める表記から、現状に合わせて `opennextjs/adapters-api` リポジトリ / Next.js Adapters API architecture として記述します。

## 変更

- `docs/cloudflare-proxy-migration.md` の Adapters API 表現を repository / architecture 基準へ修正
- revisit 条件も `opennextjs/adapters-api` の path として表現
- 契約テストを同じ表記へ同期し、旧 `@opennextjs/adapters-api` 表記が戻らないことを固定
- runtime / middleware / Cloudflare build 設定は変更しない

## 重複回避

- open PR に `cloudflare-proxy-migration` を変更するものがないことを確認済み
- #1321 の他の任意項目（再検討トリガーの具体化、source-of-truth 整理、テスト結合度など）は本PRの収束条件に含めない

Refs #1321 #1320 #417