### PR TITLE
chore: zellij monitor ignore コメントの恒久意図を明記

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,8 @@ db/planetscale/.local-backups/
 .claude/scheduled_tasks.lock
 .env*.local
 
+# Local zellij development helper removed from the repository; keep it local-only.
+/zellij_monitor.sh
 
 # supabase backup
 .backup.sql

--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,7 @@ db/planetscale/.local-backups/
 .claude/scheduled_tasks.lock
 .env*.local
 
-# Local zellij development helper removed from the repository; keep it local-only.
+# Keep this helper ignored to prevent accidental reintroduction into the repository.
 /zellij_monitor.sh
 
 # supabase backup


### PR DESCRIPTION
## 利用者向け

開発用の zellij monitor helper が誤ってリポジトリへ再追加されることを防ぐため、`.gitignore` のコメントを恒久的な再混入防止の説明へ更新しました。アプリの実行、データ、認証、配信者向け操作には影響しません。

## 変更内容

- `.gitignore` の既存コメントから、履歴上検証できない「removed from the repository」という過去形を削除し、再混入防止の意図を明記しました。
- Issue #1395 の第2項（`.git/info/exclude` / global gitignore と repository `.gitignore` の共有方針）と第3項（セクション配置）は、この PR では判断・変更していません。

## 依存関係

- `Depends on #1394` — `preview` をベースに、#1394 の HEAD `a9122a7bbb1fd43917cd0eed2ecb12c99563d9be` から分岐しています。
- 本 PR の追加コミットは `bf47d5dd` です。#1394 が先に取り込まれると、本 PR の差分はコメント1行だけになります。
- #1395 は第1項のみを扱うため `Closes #1395` ではなく `Refs #1395` としています。

## 検証

- `git diff --check`
- `git check-ignore -v --no-index zellij_monitor.sh`（`.gitignore:93` のルール適用を確認）
- `npx vitest run --cache=false tests/unit`（320 files / 3,874 tests passed）
- `npx tsc --noEmit`
- 厳格な独立レビュー: 必須指摘 0、任意指摘 0
- 親 PR #1394 の Auto Review、CI、`Workers Builds: twica-preview` は成功済み

## Preview ゲート分類

`.gitignore` のコメントだけの変更で、EventSub、ガチャ、オーバーレイ、Twitch チャット、履歴、アップロードの利用者向け経路には触れていません。そのため、実チャネルポイント引き換え・ブラウザー実経路テスト・本番デプロイは適用対象外です。PR の CI と Workers Build の結果は省略せず確認します。

Refs #1395
