### PR TITLE
docs(twitch): emotes のrefresh診断コメントをJSDoc参照へ整理

### DIFF
--- a/src/app/api/twitch/emotes/route.ts
+++ b/src/app/api/twitch/emotes/route.ts
@@ -116,8 +116,8 @@ export async function GET(request: Request) {
         { status: 401 }
       );
     }
-    // token-manager側はrefresh障害を二重報告しない。永続化責任はAPI境界のhandleApiErrorにあり、
-    // ここで安全なrefresh診断だけをadditionalInfoへ明示的に橋渡しする。
+    // refresh診断の永続化責任はAPI境界。additionalInfoへの安全な橋渡しと非二重報告の理由は
+    // twitchTokenErrorReportContext のJSDocを参照。
     return handleApiError(error, "Twitch emotes fetch", twitchTokenErrorReportContext(error));
   }
 }


### PR DESCRIPTION
## 概要

Issue #1088 の任意・ノンブロッキング事項から、判断不要なコメント整理だけを小さく対応します。

`src/app/api/twitch/emotes/route.ts` の refresh 診断コメントを、レビュー履歴に依存した説明から、恒久的な責務境界と `twitchTokenErrorReportContext` の JSDoc 参照へ整理します。

## 変更

- refresh 診断の永続化責任が API 境界にあることを短く明記
- additionalInfo への安全な橋渡し / 非二重報告の詳細は `twitchTokenErrorReportContext` の JSDoc を参照する形へ整理
- runtime / API 挙動 / エラー分類 / token 処理 / テストは変更しない

## 重複回避

- open PR に emotes ルートを変更するものがないことを確認済み
- #1088 を参照する open PR もありません
- rewards / channel-point-bootstrap のコメント統一や 401 + `requiresReauth` の設計は別判断事項のため本PRへ混ぜません

Refs #1088