### PR TITLE
test(storage): auth fixtureの冗長なliteral assertionを除去

### DIFF
--- a/tests/unit/storage-status-auth.test.ts
+++ b/tests/unit/storage-status-auth.test.ts
@@ -18,7 +18,7 @@ const SESSION = {
   twitchProfileImageUrl: '',
   broadcasterType: '',
   expiresAt: SESSION_EXPIRES_AT,
-  version: 1 as const,
+  version: 1,
 }
 
 // #1352: This contract keeps auth rejection at the route boundary: missing or


### PR DESCRIPTION
## 概要

Issue #1352 の軽量フォローアップとして、`tests/unit/storage-status-auth.test.ts` の session fixture に残っている不要な `as const` を外します。

PR #1431 で同じチェック項目の `Date.now()` 依存は解消済みです。本PRは残っていた `version: 1 as const` だけを整理し、`SessionPayload.version` の `number` 契約へ素直に合わせます。

## 変更

- `version: 1 as const` → `version: 1`
- runtime / API / assertion / mockの認証境界契約は変更なし

## 重複回避

- 着手時点の `preview` 向け open PR #1433 / #1434 は別Issue・別変更ファイル
- PR #1431 は既に `preview` へマージ済みで、本差分は同PRに残った別の1行のみ

## QA

テストfixtureだけの最小差分で、利用者可視のruntime変更はありません。CIとlatest exact HEADの手動厳正レビューを確認します。

Refs #1352