### PR TITLE
docs(test): storage auth 契約の意図を明記

### DIFF
--- a/tests/unit/storage-status-auth.test.ts
+++ b/tests/unit/storage-status-auth.test.ts
@@ -19,6 +19,8 @@ const SESSION = {
   version: 1 as const,
 }
 
+// #1352: This contract keeps auth rejection at the route boundary: missing or
+// ineligible sessions must fail before user identifiers are hashed or storage is read.
 describe('GET /api/storage-status auth contract', () => {
   beforeEach(() => {
     vi.clearAllMocks()


### PR DESCRIPTION
## 概要

Issue #1352 の判断不要な軽量フォローアップとして、`tests/unit/storage-status-auth.test.ts` の auth 契約テストが何を守るかをコメントで明記します。

## 変更

- `GET /api/storage-status` の auth contract `describe` 直上に根拠コメントを2行追加
- 未認証 / 配信者機能利用不可のセッションは、user ID hash や storage usage read より前に拒否される契約であることを明示
- runtime / API / assertion / fixture / mock の挙動変更なし

## 重複回避

- 同一 Issue #1352 を参照する open PR が無いことを確認
- 既存 open PR #1418 は `.gitignore` のみで変更領域が重複しない

## QA

- test コメントのみの変更で、`docs/QA.md` の Preview 実経路ゲート対応表に該当する runtime 変更はありません
- CI / Release PR template contract を確認します

Refs #1352