### PR TITLE
fix(cache): global rate-limit 429をno-store化

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -241,6 +241,10 @@ export async function middleware(request: NextRequest) {
           {
             status: 429,
             headers: {
+              // 429 は現在の Workers Cache heuristics では通常キャッシュ対象外だが、
+              // 早期 return は上段の fail-closed response を返さないため明示的に保存禁止する。
+              // cacheable public path でもレート制限応答だけは再利用させない（#1337）。
+              'Cache-Control': 'private, no-store',
               'X-RateLimit-Limit': String(rateLimitResult.limit),
               'X-RateLimit-Remaining': String(rateLimitResult.remaining),
               'X-RateLimit-Reset': String(rateLimitResult.reset),

--- a/tests/unit/middleware-cache-control.test.ts
+++ b/tests/unit/middleware-cache-control.test.ts
@@ -2,10 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NextRequest } from 'next/server'
 import { middleware } from '@/middleware'
 
-const { updateSessionMock } = vi.hoisted(() => ({
+const { updateSessionMock, checkRateLimitMock } = vi.hoisted(() => ({
   updateSessionMock: vi.fn(
     async () => new Response(null, { status: 200 })
   ),
+  checkRateLimitMock: vi.fn(),
 }))
 
 /**
@@ -24,7 +25,7 @@ vi.mock('@/lib/logger', () => ({
 }))
 
 vi.mock('@/lib/rate-limit', () => ({
-  checkRateLimit: vi.fn().mockResolvedValue({ success: true, limit: 1000, remaining: 999, reset: Date.now() + 60000 }),
+  checkRateLimit: checkRateLimitMock,
   getClientIp: vi.fn(() => '127.0.0.1'),
   rateLimits: { global: {} },
 }))
@@ -44,6 +45,12 @@ function makeRequest(pathname: string): NextRequest {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  checkRateLimitMock.mockResolvedValue({
+    success: true,
+    limit: 1000,
+    remaining: 999,
+    reset: Date.now() + 60000,
+  })
 })
 
 describe('middleware fail-closed Cache-Control (issue #906)', () => {
@@ -88,6 +95,22 @@ describe('middleware fail-closed Cache-Control (issue #906)', () => {
     expect(response.headers.get('Cache-Control')).toBe('private, no-store')
     // DB/session I/O より前の早期拒否契約も維持する。
     expect(updateSessionMock).not.toHaveBeenCalled()
+  })
+
+  it('global rate limit の早期429にも private, no-store を付与する', async () => {
+    // cacheable public path は通常 middleware の no-store 対象外なので、
+    // 429 自身が明示 no-store を持つことを直接固定する（#1337）。
+    checkRateLimitMock.mockResolvedValueOnce({
+      success: false,
+      limit: 1000,
+      remaining: 0,
+      reset: Date.now() + 60000,
+    })
+
+    const response = await middleware(makeRequest(CACHEABLE_PUBLIC_PATH))
+
+    expect(response.status).toBe(429)
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store')
   })
 
   it('overlay demo-events にも private, no-store を付与する（ルート側 no-store と二重防御）', async () => {


### PR DESCRIPTION
## 概要

Issue #1337 の軽量フォローアップとして、middleware の global rate-limit 早期 429 応答にも `Cache-Control: private, no-store` を明示します。

通常レスポンス用の fail-closed `response` は 429 時に返されず、新しい `errorResponse` を返すため、cacheable public path では 429 自身に明示ヘッダーがありませんでした。Cloudflare Workers Cache の現行 heuristics では 429 は通常キャッシュ対象外ですが、早期 return の保存禁止契約を maintenance 503 / overlay 400 と同じく明示します。

## 変更

- global rate-limit 429 に `Cache-Control: private, no-store` を追加
- cacheable public path (`/api/maintenance-status`) で rate limit が発火しても 429 が no-store になる focused unit test を追加
- 既存の rate-limit limit/remaining/reset ヘッダー、判定条件、正常レスポンスの cache 契約は変更しない

## 重複回避

- 着手時点の `preview` 向け open PR #1433〜#1451 に `src/middleware.ts` / `tests/unit/middleware-cache-control.test.ts` の同一変更はありません
- Issue #1337 を参照する open PR は0件でした
- #1441 は別Issue・別テストファイル (`middleware-overlay-events-validation.test.ts`) のみです

## 検証

- `npx vitest run tests/unit/middleware-cache-control.test.ts` — 10/10 success
- `npm run typecheck` — success
- `git diff --check` — success
- QA.md の Preview 実経路対応表に該当する runtime 経路（gacha/overlay/chat/DB/OAuth/Worker共有基盤等）の挙動変更ではなく、global 429 の cache header hardening のみ。新規の実経路ゲートは追加しません

Refs #1337
