### PR TITLE
docs(release): 契約テストの専用filter維持理由を明記

### DIFF
--- a/.github/workflows/release-template-contract.yml
+++ b/.github/workflows/release-template-contract.yml
@@ -25,6 +25,8 @@ jobs:
         id: filter
         with:
           base: ${{ github.ref }}
+          # Keep the contract test itself in this dedicated filter even though broad CI also
+          # runs it: test-only edits should still produce the stable release-contract check.
           filters: |
             contract:
               - '.github/PULL_REQUEST_TEMPLATE/**'


### PR DESCRIPTION
## 概要

Issue #1371 の軽量フォローアップとして、`.github/workflows/release-template-contract.yml` で契約テスト自身を専用 paths-filter に残す理由をコメントで明記します。

## 変更

- broad CI と二重実行になっても、test-only edit で安定した専用 release-contract check を残すためだと明文化
- workflow の条件・paths・job・実行コマンドは変更なし

## 確認

- `preview` `c30f01580387157bab8061af612f0e52c32ad8da` から分岐
- コメントのみの差分で runtime / CI 挙動変更なし

Refs #1371