### PR TITLE
docs(cache): 早期エラーno-store基準を明記

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -192,8 +192,10 @@ export async function middleware(request: NextRequest) {
   // 明示的にキャッシュを許可した公開パス以外には private, no-store を付与する。
   // キャッシュ許可パスはルート側で Cache-Control: public を設定する（この middleware は
   // ルートより先に実行されるため、ルートが最終的にヘッダーを上書きできる）。
-  // 400/429/503 等は Workers Cache のヒューリスティック対象外だが、早期 return でも
-  // fail-closed 契約が必要な経路は個別に private, no-store を明示する。
+  // 400/429/503 等は Workers Cache のヒューリスティック対象外だが、それには依存しない。
+  // 後段の通常キャッシュ方針を通らず早期 return するレスポンスは、公開キャッシュ許可
+  // パス上でも保存されないよう、自身で private, no-store を明示する。現在は不正 overlay
+  // events の 400、global rate-limit の 429、maintenance guard の 503 がこの基準に従う（#1337）。
   // /api/overlay/ 配下は prefix ではなくエンドポイント単位で判定する。
   // events は OBS オーバーレイの 3 秒間隔ポーリングだが Cache-Control を設定
   // しないため、prefix 許可だと Workers Caching のヒューリスティック TTL


### PR DESCRIPTION
## 概要

Issue #1337 の残り任意事項「早期 return のどの経路へ明示 no-store を付けるか基準を整理する」の軽量フォローアップです。

## 変更

- `src/middleware.ts` の既存 cache policy コメントを整理
- 400 / 429 / 503 が Workers Cache の通常ヒューリスティック対象外であることへ依存せず、後段の通常 cache policy を通らない早期 return は自身で `Cache-Control: private, no-store` を明示する基準を記録
- 現行の invalid overlay events 400 / global rate-limit 429 / maintenance guard 503 が同じ基準に揃っていることを明記
- runtime / status / header / API / DB の挙動変更なし

## 検証

- `npx vitest run tests/unit/middleware-cache-control.test.ts tests/unit/middleware-maintenance.test.ts` — 23/23 success
- `npm run typecheck` — success
- `git diff --check` — success

Preview 実経路の runtime 挙動は変更していないため、本PR自体は新しい実経路ゲートを追加しません。既存の累積ゲート #1405 / #1406 は別途維持します。

Refs #1337