### PR TITLE
Discordのリリース通知見出しを本文と統一し、内容のずれを自動検知

### DIFF
--- a/.github/workflows/release-template-contract.yml
+++ b/.github/workflows/release-template-contract.yml
@@ -32,6 +32,7 @@ jobs:
               - '.github/PULL_REQUEST_TEMPLATE/**'
               - 'docs/QA.md'
               - 'tests/unit/release-pr-template-contract.test.ts'
+              - '.github/workflows/notify-discord-main-merge.yml'
               - '.github/workflows/release-template-contract.yml'
 
   contract:

--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -8,6 +8,10 @@ const releaseTemplate = readFileSync(
   "utf8"
 );
 const qaDocument = readFileSync(join(repositoryRoot, "docs/QA.md"), "utf8");
+const notifyWorkflow = readFileSync(
+  join(repositoryRoot, ".github/workflows/notify-discord-main-merge.yml"),
+  "utf8"
+);
 
 const REQUIRED_TEMPLATE_HEADINGS = [
   "## このリリースで変わること",
@@ -49,6 +53,18 @@ describe("preview -> main release PR template contract", () => {
   // レビュー・通知の読み手が確認できるという QA.md の本文契約を守る。
   it("keeps the user-facing release summary as the first H2 heading", () => {
     expect(h2Headings(releaseTemplate)[0]).toBe(REQUIRED_TEMPLATE_HEADINGS[0]);
+  });
+
+  it("keeps the Discord promotion consumer on the same summary heading", () => {
+    const sectionHeadings = Array.from(
+      notifyWorkflow.matchAll(/section_heading = "([^"]+)"/g),
+      (match) => match[1]
+    );
+
+    expect(sectionHeadings).toEqual([
+      REQUIRED_TEMPLATE_HEADINGS[0],
+      REQUIRED_TEMPLATE_HEADINGS[0],
+    ]);
   });
 
   it("keeps the required release sections in the documented order", () => {


### PR DESCRIPTION
## このリリースで変わること

Discordのリリース通知で、利用者が最初に読む要約見出しとリリース本文の見出しが常に一致するようになります。通知の見出しが古い表現や別の表現にずれる状態を自動検知できるため、今回の変更は通知を読む利用者とリリース担当者の双方に影響します。通知の送信条件・権限・アプリの実行時挙動は変わりません。

## 対象PRと固定SHA

- #1454 `ae570552dd3d1b2bc90c4d6f46d17900ddf5ce25`（Discord通知見出しとリリース契約テストの同期）
- preview merge SHA: `e5d3c9c7bd5eff20e9c56702039ec42be6f983bf`
- mainとの差分: `.github/workflows/release-template-contract.yml` と `tests/unit/release-pr-template-contract.test.ts` の2ファイル、17行追加

## 累積release-unit一覧

- preview-head:`e5d3c9c7bd5eff20e9c56702039ec42be6f983bf`（#1454、status=open）

## 確認済み

- レビュー: #1454の本文・差分・呼び出し元・共有契約・issueコメント・inlineコメント・レビュー依頼・スレッドを確認。必須指摘0件、任意指摘0件、changes requestedなし、レビュー依頼なし。既存の通知/トリガー/権限/runtimeは変更なし。
- CI: preview push run `34048494299`（test、typecheck、integration、Application build、Action lint）成功、Release PR template contract run `34048494303` 成功。該当しない分析・migration・lint i18nジョブはpath filterでskip。Workers Build `12e5f45e-64c2-49fb-9748-fc782d54c593` 成功。
- previewデプロイ: Cloudflare Deploy Support `34048494335` のoverlay-realtime成功。固定URL `https://twica-preview.tsubasa-azumagakito.workers.dev` はGET 200、overlay health `https://twica-overlay-realtime-preview.tsubasa-azumagakito.workers.dev/health` はGET 200（`{\"ok\":true,\"protocolVersion\":1}`）。
- ブラウザー／実経路の確認: <!-- 対象外の場合は理由を記載 --> #1454は契約テストとCI変更検出のみで、EventSub・gacha・overlay・chat・upload・WebSocketの利用者向けruntimeを変更しないため、実引き換え・Twitch chat・固定overlayカード画素の追加確認は対象外。Queue replay等の内部保守経路も実行していない。

## main昇格条件

- 上記の固定preview HEADが変化していないこと、#1455のレビュー/必須CI/Workers Buildが成功することを確認してからmainへマージする。mainマージ後にmain CI、Workers Build、Auto Releaseタグ/本文、本番Workers（twica・overlay-realtime・error-reporter）のデプロイと公開GETを再確認する。Cloudflare MCPの直接API確認は現セッションでAuth requiredのため未確認として記録し、認証回避は行わない。
