### PR TITLE
test(next): proxy移行契約を文言から分離

### DIFF
--- a/tests/unit/cloudflare-proxy-migration.test.ts
+++ b/tests/unit/cloudflare-proxy-migration.test.ts
@@ -16,8 +16,8 @@ describe("Cloudflare proxy migration policy", () => {
     const doc = readSource("docs/cloudflare-proxy-migration.md");
     const middleware = readSource("src/middleware.ts");
 
-    expect(doc).toContain("Node.js middleware is not currently supported");
-    expect(doc).toContain("Do not add `src/proxy.ts` yet");
+    // Keep this contract on observable migration gates, not prose copied from
+    // the policy document. Wording changes must not require a test rewrite.
     expect(doc).toContain("@opennextjs/cloudflare` 1.20.2");
     expect(doc).toContain("opennextjs-cloudflare#1309");
     expect(doc).toContain("1.20.3");


### PR DESCRIPTION
## 概要

Issue #1321 の軽量フォローアップとして、Cloudflare Proxy移行方針の契約テストが docs の説明文そのものへ過剰結合しないよう整理します。

- 過去の build error 文言と `Do not add src/proxy.ts yet` の完全一致 assertion を削除
- 現行 adapter pin、対応 upstream PR/release、再検証コマンド、実ファイル構成、正本参照という観測可能な移行ゲートは維持
- runtime / middleware / docs 本文は変更なし

Refs #1321