### PR TITLE
chore: zellij monitor をローカル専用として無視

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,8 @@ db/planetscale/.local-backups/
 .claude/scheduled_tasks.lock
 .env*.local
 
+# Local zellij development helper removed from the repository; keep it local-only.
+/zellij_monitor.sh
 
 # supabase backup
 .backup.sql


### PR DESCRIPTION
## 概要

Issue #837 のうち、判断不要で未完了だった `zellij_monitor.sh` の再混入防止だけを小さく対応します。

- 現行 `preview` では `zellij_monitor.sh` 自体は既に削除済み
- `.gitignore` にルートの `/zellij_monitor.sh` を追加し、個人用 zellij 監視スクリプトが再度コミットされないようにする
- runtime / CI / application code は変更しない

## 重複回避

進行中の open PR を確認し、必須 review changes / コード起因の CI failure はありません。Issue #837 に対する現在進行中の同一変更も確認できなかったため、この独立した `.gitignore` 1ファイルだけを扱います。

## 確認

差分は `.gitignore` の2行（説明コメント + ignore entry）のみです。

Refs #837