### PR TITLE
test(channel-points): collection_name単独欠落の回帰を固定

### DIFF
--- a/tests/unit/channel-point-bootstrap-driver-parity.test.ts
+++ b/tests/unit/channel-point-bootstrap-driver-parity.test.ts
@@ -376,6 +376,42 @@ describe('GET /api/twitch/channel-point-bootstrap?diagnostics=1: raid系カラ�
     expect(db.select).toHaveBeenCalledTimes(1)
   })
 
+  it('collection_nameだけが欠落した場合はraid設定を保持して2段目で復旧する', async () => {
+    const rewardWithoutCollectionName = {
+      id: 'extra-1',
+      reward_id: 'reward-2',
+      reward_name: 'Extra Reward',
+      draw_count: 2,
+      is_raid_limited: true,
+      created_at: '2020-01-01T00:00:00.000+00:00',
+    }
+    const { res, body, db } = await runPlanetscalePath(
+      [{ rows: [FULL_STREAMER_ROW] }],
+      [
+        {
+          error: {
+            code: '42703',
+            message: 'column \"collection_name\" of relation \"streamer_additional_gacha_rewards\" does not exist',
+          },
+        },
+        { rows: [rewardWithoutCollectionName] },
+      ]
+    )
+
+    expect(res.status).toBe(200)
+    expect(body.additionalRewards).toEqual([
+      { ...rewardWithoutCollectionName, collection_name: null },
+    ])
+    // streamers 1回 + rewards 2回(full → no-collection_name)で復旧し、
+    // raid列まで剥がすminimal queryには進まない。
+    expect(db.calls).toHaveLength(3)
+    expect(Object.keys(db.calls[1].fields)).toContain('collection_name')
+    expect(Object.keys(db.calls[2].fields)).not.toContain('collection_name')
+    expect(Object.keys(db.calls[2].fields)).toEqual(
+      expect.arrayContaining(['draw_count', 'is_raid_limited'])
+    )
+  })
+
   // collection_name 欠落 → さらに raid 列欠落へカスケードする分岐の回帰テスト。
   // 2段目（collection_name なし）でも 42703 なら最小列セットへ落ち、
   // draw_count: 1 / is_raid_limited: false / collection_name: null を補完する。


### PR DESCRIPTION
## 概要

Issue #1327 の軽量フォローアップとして、`channel-point-bootstrap` の deploy-window フォールバック契約を回帰テストで固定します。

現在の `preview` では `collection_name` だけが未デプロイの場合、2段目の select で `collection_name` だけを外し、`draw_count` / `is_raid_limited` は維持する実装になっています。既存テストは `collection_name` 欠落後に raid 列も欠落する3段カスケードを検証していましたが、`collection_name` だけが欠落するケースを直接固定していませんでした。

## 変更

- `collection_name` だけが SQLSTATE 42703 になるケースを追加
- 2段目で `collection_name: null` を補完しつつ `draw_count=2` / `is_raid_limited=true` を保持することを確認
- minimal query へ進まず、2段目 select に raid 列が残ることを確認

runtime 実装・API 契約・DB スキーマは変更していません。

## 検証

- `npx vitest run tests/unit/channel-point-bootstrap-driver-parity.test.ts` — 11/11 success
- `npm run test:unit` — 321 files / 3936 tests success
- `npm run typecheck` — success
- `git diff --check` — success

Refs #1327