### PR TITLE
test(r2): 503非対応書式を負例で固定

### DIFF
--- a/tests/unit/r2-client-transient-error.test.ts
+++ b/tests/unit/r2-client-transient-error.test.ts
@@ -46,14 +46,17 @@ describe('isTransientR2Error', () => {
     expect(isTransientR2Error(errorMessage)).toBe(true)
   })
 
-  // 【Issue #989】status文脈の無い数値やURL中の数値は、R2/S3のHTTP statusを表す保証が
-  // ないため一時障害としない。特に短いURLは旧\D{0,10}実装で誤って一致していた。
+  // 【Issue #989/#1397】status文脈の無い数値やURL中の数値、区切りのないstatus503、
+  // quoted JSON keyのstatusCodeは標準的なHTTP status表記とはみなさず、一時障害にしない。
+  // 特に短いURLは旧\D{0,10}実装で誤って一致していたため、偽陽性境界を負例で固定する。
   it.each([
     '503',
     'PUT http://a/503 failed',
     'Request failed with HTTP 5030',
     'SDK response: statusCode=5030',
     'SDK response from myhttp 503',
+    'status503',
+    '{"statusCode":503}',
   ])('標準的なstatus文脈のない503を一時障害として扱わない: %s', (errorMessage) => {
     expect(isTransientR2Error(errorMessage)).toBe(false)
   })


### PR DESCRIPTION
## 概要

Issue #1397 の判断不要な軽量フォローアップとして、503判定で意図的に受理しない書式を負例テストで固定します。

## 変更

- `status503` を一時障害として扱わないことを固定
- `{"statusCode":503}` のように JSON の quoted key を含む形を一時障害として扱わないことを固定
- 既存の「標準的な HTTP status 文脈のみを受理する」テストコメントを、この境界が分かる表現へ更新
- runtime の503判定ロジック自体は変更しない

## 重複回避

- #1397 を参照する open PR がないことを確認済み
- PR #1385 はすでに `preview` へ取り込まれており、その後続テストだけを扱う
- #1397 の判定器共通化・コメント精度・旧実装で受理した他書式の扱いは本PRへ混ぜない

## レビュー・CI

exact HEAD `714cfbb7f19d1ba9c0df04c8140b0164796a659f`

- 手動厳正レビュー: 必須・マージブロッカー0件、任意指摘0件
- CI #2659: completed / success
- Release PR template contract #49: completed / success
- Claude Auto Review は現在自動実行停止中のため生成されず、exact HEAD を手動レビューで補完済み
- 差分は `tests/unit/r2-client-transient-error.test.ts` の負例2件と説明コメントのみ。runtime / API / R2 upload behavior への変更なし

Refs #1397 #989 #1385