### PR TITLE
test(storage): auth fixtureの期限を固定

### DIFF
--- a/tests/unit/storage-status-auth.test.ts
+++ b/tests/unit/storage-status-auth.test.ts
@@ -9,13 +9,15 @@ vi.mock('@/lib/session')
 vi.mock('@/lib/storage-usage')
 vi.mock('@/lib/crypto-utils')
 
+const SESSION_EXPIRES_AT = Date.UTC(2100, 0, 1)
+
 const SESSION = {
   twitchUserId: 'viewer-twitch-id',
   twitchUsername: 'viewer',
   twitchDisplayName: 'Viewer',
   twitchProfileImageUrl: '',
   broadcasterType: '',
-  expiresAt: Date.now() + 100_000,
+  expiresAt: SESSION_EXPIRES_AT,
   version: 1 as const,
 }
 


### PR DESCRIPTION
## 概要

Issue #1352 の軽量フォローアップとして、`tests/unit/storage-status-auth.test.ts` の session fixture から `Date.now()` 依存を外し、固定の将来時刻を使うようにします。

## 変更

- `SESSION_EXPIRES_AT = Date.UTC(2100, 0, 1)` を追加
- `expiresAt` を実行時刻依存から上記固定値へ変更
- route / runtime / API 契約 / assertion は変更なし

## 確認

- test-only の最小差分
- 既存 open PR との重複なし
- CI と exact HEAD の手動レビューを確認する

Refs #1352