### PR TITLE
docs(review): Claude手動レビューがno-opであることを明記

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -61,9 +61,11 @@
 name: Claude Auto Review (preview)
 
 on:
-  # 自動実行は停止中。手動実行のみ受け付ける。
-  # 旧 pull_request トリガー（opened/synchronize/reopened/ready_for_review、
-  # branches: [preview]、paths フィルタ付き）は git 履歴を参照すること。
+  # 自動レビューは停止中。workflow_dispatch は停止状態を GitHub UI から確認できるよう
+  # 残しているだけの no-op で、pr_number input も持たないため手動レビュー経路ではない。
+  # 再設計は Issue #1390 で追跡する。旧 pull_request トリガー
+  # （opened/synchronize/reopened/ready_for_review、branches: [preview]、paths フィルタ付き）は
+  # git 履歴を参照すること。
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
## 概要

Issue #1390 の判断不要な軽量フォローアップとして、停止中の Claude review workflow に残っている `workflow_dispatch` が「手動レビュー経路」ではなく意図的な no-op であることをコメント上で明示します。

## 変更

- `.github/workflows/claude-review.yml` の trigger コメントだけを更新
- `workflow_dispatch` は停止状態を GitHub UI から確認するためだけに残していることを明記
- `pr_number` input が無く、現状は手動レビューを実行できないことを明記
- 再設計の追跡先として Issue #1390 を記載
- workflow trigger / job condition / permissions / runtime は変更しない

## 重複回避

- 着手時点の `preview` 向け open PR #1433〜#1450 に `.github/workflows/claude-review.yml` の変更はありません
- Issue #1390 を参照する既存PRはありません

## 検証

- `preview` exact base: `c30f01580387157bab8061af612f0e52c32ad8da`
- YAML parse: success
- `git diff --check`: success
- comment-only のため workflow 挙動は不変

Refs #1390