### PR TITLE
test(storage): auth契約テストの固定理由を明記

### DIFF
--- a/tests/unit/storage-status-auth.test.ts
+++ b/tests/unit/storage-status-auth.test.ts
@@ -5,6 +5,11 @@ import { getStorageUsage } from '@/lib/storage-usage'
 import { sha256Prefix } from '@/lib/crypto-utils'
 import { ERROR_MESSAGES } from '@/lib/constants'
 
+/**
+ * Issue #1352: storage-status は未認証と配信者機能を使えないセッションを
+ * 同じ 401 契約で拒否する。ここでは認証完了前に storage 読み取りへ進まない
+ * 境界も含め、既存 API 契約として意図的に固定する。
+ */
 vi.mock('@/lib/session')
 vi.mock('@/lib/storage-usage')
 vi.mock('@/lib/crypto-utils')


### PR DESCRIPTION
## 概要

Issue #1352 の任意・ノンブロッキング事項から、判断不要なコメント整理だけを小さく対応します。

`tests/unit/storage-status-auth.test.ts` の冒頭に、このテストが固定している契約と Issue 参照を明記しました。

## 変更

- 未認証と配信者機能を使えないセッションを現行どおり 401 で拒否する契約を明記
- 認証完了前に `sha256Prefix` / `getStorageUsage` へ進まない境界も意図的に固定していることを明記
- runtime / API / assertion / fixture / mock 挙動は変更しない

## 重複回避

- open PR に `tests/unit/storage-status-auth.test.ts` を対象とするものがないことを確認済み
- 進行中の storage 系 PR #1373 / #1382 とは変更ファイルを分離
- 401→403 の意味論変更や fixture 決定性、mock 簡素化は判断を伴うため本PRの収束条件に含めない

Refs #1352