### PR TITLE
test(gacha): entrypoint guardの責務を明記

### DIFF
--- a/tests/unit/gacha-public-entrypoint-contract.test.ts
+++ b/tests/unit/gacha-public-entrypoint-contract.test.ts
@@ -42,6 +42,9 @@ function findExecuteGachaCalls(path: string): string[] {
 
 describe("GachaService production entrypoints (#1301)", () => {
   it("does not call the low-level executeGacha method outside GachaService", () => {
+    // Scan production `src` only: tests/fixtures may exercise the low-level contract directly.
+    // Exclude GachaService itself because internal composition is allowed inside the implementation.
+    // AST matching keeps the guard semantic and avoids false positives from comments or strings.
     const srcRoot = resolve(process.cwd(), "src");
     const servicePath = resolve(srcRoot, "lib/services/gacha.ts");
     const directCallSites = collectTypeScriptFiles(srcRoot)


### PR DESCRIPTION
## 概要

Issue #1301 の任意・ノンブロッキング項目から、既存 source-contract test の恒久的な責務だけをコメントで明記します。

## 変更

- production `src` だけを走査する理由を明記
- `GachaService` 実装本体を除外する理由を明記
- TypeScript AST を使う理由（コメント・文字列の誤検知回避）を明記
- assertion / runtime / API / DB / gacha 実装は変更しない

## 検証

- `git diff --check` — success
- 差分は `tests/unit/gacha-public-entrypoint-contract.test.ts` のコメント3行のみ
- GitHub CI / Workers Preview Build で回帰確認する

Refs #1301

exact HEAD: `5dfb17265ef45e48e05c0b51c44b21e756b6a307`