### PR TITLE
test(twitch): emotes診断contextなしの境界を固定

### DIFF
--- a/tests/unit/twitch-emotes-error-reporting.test.ts
+++ b/tests/unit/twitch-emotes-error-reporting.test.ts
@@ -65,4 +65,28 @@ describe('GET /api/twitch/emotes error reporting', () => {
       reportContext
     )
   })
+
+  it('診断contextがないrefresh失敗でもundefinedをhandleApiErrorへ渡す', async () => {
+    const tokenError = new Error('refresh failed without diagnostics')
+
+    const { getTwitchAccessToken, twitchTokenErrorReportContext } =
+      await import('@/lib/twitch/token-manager')
+    const { handleApiError } = await import('@/lib/error-handler')
+
+    vi.mocked(getTwitchAccessToken).mockRejectedValue(tokenError)
+    vi.mocked(twitchTokenErrorReportContext).mockReturnValue(undefined)
+    vi.mocked(handleApiError).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'handled' }), { status: 500 }) as never
+    )
+
+    const { GET } = await import('@/app/api/twitch/emotes/route')
+    await GET(new Request('http://localhost:3000/api/twitch/emotes'))
+
+    expect(twitchTokenErrorReportContext).toHaveBeenCalledWith(tokenError)
+    expect(handleApiError).toHaveBeenCalledWith(
+      tokenError,
+      'Twitch emotes fetch',
+      undefined
+    )
+  })
 })


### PR DESCRIPTION
## 概要

Issue #1088 の軽量フォローアップとして、emotes ルートで `twitchTokenErrorReportContext(error)` が `undefined` を返す場合も、API境界がそのまま `handleApiError` へ渡す契約を focused unit test で固定します。

## 変更

- refresh失敗を発生させ、診断context helperが `undefined` を返すケースを追加
- 同一 error が helper に渡ることを確認
- `handleApiError(error, "Twitch emotes fetch", undefined)` が呼ばれることを固定
- runtime / API / DB / Worker の実装変更なし

## 重複回避

- 着手時点の `preview` 向け open PR #1433〜#1438 は別Issue・別変更ファイル
- Issue #1088 を参照する open PR はなく、既存の診断context有りケースを変更せず補完のみ

## QA

`tests/unit/twitch-emotes-error-reporting.test.ts` だけの test-only 差分です。`docs/QA.md` の Preview 実経路対応表に該当する runtime 経路は変更していません。

Refs #1088