### PR TITLE
gachaデモの認証エラー判定を明確にし、動作確認を安定化

### DIFF
--- a/tests/unit/api/gacha-demo-route.test.ts
+++ b/tests/unit/api/gacha-demo-route.test.ts
@@ -112,7 +112,7 @@ describe('POST /api/gacha/demo: KV demo publication authorization', () => {
     expect(mockPublishOverlayDemoRealtimeEvent).not.toHaveBeenCalled()
   })
 
-  it('returns 401 for unauthenticated publication', async () => {
+  it('keeps a downstream 401 when the session is unavailable after CSRF validation', async () => {
     mockGetSession.mockResolvedValue(null)
 
     const response = await POST(makeRequest({ streamerId: 'streamer-1', broadcast: true }))


### PR DESCRIPTION
## このリリースで変わること

gachaデモのエラー判定について、CSRF検証を通過したあとにセッションを取得できない場合も、利用者に対して適切な401（認証が必要）として扱う確認ルールを明確にします。これにより、公開デモの既存挙動を保ったまま、将来の回帰を早く検知できます。

この変更はテスト名の明確化だけで、実行コード、API、認証、CSRF判定、データ保存、Twitch/EventSub、overlay、chat、アップロードの動作は変更しません。

## 技術詳細

### 累積対象

| PR | 固定したHEAD SHA | preview merge SHA | 内容 |
|---|---|---|---|
| #1477 | `f8894dac27cc3c5278c9a01f009a2b0b3e2993a3` | `459e7f2db6c3926ee83db0d3c320a4e668c6db0b` | `gacha-demo-route` の downstream 401 テスト名を実運用上の意味に更新 |

- 累積preview HEAD / `preview` merge SHA: `459e7f2db6c3926ee83db0d3c320a4e668c6db0b`
- `origin/main...origin/preview` の累積差分: 1ファイル、1行追加・1行削除（テスト名のみ）
- レビュー: 必須指摘0、未解決スレッド0、changes requestedなし、レビュー依頼なし。required pull-request reviewsはブランチ保護に未設定。
- ローカル確認: 関連15テスト pass、`npm run typecheck` pass、`git diff --check` pass
- PR CI: test pass、型チェック・overlay Worker型チェック・Supabase停止独立性・maintenance write surface pass。変更対象外のlint/i18n/migration/analysisはpath filterでskip。
- preview CI: [CI run 34138677078](https://github.com/azumag/twica/actions/runs/34138677078) success
- Workers Builds/Deploy: [Cloudflare Deploy Support run 34138677044](https://github.com/azumag/twica/actions/runs/34138677044) success（preview room Worker build/deploy success）
- 固定preview URL `https://twica-preview.tsubasa-azumagakito.workers.dev` の安全なGET: HTTP 200
- ブラウザー画面: 未確認（Codexのブラウザー管理ポリシーによりアクセス許可を取得できず、回避はしていない）
- 実経路（Twitch/EventSub/gacha実引き換え、Twitch chat、overlay画像画素、upload）: 対象外。変更はテスト名のみで、利用者向け実経路の契約を変更しないため、秘密情報や追加消費を伴う確認は行わない。
- 内部保守経路（Queue replay等）: 変更なし。秘密情報を使う内部管理APIの直接呼び出しは行わない。

## main昇格条件

このPRのレビュー状態、必須CI、Workers Builds、累積preview HEADが上記のまま再確認できた場合のみ、`459e7f2db6c3926ee83db0d3c320a4e668c6db0b` をmainへマージします。mainマージ後は、main CI、Auto Releaseのタグと本文、production Workers/補助Workerのデプロイ、安全な公開GETを確認し、タグまたは本番デプロイが確認できない場合は成功扱いにしません。
