### PR TITLE
test(r2): status grammarの距離境界を固定

### DIFF
--- a/tests/unit/r2-client-status-grammar-distance.test.ts
+++ b/tests/unit/r2-client-status-grammar-distance.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { isTransientR2Error } from '@/lib/r2-client'
+
+// Issue #989: 旧判定は文脈語と 503 の距離を \D{0,10} で制限していたため、
+// provider が空白を多めに入れただけでも一時障害を取りこぼし得た。
+// 現行の明示的な status grammar が任意の文字列距離ではなく構文で判定することを固定する。
+describe('isTransientR2Error: HTTP status grammar distance regression (#989)', () => {
+  it('status code と 503 の間が11文字を超える空白でも一時障害として扱う', () => {
+    expect(isTransientR2Error(`request failed with status code:${' '.repeat(16)}503`)).toBe(true)
+  })
+
+  it('status と 503 の間に未定義の語が入る場合は一時障害として扱わない', () => {
+    expect(isTransientR2Error('request failed with status metadata 503')).toBe(false)
+  })
+})


### PR DESCRIPTION
## このPRで行うこと

Issue #989 の任意フォローアップとして、旧 `\D{0,10}` 距離制限に依存しない現行 HTTP status grammar の回帰テストを追加します。

- `status code:` と `503` の間に 11 文字を超える空白があっても一時障害として扱う
- `status metadata 503` のような未定義の語を挟む文字列は一時障害として扱わない
- runtime / retry 実装は変更しない

## 重複回避

- 現在の `preview` 向け open PR #1433〜#1442 の変更ファイルとは重複しません
- Issue #989 を参照する open PR が無いことを確認済みです
- 既存 `r2-client-transient-error.test.ts` の標準 status 表記検証を置き換えず、旧距離上限の再導入だけを狭く防ぎます

Refs #989