### PR TITLE
chore: group local development helper ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ db/planetscale/.local-backups/
 .claude/scheduled_tasks.lock
 .env*.local
 
+# Local development helpers
 # Keep the local zellij development helper out of repository history.
 /zellij_monitor.sh
 


### PR DESCRIPTION
## 概要

Issue #1395 の軽量フォローアップとして、既存の `zellij_monitor.sh` ignore を `# Local development helpers` セクション配下へ整理します。

## 変更

- `.gitignore` にセクション見出しを1行追加
- 既存の `/zellij_monitor.sh` ignore rule と恒久コメントは変更しない
- runtime / build / CI / dependency への変更なし

## 確認

- 最新 `preview` から専用ブランチを作成
- net diff: `.gitignore` +1 / -0
- 個人 helper を repository ignore に残すかという方針判断には踏み込まず、repository ignore を維持する現状でのコメント配置だけを整理

Refs #1395