### PR TITLE
docs(test): R2 URL fixture comment の根拠を恒久化

### DIFF
--- a/tests/unit/error-handler.test.ts
+++ b/tests/unit/error-handler.test.ts
@@ -130,7 +130,7 @@ describe('error-handler', () => {
       'avatar-401.jpg',
       'asset-507-preview.png',
       'https://example.com/assets/503.png',
-      // 短いホスト名 `a` は `http` と `503` の距離を意図的に詰め、r2-client の `\D{0,10}` 近傍regexへ戻した退行も検知する。
+      // 短いホスト名 `a` は URL 内の 503 が HTTP status と誤分類されない境界を固定する。背景は r2-client / #984 を参照。
       'PUT http://a/503 failed',
     ])('文脈のない数値をHTTP statusとして誤分類しない: %s', async (errorMessage) => {
       const response = await handleBlobError(new Error(errorMessage), 'blob');


### PR DESCRIPTION
## Summary

- `tests/unit/error-handler.test.ts` の短いホスト名 fixture コメントから、既に置き換えられた `\D{0,10}` regex リテラルの複製を除去
- `PUT http://a/503 failed` が URL 内の 503 を HTTP status と誤分類しない境界を固定する、という恒久的なテスト意図へ整理
- fixture / assertion / runtime 実装は変更なし

## Scope

Issue #989 の既存フォローアップコメント（PR #1313 Auto Review 由来）にある、regex リテラル複製によるコメント陳腐化の回避だけを扱います。現在 open の preview 向け PR と同一 Issue / 同一変更ファイルの重複はありません。

## QA

コメントのみの +1/-1。通常 CI で既存テスト契約の非変更を確認します。Preview 実経路を新たに要求する変更ではありません。

Refs #989