### PR TITLE
test(storage): storage-status fixture expiry を固定

### DIFF
--- a/tests/unit/storage-status-api.test.ts
+++ b/tests/unit/storage-status-api.test.ts
@@ -19,6 +19,9 @@ const mockGetStorageUsage = vi.mocked(getStorageUsage)
 const mockFormatBytes = vi.mocked(formatBytes)
 const mockSha256Prefix = vi.mocked(sha256Prefix)
 
+// 認証済みfixtureは実行時刻に依存させず、十分未来の固定時刻で有効状態を表現する。
+const SESSION_EXPIRES_AT = Date.UTC(2100, 0, 1)
+
 const baseUsage: StorageUsage = {
   userUsage: 1024,
   globalUsage: 2048,
@@ -47,7 +50,7 @@ describe('GET /api/storage-status message compatibility', () => {
       twitchDisplayName: 'Test User',
       twitchProfileImageUrl: 'https://example.com/avatar.jpg',
       broadcasterType: 'affiliate',
-      expiresAt: Date.now() + 3600000,
+      expiresAt: SESSION_EXPIRES_AT,
       version: 1,
     })
     mockCanUseStreamerFeatures.mockReturnValue(true)


### PR DESCRIPTION
## 変更
- `tests/unit/storage-status-api.test.ts` の認証済み session fixture から `Date.now()` 依存を除去
- 十分未来の固定 UTC 時刻を使い、テスト実行時刻に依存しない fixture にする

## 検証
- test-only の最小差分
- runtime / API / DB / UI の挙動変更なし

Refs #1352