### PR TITLE
test: limit_reached 再抽選の直前カード状態を固定

### DIFF
--- a/tests/unit/gacha-repeat-protection-service.test.ts
+++ b/tests/unit/gacha-repeat-protection-service.test.ts
@@ -223,6 +223,31 @@ describe('GachaService repeat protection', () => {
     expect(fixture.transactionCalls[0][3]).toBe('card-a')
   })
 
+  it('limit_reached 再抽選でも同じ直前カード状態を維持する', async () => {
+    const fixture = installDbFixture({
+      latestCardId: 'card-a',
+      transactions: [
+        { result: { is_duplicate: false, limit_reached: true, history_id: null } },
+        { result: { is_duplicate: false, limit_reached: false, history_id: 'history-2' } },
+      ],
+    })
+    mockSecureRandomUnit(0)
+
+    const service = new GachaService()
+    const selectSpy = vi.spyOn(service as any, 'selectCardFromPool')
+    const result = await service.executeGachaWithRepeatProtection(
+      'streamer-1',
+      'user-1',
+      'Viewer',
+      'event-limit-retry',
+    )
+
+    expect(result.success).toBe(true)
+    expect(fixture.transactionCalls.map((call) => call[3])).toEqual(['card-b', 'card-a'])
+    expect(selectSpy.mock.calls.map((call) => call[2])).toEqual(['card-a', 'card-a'])
+    expect(fixture.tableReads.filter((table) => table === 'gacha_history')).toHaveLength(1)
+  })
+
   it('N連では履歴を冒頭に1回だけ読み、以後は直前の確定結果を引き継ぐ', async () => {
     const fixture = installDbFixture({
       latestCardId: 'card-a',


### PR DESCRIPTION
## 概要

Issue #1302 の判断不要な軽量フォローアップとして、`limit_reached` 後の再抽選でも最初に読んだ `previousCardId` をそのまま使う契約を unit test で直接固定します。

## 変更

- `tests/unit/gacha-repeat-protection-service.test.ts` に1ケース追加
- 最初の RPC が `limit_reached: true` を返した後、残りプールで再抽選する経路を再現
- `selectCardFromPool` の呼び出しを観測し、初回・再抽選とも `previousCardId === 'card-a'` であることを固定
- RPC へ渡るカードが `card-b` → `card-a` になること、履歴 read が追加発生しないことも確認
- runtime / 抽選実装 / DB契約は変更しない

## 重複回避

- Issue #1302 を参照する open PR が無いことを確認して着手
- 既存 open PR #1418〜#1424 と対象Issue・変更ファイルは重複しない

## QA

- test-only のため新しい Preview 実経路ゲートは発生しません
- latest exact HEAD `d23329d29ee350168734d2729af58ab57a964563` を手動厳正レビュー済み（必須・マージブロッカー0件、未解決thread 0件）
- CI #2720: success
- Release PR template contract #110: success

Refs #1302