### PR TITLE
docs(r2): 503判定の受理形式と判定責務を明記

### DIFF
--- a/src/lib/error-handler.ts
+++ b/src/lib/error-handler.ts
@@ -59,13 +59,17 @@ const HTTP_STATUS_REASON_PHRASES = {
   507: 'insufficient\\s+storage',
 } as const
 
-// Issue #989: 裸の `503` などを部分一致させると `photo-503.png` や URL 中の数値まで
+// Issue #989/#1397: 裸の `503` などを部分一致させると `photo-503.png` や URL 中の数値まで
 // HTTP status と誤認するため、明示的な status ラベルか標準的な status line だけを受理する。
 // `httpStatusCode` は識別子途中に `status` があるため `\bstatus` 枝では一致せず、専用枝が必要。
 // `503 Service Unavailable` のような数値先頭形式は理由句まで一致させ、文脈のない数値を除外する。
-// r2-client のリトライ判定は一時障害メッセージを拾う目的でより広い書式を許容する一方、
-// ここでは最終レスポンスの誤分類を避けるため `\D{0,10}` のような緩い範囲を意図的に使わない。
-// 両者の判定器統合・入力形の整理は Issue #989 の残フォローアップとして扱う。
+//
+// この判定器は r2-client.ts のリトライ判定とは意図的に共通化しない。こちらは provider
+// のエラーメッセージを利用者向けの 401/503/507 応答へ分類する境界であり、r2-client は
+// upload の再試行による副作用を避けるため、再試行してよい証拠だけを狭く拾う境界である。
+// 同じ matcher を共有すると、一方の false positive / false negative を避けるための規則が
+// 他方へ波及する。入力契約と返却契約が同じになった場合に限り、status 番号を引数に取る
+// 共通 helper を再評価する。
 function hasHttpStatusContext(errorMessage: string, status: 401 | 503 | 507): boolean {
   const reasonPhrase = HTTP_STATUS_REASON_PHRASES[status]
   return new RegExp(

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -162,7 +162,13 @@ const TRANSIENT_R2_ERROR_PATTERNS: Array<string | RegExp> = [
   // （最大 maxRetries+1 回・最大約7秒）を発生させる。文字列間の距離（旧\D{0,10}）
   // はR2/S3が保証する契約ではないため、標準的なHTTP status文法だけを明示的に受理する。
   // HTTP status line（HTTP 503 / HTTP/1.1 503）、statusラベル（status: 503 / status code=503）、
-  // および文字列化された httpStatusCode: 503 を許容し、http://a/503 のようなURLは拒否する。
+  // および識別子と区切りの間に引用符を挟まない httpStatusCode: 503 /
+  // httpStatusCode=503 を許容し、http://a/503 のようなURLは拒否する。
+  // 旧実装で一致していた `HTTP Error 503` / `HTTP response 503` /
+  // `status code is 503` / `status503` / `{"statusCode":503}` は、R2/S3 SDKや
+  // ネイティブ binding が返す保証された形式ではないため、意図的に受理しない。
+  // この境界を変える場合は、単なる文字列の類似ではなく実際の provider message を
+  // fixture にして、リトライによる副作用（同じ upload の再試行）を含めて再評価する。
   /\b(?:http(?:\/\d+(?:\.\d+)?)?\s+503|status(?:\s*code)?(?:\s*[:=]\s*|\s+)503|httpstatuscode\s*[:=]\s*503)\b/i,
   'NetworkingError',
   'Unspecified error',


### PR DESCRIPTION
Closes #1397

## 変更内容

R2 アップロードのリトライ条件と、ストレージ API が返す利用者向けエラー分類について、実際の判定契約をコードコメントへ明記しました。リトライ回数・HTTP 応答・アップロード処理そのものは変わらないため、既存の利用者向け挙動に影響はありません。

- `src/lib/r2-client.ts`: 受理する `httpStatusCode: 503` / `httpStatusCode=503` の形を明確化し、旧実装で一致したが保証された provider 形式ではない非対応形と、その境界を変える際の再評価条件を記載
- `src/lib/error-handler.ts`: 利用者向け応答分類とアップロード再試行判定を共通化しない理由を、入力・副作用・誤分類リスクの差として記載
- 既存の PR #1400 が追加した `status503` / `{"statusCode":503}` の負例テストとは、テストファイルを変更せず重複を回避

## 検証

- `npx vitest run --cache=false tests/unit/r2-client-transient-error.test.ts` — 22 tests passed
- `npx tsc --noEmit` — passed
- `npx eslint src/lib/r2-client.ts src/lib/error-handler.ts` — passed
- `git diff --check` — passed

## 変更分類

`静的/CI検証`。コメントのみの変更で、EventSub・ガチャ・overlay・Twitchチャット・履歴・R2 upload runtime 経路は変更していません。このため Preview 実引き換えは不要です。

## 参照

- 元Issue: #1397
- 関連PR: #1385、#1400
