### PR TITLE
docs(test): storage message契約コメントの位置を整理

### DIFF
--- a/tests/unit/storage-status-api.test.ts
+++ b/tests/unit/storage-status-api.test.ts
@@ -36,9 +36,9 @@ async function getStorageStatus(overrides: Partial<StorageUsage> = {}) {
   return response.json() as Promise<{ message: string | null }>
 }
 
+// 互換契約の退行を検知するため、production の定数を参照せず期待文字列をリテラルで固定する。
+// 定数側の文言変更へテストも同時追従すると、未知クライアント向け message の意図しない変更を検知できない。
 describe('GET /api/storage-status message compatibility', () => {
-  // 互換契約の退行を検知するため、production の定数を参照せず期待文字列をリテラルで固定する。
-  // 定数側の文言変更へテストも同時追従すると、未知クライアント向け message の意図しない変更を検知できない。
   beforeEach(() => {
     vi.clearAllMocks()
     mockGetSession.mockResolvedValue({


### PR DESCRIPTION
## 概要

Issue #1352 の判断不要な軽量フォローアップとして、`storage-status` の互換 `message` をリテラル固定している理由コメントを `describe` 直上へ移します。

## 変更

- `tests/unit/storage-status-api.test.ts` の説明コメント2行を `describe` 内から直上へ移動
- コメントが `beforeEach` ではなく message compatibility テスト群全体の設計理由であることを明確化
- テスト期待値・fixture・runtime / API 実装は変更しない

## 重複回避

- 現在の `preview` 向け open PR #1407 は `gacha/demo` のコメント変更で、変更ファイル・Issueとも重複しない
- #1352 の他の任意事項は本PRの収束条件に含めない

## 差分

コメント2行の位置変更のみ（+2/-2）。

Refs #1352