### PR TITLE
fix(r2): HTTP 503判定を標準文法に限定

### DIFF
--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -157,11 +157,13 @@ const TRANSIENT_R2_ERROR_PATTERNS: Array<string | RegExp> = [
   'ETIMEDOUT',
   'ENOTFOUND',
   'service unavailable',
-  // 【Issue #984】裸の'503'部分文字列は、キー名やリクエストIDにたまたま'503'という
-  // 数字列が含まれる場合（例: 'photo-503.png' 等）に恒久エラーを一時障害と誤判定し、
-  // 無駄なリトライ（最大 maxRetries+1 回・最大約7秒）を発生させるリスクがあった。
-  // 'http'/'status'という文脈語が近傍にある場合のみHTTP 503相当として扱うよう限定する。
-  /\b(?:http|status)\D{0,10}503\b/i,
+  // 【Issue #984/#989】裸の'503'部分文字列やURL中の'503'は、キー名・リクエストID・
+  // パスに偶然数字列が含まれる恒久エラーを一時障害と誤判定し、無駄なリトライ
+  // （最大 maxRetries+1 回・最大約7秒）を発生させる。文字列間の距離（旧\D{0,10}）
+  // はR2/S3が保証する契約ではないため、標準的なHTTP status文法だけを明示的に受理する。
+  // HTTP status line（HTTP 503 / HTTP/1.1 503）、statusラベル（status: 503 / status code=503）、
+  // および文字列化された httpStatusCode: 503 を許容し、http://a/503 のようなURLは拒否する。
+  /\b(?:http(?:\/\d+(?:\.\d+)?)?\s+503|status(?:\s*code)?(?:\s*[:=]\s*|\s+)503|httpstatuscode\s*[:=]\s*503)\b/i,
   'NetworkingError',
   'Unspecified error',
   ...CLOUDFLARE_R2_TRANSIENT_MARKERS,

--- a/tests/unit/r2-client-transient-error.test.ts
+++ b/tests/unit/r2-client-transient-error.test.ts
@@ -36,6 +36,10 @@ describe('isTransientR2Error', () => {
     expect(isTransientR2Error('put: status: 503, please retry later')).toBe(true)
   })
 
+  it('文脈語のない裸の503は一時障害として扱わない (Issue #989)', () => {
+    expect(isTransientR2Error('503')).toBe(false)
+  })
+
   // 【Issue #984/#1252】裸の'503'部分文字列マッチは、キー名やリクエストIDに偶然数字列を含む
   // 恒久エラーを誤って一時障害と判定するリスクがあった。500は現状リトライ対象外だが、
   // HTTP statusの文脈が無い数字列を扱わない負例として503とあわせて固定する。

--- a/tests/unit/r2-client-transient-error.test.ts
+++ b/tests/unit/r2-client-transient-error.test.ts
@@ -36,8 +36,26 @@ describe('isTransientR2Error', () => {
     expect(isTransientR2Error('put: status: 503, please retry later')).toBe(true)
   })
 
-  it('文脈語のない裸の503は一時障害として扱わない (Issue #989)', () => {
-    expect(isTransientR2Error('503')).toBe(false)
+  it.each([
+    'Request failed with HTTP/1.1 503',
+    'Request failed with HTTP/2 503',
+    'put: status code=503, please retry later',
+    'SDK response: statusCode=503',
+    'SDK response: httpStatusCode: 503',
+  ])('標準的なHTTP status表記%sを一時障害として扱う (Issue #989)', (errorMessage) => {
+    expect(isTransientR2Error(errorMessage)).toBe(true)
+  })
+
+  // 【Issue #989】status文脈の無い数値やURL中の数値は、R2/S3のHTTP statusを表す保証が
+  // ないため一時障害としない。特に短いURLは旧\D{0,10}実装で誤って一致していた。
+  it.each([
+    '503',
+    'PUT http://a/503 failed',
+    'Request failed with HTTP 5030',
+    'SDK response: statusCode=5030',
+    'SDK response from myhttp 503',
+  ])('標準的なstatus文脈のない503を一時障害として扱わない: %s', (errorMessage) => {
+    expect(isTransientR2Error(errorMessage)).toBe(false)
   })
 
   // 【Issue #984/#1252】裸の'503'部分文字列マッチは、キー名やリクエストIDに偶然数字列を含む


### PR DESCRIPTION
## 利用者向け

R2への画像・効果音アップロードで、ファイル名やURLに含まれる `503` を一時障害と誤認して不要なリトライを行わないようにしました。標準的なHTTPステータス表記を含む明確な一時障害は、これまでどおりリトライされます。

## 決定した境界仕様（Issue #989）

- `\D{0,10}` の10文字／11文字という距離境界は、R2/S3のエラー契約ではないため仕様にしない。
- 文字列フォールバックでは、次の明示的な表記だけをHTTP 503として受理する。
  - `HTTP 503`、`HTTP/1.1 503`、`HTTP/2 503`
  - `status: 503`、`status code=503`、`statusCode=503`
  - 文字列化された `httpStatusCode: 503`
- 裸の `503`、`photo-503.png`、`PUT http://a/503 failed`、`HTTP 5030`、`statusCode=5030`、`myhttp 503` は一時障害としない。
- 既存の `service unavailable` とCloudflare R2固有マーカー（`(10001)`／`(10043)`等）は維持する。

## 変更内容

- `src/lib/r2-client.ts` の503判定を、HTTP status line／statusラベル／`httpStatusCode` の標準文法に限定。
- `tests/unit/r2-client-transient-error.test.ts` に正例・負例の境界テストを追加し、重複していた負例を整理。
- Issue #1212で扱われた構造化 `$metadata.httpStatusCode` の伝播は、現在の `withR2UploadRetry` がエラーを文字列化する別課題のため本PRには混在させない。

## 検証

- 関連3ファイル: 32 tests passed
- 全 unit: 320 files / 3,884 tests passed
- `npx tsc --noEmit`: 成功
- ESLint（変更2ファイル）: 成功
- `git diff --check`: 成功
- 独立厳格レビュー: 必須0件、任意0件

## Previewゲート（固定URL）

- 変更分類: R2アップロードのruntime判定変更。unit・型・lintは完了。
- 確認先: `https://twica-preview.tsubasa-azumagakito.workers.dev`
- 対象チャネル: `azumagbanjo`（preview設定の配信者本人セッション）。配信はオフラインだったが、報酬メニューと交換操作は利用可能だった。
- Twitchの表示「18」は `18ビッツ` であり、チャネルポイント残高ではない。Bits表示をポイント不足の根拠にせず、配信者本人セッションで実引き換えを継続した。

### 実引き換え・overlay・chat

- 1回目（2026-09-04 02:58:50 JST）: `ドッスン君？！` → `あsdふぁ`（コモン）。overlayの表示インスタンス1、受信約2.9秒後にカードDOMと `img.naturalWidth=800` / `naturalHeight=800` を確認。Twitchチャットに交換受付と獲得通知を確認。
- 2回目（2026-09-04 02:59:29 JST）: `ドッスン君？！` → `dda`（コモン）。overlayの表示インスタンス2、受信約2.6秒後にカードDOMと `img.naturalWidth=800` / `naturalHeight=800` を確認。Twitchチャットに交換受付と獲得通知を確認。
- 固定overlayは交換前から同じタブで `POLLING_ACTIVE` / `DO_CONNECTED`。両回で `Received payload: gacha` → `Card display scheduled` → `Card display committed` を確認。情報ログの `DUPLICATE_EVENT:polling` は重複排除として記録され、overlayのERROR/WARNは0件。

### Cloudflare Observability・アップロード

- `twica-preview` のEventSub通知2件は `channel.channel_points_custom_reward_redemption.add`、HTTP 200、`twitch-eventsub-message-retry=0`。
- 同じ2件で `Gacha success` と `Chat message sent successfully` を確認（Preview Worker）。
- 公開リポジトリの `src/app/icon.png` を一時カード `issue989-r2-upload-20260904-ebabdc6` として投入。画像処理後、`POST /api/upload` と `POST /api/cards` がともにHTTP 200、R2保存ログ（JPEG 33,295 bytes）を確認。ダッシュボードの画像拡大表示で保存先から800x800画像を取得・表示できた。
- 検証後に一時カードを削除。UIからカードが消え、`DELETE /api/cards/{redacted}` HTTP 200 とblob削除ログを確認し、カード件数を30件へ復元した。
- 権限境界は配信者本人の認証セッションでのupload／card作成／削除を確認。未認証・非所有者のブラウザー負例はこのセッションでは実施せず、既存のownership unitテストで担保する。
- Workerログに対象処理のERROR/failedは無かった。アップロード時にpreview環境既存の `SESSION_COOKIE_SECRET not set` 警告が1件出たため、環境課題として記録する（本PRの変更による失敗ではない）。

## 判定

Issue #989の境界仕様、2回の実引き換え、固定overlay、Twitchチャット、Preview WorkerのHTTP 200／retry=0、R2投入・取得・削除を確認した。未認証／非所有者ブラウザー負例と本番反映は未実施のため、main／productionへの昇格は行わない。

Closes #989
