### PR TITLE
fix(channel-points): 編集ボタンを報酬名で識別可能にする

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -668,6 +668,7 @@
       "addFailed": "Failed to register additional redemption",
       "removeFailed": "Failed to remove additional redemption",
       "edit": "Edit pack/draws",
+      "editAccessibleLabel": "Edit pack/draws for {name}",
       "update": "Save Changes",
       "updateSuccess": "Additional redemption updated",
       "updateSuccessPackPending": "Additional redemption updated (pack change pending deployment)",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -668,6 +668,7 @@
       "addFailed": "追加の引き換えの登録に失敗しました",
       "removeFailed": "追加の引き換えの削除に失敗しました",
       "edit": "パック・枚数を編集",
+      "editAccessibleLabel": "{name}のパック・枚数を編集",
       "update": "変更を保存",
       "updateSuccess": "追加の引き換えを更新しました",
       "updateSuccessPackPending": "追加の引き換えを更新しました（パックの変更は反映待ちです）",

--- a/src/components/ChannelPointSettings.tsx
+++ b/src/components/ChannelPointSettings.tsx
@@ -1463,6 +1463,9 @@ export default function ChannelPointSettings({
                           <div className="flex shrink-0 items-center gap-3 pl-3">
                             <button
                               onClick={() => handleStartEditAdditionalReward(reward)}
+                              aria-label={t("additionalRewards.editAccessibleLabel", {
+                                name: reward.reward_name || reward.reward_id.slice(0, 8) + "...",
+                              })}
                               // 編集中の行の再クリックは無効（未保存入力の無告知リセット防止）。
                               // 保存中（updatingAdditional）も他行への切替は許可するが、
                               // 保存完了時に開いているフォームは閉じない（上記参照）。

--- a/tests/unit/components/channel-point-settings-edit-additional.test.tsx
+++ b/tests/unit/components/channel-point-settings-edit-additional.test.tsx
@@ -119,10 +119,28 @@ describe("ChannelPointSettings additional-reward editing", () => {
     });
   });
 
