### PR TITLE
docs(storage): global上限文言の互換性を明記

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -446,5 +446,6 @@ export const STORAGE_LIMIT_MESSAGES = {
   // なお同種の10MB固定文言は messages/ja.json・en.json の userLimitReached /
   // storageLimitReason にも存在するため、見直す際は i18n 側と併せて行うこと。
   USER_LIMIT_REACHED: '画像のアップロード上限は現在一アカウントにつき10MBです。上限を超える場合は、既存の画像を削除してから再度お試しください。',
+  // GLOBAL_LIMIT_REACHED も同じく外部・未知クライアント向けの互換文言として維持する。
   GLOBAL_LIMIT_REACHED: '画像のアップロード上限に達しました。',
 } as const


### PR DESCRIPTION
## 概要

Issue #1345 の判断不要なコメント整理です。

- `GLOBAL_LIMIT_REACHED` も `USER_LIMIT_REACHED` と同じく外部・未知クライアント向け互換文言として維持することを近傍コメントで明示
- 文言・API・runtime挙動は変更しない
- 既存のオブジェクト全体コメントと `USER_LIMIT_REACHED` 側の詳細説明は維持

## 検証

- `git diff --check`
- 差分は `src/lib/constants.ts` のコメント1行のみ

Refs #1345