### PR TITLE
test(channel-points): RETURNING helperコメントを現行契約へ同期

### DIFF
--- a/tests/unit/additional-rewards-api.test.ts
+++ b/tests/unit/additional-rewards-api.test.ts
@@ -94,9 +94,9 @@ function primeDb(config: { selects?: DbResponse[]; inserts?: DbResponse[]; updat
         }),
         where: vi.fn(() => builder),
         returning: vi.fn((columns?: unknown) => {
-          // 引数なし returning() と明示列 returning({...}) を区別して記録する
-          // （collection_name 列未デプロイ窓で RETURNING 側の 42703 再発を防ぐ
-          // 明示列への切り替えを検証するため）
+          // PUT は初回から明示列 returning({...}) を使うため、各呼び出しの列セットを記録する。
+          // collection_name を含む通常列と、列欠落時に除外した再試行列を比較し、
+          // deploy window で RETURNING 側の 42703 が再発しない契約を検証する。
           returningCalls.push(columns);
           return builder;
         }),


### PR DESCRIPTION
## 概要

Issue #1379 の軽量フォローアップとして、`tests/unit/additional-rewards-api.test.ts` の `primeDb` update mock helper に残っていた stale な RETURNING 説明コメントを現行実装へ同期します。

PR #1413 は既に `preview` へマージ済みで、同PRが修正したのはテストケース本体（旧 604-607 行）の stale コメントです。本PRは、その後も現在の `preview` に残っていた別hunkの helper コメントだけを対象にします。

## 変更

- helper の旧説明「引数なし `returning()` と明示列を区別する」を削除
- PUT は初回から明示列 `returning({...})` を使い、`collection_name` を含む通常列セットと列欠落時の再試行列セットを記録して比較する契約であることを明記
- runtime / assertion / mock の挙動は変更なし

## 重複回避

- #1413: テストケース本体のコメントを修正済み。本PRとは別hunk
- 着手時点の `preview` 向け open PR #1433〜#1436 は別Issue・別変更ファイル
- 現在の `preview` に helper 側の stale コメントが残っていることを確認した上で、その箇所だけを変更

## 検証

- `npx vitest run tests/unit/additional-rewards-api.test.ts` — 35/35 success
- `git diff --check` — success
- CI #2747 — success
- Release PR template contract #137 — success

コメントのみの変更で、利用者可視のruntime挙動やPreview実経路は変更しません。

Refs #1379