### PR TITLE
docs(overlay): realtime-config 400 の no-store 根拠を明記

### DIFF
--- a/src/app/api/overlay/[streamerId]/realtime-config/route.ts
+++ b/src/app/api/overlay/[streamerId]/realtime-config/route.ts
@@ -31,6 +31,8 @@ export async function GET(
   { params }: RouteParams
 ): Promise<NextResponse> {
   const { streamerId } = await params
+  // This validation returns before the normal config response. Keep the early
+  // 400 explicitly non-cacheable so future edge-cache policy changes cannot persist it.
   if (!isValidStreamerId(streamerId)) {
     return NextResponse.json(
       { error: 'Invalid streamer ID' },


### PR DESCRIPTION
## 概要

Issue #1337 の任意・ノンブロッキング項目から、`/api/overlay/[streamerId]/realtime-config` の不正 `streamerId` 早期400に `Cache-Control: private, no-store` を付ける理由をコード近傍へ明記します。

## 変更

- 早期400は通常のconfigレスポンスより前にreturnするため、将来edge cache policyが変わってもvalidation errorをキャッシュしない意図を2行コメントで記録
- runtime、header値、status/body、cache TTL、テスト契約は変更なし

## 確認

- `preview` HEAD `6aaf5a89a8795a412895e0ecf92464a371e2e6a0` から分岐
- 同一Issueまたは `realtime-config` を扱う open PR がないことを確認済み

Refs #1337