### PR TITLE
test: gacha demo CSRF モックの型検査を強化

### DIFF
--- a/tests/unit/api/gacha-demo-route.test.ts
+++ b/tests/unit/api/gacha-demo-route.test.ts
@@ -75,7 +75,7 @@ function makeRequest(body: unknown) {
 describe('POST /api/gacha/demo: KV demo publication authorization', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockValidateCSRFToken.mockResolvedValue({ valid: true } as any)
+    mockValidateCSRFToken.mockResolvedValue({ valid: true })
     mockCreateOverlayDemoEvent.mockReturnValue(DEMO_EVENT)
     mockStoreOverlayDemoEvent.mockResolvedValue(undefined)
     mockPublishOverlayDemoRealtimeEvent.mockResolvedValue({
@@ -99,7 +99,7 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
   })
 
   it('returns 403 before authentication or publication when broadcast CSRF validation fails', async () => {
-    mockValidateCSRFToken.mockResolvedValue({ valid: false, error: 'bad csrf' } as any)
+    mockValidateCSRFToken.mockResolvedValue({ valid: false, error: 'bad csrf' })
 
     const response = await POST(makeRequest({ streamerId: 'streamer-1', broadcast: true }))
 


### PR DESCRIPTION
## 概要

Issue #1331 の判断不要な軽量フォローアップとして、`validateCSRFToken` のテストfixtureに残っていた不要な `as any` を外し、実関数の戻り値型による回帰検出を効かせます。

## 変更

- `tests/unit/api/gacha-demo-route.test.ts` の成功fixture `{ valid: true }` から `as any` を削除
- CSRF拒否fixture `{ valid: false, error: 'bad csrf' }` から `as any` を削除
- assertion / mock挙動 / runtime / API契約の変更なし

## 重複回避

- Issue #1331 を参照する open PR が無いことを確認
- 既存 open PR #1418 / #1419 / #1420 と対象Issue・変更ファイルが重複しない
- `src/app/api/gacha/demo/route.ts` には既に #1331 の broadcast-only CSRF 根拠コメントが存在するため、その項目へ重複着手しない

## QA

- test-only の型安全性改善で、`docs/QA.md` の Preview 実経路ゲートに該当する runtime 変更はありません
- CI と latest exact HEAD の手動レビューを確認します

Refs #1331