### PR TITLE
docs(test): realtime config cache契約の意図を明記

### DIFF
--- a/tests/unit/overlay-realtime-config-route.test.ts
+++ b/tests/unit/overlay-realtime-config-route.test.ts
@@ -23,6 +23,8 @@ describe('overlay realtime runtime config', () => {
     expect(response.status).toBe(200)
     expect(body.mode).toBe('polling-only')
     expect(JSON.stringify(body)).not.toContain('must-never-leak')
+    // Keep the complete header value as the contract: changing cache scope or either
+    // 15-second freshness window can leave overlay runtime config stale at the edge.
     expect(response.headers.get('cache-control')).toBe(
       'public, max-age=15, stale-while-revalidate=15'
     )


### PR DESCRIPTION
## 概要

Issue #1337 の判断不要な軽量フォローアップとして、realtime-config の正常200レスポンスで `Cache-Control` を完全一致検証している理由をテストコメントへ明記します。

## 変更

- `tests/unit/overlay-realtime-config-route.test.ts` の既存 exact-match assertion 直前に、cache scope と 15秒 freshness window の両方を契約として固定する意図を追記
- テスト期待値・runtime/API/cache header 値は変更しない

## 重複回避

- 着手時点で `preview` 向け open PR は0件
- Issue #1337 を扱う open PR は0件
- realtime-config 400の no-store 実装・根拠コメントは既存 #1336 / #1412 側で対応済みで、本PRは200側テスト意図だけに限定

Refs #1337