### PR TITLE
test(release): Discord通知見出しを昇格契約に固定

### DIFF
--- a/.github/workflows/release-template-contract.yml
+++ b/.github/workflows/release-template-contract.yml
@@ -32,6 +32,7 @@ jobs:
               - '.github/PULL_REQUEST_TEMPLATE/**'
               - 'docs/QA.md'
               - 'tests/unit/release-pr-template-contract.test.ts'
+              - '.github/workflows/notify-discord-main-merge.yml'
               - '.github/workflows/release-template-contract.yml'
 
   contract:

--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -8,6 +8,10 @@ const releaseTemplate = readFileSync(
   "utf8"
 );
 const qaDocument = readFileSync(join(repositoryRoot, "docs/QA.md"), "utf8");
+const notifyWorkflow = readFileSync(
+  join(repositoryRoot, ".github/workflows/notify-discord-main-merge.yml"),
+  "utf8"
+);
 
 const REQUIRED_TEMPLATE_HEADINGS = [
   "## このリリースで変わること",
@@ -49,6 +53,18 @@ describe("preview -> main release PR template contract", () => {
   // レビュー・通知の読み手が確認できるという QA.md の本文契約を守る。
   it("keeps the user-facing release summary as the first H2 heading", () => {
     expect(h2Headings(releaseTemplate)[0]).toBe(REQUIRED_TEMPLATE_HEADINGS[0]);
+  });
+
+  it("keeps the Discord promotion consumer on the same summary heading", () => {
+    const sectionHeadings = Array.from(
+      notifyWorkflow.matchAll(/section_heading = "([^"]+)"/g),
+      (match) => match[1]
+    );
+
+    expect(sectionHeadings).toEqual([
+      REQUIRED_TEMPLATE_HEADINGS[0],
+      REQUIRED_TEMPLATE_HEADINGS[0],
+    ]);
   });
 
   it("keeps the required release sections in the documented order", () => {


### PR DESCRIPTION
## 概要

Issue #1371 の任意・ノンブロッキング項目から、Discord 通知 workflow が消費する昇格PR要約見出しを release contract test に結線します。

- `notify-discord-main-merge.yml` 内の2つの `section_heading` が release template の先頭H2と一致することを固定
- notify workflow 自身の変更でも dedicated `Release PR template contract` が起動するよう paths-filter に追加
- 通知ロジック、trigger、permissions、runtime 挙動は変更なし

## 変更範囲

- `.github/workflows/release-template-contract.yml`
- `tests/unit/release-pr-template-contract.test.ts`

## 確認

GitHub CI / Release PR template contract で検証する。

Refs #1371