### PR TITLE
test(storage): authテストの内部順序依存を外す

### DIFF
--- a/tests/unit/storage-status-auth.test.ts
+++ b/tests/unit/storage-status-auth.test.ts
@@ -37,7 +37,8 @@ describe('GET /api/storage-status auth contract', () => {
 
     expect(response.status).toBe(401)
     await expect(response.json()).resolves.toEqual({ error: ERROR_MESSAGES.UNAUTHORIZED })
-    expect(canUseStreamerFeatures).not.toHaveBeenCalled()
+    // canUseStreamerFeatures() の内部呼び出し順序はこの境界契約に含めず、
+    // 未認証で hash / storage I/O へ進まないことだけを固定する。
     expect(sha256Prefix).not.toHaveBeenCalled()
     expect(getStorageUsage).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## 概要

Issue #1352 の判断不要なテスト保守性フォローアップです。

- 未認証 401 ケースから `canUseStreamerFeatures` の非呼び出し assertion を外す
- route 境界として重要な `sha256Prefix` / `getStorageUsage` 非呼び出し契約は維持
- runtime / API / 認証実装は変更しない

## 変更範囲

`tests/unit/storage-status-auth.test.ts` のみ（+2/-1）。

Refs #1352