### PR TITLE
test: sound-settings の非キャッシュエラー契約を固定

### DIFF
--- a/tests/unit/sound-settings-api.test.ts
+++ b/tests/unit/sound-settings-api.test.ts
@@ -83,6 +83,26 @@ describe("GET /api/streamer/[streamerId]/sound-settings", () => {
     expect(pg.select).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps missing streamerId as a non-cacheable 400", async () => {
+    const response = await GET(request(), {
+      params: Promise.resolve({ streamerId: "" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Cache-Tag")).toBeNull();
+  });
+
+  it("keeps unexpected catch responses non-cacheable and untagged", async () => {
+    const response = await GET(request(), {
+      params: Promise.reject(new Error("params failed")),
+    });
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("Cache-Tag")).toBeNull();
+  });
+
   it("keeps streamer-not-found as a non-cacheable 404", async () => {
     primeSoundSettingsDb({});
 


### PR DESCRIPTION
## 概要

Issue #1334 の軽量フォローアップとして、`/api/streamer/[streamerId]/sound-settings` の非正常系キャッシュ契約を unit test で固定します。

- streamerId 欠落の 400 が `Cache-Control: private, no-store`
- catch 経路の 500 が `Cache-Control: private, no-store`
- どちらも `Cache-Tag` を付与しない

runtime 実装は変更していません。既存の 200 / 404 / DB縮退テストと同じファイルに最小差分で追加しています。

Refs #1334