### PR TITLE
test(middleware): 不要なlogger mockを整理

### DIFF
--- a/tests/unit/middleware-overlay-events-validation.test.ts
+++ b/tests/unit/middleware-overlay-events-validation.test.ts
@@ -1,10 +1,6 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { NextRequest } from 'next/server'
 import { middleware } from '@/middleware'
-
-vi.mock('@/lib/logger', () => ({
-  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
-}))
 
 describe('middleware overlay events validation', () => {
   it('不正なstreamerIdを400の固定JSON本文で拒否する', async () => {


### PR DESCRIPTION
## Summary

Issue #1321 で残っている軽量フォローアップとして、`tests/unit/middleware-overlay-events-validation.test.ts` の未使用 `logger` mock を削除します。

- `middleware()` の不正 `streamerId` 400 応答契約はそのまま維持
- `vi` import と実行経路で不要な `@/lib/logger` mock だけを削除
- runtime / API / Cloudflare 設定の変更なし

## Test plan

- CI の unit / typecheck を確認

Refs #1321