### PR TITLE
docs(storage): 固定10MB文言の棚卸しを記録

### DIFF
--- a/docs/storage-limit-copy-inventory.md
+++ b/docs/storage-limit-copy-inventory.md
@@ -1,0 +1,20 @@
+# Storage limit copy inventory
+
+Issue #1354 で扱う固定 10MB 表記の棚卸しです。ここでは文言変更の判断はせず、現行の表示経路と動的な実効上限の正本を分けて記録します。
+
+## 動的な実効上限
+
+- `src/lib/storage-usage.ts`: `getStorageUsage()` が base limit + bonus + plan allowance から `userLimitBytes` を確定する。
+- `src/app/api/storage-status/route.ts`: `userLimitFormatted` は `userLimitBytes` から生成する。
+- `src/app/dashboard/page.tsx`: 使用量表示は `storageUsage.userLimitBytes` を `formatBytes()` して表示する。
+
+このため、利用者ごとの実効上限そのものは固定 10MB 文字列ではなく `userLimitBytes` を正本とする。
+
+## 固定 10MB 表記
+
+- `src/lib/constants.ts` の `STORAGE_LIMIT_MESSAGES.USER_LIMIT_REACHED`: 外部・未知クライアント向けの互換フォールバック。
+- `messages/ja.json` / `messages/en.json` の `CardManager.messages.userLimitReached`: 公式 UI の上限到達メッセージ。
+- 同 `CardManager.messages.storageLimitReason`: 公式 UI の容量案内。
+- `src/app/plans/page.tsx` の素地プラン「ストレージ容量: 10MB」: プラン一覧上の固定表記。1ファイル上限の 1MB / 5MB / 10MB 表記とは別の項目。
+
+固定値の案内を将来変更する場合は、API 互換文言と ja/en の UI 文言を同時に確認する。プラン一覧の 10MB は利用者ごとの動的 `userLimitBytes` 表示とは用途が異なるため、同じ変更として扱うかは別途判断する。


### PR DESCRIPTION
## 概要

Issue #1354 の軽量フォローアップとして、固定 10MB 表記が残る表示・互換文言と、利用者ごとの動的な実効上限の正本を docs に棚卸しします。文言変更や仕様判断は行いません。

## 変更

- `docs/storage-limit-copy-inventory.md` を追加
- `userLimitBytes` を正本とする動的な実効上限の経路を記録
- 固定 10MB 表記の所在（API互換フォールバック、ja/en UI文言、プラン一覧）を記録
- 1ファイル上限の 1MB / 5MB / 10MB 表記とは別項目であることを明記
- runtime / API / DB / i18n文言は変更なし

## 重複回避

- 着手時点の `preview` 向け open PR #1433〜#1449 に同一ドキュメントの変更はありません
- Issue #1354 を参照する open PR は0件であることを確認済みです
- #1448 は `CardManager` の互換 `message` 型に `@deprecated` を付ける別変更であり、今回の棚卸しとは差分が重複しません

## 検証

- `preview` exact base: `c30f01580387157bab8061af612f0e52c32ad8da`
- `npm run typecheck` — success
- `git diff --check` — success
- docs-only のため新しい Preview 実経路ゲートはありません

Refs #1354
