### PR TITLE
test(overlay): sound delegateを各テストで復元

### DIFF
--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -8,15 +8,18 @@ import { pickSoundBearingCardIndex } from '@/lib/gacha-sound-rules'
 import { OVERLAY_EFFECT_PARTICLE_CONFIG } from '@/lib/overlay-effect'
 import { serializePollState } from '@/lib/overlay-version'
 
+type ResolvePlayableGachaSound = typeof import('@/lib/gacha-sound-rules')['resolvePlayableGachaSound']
+
 const HISTORY_ID_BEFORE_RELOAD = '00000000-0000-4000-8000-000000000101'
 const HISTORY_ID_RESTORED = '00000000-0000-4000-8000-000000000102'
 
-const { subscribeMock, resolvePlayableGachaSoundMock, streamerIdRef } = vi.hoisted(() => ({
+const { subscribeMock, resolvePlayableGachaSoundMock, resolvePlayableGachaSoundActualRef, streamerIdRef } = vi.hoisted(() => ({
   subscribeMock: vi.fn(),
   // 既定では実装(actual)へ委譲するdelegateとして下のvi.mockファクトリ内で
   // 設定する。個々のテストはmockImplementationOnce()で1回だけ差し替え、
   // それ以外の全テストへは実際のsound-rulesロジックがそのまま使われる。
   resolvePlayableGachaSoundMock: vi.fn(),
+  resolvePlayableGachaSoundActualRef: { current: null as ResolvePlayableGachaSound | null },
   streamerIdRef: { current: 'streamer-1' },
 }))
 
@@ -38,6 +41,7 @@ vi.mock('@/lib/realtime', () => ({
 // getterトリックではなく明示的に制御するための部分モック。
 vi.mock('@/lib/gacha-sound-rules', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/gacha-sound-rules')>()
+  resolvePlayableGachaSoundActualRef.current = actual.resolvePlayableGachaSound
   resolvePlayableGachaSoundMock.mockImplementation(actual.resolvePlayableGachaSound)
   return {
     ...actual,
@@ -60,6 +64,10 @@ const terminalDisplayBlockError: RealtimeError = {
 
 describe('OverlayPage', () => {
   beforeEach(() => {
+    // Nested suites use vi.restoreAllMocks(), which also resets this vi.fn delegate.
+    // Reinstall the actual implementation for every test so execution order cannot leak state (#1308).
+    resolvePlayableGachaSoundMock.mockReset()
+    resolvePlayableGachaSoundMock.mockImplementation(resolvePlayableGachaSoundActualRef.current!)
     streamerIdRef.current = 'streamer-1'
     window.history.replaceState({}, '', '/overlay/streamer-1')
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({


### PR DESCRIPTION
## 概要

Issue #1308 のテスト隔離性フォローアップとして、`tests/unit/components/overlay-page.test.tsx` の `resolvePlayableGachaSoundMock` delegate を各テストの `beforeEach` で actual 実装へ復元します。

- nested suite の `vi.restoreAllMocks()` が `vi.fn` delegate をresetしても、次テスト開始時に actual 実装へ戻す
- `mockImplementationOnce()` を使う例外系テストの差し替えをテスト間へ持ち越さない
- production/runtime/API/DB 変更なし

## 確認

- `preview` exact base: `c30f01580387157bab8061af612f0e52c32ad8da`
- `npx vitest run tests/unit/components/overlay-page.test.tsx`: 57/57 pass
- `npm run typecheck`: pass
- `git diff --check`: pass

Refs #1308
