### PR TITLE
test(release): contract test の repository root 解決を cwd 非依存化

### DIFF
--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -1,10 +1,9 @@
-// @vitest-environment node
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const releaseTemplate = readFileSync(
   join(repositoryRoot, ".github/PULL_REQUEST_TEMPLATE/release.md"),
   "utf8"

--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -1,8 +1,9 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-const repositoryRoot = process.cwd();
+const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
 const releaseTemplate = readFileSync(
   join(repositoryRoot, ".github/PULL_REQUEST_TEMPLATE/release.md"),
   "utf8"

--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";


### PR DESCRIPTION
## 概要

Issue #1371 の任意フォローアップから、`tests/unit/release-pr-template-contract.test.ts` の repository root 解決を `process.cwd()` 非依存にします。

## 変更

- `dirname(fileURLToPath(import.meta.url))` をテストファイル自身の位置として repository root を解決
- `new URL(relative, import.meta.url)` は Vite の asset URL transform 対象になるため使用しない
- runtime / workflow / release template / QA contract / assertion 自体は変更しない

## 差分

- 1 file / +3 -2
- exact HEAD: `968c06be6bcf8404cd516bc0638c6b64d4b3049b`

## 確認

- 初回HEAD: Vite URL transform による `ERR_INVALID_URL_SCHEME` を特定
- 次HEAD: node environment が共通 `tests/setup.ts` の navigator 前提と衝突することを特定
- latest HEAD: 既定Vitest環境で focused test 5/5 pass
- latest exact HEAD へ手動厳正レビュー記録済み
- GitHub CI / Release PR template contract を継続確認

Refs #1371