### PR TITLE
docs(test): 昇格PR先頭H2固定の理由を明記

### DIFF
--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -45,6 +45,8 @@ const qaReleaseContract = h2Section(
 );
 
 describe("preview -> main release PR template contract", () => {
+  // 最初のH2を利用者向け要約に固定し、技術的な証跡より先に「何が変わるか」を
+  // レビュー・通知の読み手が確認できるという QA.md の本文契約を守る。
   it("keeps the user-facing release summary as the first H2 heading", () => {
     expect(h2Headings(releaseTemplate)[0]).toBe(REQUIRED_TEMPLATE_HEADINGS[0]);
   });


### PR DESCRIPTION
## 概要

Issue #1371 の判断不要な軽量フォローアップとして、昇格PRテンプレートの最初の H2 を `## このリリースで変わること` に固定している理由を契約テスト内の恒久コメントとして明記します。

## 変更

- `tests/unit/release-pr-template-contract.test.ts` に説明コメント2行を追加
- 技術的な証跡より先に、レビュー・通知の読み手が「何が変わるか」を確認できるという `docs/QA.md` の本文契約を理由として記録
- テスト期待値、release template、`docs/QA.md`、workflow、runtime は変更しない

## 重複回避

- 現在の `preview` 向け open PR #1407 は `gacha/demo` コメント、#1408 は `storage-status` テストコメントで、変更ファイル・Issueとも重複しない
- #1371 の他の未完了項目へは広げない

## 差分

既存テスト直上のコメント2行のみ（+2/-0）。

Refs #1371