### PR TITLE
docs(chore): zellij ignore コメントを恒久意図へ整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,7 @@ db/planetscale/.local-backups/
 .claude/scheduled_tasks.lock
 .env*.local
 
-# Local zellij development helper removed from the repository; keep it local-only.
+# Keep the local zellij development helper out of repository history.
 /zellij_monitor.sh
 
 # supabase backup


### PR DESCRIPTION
## 概要

Issue #1395 の判断不要な軽量フォローアップとして、`.gitignore` の `zellij_monitor.sh` 説明コメントだけを恒久的な意図へ整理します。

## 変更

- 履歴上の事実を断定する `removed from the repository` という過去形を削除
- `zellij_monitor.sh` を repository history へ入れない、という現在の ignore 意図だけを記述
- ignore entry 自体、配置、runtime / CI / application code は変更しない

## 重複回避

- 現在 open PR はなく、#1395 を扱う進行中PRもないことを確認済み
- #1395 の `.git/info/exclude` / global gitignore 採用可否やセクション移動は判断事項なので本PRへ混ぜない

## 検証

- `preview` 最新 `500a0f2d26638b0b33b591dbd2825f734655611b` から分岐
- 差分は `.gitignore` のコメント1行のみ（+1/-1）
- runtime / tests / build configuration への変更なし

Refs #1395 #1394 #837