### PR TITLE
docs(qa): chat retry の info ログ確認を明記

### DIFF
--- a/docs/QA.md
+++ b/docs/QA.md
@@ -34,6 +34,8 @@ analysis dashboard は `analysis/` で `npm ci`, `npx tsc --noEmit`, `npm run bu
 
 ここでいうE2Eは、利用者の操作（Twitchでの報酬引き換え）から利用者が観測できる結果（履歴、chat、overlay表示）までを実際に通す確認です。EventSub direct、Queue replay、DB relay、管理APIなどの内部保守経路や、秘密情報・管理者権限を必要とする操作は、通常の利用者向けE2Eの必須条件にしません。内部経路を変更した場合は、実引き換えを代用にせず、秘密情報なしで実行できる適切な unit/integration/contract/maintenance test を別に行います。Worker/DBログはE2E結果を相関する証拠として扱い、MCPで取得できない場合は未確認として記録します。認証回避や秘密情報の取得で補完してはなりません。
 
+chat の再試行挙動を確認する場合、自己回復中の `pending` は warn ではなく info の `[postRedemptionNotify] chat announcement retry scheduled` として記録されるため、この文字列を明示的に検索し、warn だけの確認で見落とさないようにします。
+
 Twitch画面の「ビッツとポイントの残高」はBitsを含む複合表示であり、数値だけをチャネルポイント残高と解釈しません。対象チャネルの配信者本人（アカウント所有者）は、ポイント残高表示やBits残高を理由に実引き換えを中止せず、報酬メニュー表示・交換操作・引き換え結果を一次証拠にします。視聴者アカウントでは実際のチャネルポイント不足を別途確認し、Bits残高を代用根拠にしません。
 
 この対応表は `docs/E2E_SCENARIO.md` に定義された Preview Twitch 実経路の必須シナリオを置き換えません。変更が同シナリオの対象になる場合は、対応表の項目と併せて該当シナリオも実行します。


### PR DESCRIPTION
## 概要

Issue #1037 の任意・ノンブロッキング事項から、判断不要な Preview QA 運用メモだけを追加します。

chat 通知が retryable outcome で `pending` に戻る場合、現行実装は warn ではなく info の `[postRedemptionNotify] chat announcement retry scheduled` を記録します。Preview 実経路で Worker ログを確認する際、この自己回復中ログを warn だけの確認で見落とさないよう `docs/QA.md` に明記します。

## 変更

- `docs/QA.md` の Preview 実経路ゲートに、chat retry の info ログ文字列を明記
- runtime / retry / DLQ / reportError / ログレベル / ログ文字列は変更なし
- 既存 `docs/eventsub-notification-log-contract.md` の契約と現行実装をそのまま QA 手順へ接続

## 重複回避

- 着手時点の `preview` 向け open PR #1433〜#1446 に `docs/QA.md` の変更はありません
- Issue #1037 を参照する open PR は0件です
- 既にマージ済みの #1383 はログレベル文書自体の同期、本PRは Preview QA での検索手順の明記で変更箇所・役割が異なります

## 検証

- `preview` exact base: `c30f01580387157bab8061af612f0e52c32ad8da`
- `npx vitest run tests/unit/release-pr-template-contract.test.ts` — 4/4 success
- `git diff --check` — success

Refs #1037
