### PR TITLE
docs(storage): API互換message型を非推奨として明記

### DIFF
--- a/src/components/CardManager.tsx
+++ b/src/components/CardManager.tsx
@@ -47,6 +47,7 @@ interface StorageStatus {
   uploadDisabled: boolean;
   // プランダウングレード後のストレージ超過フラグ
   planOverLimit?: boolean;
+  /** @deprecated 公式UIは構造化された制限フラグから i18n 文言を解決するため、API互換用フォールバックとしてのみ保持する。 */
   message: string | null;
 }
 


### PR DESCRIPTION
## 概要

Issue #1345 の軽量フォローアップとして、`CardManager` が保持する `StorageStatus.message` を API 互換フォールバック専用の非推奨フィールドであることを型上でも明記します。

公式UIは `planOverLimit` / `globalLimitReached` / `userLimitReached` などの構造化フラグから i18n 文言を解決しており、`message` 自体は参照していません。新しいUIコードがAPI自由文へ再依存しないよう、既存レスポンス互換性を残したまま `@deprecated` JSDoc を追加します。

## 変更

- `src/components/CardManager.tsx` のローカル `StorageStatus.message` に `@deprecated` を追加
- runtime / APIレスポンス / ストレージ制限判定 / i18n 文言は変更なし
- 型からの削除は行わず、API互換性を維持

## 重複回避

- 着手時点の `preview` 向け open PR #1433〜#1447 に `src/components/CardManager.tsx` の変更はありません
- Issue #1345 を参照する open PR は0件です
- `tests/unit/storage-status-api.test.ts` には既に複数上限時のプラン優先テストがあるため、その項目は重複実装していません

## 検証

- `preview` exact base: `c30f01580387157bab8061af612f0e52c32ad8da`
- `npm run typecheck` — success
- `git diff --check` — success
- `npx vitest run tests/unit/storage-status-api.test.ts` — ローカルSupabaseランタイム情報を取得できずテスト起動前に停止（コード失敗ではないためGitHub CIで確認）

Refs #1345
