### PR TITLE
test(gacha): 実効レアリティ重みの反復抑制を固定

### DIFF
--- a/tests/unit/gacha-repeat-protection-rarity-weights.test.ts
+++ b/tests/unit/gacha-repeat-protection-rarity-weights.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { GachaService } from '@/lib/services/gacha'
+import { mockSecureRandomUnit } from '../utils/secure-random'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('GachaService repeat protection with rarity weights', () => {
+  it('実効レアリティ重みを使って反復を抑制し、返却値は元のdrop_rateを維持する', () => {
+    mockSecureRandomUnit(0)
+
+    const pool = [
+      {
+        id: 'card-a',
+        name: 'Card A',
+        description: null,
+        image_url: null,
+        rarity: 'common' as const,
+        drop_rate: 0.9,
+        intra_rarity_weight: 1,
+      },
+      {
+        id: 'card-b',
+        name: 'Card B',
+        description: null,
+        image_url: null,
+        rarity: 'rare' as const,
+        drop_rate: 0.1,
+        intra_rarity_weight: 1,
+      },
+    ]
+
+    const service = new GachaService()
+    const selectCardFromPool = (service as any).selectCardFromPool.bind(service)
+
+    // 同じ乱数・直前カードでも元の 90:10 重みでは A が不可避に連続する。
+    expect(selectCardFromPool(pool, null, 'card-a')?.id).toBe('card-a')
+
+    // レアリティ配分を 10:90 に反転すると effectiveWeight 側の反復抑制が B を選ぶ。
+    const selected = selectCardFromPool(pool, { common: 10, rare: 90 }, 'card-a')
+    expect(selected?.id).toBe('card-b')
+    // effectiveWeight は選択専用で、下流へ返す drop_rate は元カードの値を維持する。
+    expect(selected?.drop_rate).toBe(0.1)
+  })
+})

--- a/tests/unit/gacha-repeat-protection-rarity-weights.test.ts
+++ b/tests/unit/gacha-repeat-protection-rarity-weights.test.ts
@@ -17,7 +17,7 @@ describe('GachaService repeat protection with rarity weights', () => {
         description: null,
         image_url: null,
         rarity: 'common' as const,
-        drop_rate: 0.9,
+        drop_rate: 0.75,
         intra_rarity_weight: 1,
       },
       {
@@ -26,7 +26,7 @@ describe('GachaService repeat protection with rarity weights', () => {
         description: null,
         image_url: null,
         rarity: 'rare' as const,
-        drop_rate: 0.1,
+        drop_rate: 0.25,
         intra_rarity_weight: 1,
       },
     ]
@@ -34,13 +34,13 @@ describe('GachaService repeat protection with rarity weights', () => {
     const service = new GachaService()
     const selectCardFromPool = (service as any).selectCardFromPool.bind(service)
 
-    // 同じ乱数・直前カードでも元の 90:10 重みでは A が不可避に連続する。
+    // 同じ乱数・直前カードでも元の 75:25 重みでは A が不可避に連続する。
     expect(selectCardFromPool(pool, null, 'card-a')?.id).toBe('card-a')
 
-    // レアリティ配分を 10:90 に反転すると effectiveWeight 側の反復抑制が B を選ぶ。
-    const selected = selectCardFromPool(pool, { common: 10, rare: 90 }, 'card-a')
+    // レアリティ配分を 25:75 に反転すると effectiveWeight 側の反復抑制が B を選ぶ。
+    const selected = selectCardFromPool(pool, { common: 25, rare: 75 }, 'card-a')
     expect(selected?.id).toBe('card-b')
     // effectiveWeight は選択専用で、下流へ返す drop_rate は元カードの値を維持する。
-    expect(selected?.drop_rate).toBe(0.1)
+    expect(selected?.drop_rate).toBe(0.25)
   })
 })


### PR DESCRIPTION
## 概要

Issue #1302 の任意フォローアップとして、`GachaService.selectCardFromPool` の `resolvedRarityWeights -> effectiveWeight` 分岐でも直前カードの反復抑制が適用されることを focused unit test で固定します。

## 変更

- 同じ乱数・直前カードで、元の `drop_rate` 75:25 では直前カードが連続する基準ケースを固定
- レアリティ実効重みを 25:75 に切り替えると別カードが選ばれることを固定
- 選択に effectiveWeight を使っても、返却カードの `drop_rate` は元値のままであることを固定
- runtime / API / DB スキーマは変更しない

## 重複回避

現在の `preview` 向け open PR #1433〜#1437 はいずれも別 Issue / 別変更領域で、Issue #1302 を参照する open PR はありません。

Refs #1302