### PR TITLE
chore(release): GITHUB_REPOSITORYの重複定義を削除

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -25,7 +25,6 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           python3 - <<'PY'
           import os
@@ -73,8 +72,7 @@ jobs:
     env:
       # PR/repository-derived strings stay in env and are consumed as data by Python/jq;
       # do not interpolate them directly into the shell script.
-      # Re-declare the runner default so the fork check's trusted base input is explicit.
-      GITHUB_REPOSITORY: ${{ github.repository }}
+      # GITHUB_REPOSITORY is a GitHub-provided default env and is the trusted base for fork checks.
       REPOSITORY_NAME: ${{ github.event.repository.name }}
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_BODY: ${{ github.event.pull_request.body }}


### PR DESCRIPTION
## 概要

Issue #1113 の軽量フォローアップとして、Discord mainマージ通知 workflow で GitHub Actions が既定で提供する `GITHUB_REPOSITORY` を明示的に再定義していた重複を削除します。

## 変更

- `validate-promotion-summary` step の `GITHUB_REPOSITORY: ${{ github.repository }}` を削除
- `notify` job の同じ重複定義を削除
- fork 判定は引き続き runner 既定の `GITHUB_REPOSITORY` と PR head 由来の `HEAD_REPOSITORY` を比較
- runtime / Discord本文 / promotion判定 / fork制御の契約は変更なし

## 重複回避

- 着手時点の `preview` 向け open PR #1433〜#1448 に `.github/workflows/notify-discord-main-merge.yml` の変更はありません
- Issue #1113 を参照する open PR は0件であることを確認済みです

## 検証

- `preview` exact base: `c30f01580387157bab8061af612f0e52c32ad8da`
- `ruby` YAML parse — success
- `git diff --check` — success
- GitHub CI の actionlint / workflow checks を確認予定

Refs #1113