### PR TITLE
docs(env): 効果音 allowlist 設定を R2 セクションへ集約

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -77,6 +77,11 @@ R2_SOUND_SECRET_ACCESS_KEY=your_r2_sound_secret_access_key
 R2_SOUND_BUCKET_NAME=your_sound_bucket_name
 # R2効果音パブリックURL
 R2_SOUND_PUBLIC_URL=https://your-sound-bucket.your-domain.com
+# 効果音 URL の追加許可ホスト（カンマ区切り）。
+# HTTPS は常に必須。R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL 由来ホストとの和集合で判定する。
+# R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL / ALLOWED_SOUND_HOSTS の3系統がすべて未設定なら、
+# 後方互換のため任意の HTTPS URL を許可する。いずれか設定時も HTTPS の同一オリジンは許可する。
+# ALLOWED_SOUND_HOSTS=cdn.example.com,media.example.com
 
 # Cloudflare Web Analytics (optional)
 # CloudflareダッシュボードでWeb Analyticsを有効にしてトークンを取得
@@ -113,12 +118,6 @@ NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 # MAINTENANCE_EXPECTED_END_AT=xxx
 # MAINTENANCE_MESSAGE_KEY=xxx
 # MAINTENANCE_OPERATION_ID=xxx
-
-# 効果音 URL の追加許可ホスト（カンマ区切り）。
-# HTTPS は常に必須。R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL 由来ホストとの和集合で判定する。
-# R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL / ALLOWED_SOUND_HOSTS の3系統がすべて未設定なら、
-# 後方互換のため任意の HTTPS URL を許可する。いずれか設定時も HTTPS の同一オリジンは許可する。
-# ALLOWED_SOUND_HOSTS=cdn.example.com,media.example.com
 
 # その他
 # NEXT_PUBLIC_CF_IMAGES_ENABLED=false


### PR DESCRIPTION
## 概要

Issue #1342 の判断不要な軽量フォローアップとして、`.env.local.example` の `ALLOWED_SOUND_HOSTS` 説明を、実際に和集合で使う `R2_SOUND_PUBLIC_URL` / `R2_PUBLIC_URL` と同じ R2 効果音設定セクションへ移動します。

## 変更

- `ALLOWED_SOUND_HOSTS` の既存5行コメントを `R2_SOUND_PUBLIC_URL` の直後へ移動
- 文言・環境変数名・fallback 契約は変更なし
- runtime / build / dependency / 設定値の変更なし

## 重複回避

- Issue #1342 を参照する open PR が無いことを確認
- 既存 open PR #1418 / #1419 / #1420 / #1421 と対象Issue・変更ファイルが重複しない

## QA

- docs/example-env の並び替えのみで runtime 経路は変更しません
- `docs/QA.md` の Preview 実経路ゲートに該当する新規変更はありません
- CI と latest exact HEAD の手動レビューを確認します

Refs #1342