+  it("includes each reward name in the edit button accessible name", async () => {
+    const secondReward = {
+      id: "ar-2",
+      reward_id: "extra-reward-2",
+      reward_name: "Extra 2",
+      draw_count: 1,
+      is_raid_limited: false,
+      collection_name: "characters",
+      created_at: "2026-01-02T00:00:00.000Z",
+    };
+    vi.unstubAllGlobals();
+    vi.stubGlobal("fetch", mockFetch([...DEFAULT_ADDITIONAL_REWARDS, secondReward]));
+    renderComponent();
+
+    expect(await screen.findByRole("button", { name: "Extraのパック・枚数を編集" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Extra 2のパック・枚数を編集" })).toBeInTheDocument();
+  });
+
   it("opens the inline edit form prefilled with the current binding", async () => {
     renderComponent();
 
-    const editButton = await screen.findByRole("button", { name: "パック・枚数を編集" });
+    const editButton = await screen.findByRole("button", { name: /のパック・枚数を編集$/ });
     fireEvent.click(editButton);
 
 // 編集フォームが表示され、パック選択に現在値（weapons）がプリフィルされる
@@ -138,7 +156,7 @@ describe("ChannelPointSettings additional-reward editing", () => {
   it("sends a PUT with the new collection and draw count, then closes the form", async () => {
     renderComponent();
 
-    const editButton = await screen.findByRole("button", { name: "パック・枚数を編集" });
+    const editButton = await screen.findByRole("button", { name: /のパック・枚数を編集$/ });
     fireEvent.click(editButton);
 
     const packSelect = (await screen.findByLabelText("編集する引き換えのカードパック")) as HTMLSelectElement;
@@ -171,7 +189,7 @@ describe("ChannelPointSettings additional-reward editing", () => {
   it("closes the edit form on cancel without sending a PUT", async () => {
     renderComponent();
 
-    const editButton = await screen.findByRole("button", { name: "パック・枚数を編集" });
+    const editButton = await screen.findByRole("button", { name: /のパック・枚数を編集$/ });
     fireEvent.click(editButton);
     await screen.findByRole("button", { name: "キャンセル" });
 
@@ -191,7 +209,7 @@ describe("ChannelPointSettings additional-reward editing", () => {
   it("disables the pack select in edit mode when canManage=false with an existing binding", async () => {
     renderComponent({ cardPacks: { canManage: false, defaultPackName: null } });
 
-    const editButton = await screen.findByRole("button", { name: "パック・枚数を編集" });
+    const editButton = await screen.findByRole("button", { name: /のパック・枚数を編集$/ });
     fireEvent.click(editButton);
 
     const packSelect = (await screen.findByLabelText("編集する引き換えのカードパック")) as HTMLSelectElement;
@@ -218,7 +236,7 @@ describe("ChannelPointSettings additional-reward editing", () => {
     vi.stubGlobal("fetch", hiddenMock);
     renderComponent({ cardPacks: { canManage: false, defaultPackName: null } });
 
-    const editButton = await screen.findByRole("button", { name: "パック・枚数を編集" });
+    const editButton = await screen.findByRole("button", { name: /のパック・枚数を編集$/ });
     fireEvent.click(editButton);
     // プルダウン自体が表示されない（アップセル表示になる）
     expect(screen.queryByLabelText("編集する引き換えのカードパック")).not.toBeInTheDocument();
@@ -241,11 +259,11 @@ describe("ChannelPointSettings additional-reward editing", () => {
   it("disables the edit button of the row being edited (no silent reset)", async () => {
     renderComponent();
 
-    const editButton = await screen.findByRole("button", { name: "パック・枚数を編集" });
+    const editButton = await screen.findByRole("button", { name: /のパック・枚数を編集$/ });
     fireEvent.click(editButton);
     // 編集フォームが開いたら、同じ行の編集ボタンは disabled になる
     await screen.findByLabelText("編集する引き換えのカードパック");
-    expect(screen.getByRole("button", { name: "パック・枚数を編集" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /のパック・枚数を編集$/ })).toBeDisabled();
   });
 
   // メンテナンスモード中は編集ボタン自体が disabled になる
@@ -253,7 +271,7 @@ describe("ChannelPointSettings additional-reward editing", () => {
   it("disables the edit button itself during maintenance mode", async () => {
     renderComponent({}, "read_only");
 
-    const editButton = await screen.findByRole("button", { name: "パック・枚数を編集" });
+    const editButton = await screen.findByRole("button", { name: /のパック・枚数を編集$/ });
     expect(editButton).toBeDisabled();
   });
 
@@ -268,7 +286,7 @@ describe("ChannelPointSettings additional-reward editing", () => {
     vi.stubGlobal("fetch", notFoundMock);
     renderComponent();
 
-    const editButton = await screen.findByRole("button", { name: "パック・枚数を編集" });
+    const editButton = await screen.findByRole("button", { name: /のパック・枚数を編集$/ });
     fireEvent.click(editButton);
     await screen.findByLabelText("編集する引き換えのカードパック");
 
@@ -307,7 +325,7 @@ describe("ChannelPointSettings additional-reward editing", () => {
     vi.stubGlobal("confirm", confirmMock);
     renderComponent();
 
-    const editButtons = await screen.findAllByRole("button", { name: "パック・枚数を編集" });
+    const editButtons = await screen.findAllByRole("button", { name: /のパック・枚数を編集$/ });
     fireEvent.click(editButtons[0]);
     // 未保存の変更を作る
     const packSelect = (await screen.findByLabelText("編集する引き換えのカードパック")) as HTMLSelectElement;
@@ -335,7 +353,7 @@ describe("ChannelPointSettings additional-reward editing", () => {
     vi.stubGlobal("confirm", vi.fn().mockReturnValue(true));
     renderComponent();
 
-    const editButtons = await screen.findAllByRole("button", { name: "パック・枚数を編集" });
+    const editButtons = await screen.findAllByRole("button", { name: /のパック・枚数を編集$/ });
     fireEvent.click(editButtons[0]);
     const packSelect = (await screen.findByLabelText("編集する引き換えのカードパック")) as HTMLSelectElement;
     fireEvent.change(packSelect, { target: { value: "characters" } });
@@ -366,7 +384,7 @@ describe("ChannelPointSettings additional-reward editing", () => {
     vi.stubGlobal("confirm", confirmMock);
     renderComponent();
 
-    const editButtons = await screen.findAllByRole("button", { name: "パック・枚数を編集" });
+    const editButtons = await screen.findAllByRole("button", { name: /のパック・枚数を編集$/ });
     fireEvent.click(editButtons[0]);
     await screen.findByLabelText("編集する引き換えのカードパック");
 
@@ -406,13 +424,13 @@ describe("ChannelPointSettings additional-reward editing", () => {
     vi.stubGlobal("confirm", vi.fn().mockReturnValue(true));
     renderComponent();
 
-    const editButtons = await screen.findAllByRole("button", { name: "パック・枚数を編集" });
+    const editButtons = await screen.findAllByRole("button", { name: /のパック・枚数を編集$/ });
     // 1 件目の編集を開いて保存を開始する
     fireEvent.click(editButtons[0]);
     await screen.findByLabelText("編集する引き換えのカードパック");
     fireEvent.click(screen.getByRole("button", { name: "変更を保存" }));
     // PUT 実行中に 2 件目の編集へ移る（confirm なしで開けること）
-    const secondButtons = screen.getAllByRole("button", { name: "パック・枚数を編集" });
+    const secondButtons = screen.getAllByRole("button", { name: /のパック・枚数を編集$/ });
     expect(secondButtons[1]).not.toBeDisabled();
     fireEvent.click(secondButtons[1]);
     const switched = (await screen.findByLabelText("編集する引き換えのカードパック")) as HTMLSelectElement;


### PR DESCRIPTION
## 概要

Issue #1379 の判断不要なアクセシビリティ改善です。

- 追加報酬の各編集ボタンへ報酬名を含む i18n accessible name を付与
- ja/en の文言を追加
- 複数行でもスクリーンリーダー上で対象報酬を区別できる回帰テストを追加
- API / DB / EventSub / 更新ロジックは変更しない

## 確認

- `npx vitest run tests/unit/components/channel-point-settings-edit-additional.test.tsx` (14/14)
- `npm run typecheck`
- `npm run lint:i18n`
- `git diff --check`

Refs #1379