### PR TITLE
docs(eventsub): pending retry のログレベルを実装に同期

### DIFF
--- a/docs/eventsub-notification-log-contract.md
+++ b/docs/eventsub-notification-log-contract.md
@@ -9,7 +9,7 @@
 
 chat 通知が `pending` に戻る場合でも、通報契約は経路によって異なる。
 
-- `sendChatAnnouncement` が retryable outcome を返した通常の再試行経路は、`chat announcement retry scheduled` の warn を残して正常終了し、`reportError` へは到達しない。
+- `sendChatAnnouncement` が retryable outcome を返した通常の再試行経路は、`chat announcement retry scheduled` を `logger.info` で残して正常終了し、`reportError` へは到達しない。`pending` は自動回復中の正常状態として扱うため、ここでは warn に昇格させない。
 - `sendChatAnnouncement` 自体が予期せず throw した catch 経路は、delivery state が未確定なら `retryChatNotification` を呼ぶ。これは試行回数や lease 状態に応じて `pending` / `dead` / `lost-lease` になり得るが、その結果にかかわらず元の例外を rethrow するため、呼び出し元の失敗処理を通って `reportError` の対象になり得る。
 
 したがって、outbox の最終状態が `pending` であることだけを根拠に「`reportError` されない」と判断してはならない。通常の retryable outcome と unexpected throw は別の経路として扱う。


### PR DESCRIPTION
## 概要

Issue #1037 の任意・ノンブロッキング事項から、判断不要な文書整合だけを小さく修正します。

`docs/eventsub-notification-log-contract.md` は通常の retryable outcome が `pending` へ戻る経路について `chat announcement retry scheduled` の **warn** を残すと説明していましたが、現行 `src/lib/services/eventsub-redemption.ts` はこの状態を自動回復中の正常状態として扱い、実際には `logger.info` を使っています。

## 変更

- pending retry のログレベル表記を `warn` から `logger.info` へ訂正
- `pending` は自動回復中の正常状態なので warn へ昇格させない現行理由を明記
- runtime / retry 判定 / ログ文字列 / `reportError` 契約は変更しない

## 重複回避

- open PR に `docs/eventsub-notification-log-contract.md` を変更するものがないことを確認済み
- PR #1378 など進行中PRの変更領域とは独立
- #1037 の監視方針・dead/lost-lease テスト強化など判断を伴う残件は本PRの収束条件に含めない

## レビュー・CI

exact HEAD `50a737540e3951094144204708cea029dc319d11`

- CI #2634: completed / success
- Release PR template contract #24: completed / success
- Claude Auto Review run / コメントは生成されていないため、exact HEAD を手動で厳正レビュー済み
- 手動レビュー: 必須・マージブロッカー0件、任意指摘0件

Refs #1037 #1348