### PR TITLE
ci(discord): fork昇格候補のsummary検証をskip

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -17,6 +17,7 @@ jobs:
     if: >-
       github.event.action != 'closed' &&
       github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.head.ref == 'preview'
     runs-on: ubuntu-latest
     steps:

--- a/tests/unit/discord-promotion-fork-guard.test.ts
+++ b/tests/unit/discord-promotion-fork-guard.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  join(process.cwd(), ".github/workflows/notify-discord-main-merge.yml"),
+  "utf8"
+);
+
+function validationCondition(source: string): string {
+  const match = source.match(
+    /validate-promotion-summary:\n\s+if: >-\n([\s\S]*?)\n\s+runs-on:/
+  );
+  return match?.[1] ?? "";
+}
+
+describe("Discord promotion validation fork guard", () => {
+  it("skips the validation job for fork-owned preview branches", () => {
+    const condition = validationCondition(workflow);
+
+    expect(condition).toContain(
+      "github.event.pull_request.head.repo.full_name == github.repository"
+    );
+    expect(condition).toContain(
+      "github.event.pull_request.head.ref == 'preview'"
+    );
+  });
+});


### PR DESCRIPTION
## 概要

Refs #1113

`pull_request_target` の `validate-promotion-summary` を、同一リポジトリの `preview -> main` PR に限定します。fork 側に `preview` という同名ブランチがある場合、修正不能な promotion summary required check が赤くならないようにします。

## 変更

- validate job の `if` に `head.repo.full_name == github.repository` を追加
- 同一repo guard と `head.ref == 'preview'` の組み合わせを静的回帰テストで固定
- job内部の `HEAD_REPOSITORY` 防御チェックは defense-in-depth として維持

## 影響

workflow/test のみ。runtime、API、DB、Discord merge通知本体の挙動は変更しません。同一repoの `preview -> main` 昇格PRでは従来どおり summary validation が走ります。

## QA

Preview実経路ゲートの対象外。CI と workflow contract test で確認します。