### PR TITLE
test(chat): terminal retry契約を強化

### DIFF
--- a/tests/unit/post-redemption-notify-chat-retry.test.ts
+++ b/tests/unit/post-redemption-notify-chat-retry.test.ts
@@ -145,12 +145,19 @@ describe('postRedemptionNotify: chatAnnouncement retryState別のreportError到�
 
     await postRedemptionNotify(notifyData)
 
-    // レビュー指摘: expect.any(Error)だけだとretryStateの文字列連結が壊れても
-    // 検知できないため、メッセージ本文と呼び出し回数まで固定する。
+    // retry結果を永続化済みとして扱う契約も固定し、catch経路で同じoutboxを
+    // 二重にretryする退行を検知する。
+    expect(mockRetry).toHaveBeenCalledTimes(1)
+    expect(mockRetry).toHaveBeenCalledWith(
+      claim,
+      'Twitch API 429: Your message was not sent because you are sending messages too quickly.',
+    )
+    // expect.any(Error)だけだとretryStateやreasonの連結が壊れても検知できないため、
+    // terminal messageを完全一致で固定する。
     expect(mockReportError).toHaveBeenCalledTimes(1)
     expect(mockReportError).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: expect.stringContaining('Chat announcement dead: '),
+        message: 'Chat announcement dead: Twitch API 429: Your message was not sent because you are sending messages too quickly.',
       }),
       expect.objectContaining({
         context: 'eventsub:postRedemptionNotify:chatAnnouncement',
@@ -170,10 +177,15 @@ describe('postRedemptionNotify: chatAnnouncement retryState別のreportError到�
 
     await postRedemptionNotify(notifyData)
 
+    expect(mockRetry).toHaveBeenCalledTimes(1)
+    expect(mockRetry).toHaveBeenCalledWith(
+      claim,
+      'Twitch API 429: Your message was not sent because you are sending messages too quickly.',
+    )
     expect(mockReportError).toHaveBeenCalledTimes(1)
     expect(mockReportError).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: expect.stringContaining('Chat announcement lost-lease: '),
+        message: 'Chat announcement lost-lease: Twitch API 429: Your message was not sent because you are sending messages too quickly.',
       }),
       expect.objectContaining({
         context: 'eventsub:postRedemptionNotify:chatAnnouncement',


### PR DESCRIPTION
## 概要

Issue #1037 の任意・ノンブロッキング項目「dead / lost-lease のメッセージ契約と呼び出し回数を固定する」の軽量フォローアップです。

## 変更

- `post-redemption-notify-chat-retry.test.ts` の `dead` / `lost-lease` ケースで `retryChatNotification` が1回だけ呼ばれることを固定
- retry reason の伝播を完全一致で確認
- `reportError` へ渡る terminal message を完全一致で固定
- runtime / retry実装 / API / DB は変更しない

## 検証

- `npx vitest run --cache=false tests/unit/post-redemption-notify-chat-retry.test.ts` — 3 tests passed
- `npm run typecheck` — passed
- `git diff --check` — passed

Refs #1037