### PR TITLE
test(sound): allowlist hostname normalizationを固定

### DIFF
--- a/tests/unit/gacha-sound-url-allowlist-normalization.test.ts
+++ b/tests/unit/gacha-sound-url-allowlist-normalization.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { isAllowedSoundUrl } from '@/lib/gacha-sound-rules'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('gacha sound URL allowlist normalization (#1375)', () => {
+  it('明示allowlistはtrim・大小文字無視のhostname完全一致で判定し、URL側のportは比較しない', () => {
+    vi.stubEnv('R2_SOUND_PUBLIC_URL', '')
+    vi.stubEnv('R2_PUBLIC_URL', '')
+    vi.stubEnv('ALLOWED_SOUND_HOSTS', '  CDN.Example.COM , media.example.com  ')
+
+    expect(isAllowedSoundUrl('https://cdn.example.com:8443/sound.mp3')).toBe(true)
+    expect(isAllowedSoundUrl('https://media.example.com/sound.mp3')).toBe(true)
+    expect(isAllowedSoundUrl('https://cdn.example.com.evil.test/sound.mp3')).toBe(false)
+  })
+
+  it('R2由来allowlistもURLのhostnameだけを正規化して使う', () => {
+    vi.stubEnv('ALLOWED_SOUND_HOSTS', '')
+    vi.stubEnv('R2_SOUND_PUBLIC_URL', 'https://SOUNDS.Example.COM:9443/assets')
+    vi.stubEnv('R2_PUBLIC_URL', 'https://images.example.com/base')
+
+    expect(isAllowedSoundUrl('https://sounds.example.com/sound.mp3')).toBe(true)
+    expect(isAllowedSoundUrl('https://images.example.com:8443/sound.mp3')).toBe(true)
+    expect(isAllowedSoundUrl('https://other.example.com/sound.mp3')).toBe(false)
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1375 で docs に固定済みの効果音 URL allowlist の hostname 照合契約を、focused unit test で直接固定します。

- `ALLOWED_SOUND_HOSTS` は前後空白を trim し、大小文字を無視して hostname 完全一致で比較する
- 対象 URL の port は `URL.hostname` 比較に含めない
- `R2_SOUND_PUBLIC_URL` / `R2_PUBLIC_URL` 由来ホストも URL から hostname を正規化して使う
- サブドメイン風の部分一致や未許可ホストは拒否する

## 変更範囲

- `tests/unit/gacha-sound-url-allowlist-normalization.test.ts` の新規追加のみ
- runtime / API / DB / Cloudflare 設定は変更しない
- 既存 open PR の変更ファイルとは重複しない

Refs #1375