### PR TITLE
docs(ci): release contract workflow の意図を明記

### DIFF
--- a/.github/workflows/release-template-contract.yml
+++ b/.github/workflows/release-template-contract.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main, preview]
 
+# #1371: Keep this as a dedicated workflow so template/QA-only changes still
+# exercise the release contract; the job-level path filter skips its cost for unrelated changes.
 jobs:
   changes:
     name: Detect release contract changes


### PR DESCRIPTION
## 概要

Issue #1371 の判断不要な軽量フォローアップとして、release template contract 専用 workflow と job-level paths filter を併用する理由をコメントで明記します。

## 変更

- `.github/workflows/release-template-contract.yml` の `jobs` 直前に説明コメントを2行追加
- template / `docs/QA.md` だけの変更でも契約テストを起動するため専用 workflow を維持することを明記
- 無関係な変更では job-level paths filter でコストを抑える意図を明記
- workflow trigger / filter / job / runtime / test contract の挙動変更なし

## 重複回避

- Issue #1371 を参照する open PR が無いことを確認
- 既存 open PR #1418 / #1419 と変更ファイル・対象Issueともに重複しない

## QA

- コメントのみの変更で、`docs/QA.md` の Preview 実経路ゲート対応表に該当する runtime 変更はありません
- CI / Release PR template contract と latest exact HEAD の手動レビューを確認します

Refs #1371