### PR TITLE
docs(storage): storage互換文言の履歴コメントを実効上限の説明へ整理

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -443,6 +443,8 @@ export const STORAGE_LIMIT_MESSAGES = {
   // （UPLOAD_CONFIG.USER_STORAGE_LIMIT + ボーナス + プラン加算）で変動し、
   // 10MB を超え得る。文言自体の見直しは外部互換の判断を伴うため本変更では行わず、
   // ここでは現状の乖離を明記するのみとする（#1354）。
+  // なお同種の10MB固定文言は messages/ja.json・en.json の userLimitReached /
+  // storageLimitReason にも存在するため、見直す際は i18n 側と併せて行うこと。
   USER_LIMIT_REACHED: '画像のアップロード上限は現在一アカウントにつき10MBです。上限を超える場合は、既存の画像を削除してから再度お試しください。',
   GLOBAL_LIMIT_REACHED: '画像のアップロード上限に達しました。',
 } as const

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -438,8 +438,11 @@ export const PLAN_CONFIG = {
 // storage-status の構造化フラグを使って t() で表示文言を解決するため、
 // ここでは外部・未知クライアント向けの互換文字列を維持する（#835 / #1345）。
 export const STORAGE_LIMIT_MESSAGES = {
-  // User limit message: increased to 10MB
-  // ユーザー制限メッセージ: 10MBに増加
+  // 注意: この互換文言は「一アカウントにつき10MB」と固定値を案内しているが、
+  // 実効上限は getStorageUsage() の effectiveLimit
+  // （UPLOAD_CONFIG.USER_STORAGE_LIMIT + ボーナス + プラン加算）で変動し、
+  // 10MB を超え得る。文言自体の見直しは外部互換の判断を伴うため本変更では行わず、
+  // ここでは現状の乖離を明記するのみとする（#1354）。
   USER_LIMIT_REACHED: '画像のアップロード上限は現在一アカウントにつき10MBです。上限を超える場合は、既存の画像を削除してから再度お試しください。',
   GLOBAL_LIMIT_REACHED: '画像のアップロード上限に達しました。',
 } as const


### PR DESCRIPTION
## 概要

Issue #1354 の任意フォローアップのうち、判断不要な1点（履歴コメントの整理）のみ対応するコメント-only修正です。runtime・API挙動・文言の変更はありません。

## 変更内容

- `src/lib/constants.ts` の `STORAGE_LIMIT_MESSAGES.USER_LIMIT_REACHED` 直上に残っていた変更履歴コメント（`increased to 10MB`）を削除
- 現在有効な「実効上限はプラン/ボーナス加算で変動する」説明へ置き換え（実測: `src/lib/storage-usage.ts` の `effectiveLimit = USER_STORAGE_LIMIT + bonusBytes + planBytes`）
- 固定値案内（10MB）の互換文言自体の見直しは外部互換の判断を伴うため対象外（#1354 の非スコープ整理どおり）

## 非スコープ

- `USER_LIMIT_REACHED` 文言の変更（上限値を断定しない案・実効上限を表現する案）は外部互換性・文言設計の判断が必要なため含めない
- `storage-status.message` の削除・deprecated化は #1345 の別判断事項として扱う

## 検証

- 差分がコメント行のみであることを機械検証（追加5行・削除2行すべて `//` 行）
- storage系 unit test 62件すべて成功（`storage-usage` 17件、`storage-status-*`、`storage-utils` 18件、`storage-db-driver-parity` 含む）

## 自己レビュー

- 必須（マージブロッカー）: 0件 — runtime変更なし、データ破損・セキュリティ・退行なし、CI破壊なし
- 任意（改善推奨）: なし

Refs #1354 #1345 #835