### PR TITLE
docs(csrf): 現行エラー監視先へ更新

### DIFF
--- a/docs/PRODUCTION_FIX_CSRF_SALT.md
+++ b/docs/PRODUCTION_FIX_CSRF_SALT.md
@@ -42,7 +42,7 @@ npx wrangler secret put CSRF_TOKEN_SALT --name twica --env preview
 
 ### 4. 反映を検証する
 
-1. Cloudflare のデプロイ完了後、Worker のログと `errors` テーブルに `CSRF_TOKEN_SALT` の検証エラーがないことを確認します。
+1. Cloudflare のデプロイ完了後、Worker のログに `CSRF_TOKEN_SALT` の検証エラーがないことを確認します。
 2. 認証済みセッションで、CSRF 保護される状態変更 API を正しい同一オリジン Cookie と Origin/Referer で実行します。
 3. CSRF Cookie の欠落、または不正な Origin/Referer のリクエストが拒否されることを確認します。
 

--- a/docs/PRODUCTION_FIX_CSRF_SALT.md
+++ b/docs/PRODUCTION_FIX_CSRF_SALT.md
@@ -42,7 +42,7 @@ npx wrangler secret put CSRF_TOKEN_SALT --name twica --env preview
 
 ### 4. 反映を検証する
 
-1. Cloudflare のデプロイ完了後、Worker のログと Sentry に `CSRF_TOKEN_SALT` の検証エラーがないことを確認します。
+1. Cloudflare のデプロイ完了後、Worker のログと `errors` テーブルに `CSRF_TOKEN_SALT` の検証エラーがないことを確認します。
 2. 認証済みセッションで、CSRF 保護される状態変更 API を正しい同一オリジン Cookie と Origin/Referer で実行します。
 3. CSRF Cookie の欠落、または不正な Origin/Referer のリクエストが拒否されることを確認します。
 


### PR DESCRIPTION
## 概要

Issue #837 の obsolete docs cleanup の軽量フォローアップとして、`docs/PRODUCTION_FIX_CSRF_SALT.md` に残っていた Sentry 参照を現行実装に合わせます。

## 変更

- CSRF salt 反映確認の監視先から、現在使っていない Sentry の記述を削除
- import 時に throw される環境変数検証エラーは永続化を保証できないため、確認先を Cloudflare Worker ログに限定
- runtime / API / DB schema / Secret 設定手順には変更なし

## 根拠

`src/lib/env-validation.ts` は `CSRF_TOKEN_SALT` 不備をモジュール初期化時に throw するため、`errors` テーブルへの記録を前提にせず Worker ログを確認する手順が実装と一致します。

Refs #837