### PR TITLE
test(gacha): session消失時401の意図を明記

### DIFF
--- a/tests/unit/api/gacha-demo-route.test.ts
+++ b/tests/unit/api/gacha-demo-route.test.ts
@@ -112,7 +112,7 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
     expect(mockPublishOverlayDemoRealtimeEvent).not.toHaveBeenCalled()
   })
 
-  it('returns 401 for unauthenticated publication', async () => {
+  it('keeps a downstream 401 when the session is unavailable after CSRF validation', async () => {
     mockGetSession.mockResolvedValue(null)
 
     const response = await POST(makeRequest({ streamerId: 'streamer-1', broadcast: true }))


### PR DESCRIPTION
## 変更内容

Issue #1331 の任意フォローアップから、CSRF 検証通過後に session が取得できない場合の 401 テスト名を、実運用上の意味が分かる表現へ更新します。

- `broadcast && streamerId` の CSRF 検証後にも session が失効・取得不能になり得るため、後段 401 は防御として維持することをテスト名で明示
- runtime / API / assertion / status / publication 処理は変更しない
- 現行 `preview` には、公開デモ全体ではなく状態変更する broadcast 分岐だけを CSRF 保護する理由コメントが既に存在するため、その項目への重複実装はしない

## 検証

- `npx vitest run tests/unit/api/gacha-demo-route.test.ts tests/unit/api/gacha-demo-csrf-guard.test.ts tests/unit/api/gacha-demo-csrf-order.test.ts` — 15/15 pass
- `npm run typecheck` — pass
- `git diff --check` — pass

Refs #1331