### PR TITLE
test(release): 通知workflowと見出し抽出を揃える

### DIFF
--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -48,7 +48,7 @@ function headingScanLines(source: string): string[] {
   // Preserve their newline count here so scan-line indexes still map to the
   // original source used by the rest of the contract assertions.
   const withoutHtmlCommentText = source.replace(
-    /<!--.*?(?:-->|$)/gs,
+    /<!--[\s\S]*?(?:-->|$)/g,
     (comment) => comment.replace(/[^\r\n]/g, "")
   );
   return withoutHtmlCommentText.split(/\r?\n/);

--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -43,34 +43,38 @@ const REQUIRED_CONFIRMATION_LINES = [
   "- ブラウザー／実経路の確認: <!-- 対象外の場合は理由を記載 -->",
 ] as const;
 
-function promotionWorkflowLines(source: string): string[] {
-  // Keep heading extraction aligned with notify-discord-main-merge.yml: remove
-  // HTML comments before looking for the promotion section.
-  const withoutHtmlComments = source.replace(/<!--.*?(?:-->|$)/gs, "");
-  return withoutHtmlComments.split(/\r?\n/);
+function headingScanLines(source: string): string[] {
+  // The promotion workflow removes HTML comments before heading extraction.
+  // Preserve their newline count here so scan-line indexes still map to the
+  // original source used by the rest of the contract assertions.
+  const withoutHtmlCommentText = source.replace(
+    /<!--.*?(?:-->|$)/gs,
+    (comment) => comment.replace(/[^\r\n]/g, "")
+  );
+  return withoutHtmlCommentText.split(/\r?\n/);
 }
 
 function normalizedHeading(line: string): string {
-  // The workflow compares headings with Python's strip(), but preserving the
-  // original section lines keeps indentation meaningful to the contract tests.
+  // Match the workflow's Python line.strip() comparison for H2 detection only.
   return line.trim();
 }
 
 function h2Headings(source: string): string[] {
-  return promotionWorkflowLines(source)
+  return headingScanLines(source)
     .map(normalizedHeading)
     .filter((line) => line.startsWith("## "));
 }
 
 function h2Section(source: string, heading: string): string {
-  const lines = promotionWorkflowLines(source);
-  const start = lines.findIndex((line) => normalizedHeading(line) === heading);
+  const sourceLines = source.split(/\r?\n/);
+  const scanLines = headingScanLines(source);
+  const start = scanLines.findIndex((line) => normalizedHeading(line) === heading);
   if (start === -1) return "";
 
-  const next = lines.findIndex(
+  const next = scanLines.findIndex(
     (line, index) => index > start && normalizedHeading(line).startsWith("## ")
   );
-  return lines.slice(start, next === -1 ? undefined : next).join("\n");
+  return sourceLines.slice(start, next === -1 ? undefined : next).join("\n");
 }
 
 const qaReleaseContract = h2Section(
@@ -91,7 +95,7 @@ describe("preview -> main release PR template contract", () => {
       "## hidden guidance heading",
       "-->",
       "  ## visible heading  ",
-      "  release text",
+      "  release text <!-- keep this in the returned contract section -->",
       "   ## next heading   ",
     ].join("\n");
 
@@ -100,7 +104,7 @@ describe("preview -> main release PR template contract", () => {
       "## next heading",
     ]);
     expect(h2Section(source, "## visible heading")).toBe(
-      "  ## visible heading  \n  release text"
+      "  ## visible heading  \n  release text <!-- keep this in the returned contract section -->"
     );
   });
 

--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -45,22 +45,30 @@ const REQUIRED_CONFIRMATION_LINES = [
 
 function promotionWorkflowLines(source: string): string[] {
   // Keep heading extraction aligned with notify-discord-main-merge.yml: remove
-  // HTML comments first, then compare headings after strip()/trim() normalization.
+  // HTML comments before looking for the promotion section.
   const withoutHtmlComments = source.replace(/<!--.*?(?:-->|$)/gs, "");
-  return withoutHtmlComments.split(/\r?\n/).map((line) => line.trim());
+  return withoutHtmlComments.split(/\r?\n/);
+}
+
+function normalizedHeading(line: string): string {
+  // The workflow compares headings with Python's strip(), but preserving the
+  // original section lines keeps indentation meaningful to the contract tests.
+  return line.trim();
 }
 
 function h2Headings(source: string): string[] {
-  return promotionWorkflowLines(source).filter((line) => line.startsWith("## "));
+  return promotionWorkflowLines(source)
+    .map(normalizedHeading)
+    .filter((line) => line.startsWith("## "));
 }
 
 function h2Section(source: string, heading: string): string {
   const lines = promotionWorkflowLines(source);
-  const start = lines.findIndex((line) => line === heading);
+  const start = lines.findIndex((line) => normalizedHeading(line) === heading);
   if (start === -1) return "";
 
   const next = lines.findIndex(
-    (line, index) => index > start && line.startsWith("## ")
+    (line, index) => index > start && normalizedHeading(line).startsWith("## ")
   );
   return lines.slice(start, next === -1 ? undefined : next).join("\n");
 }
@@ -77,13 +85,13 @@ describe("preview -> main release PR template contract", () => {
     expect(h2Headings(releaseTemplate)[0]).toBe(REQUIRED_TEMPLATE_HEADINGS[0]);
   });
 
-  it("mirrors the promotion workflow's HTML-comment and whitespace normalization", () => {
+  it("mirrors the promotion workflow's HTML-comment and heading whitespace normalization", () => {
     const source = [
       "<!--",
       "## hidden guidance heading",
       "-->",
       "  ## visible heading  ",
-      "release text",
+      "  release text",
       "   ## next heading   ",
     ].join("\n");
 
@@ -92,7 +100,7 @@ describe("preview -> main release PR template contract", () => {
       "## next heading",
     ]);
     expect(h2Section(source, "## visible heading")).toBe(
-      "## visible heading\nrelease text"
+      "  ## visible heading  \n  release text"
     );
   });
 

--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -43,12 +43,19 @@ const REQUIRED_CONFIRMATION_LINES = [
   "- ブラウザー／実経路の確認: <!-- 対象外の場合は理由を記載 -->",
 ] as const;
 
+function promotionWorkflowLines(source: string): string[] {
+  // Keep heading extraction aligned with notify-discord-main-merge.yml: remove
+  // HTML comments first, then compare headings after strip()/trim() normalization.
+  const withoutHtmlComments = source.replace(/<!--.*?(?:-->|$)/gs, "");
+  return withoutHtmlComments.split(/\r?\n/).map((line) => line.trim());
+}
+
 function h2Headings(source: string): string[] {
-  return source.split(/\r?\n/).filter((line) => line.startsWith("## "));
+  return promotionWorkflowLines(source).filter((line) => line.startsWith("## "));
 }
 
 function h2Section(source: string, heading: string): string {
-  const lines = source.split(/\r?\n/);
+  const lines = promotionWorkflowLines(source);
   const start = lines.findIndex((line) => line === heading);
   if (start === -1) return "";
 
@@ -68,6 +75,25 @@ describe("preview -> main release PR template contract", () => {
   // レビュー・通知の読み手が確認できるという QA.md の本文契約を守る。
   it("keeps the user-facing release summary as the first H2 heading", () => {
     expect(h2Headings(releaseTemplate)[0]).toBe(REQUIRED_TEMPLATE_HEADINGS[0]);
+  });
+
+  it("mirrors the promotion workflow's HTML-comment and whitespace normalization", () => {
+    const source = [
+      "<!--",
+      "## hidden guidance heading",
+      "-->",
+      "  ## visible heading  ",
+      "release text",
+      "   ## next heading   ",
+    ].join("\n");
+
+    expect(h2Headings(source)).toEqual([
+      "## visible heading",
+      "## next heading",
+    ]);
+    expect(h2Section(source, "## visible heading")).toBe(
+      "## visible heading\nrelease text"
+    );
   });
 
   it("reports the logical contract name when a source file is missing", () => {


### PR DESCRIPTION
## 概要

Issue #1371 の未完了フォローアップから、昇格PR契約テストの見出し抽出を Discord 通知 workflow の実装へ寄せます。

- HTML コメントを先に除去して見出し走査（本文は原文保持）
- 見出し判定だけ `trim()` で空白を正規化
- コメント内の偽 H2 と前後空白付き H2 の回帰テストを追加

runtime / workflow 本体の挙動は変更しません。

## 確認

- [x] CI #2851 success
- [x] Release PR template contract #241 success
- [x] latest exact HEAD `868e8e9c4e2cf0a411c87162d8b2f1560d07568e` の手動レビュー（COMMENT review #5138652518）

Refs #1371