### PR TITLE
test(gacha): NULL履歴の独立抽選fallbackを固定

### DIFF
--- a/tests/unit/gacha-repeat-protection-service.test.ts
+++ b/tests/unit/gacha-repeat-protection-service.test.ts
@@ -203,6 +203,28 @@ describe('GachaService repeat protection', () => {
     expect(fixture.tableReads.filter((table) => table === 'gacha_history')).toHaveLength(1)
   })
 
+  it('redeemed_atがNULLの履歴しかなくても、従来の独立抽選へ安全にフォールバックする', async () => {
+    // getLatestCardIdForStreamer は redeemed_at IS NOT NULL で候補を絞るため、
+    // legacy NULL 行しかない状態は「有効な最新履歴0件」として返る契約を再現する。
+    const fixture = installDbFixture({ latestCardId: null })
+    mockSecureRandomUnit(0)
+
+    const result = await new GachaService().executeGachaWithRepeatProtection(
+      'streamer-1',
+      'user-1',
+      'Viewer',
+      'event-empty-history',
+    )
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.card.id).toBe('card-a')
+    }
+    expect(fixture.transactionCalls).toHaveLength(1)
+    expect(fixture.transactionCalls[0][3]).toBe('card-a')
+    expect(fixture.tableReads.filter((table) => table === 'gacha_history')).toHaveLength(1)
+  })
+
   it('最新履歴の読み取りに失敗しても、従来の独立抽選へフォールバックする', async () => {
     const fixture = installDbFixture({
       latestHistoryError: new Error('history read unavailable'),


### PR DESCRIPTION
## 概要

Issue #1300 の軽量フォローアップとして、`redeemed_at IS NOT NULL` で有効な最新履歴が0件になる場合に、反復抑制が従来の独立抽選へ安全にフォールバックする契約を focused unit test で固定します。

## 変更

- legacy の `redeemed_at = NULL` 行しかなく、最新履歴候補が空になるケースを追加
- 同じ乱数なら previous card なしの独立抽選として `card-a` を選ぶことを確認
- `gacha_history` 読み取り1回・transaction 1回に留まることを固定
- runtime / API / DB schema は変更なし

## 重複回避

- 着手時点の `preview` 向け open PR #1433〜#1445 は別Issue・別変更ファイル
- Issue #1300 を参照する open PR は0件

## 検証

- `npx vitest run tests/unit/gacha-repeat-protection-service.test.ts` — 6/6 success
- `npm run typecheck` — success
- `git diff --check` — success

Refs #1300
