### PR TITLE
docs(env): 効果音URLのHTTPS fallback条件を明記

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -116,7 +116,8 @@ NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 
 # 効果音 URL の追加許可ホスト（カンマ区切り）。
 # HTTPS は常に必須。R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL 由来ホストとの和集合で判定する。
-# 許可ホストがすべて未設定なら任意の HTTPS URL を許可し、設定時も HTTPS の同一オリジンは許可する。
+# R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL / ALLOWED_SOUND_HOSTS の3系統がすべて未設定なら、
+# 後方互換のため任意の HTTPS URL を許可する。いずれか設定時も HTTPS の同一オリジンは許可する。
 # ALLOWED_SOUND_HOSTS=cdn.example.com,media.example.com
 
 # その他


### PR DESCRIPTION
## 概要

Issue #1375 の判断不要な軽量フォローアップとして、`.env.local.example` の効果音URL allowlist説明を現行実装と一致する条件へ明確化します。

## 変更

- `R2_SOUND_PUBLIC_URL` / `R2_PUBLIC_URL` / `ALLOWED_SOUND_HOSTS` の3系統がすべて未設定の場合だけ、後方互換の HTTPS-only fallback が有効になることを明記
- いずれかが設定されている場合も、ブラウザの same-origin HTTPS は許可される既存仕様を維持して説明
- runtime / `isAllowedSoundUrl` / 環境変数名・設定値は変更しない

## 重複回避

着手時点の `preview` 向け open PR #1407〜#1410 は別Issue・別ファイルで、この変更領域とは重複しません。同Issue #1375 の open PR もありません。

## 差分

`.env.local.example` の説明コメントのみ（+2/-1）。

Refs #1375