### PR TITLE
Claude Auto Review の自動実行を停止する

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,7 +3,8 @@
 # 2026-09-03 以降、Claude Code Review が structured_output 未返却で連続失敗し、
 # レビュー未投稿のまま Checks だけが赤くなる状態が続いたため、pull_request
 # 駆動を外して手動実行（workflow_dispatch）のみに切り替えた。
-# 再開する場合は git 履歴から下の pull_request トリガーを復元すること。
+# 手動実行は停止通知だけを記録してレビューjobをスキップする。
+# 再開する場合は git 履歴から下の pull_request トリガーとjob条件を復元すること。
 #
 # preview をターゲットにした PR のたびに、Claude Code（モデル: opus）が追加された
 # 変更を自動レビューし、PR コメントで指摘を報告する。
@@ -66,15 +67,16 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  # workflow_dispatchにはpull_requestコンテキストがないためrun_idへフォールバックする。
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   claude_review:
     name: Review PR changes
-    # draft PR では opus を回さない。bot 作成 PR（Renovate / Dependabot /
-    # エージェント等）はレビュー対象に含める（エージェント起点の変更こそ要レビュー）。
-    if: github.event.pull_request.draft == false
+    # 現在は自動レビュー停止中。pull_requestトリガーを復元したときだけ実行する。
+    # workflow_dispatchではPRコンテキストが無いため、手動実行しても安全にskipとなる。
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     # コスト受容: preview 向け PR の synchronize ごとに opus（最大70ターン）を

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,4 +1,9 @@
-# Claude Auto Review (preview)
+# Claude Auto Review (preview) — 現在は停止中
+#
+# 2026-09-03 以降、Claude Code Review が structured_output 未返却で連続失敗し、
+# レビュー未投稿のまま Checks だけが赤くなる状態が続いたため、pull_request
+# 駆動を外して手動実行（workflow_dispatch）のみに切り替えた。
+# 再開する場合は git 履歴から下の pull_request トリガーを復元すること。
 #
 # preview をターゲットにした PR のたびに、Claude Code（モデル: opus）が追加された
 # 変更を自動レビューし、PR コメントで指摘を報告する。
@@ -55,23 +60,10 @@
 name: Claude Auto Review (preview)
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    branches: [preview]
-    # ドキュメントのみの変更では opus を回さない（コスト抑制）。ただし
-    # AGENTS.md / CLAUDE.md はレビュー基準そのものなので対象から外さない。
-    # paths は最後にマッチしたパターンが優先されるため、
-    # 全ファイル含む → md 除外 → 上記2ファイル再含む、の順で書く。
-    paths:
-      - '**'
-      # GitHub のドキュメント表記に合わせる（`!**/*.md` はルート直下の md に
-      # 対する挙動が実装依存のため）
-      - '!**.md'
-      - 'AGENTS.md'
-      - 'CLAUDE.md'
-    # main 向け PR は対象外（preview でレビュー済みの内容を昇格するだけのため意図的）
-    # preview への直接 push は branch protection で禁止されている前提
-    # （直 push できる場合、その変更は本レビューの対象外になる）
+  # 自動実行は停止中。手動実行のみ受け付ける。
+  # 旧 pull_request トリガー（opened/synchronize/reopened/ready_for_review、
+  # branches: [preview]、paths フィルタ付き）は git 履歴を参照すること。
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## 概要

Claude Auto Review（preview向けPRの自動レビュー）を一旦停止し、`workflow_dispatch` による手動起動だけにします。これにより、Claudeの構造化出力障害でPRのChecksが赤くなる状態を止めます。

## 理由

Claude Code Reviewが `--json-schema was provided but Claude did not return structured_output` で連続失敗し、レビューが投稿されないままChecksだけが失敗していました。

## 変更内容

- `.github/workflows/claude-review.yml` の自動 `pull_request` トリガーを停止し、`workflow_dispatch` のみに変更。
- 手動起動には `pull_request` コンテキストがないため、concurrencyの識別子は `run_id` へフォールバック。
- 手動起動時はレビューjobを安全にskipし、PR番号やbase/head SHAの参照で失敗しないように条件を明示。
- レビュー整形ロジックと既存テストは残し、再開時に復元できるようにする。

## 検証

- YAML構文・`workflow_dispatch`・job条件をローカル検証
- `git diff --check`: 成功
- 既存CI: test、lint、Workers Build、release contract が成功

Claudeレビューの再開は、構造化出力の原因を解消してから、トリガーとjob条件を復元して行います。
