### PR TITLE
ci(release): contract job に timeout を設定

### DIFF
--- a/.github/workflows/release-template-contract.yml
+++ b/.github/workflows/release-template-contract.yml
@@ -42,6 +42,7 @@ jobs:
       (needs.changes.result != 'success' ||
        needs.changes.outputs.contract == 'true')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## 概要

Issue #1371 の軽量フォローアップとして、専用 `Release PR template contract` workflow の `contract` job に `timeout-minutes: 10` を設定します。

## 変更

- `.github/workflows/release-template-contract.yml` の `contract` job に 10 分の上限を追加
- trigger / paths-filter / permissions / 実行コマンドは変更しない
- production/runtime 挙動への変更なし

## 確認

- 差分は workflow 1行のみ
- CI / Release PR template contract / Workers Preview Build を確認する
- latest exact HEAD に手動レビュー記録を残す

Refs #1371