### PR TITLE
docs(test): overlay 400 no-store の多層防御意図を明記

### DIFF
--- a/tests/unit/middleware-cache-control.test.ts
+++ b/tests/unit/middleware-cache-control.test.ts
@@ -79,6 +79,8 @@ describe('middleware fail-closed Cache-Control (issue #906)', () => {
   })
 
   it('不正 streamerId の overlay events 400 にも private, no-store を付与する', async () => {
+    // 現行の Workers Cache heuristics では 400 は通常キャッシュ対象外だが、将来の
+    // edge cache 設定変更でも保存されないよう、多層防御として no-store を固定する（#1337）。
     const response = await middleware(makeRequest('/api/overlay/not-a-uuid/events'))
 
     expect(response.status).toBe(400)


### PR DESCRIPTION
## 概要

Issue #1337 の判断不要な軽量フォローアップとして、不正 `streamerId` の overlay events 400 に `private, no-store` を固定している理由を、既存契約テストの直上コメントで明示します。

## 変更

- `tests/unit/middleware-cache-control.test.ts` の 400 契約テストへ説明コメントを2行追加
- 現行 Workers Cache heuristics では 400 が通常キャッシュ対象外でも、将来の edge cache 設定変更に備える多層防御として明示 no-store を維持する意図を記録
- assertion / middleware / runtime / header値 / status / body の変更なし

## 重複回避

- 同一 Issue #1337 を参照する open PR が無いことを確認
- 既存 open PR #1418 / #1419 / #1420 / #1421 / #1422 と対象Issue・変更ファイルが重複しない
- #1337 の realtime-config 項目は既に #1412 / #1415 で対応済みのため再着手しない

## QA

- testコメントのみの変更で runtime 経路は変更しません
- `docs/QA.md` の Preview 実経路ゲートに該当する新規変更はありません
- CI と latest exact HEAD の手動レビューを確認します

Refs #1337