### PR TITLE
docs(gacha): OBS demoのcredential意図を明記

### DIFF
--- a/src/components/OverlayPreview.tsx
+++ b/src/components/OverlayPreview.tsx
@@ -504,6 +504,8 @@ export default function OverlayPreview({
       const response = await fetch("/api/gacha/demo", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        // 相対URLの same-origin fetch では Cookie は既定でも送信されるが、認証必須の
+        // broadcast 経路であることを明示し、triggerRealGacha と credential 方針を揃える。
         credentials: "include",
         body: JSON.stringify({
           streamerId,


### PR DESCRIPTION
## Summary
- `OverlayPreview` の OBS DEMO (`/api/gacha/demo`) で `credentials: "include"` を明示している理由をコードコメント化
- 現在の相対URL / same-origin fetch では挙動変更はなく、認証必須の broadcast 経路であることと `triggerRealGacha` との credential 方針を明確化

## Testing
- `npm exec vitest run tests/unit/components/overlay-preview.test.tsx tests/unit/components/overlay-preview-maintenance.test.tsx` (28 tests passed)
- `npm run typecheck`
- `git diff --check`

Refs #1331