### PR TITLE
docs(next): Proxy移行方針を上流の現状へ同期

### DIFF
--- a/docs/cloudflare-proxy-migration.md
+++ b/docs/cloudflare-proxy-migration.md
@@ -2,41 +2,51 @@
 
 Next.js 16 reports the `middleware.ts` convention as deprecated and recommends
 renaming it to `proxy.ts`. TwiCa intentionally keeps `src/middleware.ts` for
-now because the current Cloudflare deployment path cannot build a Next.js Proxy.
+now because the repository is pinned to `@opennextjs/cloudflare` 1.20.2, which
+predates the adapter's Node.js middleware / `proxy.ts` support.
 
 ## Current Decision
 
-- Keep `src/middleware.ts` on `preview` while the current `@opennextjs/cloudflare`
-  deployment path rejects Next.js Proxy / Node.js middleware.
+- Keep `src/middleware.ts` on `preview` while TwiCa remains on
+  `@opennextjs/cloudflare` 1.20.2 and the `proxy.ts` path has not been verified
+  with TwiCa's existing middleware behavior.
 - Do not add `src/proxy.ts` yet.
-- Do not wait for `@opennextjs/cloudflare` itself to gain Proxy support. The
-  upstream direction is to handle Node.js middleware through the newer Next.js
-  Adapters API architecture tracked in the `opennextjs/adapters-api` repository.
+- Upstream support is no longer only a future Adapters API direction:
+  `opennextjs/opennextjs-cloudflare#1309` added experimental Node.js middleware
+  (`proxy.ts`) support directly to `@opennextjs/cloudflare`, and it shipped in
+  1.20.3. The support requires the `nodejs_compat` compatibility flag.
 - Accept the Next.js deprecated convention warning as the smaller operational
-  risk while Cloudflare builds still require Edge Middleware output.
+  risk until the dependency is upgraded and `npm run workers:build` is verified
+  on TwiCa's actual middleware path.
 
 ## Verification
 
-A direct migration from `src/middleware.ts` to `src/proxy.ts` removes the
-Next.js warning, but `npm run workers:build` fails with:
+With TwiCa's currently pinned adapter version, a direct migration from
+`src/middleware.ts` to `src/proxy.ts` removes the Next.js warning, but the
+previous verification failed `npm run workers:build` with:
 
 ```text
 ERROR Node.js middleware is not currently supported. Consider switching to Edge Middleware.
 ```
 
-Next.js 16 rejects forcing Proxy back to Edge runtime, so the blocker is in the
-deployment compatibility layer rather than in TwiCa's middleware logic.
+The upstream blocker tracked as
+[`opennextjs-cloudflare#1277`](https://github.com/opennextjs/opennextjs-cloudflare/issues/1277)
+was closed on 2026-08-25 when
+[`opennextjs-cloudflare#1309`](https://github.com/opennextjs/opennextjs-cloudflare/pull/1309)
+merged. `@opennextjs/cloudflare` 1.20.3, published on 2026-08-26, includes that
+experimental `proxy.ts` support.
 
-The incompatibility remains observable upstream as
-[`opennextjs-cloudflare#1277`](https://github.com/opennextjs/opennextjs-cloudflare/issues/1277).
+Upstream status last checked: **2026-09-05**. TwiCa is still pinned to
+`@opennextjs/cloudflare` 1.20.2, so the upstream fix has not yet changed the
+repository's verified deployment contract.
 
 ## Revisit Conditions
 
 Revisit this decision when either of these is true:
 
-- Migrating TwiCa to the Next.js Adapters API path from
-  `opennextjs/adapters-api` (or another Cloudflare deployment path with Next.js
-  Proxy / Node.js middleware support) becomes practical and
-  `npm run workers:build` can be verified on that path.
+- TwiCa upgrades to an `@opennextjs/cloudflare` release containing #1309
+  (1.20.3 or newer) and `npm run workers:build` succeeds with `src/proxy.ts`
+  while the existing session refresh, protected-route, and middleware contract
+  tests remain green.
 - TwiCa changes deployment architecture so request interception no longer needs
   to run in Cloudflare Workers middleware.

--- a/tests/unit/cloudflare-proxy-migration.test.ts
+++ b/tests/unit/cloudflare-proxy-migration.test.ts
@@ -12,15 +12,17 @@ describe("Cloudflare proxy migration policy", () => {
     expect(existsSync(join(process.cwd(), "src/proxy.ts"))).toBe(false);
   });
 
-  it("documents the deploy blocker and current revisit path", () => {
+  it("documents the current pin, upstream support, and verification gate", () => {
     const doc = readSource("docs/cloudflare-proxy-migration.md");
     const middleware = readSource("src/middleware.ts");
 
     expect(doc).toContain("Node.js middleware is not currently supported");
     expect(doc).toContain("Do not add `src/proxy.ts` yet");
-    expect(doc).toContain("Next.js Adapters API");
-    expect(doc).toContain("opennextjs/adapters-api");
-    expect(doc).not.toContain("@opennextjs/adapters-api");
+    expect(doc).toContain("@opennextjs/cloudflare` 1.20.2");
+    expect(doc).toContain("opennextjs-cloudflare#1309");
+    expect(doc).toContain("1.20.3");
+    expect(doc).toContain("Upstream status last checked");
+    expect(doc).toContain("npm run workers:build");
     expect(middleware).toContain("export async function middleware");
     expect(middleware).not.toContain("export async function proxy");
     expect(middleware).toContain("intentionally stays on the deprecated middleware.ts convention");


### PR DESCRIPTION
## 概要

Issue #1321 の判断不要なフォローアップとして、`docs/cloudflare-proxy-migration.md` の上流状況を現状へ同期し、文言完全一致へ過結合していた契約テストを現行の本質的な追跡条件へ合わせます。

- `opennextjs/opennextjs-cloudflare#1277` は 2026-08-25 に close 済み
- 修正 PR `#1309` は同日に merge 済み
- `@opennextjs/cloudflare` 1.20.3（2026-08-26）で experimental な Node.js middleware / `proxy.ts` 対応がリリース済み
- TwiCa は現在 1.20.2 に固定されているため、実際の移行は依存更新 + `workers:build` + 既存 middleware 契約の検証後と明記
- 上流状況の確認日を 2026-09-05 として記録
- 初回CIで旧 `Next.js Adapters API` 文言への完全一致テストが失敗したため、Issue #1321 の方針どおり、現在の pin / upstream support / verification gate を固定する契約テストへ更新

## 変更範囲

- `docs/cloudflare-proxy-migration.md`
- `tests/unit/cloudflare-proxy-migration.test.ts`

runtime、依存バージョン、`src/middleware.ts`、Cloudflare 設定は変更しません。

## 確認

- 現行 `preview` の `package.json`: `@opennextjs/cloudflare` 1.20.2
- upstream issue #1277: closed 2026-08-25
- upstream PR #1309: merged 2026-08-25
- upstream release 1.20.3: published 2026-08-26 and #1309 を含む
- 初回 CI #2695: unit test が旧文言契約で1件 failure
- HEAD `c54f76f2d70f41701c4c4058517faf567287857f` でテスト契約を更新
- Release PR template contract #86: success
- CI #2696: success（unit / integration / Application build without Supabase variables を含む）

Refs #1321