### PR TITLE
test(release): QAの昇格責務を同一行と順序で検証 (#1371)

### DIFF
--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -60,7 +60,7 @@ describe("preview -> main release PR template contract", () => {
       ".github/PULL_REQUEST_TEMPLATE/release.md"
     );
 
-    for (const requiredTerm of [
+    const requiredTerms = [
       "対象PRと固定SHA",
       "累積release-unit一覧",
       "レビュー",
@@ -68,8 +68,24 @@ describe("preview -> main release PR template contract", () => {
       "previewデプロイ",
       "ブラウザー／実経路の確認",
       "main昇格条件",
-    ]) {
-      expect(qaReleaseContract).toContain(requiredTerm);
+    ];
+
+    // Keep the contract tied to the documented responsibility list. Searching
+    // only this bullet prevents unrelated mentions elsewhere in QA.md from
+    // making a missing or reordered responsibility pass.
+    const responsibilityLines = qaReleaseContract
+      .split(/\r?\n/)
+      .filter(
+        (line) => line.startsWith("- ") && line.includes("対象PRと固定SHA")
+      );
+    expect(responsibilityLines).toHaveLength(1);
+    const responsibilityLine = responsibilityLines[0] ?? "";
+
+    let previousIndex = -1;
+    for (const requiredTerm of requiredTerms) {
+      const currentIndex = responsibilityLine.indexOf(requiredTerm);
+      expect(currentIndex).toBeGreaterThan(previousIndex);
+      previousIndex = currentIndex;
     }
   });
 });


### PR DESCRIPTION
## この変更で変わること

利用者向けの動作・画面・データは変わりません。昇格PRのQA文書にある7つの確認責務について、同じ列挙行に存在し、記載順が崩れていないことを契約テストで検出できるようにします。

## 変更内容

- `tests/unit/release-pr-template-contract.test.ts` の既存QA整合性テストを補強
- `- ` 始まりで `対象PRと固定SHA` を含む列挙行を一意に特定
- 同一行内の `対象PRと固定SHA` → `累積release-unit一覧` → `レビュー` → `CI` → `previewデプロイ` → `ブラウザー／実経路の確認` → `main昇格条件` の順序を検証
- QA.md本文、runtime、workflow、テンプレート本文は変更しない

## 検証

- 対象Vitest: `tests/unit/release-pr-template-contract.test.ts`（3 tests passed）
- ESLint: 成功
- TypeScript: `npx tsc --noEmit` 成功
- 差分分類: 静的・CI検証
- 実チャネルポイント引き換え: 不要（利用者向け実引き換え経路を変更しないため）

## 対象範囲と状態

- Refs #1371（部分対応。Issue全体を閉じる `Closes` は使用しない）
- base: `preview`
- 作業起点: `f07088be897a358ee408aba1d23464fe9adbeb81`
- PR #1372とは別の既存 `it` 内の変更で、同PRの未マージ差分には依存しない
- Claude Auto Review workflowは停止中
- sol独立レビュー完了（必須指摘0件・任意指摘0件、対象3テスト/lint/typecheck再実測成功、QA責務の欠落・順序入替・別箇条書き移動の隔離変異を検出）
- CIとWorkers BuildはGitHub上で完了するまで成功扱いにしない

## GitHub確認結果

- test: pass（run `33922062633`, job `101182420531`, 5m6s）
- contract: pass（run `33922062632`, job `101182415624`, 38s）
- Workers Builds: twica-preview: pass（build `51941443-c268-4b9e-b560-faead78ec778`）
- 変更対象外のジョブは skipping。PRはopenのままで、mergeは行わない
