### PR TITLE
docs(gacha): broadcast CSRF境界の理由を明記

### DIFF
--- a/src/app/api/gacha/demo/route.ts
+++ b/src/app/api/gacha/demo/route.ts
@@ -213,6 +213,9 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // #1331: 公開デモカード取得は読み取り用途として意図的に無認証のまま維持する。
+    // session Cookie で KV / Overlay Realtime へ状態変更する broadcast 分岐だけが
+    // CSRF の対象であり、エンドポイント全体へ検証を広げて公開デモを壊さない。
     if (broadcast && streamerId) {
       const csrfValidation = await validateCSRFToken(request);
       if (!csrfValidation.valid) {


### PR DESCRIPTION
## 概要

Issue #1331 の判断不要な軽量フォローアップとして、`POST /api/gacha/demo` で公開デモ全体ではなく `broadcast && streamerId` 分岐だけを CSRF 保護している理由を恒久コメントとして明記します。

## 変更

- 公開デモカード取得は読み取り用途として意図的に無認証のまま維持することを明記
- session Cookie を使って KV / Overlay Realtime へ状態変更する broadcast 分岐だけが CSRF 対象であることを明記
- エンドポイント全体へ CSRF 検証を広げると公開デモ経路を壊すため、境界を維持する理由を記録
- runtime / API / 認証 / rate limit / CSRF 判定ロジック自体は変更しない

## 重複回避

着手時点で `preview` 向け open PR は 0 件でした。同一Issue・同一変更領域の進行中PRはありません。

## 差分

`src/app/api/gacha/demo/route.ts` の説明コメント3行のみです。

Refs #1331 #1330