### PR TITLE
test(channel-points): bootstrap検証責務を明記

### DIFF
--- a/tests/unit/channel-point-bootstrap-driver-parity.test.ts
+++ b/tests/unit/channel-point-bootstrap-driver-parity.test.ts
@@ -330,6 +330,8 @@ describe('GET /api/twitch/channel-point-bootstrap?diagnostics=1: raid系カラ�
     expect(db.select).toHaveBeenCalledTimes(4)
   })
 
+  // 応答JSONの equality は既定値補完を、select-field assertion は未デプロイ列を
+  // 再発行しないことを検証する別契約なので、意図的に両方を保持する。
   it('フォールバック時は縮退select(raid_gacha_draw_count/draw_count/is_raid_limitedを含まない)を発行する', async () => {
     const { db } = await runPlanetscalePath(
       [


### PR DESCRIPTION
## 概要

Issue #1327 の任意項目として、channel-point bootstrap parity test の response equality と select-field assertion が別契約を検証していることをコメントで明記します。

## 変更

- response equality: 既定値補完を検証
- select-field assertion: 未デプロイ列を縮退selectで再発行しないことを検証
- runtime / API / DB / assertion 自体は変更なし
- 対象ファイルの EOF 改行が既に存在することも確認

## 検証

- `npm exec vitest run tests/unit/channel-point-bootstrap-driver-parity.test.ts` — 11/11 passed
- `npm run typecheck` — success
- `git diff --check` — success

Refs #1327