### PR TITLE
docs(env): 効果音HTTPS fallback条件を明確化

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -80,13 +80,14 @@ R2_SOUND_PUBLIC_URL=https://your-sound-bucket.your-domain.com
 # 効果音 URL の追加許可ホスト（カンマ区切り）。
 # HTTPS は常に必須。R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL 由来ホストとの和集合で判定する。
 # R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL / ALLOWED_SOUND_HOSTS の3系統がすべて未設定なら、
-# 後方互換のため任意の HTTPS URL を許可する。いずれか設定時も HTTPS の同一オリジンは許可する。
+# 後方互換のため任意の HTTPS URL を許可する。3系統のどれか1つでも設定されていればこの fallback は無効になる。
+# いずれか設定時も HTTPS の同一オリジンは許可する。
 # ALLOWED_SOUND_HOSTS=cdn.example.com,media.example.com
 
 # Cloudflare Web Analytics (optional)
 # CloudflareダッシュボードでWeb Analyticsを有効にしてトークンを取得
 # 設定しない場合、アナリティクスは無効になります
-NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
+NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_analytics_token
 
 # runtime の DB 接続先は PlanetScale 固定。旧ドライバ切替変数は使用しない。
 

--- a/.env.local.example
+++ b/.env.local.example
@@ -87,7 +87,7 @@ R2_SOUND_PUBLIC_URL=https://your-sound-bucket.your-domain.com
 # Cloudflare Web Analytics (optional)
 # CloudflareダッシュボードでWeb Analyticsを有効にしてトークンを取得
 # 設定しない場合、アナリティクスは無効になります
-NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_analytics_token
+NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 
 # runtime の DB 接続先は PlanetScale 固定。旧ドライバ切替変数は使用しない。
 


### PR DESCRIPTION
## 概要

Issue #1375 の軽量フォローアップです。

`.env.local.example` で、`R2_SOUND_PUBLIC_URL` / `R2_PUBLIC_URL` / `ALLOWED_SOUND_HOSTS` がすべて未設定の場合だけ任意 HTTPS URL への後方互換 fallback が有効であり、3系統のどれか1つでも設定されればその fallback は無効になることを明示します。

## 変更範囲

- `.env.local.example` のコメントのみ
- runtime / URL 判定ロジック / 環境変数名 / API / DB は変更なし

## 確認

- base: `preview` (`e5d3c9c7bd5eff20e9c56702039ec42be6f983bf`)
- Issue #1375 の既存実装説明と `isAllowedSoundUrl` の現行契約を変えず、運用上の読み違いだけを減らす差分

Refs #1375