### PR TITLE
test(r2): URL中503の誤検知を固定

### DIFF
--- a/tests/unit/r2-client-url-503-regression.test.ts
+++ b/tests/unit/r2-client-url-503-regression.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { isTransientR2Error } from '@/lib/r2-client'
+
+// Issue #989: URL の path に偶然 503 が含まれるだけでは HTTP status 503 ではない。
+// 明示的な status grammar と短い URL を対にして、裸の数字部分文字列へ戻る退行を防ぐ。
+describe('isTransientR2Error: URL中の503誤検知回帰 (#989)', () => {
+  it('短いURLの /503 は一時障害として扱わない', () => {
+    expect(isTransientR2Error('PUT http://a/503 failed')).toBe(false)
+  })
+
+  it('HTTP status line の503は一時障害として扱う', () => {
+    expect(isTransientR2Error('PUT http://a/upload failed: HTTP/1.1 503')).toBe(true)
+  })
+})


### PR DESCRIPTION
Refs #989

## 変更
- `PUT http://a/503 failed` のように URL path にだけ `503` が含まれる場合は一時障害と判定しない回帰テストを追加
- 対になる正例として `HTTP/1.1 503` は一時障害として扱うことも固定

## スコープ
- unit test 1ファイルのみ
- runtime / retry判定実装 / API / DB は変更しない
- 既存の明示的な HTTP status grammar の契約を固定するだけ
