### PR TITLE
test: emotes error reporting を結線契約へ絞る

### DIFF
--- a/tests/unit/twitch-emotes-error-reporting.test.ts
+++ b/tests/unit/twitch-emotes-error-reporting.test.ts
@@ -56,7 +56,7 @@ describe('GET /api/twitch/emotes error reporting', () => {
     )
 
     const { GET } = await import('@/app/api/twitch/emotes/route')
-    const response = await GET(new Request('http://localhost:3000/api/twitch/emotes'))
+    await GET(new Request('http://localhost:3000/api/twitch/emotes'))
 
     expect(twitchTokenErrorReportContext).toHaveBeenCalledWith(tokenError)
     expect(handleApiError).toHaveBeenCalledWith(
@@ -64,6 +64,5 @@ describe('GET /api/twitch/emotes error reporting', () => {
       'Twitch emotes fetch',
       reportContext
     )
-    expect(response.status).toBe(500)
   })
 })


### PR DESCRIPTION
## 概要

Issue #1088 の軽量フォローアップとして、emotes の error-reporting unit test から、mock した `handleApiError` 自身が生成した 500 status を再確認するトートロジーな assertion を削除します。

## 変更

- `GET /api/twitch/emotes` を実行して `twitchTokenErrorReportContext(error)` が呼ばれることを維持
- その診断 context が `handleApiError(error, "Twitch emotes fetch", context)` へ渡る結線契約を維持
- mock が返した `Response.status === 500` の自己確認だけを削除
- runtime / API 応答 / token 判定ロジックは変更しない

## 重複回避

- 着手時点で Issue #1088 を扱う open PR は0件
- 現在の `preview` 向け open PR #1418〜#1426 は別Issue・別変更領域

Refs #1088