### PR TITLE
docs: middleware の Proxy 移行コメントを現状へ同期

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,30 +21,14 @@ const maintenanceWriteSurfaces = maintenanceWriteSurfacesJson as MaintenanceWrit
 /** maintenance write block の対象となる HTTP メソッド（読み取り系は対象外）。 */
 const MAINTENANCE_GUARDED_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
-// Next.js 16 recommends proxy.ts, but Proxy always builds as Node.js runtime
-// with no opt-out: setting `export const config = { runtime: 'edge' }` in a
-// proxy.ts file throws "Proxy always runs on Node.js runtime" at build time.
-// (https://nextjs.org/docs/messages/middleware-to-proxy)
-// @opennextjs/cloudflare (pinned 1.20.2 in this repo) hard-fails `workers:build` with
-// "Node.js middleware is not currently supported. Consider switching to Edge
-// Middleware." whenever it detects Node.js-runtime middleware/proxy output
-// (see useNodeMiddleware() in its build.js). This is still true as of
-// @opennextjs/cloudflare 1.20.2, the version pinned in this repo — confirmed
-// by inspecting that version's published
-// build.js, which contains the identical check.
-// Upstream tracking: opennextjs/opennextjs-cloudflare maintainers say real
-// proxy.ts support is planned only via Next.js's "Adapters API"
-// (opennextjs/opennextjs-cloudflare#972). The concrete bug is tracked at
-// opennextjs/opennextjs-cloudflare#1277 (open), with a community fix at PR
-// #1280 (open, changes requested by a maintainer, stalled since 2026-06-21 —
-// not merged/released). A maintainer's current guidance on #1277 is to keep
-// using middleware.ts if it doesn't need Node.js-only APIs, which is exactly
-// what this file does.
-// This file intentionally stays on the deprecated middleware.ts convention
-// (with edge-compatible code only) while the current Cloudflare deployment
-// path rejects Next.js Proxy / Node.js middleware. Revisit this when TwiCa can
-// move to an Adapters API based (or other compatible) deployment path and
-// `npm run workers:build` succeeds there; see docs/cloudflare-proxy-migration.md.
+// Next.js 16 recommends proxy.ts, but Proxy runs as Node.js middleware.
+// TwiCa remains on src/middleware.ts while @opennextjs/cloudflare is pinned
+// to 1.20.2, whose workers:build rejects that Node.js middleware output.
+// Upstream proxy.ts support shipped in @opennextjs/cloudflare 1.20.3+, so
+// migration is now gated by dependency upgrade and TwiCa-specific verification,
+// not by an open upstream blocker. Keep this file edge-compatible until the
+// proxy build and existing session/routing contracts pass.
+// Source of truth: docs/cloudflare-proxy-migration.md (#1321).
 
 /**
  * Detect locale from request (cookie or Accept-Language header)

--- a/tests/unit/cloudflare-proxy-migration.test.ts
+++ b/tests/unit/cloudflare-proxy-migration.test.ts
@@ -25,6 +25,6 @@ describe("Cloudflare proxy migration policy", () => {
     expect(doc).toContain("npm run workers:build");
     expect(middleware).toContain("export async function middleware");
     expect(middleware).not.toContain("export async function proxy");
-    expect(middleware).toContain("intentionally stays on the deprecated middleware.ts convention");
+    expect(middleware).toContain("Source of truth: docs/cloudflare-proxy-migration.md (#1321).");
   });
 });


### PR DESCRIPTION
## 概要

Issue #1321 の判断不要な軽量フォローアップとして、`src/middleware.ts` に残っていた Proxy 移行の古い上流状況説明を、現行 `docs/cloudflare-proxy-migration.md` と一致する恒久的な設計コメントへ整理します。

## 変更

- `opennextjs-cloudflare#1277` / #1280 が open という陳腐化した記述を削除
- `@opennextjs/cloudflare` 1.20.3+ では upstream `proxy.ts` support が提供済みであることを反映
- 現在は TwiCa が 1.20.2 固定であることと、移行条件が dependency upgrade + TwiCa 実経路検証であることだけをコード近傍に残す
- 詳細な上流状況と再検討条件の正本を `docs/cloudflare-proxy-migration.md` へ明示的に寄せる
- 初回 CI #2718 で、削除した旧コメント文言を `tests/unit/cloudflare-proxy-migration.test.ts` が完全一致で固定していたため unit test が1件失敗。失敗 artifact を確認し、同テストを新しい正本参照コメントの assertion へ最小同期
- runtime / middleware matcher / session / rate limit / cache / maintenance の挙動変更なし

## 重複回避

- Issue #1321 を参照する open PR が無いことを確認して着手
- 既存 open PR #1418〜#1423 と対象Issue・変更ファイルは重複しない

## QA

- runtime変更はなく、`docs/QA.md` の Preview 実経路ゲートに該当する新規経路変更はありません
- latest exact HEAD `53fe194f263440104a26e1b06bfd45a5512a5c9c` を手動再レビュー済み（必須・マージブロッカー0件、未解決thread 0件）
- latest HEAD の CI / Release PR template contract を確認する

Refs #1321