### PR TITLE
chore(actions): Discord通知jobの重複ガードを整理

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -234,7 +234,7 @@ jobs:
             -d "$payload" \
             "$DISCORD_WEBHOOK_URL"
       - name: Fail after notifying missing promotion summary
-        if: success() && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: success()
         shell: bash
         run: |
           if [[ "$PROMOTION_SUMMARY_MISSING" == "true" ]]; then


### PR DESCRIPTION
## 概要

Issue #1113 の判断不要な軽量フォローアップです。

`notify` job 自体が `closed && merged` のときだけ実行されるため、job末尾の `Fail after notifying missing promotion summary` step で同じ `closed && merged` 条件を再評価する必要はありません。step側は前段成功時だけ動く意図を残して `if: success()` へ簡素化します。

## 変更

- `.github/workflows/notify-discord-main-merge.yml` の末尾step条件のみ変更
- `closed && merged` の実行条件は `notify` job 側で維持
- Discord本文生成・通知・昇格要約検証・secret権限には変更なし

## 重複回避

- 現在 open の PR にこの workflow を変更するものがないことを確認済み
- PR #1317 は同 workflow の `ready_for_review` trigger 対応だが、すでに `preview` へマージ済み
- #1113 の他の任意事項は本PRの収束条件に含めない

Refs #1113