### PR TITLE
test(twitch): emotes 結線テストの責務を明記

### DIFF
--- a/tests/unit/twitch-emotes-error-reporting.test.ts
+++ b/tests/unit/twitch-emotes-error-reporting.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+// Issue #1088: このテストは token-manager / error-handler 自体の正当性ではなく、
+// emotes route が refresh error と診断 context を API 境界へ結線する契約だけを固定する。
+// helper / error writer の内部契約は各専用テストへ委ねるため、ここでは意図的に mock する。
 vi.mock('@/lib/session', () => ({
   getSession: vi.fn(),
   canUseStreamerFeatures: vi.fn(),


### PR DESCRIPTION
## 概要

Issue #1088 の任意フォローアップとして、`tests/unit/twitch-emotes-error-reporting.test.ts` が意図的に `token-manager` / `error-handler` を mock する浅い route 結線テストであることをコメントで明記します。

## 変更

- emotes route が refresh error と診断 context を API 境界へ渡す「結線」だけをこのテストの責務と明記
- helper / error writer 自体の内部契約は専用テストへ委ねることを明記
- runtime / API / mock 挙動 / assertion は変更なし

## 検証

- 差分はテストコメント3行のみ
- GitHub CI / Release PR template contract を確認する

Refs #1088