### PR TITLE
fix: オーバーレイの画像を読み込んでからカードを表示する

### DIFF
--- a/src/app/overlay/[streamerId]/page.tsx
+++ b/src/app/overlay/[streamerId]/page.tsx
@@ -182,11 +182,9 @@ const RELOAD_DEFER_RETRY_MS = 30 * 1000;
 // (メタデータ未ロードでNaN等)に使う「再生終了見込み」の安全上限。
 // リロード延期判定(soundPlayingUntilRef)のフォールバックにのみ使う
 const SOUND_DURATION_FALLBACK_MS = 15 * 1000;
-// OBS Browser Source may keep a large animated image metadata request pending
-// without firing either `load` or `error`. Aspect-ratio detection is
-// presentation-only, so this timeout bounds the probe lifetime/layout decision;
-// the business-event queue and card DOM mounting do not wait for it.
-const IMAGE_METADATA_TIMEOUT_MS = 1_500;
+// OBS can leave load/decode pending for a large or broken image. Bound the
+// preparation wait, then reveal the existing fallback so later cards still run.
+const IMAGE_PREPARE_TIMEOUT_MS = 1_500;
 const MIN_REVEAL_LEAD_IN_MS = 100;
 // A realtime delivery is not acknowledged until React has committed the card
 // and its image has loaded. A stopped CEF/OBS render loop must still release
@@ -310,9 +308,8 @@ export default function OverlayPage() {
   // without consuming another redemption or duplicating the visible prefix.
   const committedDrawIdsRef = useRef<Set<string>>(new Set());
   const activeDisplayInstanceIdRef = useRef<number | undefined>(undefined);
-  // Image metadata checks are presentation-only and run independently from the
-  // display queue. Cleanup still resolves pending checks so Image callbacks do
-  // not retain an obsolete card/component lifetime.
+  // Cleanup resolves image preparation waits as well as clearing their timers,
+  // so an old async queue task can exit through its lifecycle generation guard.
   const activeImageCheckCancelsRef = useRef<Set<() => void>>(new Set());
   const isOverlayMountedRef = useRef(false);
   // A streamer change can reuse this component instance. The queue generation
@@ -810,9 +807,9 @@ export default function OverlayPage() {
 
   // 画像のアスペクト比を判定（縦長かどうか）と小さい画像かどうかを判定
   // Check if image is portrait (height > width) and if image is small (< 400x400)
-  // Promiseを返すが、カード表示の前提にはしない。画像metadataはpresentation-only
-  // のため、呼び出し側は表示と並行して実行し、レイアウト更新だけを受け取る。
-  const checkImageAspectRatio = useCallback((
+  // 枠だけの先行表示を避けるため、画像のload/decodeを最大1.5秒待つ。
+  // timeout/errorではfalseを返し、代替表示でキューを継続する。
+  const prepareCardImage = useCallback((
     imageUrl: string | null,
     imageLayoutGeneration: number,
   ): Promise<boolean> => {
@@ -839,7 +836,8 @@ export default function OverlayPage() {
       const finish = (
         isPortrait: boolean,
         isSmall: boolean,
-        updateLayout = true
+        updateLayout = true,
+        imageReady = false,
       ) => {
         if (settled) return;
         settled = true;
@@ -847,6 +845,8 @@ export default function OverlayPage() {
           clearTimeout(timeoutId);
         }
         activeImageCheckCancelsRef.current.delete(cancel);
+        img.onload = null;
+        img.onerror = null;
         if (
           updateLayout
           && isOverlayMountedRef.current
@@ -855,7 +855,7 @@ export default function OverlayPage() {
           setIsPortraitImage(isPortrait);
           setIsSmallImage(isSmall);
         }
-        resolve(isPortrait);
+        resolve(imageReady);
       };
       const cancel = () => {
         // Cleanup deliberately suppresses layout updates. Lifecycle cleanup also
@@ -866,21 +866,43 @@ export default function OverlayPage() {
       activeImageCheckCancelsRef.current.add(cancel);
 
       img.onload = () => {
+        if (!(img.width > 0 && img.height > 0)) {
+          finish(false, false);
+          return;
+        }
         // 画像の縦が横より大きい（正方形でない縦長画像）の場合はポートレイト
         // Portrait if height is greater than width (not a square)
         const isPortrait = img.height > img.width;
         // 画像が400x400未満の場合は小さい画像として判定
         // 小さい画像モードを自動適用するために使用
         const isSmall = img.width < 400 && img.height < 400;
-        finish(isPortrait, isSmall);
+        // decode() avoids a blank first frame after the network load completes:
+        // https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decode
+        // Keep the timeout active during decode; OBS must never strand the queue.
+        try {
+          if (typeof img.decode === 'function') {
+            void img.decode().then(
+              () => finish(isPortrait, isSmall, true, true),
+              () => finish(false, false),
+            );
+          } else {
+            finish(isPortrait, isSmall, true, true);
+          }
+        } catch {
+          finish(false, false);
+        }
       };
       img.onerror = () => {
         finish(false, false);
       };
       timeoutId = setTimeout(() => {
         finish(false, false);
-      }, IMAGE_METADATA_TIMEOUT_MS);
-      img.src = imageUrl;
+      }, IMAGE_PREPARE_TIMEOUT_MS);
+      try {
+        img.src = imageUrl;
+      } catch {
+        finish(false, false);
+      }
     });
   }, []);
 
@@ -1115,12 +1137,8 @@ export default function OverlayPage() {
     };
 
     try {
-      // Issue #1076: the exact OBS/CEF root cause is still unconfirmed. The real
-      // preview path received a valid gacha payload but produced no card DOM/
-      // pixels. Image metadata is presentation-only, so a business event must not
-      // depend on this preflight before mounting its DOM. Decouple the probe as a
-      // defensive fix; the existing 1.5s probe timeout would normally bound the
-      // old wait, so preview real-path validation remains mandatory after merge.
+      // Bound image preparation so frames and effects appear with the artwork,
+      // while preserving the #1076 recovery path for failed or stalled requests.
       const imageLayoutGeneration = imageLayoutGenerationRef.current + 1;
       imageLayoutGenerationRef.current = imageLayoutGeneration;
       if (
@@ -1151,44 +1169,29 @@ export default function OverlayPage() {
         rarity: next.card.rarity,
       } as Card;
       const displayResult = { ...next, card: displayCard };
-      // `result`を先に確定する。エフェクト設定はpresentation-onlyなので、
-      // 解決に失敗してもbusiness eventのカードDOMを失わせない。
-      setResult(displayResult);
-      // カード表示をmetadataやタイマーの完了条件にしない。OBS/CEFや
-      // バックグラウンドのブラウザではsetTimeoutが遅延することがあり、
-      // revealを待つだけでも実交換後の有効窓を全面黒画面にしてしまう。
-      // business eventを受信した時点でカードを可視化し、metadataは
-      // presentation-onlyのレイアウト更新として並行して扱う。
-      setShowCard(true);
-      displayStarted = true;
-      // The state setter has run, but the DOM commit happens on the next React
-      // render. Use "scheduled" here; the commit effect below is the only place
-      // that reports an actual card DOM commit.
-      addDebugLogRef.current('Card display scheduled');
-
-      // Start the presentation-only metadata probe *after* scheduling the card
-      // state. Even a future Image implementation that throws before returning
-      // a Promise cannot move the business event back behind this probe.
-      const imageMetadataPromise = checkImageAspectRatio(
+      // No-image cards remain synchronous. For image cards, both the network
+      // request and decode share the bounded probe timeout. A failed probe uses
+      // the existing painted fallback instead of showing an empty image region.
+      const imageReady = !displayCard.image_url || await prepareCardImage(
         displayCard.image_url,
         imageLayoutGeneration,
-      ).catch((error) => {
-        // Metadata and its diagnostics are presentation-only. A broken logger
-        // or debug panel must not reject this already-handled Promise and leak
-        // into handleQueueError after the normal advance chain is armed.
-        try {
-          logger.warn("Overlay image metadata probe failed:", error);
-        } catch {
-          // Best-effort diagnostic only.
-        }
-        try {
-          addDebugLogRef.current(
-            `image metadata probe failed: ${error instanceof Error ? error.message : String(error)}`
-          );
-        } catch {
-          // Best-effort debug UI only.
-        }
-      });
+      ).catch(() => false);
+      if (
+        !isOverlayMountedRef.current
+        || queueGeneration !== queueGenerationRef.current
+        || imageLayoutGeneration !== imageLayoutGenerationRef.current
+      ) {
+        // Cleanup owns the old queue lock; never touch a new subscription here.
+        settleDisplayCommit(next.displayInstanceId, false);
+        return;
+      }
+      if (!imageReady && next.displayInstanceId !== undefined) {
+        setImageFallbackDisplayInstanceId(next.displayInstanceId);
+      }
+      setResult(displayResult);
+      setShowCard(true);
+      displayStarted = true;
+      addDebugLogRef.current('Card display scheduled');
 
       try {
         // このカードのレアリティに紐づくエフェクトを解決する。
@@ -1219,7 +1222,7 @@ export default function OverlayPage() {
       }
 
       // 表示は既に開始済み。ここでは効果音と表示終了だけを予約する。
-      // metadataの解決やrevealタイマーをカードDOMのliveness条件にしない。
+      // 画像準備にかかった時間をカードの表示時間から差し引かない。
       animationTimeoutRef.current = setTimeout(() => runProtected(() => {
         // The reveal timer has fired; it no longer needs lifecycle tracking.
         animationTimeoutRef.current = null;
@@ -1327,12 +1330,10 @@ export default function OverlayPage() {
           finishDisplayWindow();
         }), options.displayDuration * 1000);
       }), MIN_REVEAL_LEAD_IN_MS);
-      void imageMetadataPromise
-        .catch(handleQueueError);
     } catch (error) {
       handleQueueError(error);
     }
-  }, [armDisplayCommitTimeout, checkImageAspectRatio, failDisplayCommit, playGachaSound, options.displayDuration, options.effects, options.rarityEffectMap, requestDisplayFallback, settleDisplayCommit]);
+  }, [armDisplayCommitTimeout, prepareCardImage, failDisplayCommit, playGachaSound, options.displayDuration, options.effects, options.rarityEffectMap, requestDisplayFallback, settleDisplayCommit]);
 
   // processQueueRefを最新のcallbackで更新
   useEffect(() => {

--- a/tests/unit/components/overlay-page-metadata-fallback.test.tsx
+++ b/tests/unit/components/overlay-page-metadata-fallback.test.tsx
@@ -8,10 +8,6 @@ const { subscribeMock, streamerIdRef } = vi.hoisted(() => ({
   streamerIdRef: { current: 'streamer-1' },
 }))
 
-// metadata callback が無応答のままでも表示が維持されることを見る観測窓。
-// 現行の 1.5 秒 probe timeout を少し越えて待つ意図を数値直書きから分離する。
-const METADATA_STALL_OBSERVATION_MS = 1_600
-
 vi.mock('next/navigation', () => ({
   useParams: () => ({ streamerId: streamerIdRef.current }),
 }))
@@ -65,86 +61,79 @@ describe('OverlayPage metadata fallback', () => {
       .toHaveClass('opacity-100')
   })
 
-  // #1076 の実経路では gacha payload を受信しても最初のカードDOM自体が出ない症状が
-  // あった。既存のN連キューテストとは分け、初回カードでブラウザの metadata callback が
-  // 一度も返らなくても business event のDOM配置と期限後のrevealが進むことを固定する。
-  it('初回カードのmetadata callbackが無応答でもDOMを先に配置して表示する', async () => {
-    vi.useFakeTimers()
-    window.history.replaceState({}, '', '/overlay/streamer-1')
-
-    class PendingImage {
-      onload: (() => void) | null = null
-      onerror: (() => void) | null = null
-      width = 640
-      height = 480
-
-      set src(value: string) {
-        void value
-        // ブラウザ由来の load / error を意図的に発火させない。
+  it.each(['load', 'timeout', 'error', 'decode-error', 'decode-timeout'] as const)(
+    '画像準備待ちでは枠を表示せず、%s 後から表示時間を数える', async (outcome) => {
+      vi.useFakeTimers()
+      window.history.replaceState({}, '', '/overlay/streamer-1?duration=2')
+      const pendingImages: PendingImage[] = []
+      let finishDecode: (() => void) | undefined
+      class PendingImage {
+        onload: (() => void) | null = null
+        onerror: (() => void) | null = null
+        width = 640
+        height = 480
+        decode = () => outcome === 'decode-error'
+          ? Promise.reject(new Error('invalid image'))
+          : new Promise<void>(resolve => { finishDecode = resolve })
+        set src(_value: string) { pendingImages.push(this) }
       }
-    }
-    vi.stubGlobal('Image', PendingImage)
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ soundUrl: null, soundEnabled: false }),
-    }))
-
-    let onGachaResult: ((payload: GachaBroadcastPayload) => GachaDeliveryResult) | undefined
-    let acknowledged = false
-    subscribeMock.mockImplementation((_streamerId, callback, options: SubscribeOptions) => {
-      onGachaResult = callback as (payload: GachaBroadcastPayload) => GachaDeliveryResult
-      options.onSuccess?.()
-      return vi.fn()
-    })
-
-    render(<OverlayPage />)
-    await act(async () => {
-      await Promise.resolve()
-      await Promise.resolve()
-    })
-
-    expect(onGachaResult).toBeDefined()
-    act(() => {
-      const delivery = onGachaResult?.({
-        type: 'gacha',
-        card: {
-          id: 'metadata-pending-card',
-          name: 'Metadata Pending',
-          description: null,
-          image_url: 'https://example.com/metadata-pending.png',
-          rarity: 'rare',
-        },
-        userTwitchUsername: 'Viewer',
+      vi.stubGlobal('Image', PendingImage)
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true, json: async () => ({ soundUrl: null, soundEnabled: false }),
+      }))
+      let onPayload: ((payload: GachaBroadcastPayload) => GachaDeliveryResult) | undefined
+      subscribeMock.mockImplementation((_id, callback, options: SubscribeOptions) => {
+        onPayload = callback
+        options.onSuccess?.()
+        return vi.fn()
       })
-      expect(delivery).toBeInstanceOf(Promise)
-      void Promise.resolve(delivery).then((accepted) => {
-        acknowledged = accepted === true
+      render(<OverlayPage />)
+      await act(async () => { await Promise.resolve() })
+      await act(async () => {
+        void onPayload?.({
+          type: 'gacha',
+          card: { id: 'waiting', name: 'Waiting Card', description: null,
+            image_url: 'https://example.com/waiting.png', rarity: 'rare' },
+          userTwitchUsername: 'Viewer',
+        })
       })
-      expect(acknowledged).toBe(false)
-    })
-
-    // metadata timeoutを待つ前からカードDOMは存在し、すでに可視である。
-    // presentation-onlyなmetadata取得やrevealタイマーがbusiness eventの
-    // 表示を再びブロックする回帰をここで検知する。
-    const cardName = screen.getByText('Metadata Pending')
-    const cardRoot = cardName.closest('.transition-all')
-    expect(cardRoot).not.toBeNull()
-    expect(cardRoot).toHaveClass('opacity-100')
-    const cardImage = cardRoot?.querySelector('img') as HTMLImageElement | null
-    if (cardImage) {
-      Object.defineProperty(cardImage, 'complete', { configurable: true, value: true })
-      Object.defineProperty(cardImage, 'naturalWidth', { configurable: true, value: 320 })
-      Object.defineProperty(cardImage, 'naturalHeight', { configurable: true, value: 448 })
-      cardImage.dispatchEvent(new Event('load'))
-    }
-
-    // load/errorは無応答のままでも、metadata期限に依存せず表示が維持される。
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(METADATA_STALL_OBSERVATION_MS)
-    })
-    expect(cardRoot).toHaveClass('opacity-100')
-    expect(acknowledged).toBe(true)
-  })
+      expect(screen.queryByText('Waiting Card')).not.toBeInTheDocument()
+      await act(async () => { await vi.advanceTimersByTimeAsync(800) })
+      expect(screen.queryByText('Waiting Card')).not.toBeInTheDocument()
+      if (outcome === 'timeout') {
+        await act(async () => { await vi.advanceTimersByTimeAsync(800) })
+      } else if (outcome === 'error') {
+        await act(async () => { pendingImages[0]?.onerror?.() })
+      } else {
+        await act(async () => { pendingImages[0]?.onload?.() })
+        if (outcome === 'decode-timeout') {
+          await act(async () => { await vi.advanceTimersByTimeAsync(800) })
+        }
+        if (outcome === 'load') {
+          expect(screen.queryByText('Waiting Card')).not.toBeInTheDocument()
+          await act(async () => { finishDecode?.() })
+        }
+      }
+      const root = screen.getByText('Waiting Card').closest('[data-overlay-card="true"]')!
+      expect(root).toHaveClass('opacity-100')
+      if (outcome !== 'load') {
+        expect(root.querySelector('[data-overlay-card-fallback="true"]')).not.toBeNull()
+      } else {
+        // The real element, rather than the detached preloader, owns delivery ACK.
+        const image = root.querySelector('img')!
+        Object.defineProperties(image, {
+          complete: { configurable: true, value: true },
+          naturalWidth: { configurable: true, value: 320 },
+          naturalHeight: { configurable: true, value: 448 },
+        })
+        await act(async () => { image.dispatchEvent(new Event('load')) })
+      }
+      await act(async () => { await vi.advanceTimersByTimeAsync(800) })
+      expect(root).toHaveClass('opacity-100')
+      await act(async () => { await vi.advanceTimersByTimeAsync(1400) })
+      expect(root).toHaveClass('opacity-0')
+    },
+  )
 
   it('旧subscription世代の遅延payloadを新しいstreamerへ混ぜない', async () => {
     window.history.replaceState({}, '', '/overlay/streamer-1')

--- a/tests/unit/components/overlay-page-realtime-commit.test.tsx
+++ b/tests/unit/components/overlay-page-realtime-commit.test.tsx
@@ -78,7 +78,9 @@ describe('OverlayPage actual realtime transport commit acknowledgement', () => {
     class PendingImage {
       onload: (() => void) | null = null
       onerror: (() => void) | null = null
-      set src(_value: string) {}
+      width = 640
+      height = 480
+      set src(_value: string) { queueMicrotask(() => this.onload?.()) }
     }
     vi.stubGlobal('Image', PendingImage)
 

--- a/tests/unit/components/overlay-page.test.tsx
+++ b/tests/unit/components/overlay-page.test.tsx
@@ -783,15 +783,14 @@ describe('OverlayPage', () => {
     })
     expect(screen.getByText('Batch A')).toBeInTheDocument()
 
-    // A commits, then B becomes active but never loads an image. Its watchdog
-    // observes the committed card and ACKs the visible fallback rather than
-    // removing it and creating a retry/black-screen loop.
+    // A commits, then B waits for preparation and times out. The visible
+    // fallback ACKs B without removing it or starting a retry loop.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(6600)
     })
-    expect(screen.getByText('Batch B')).toBeInTheDocument()
+    expect(screen.queryByText('Batch B')).not.toBeInTheDocument()
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(4500)
+      await vi.advanceTimersByTimeAsync(1600)
     })
     await expect(firstAttempt).resolves.toBe(true)
     expect(screen.getByText('Batch B')).toBeInTheDocument()
@@ -921,22 +920,15 @@ describe('OverlayPage', () => {
     })
     expect(screen.getByText('Alpha')).toBeInTheDocument()
 
-    // 1枚目の表示終了後、2枚目のmetadata probeは無応答のままでも、カードDOMは
-    // 先にマウントされ、metadataの期限を待たずに可視化される。
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(6600)
-    })
+    // 2枚目は画像準備の上限まで待ち、代替カードで表示を開始する。
+    await act(async () => { await vi.advanceTimersByTimeAsync(6600) })
     expect(screen.queryByText('Alpha')).not.toBeInTheDocument()
+    expect(screen.queryByText('Beta')).not.toBeInTheDocument()
+    await act(async () => { await vi.advanceTimersByTimeAsync(1600) })
     const betaText = screen.getByText('Beta')
-    expect(betaText).toBeInTheDocument()
     expect(betaText.closest('.transition-all')).toHaveClass('opacity-100')
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1600)
-    })
-    expect(betaText.closest('.transition-all')).toHaveClass('opacity-100')
-
-    // 2枚目のmetadata timeoutの有無とは独立に通常の表示時間で3枚目へ進む。
+    // 代替表示開始後の通常の表示時間を確保して3枚目へ進む。
     await act(async () => {
       await vi.advanceTimersByTimeAsync(6600)
     })
@@ -994,15 +986,7 @@ describe('OverlayPage', () => {
         userTwitchUsername: 'Viewer',
       })
     })
-    expect(screen.getByText('Old Card')).toBeInTheDocument()
-
-    // The old card reaches its short display-window fallback. Switch the
-    // streamer before the guarded visibility timer expires; that timer must
-    // not make the newly mounted streamer's card transparent.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2100)
-    })
-    expect(document.querySelector('[data-overlay-card-fallback="true"]')).not.toBeNull()
+    expect(screen.queryByText('Old Card')).not.toBeInTheDocument()
 
     // 同一component instanceでstreamerを切り替えると旧probeはcleanupでresolveする。
     // そのmicrotaskが新subscriptionのisDisplayingRefを解除してはならない。
@@ -1232,7 +1216,7 @@ describe('OverlayPage', () => {
     expect(screen.queryByText('Viewer が引いたカード')).not.toBeInTheDocument()
   })
 
-  it('metadataが遅くてもカードDOMを先に置き、解決後に安定したレイアウトでrevealする', async () => {
+  it('画像準備を待って縦長レイアウトで表示し、実画像load後だけACKする', async () => {
     vi.useFakeTimers()
 
     const metadataImages: MockImage[] = []
@@ -1281,15 +1265,8 @@ describe('OverlayPage', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(100)
     })
-    expect(screen.getByText('Viewer が引いたカード')).toBeInTheDocument()
-    const initialCardImage = screen.getByAltText('Late Portrait')
+    expect(screen.queryByAltText('Late Portrait')).not.toBeInTheDocument()
 
-    // metadataが遅れても、DOMは既に存在し、revealタイマーを待たず可視になる。
-    expect(screen.getByText('Viewer が引いたカード').closest('.transition-all'))
-      .toHaveClass('opacity-100')
-
-    // 画像metadataが縦長として到着したあとも、カードは表示を継続しながら
-    // image-onlyレイアウトへ更新される。
     const metadataImage = metadataImages[0]
     expect(metadataImage).toBeDefined()
     metadataImage.width = 200
@@ -1302,22 +1279,9 @@ describe('OverlayPage', () => {
     const portraitCardImage = screen.getByAltText('Late Portrait')
     expect(portraitCardImage).toBeInTheDocument()
 
-    // autoPortrait remounts the <img>. A late load from the detached old
-    // element must not ACK the draw; only the currently mounted image may do
-    // so after it has positive natural dimensions.
-    Object.defineProperties(initialCardImage, {
-      complete: { configurable: true, value: true },
-      naturalWidth: { configurable: true, value: 320 },
-      naturalHeight: { configurable: true, value: 448 },
-    })
     let delivered = false
-    delivery?.then(() => {
-      delivered = true
-    })
-    await act(async () => {
-      initialCardImage.dispatchEvent(new Event('load'))
-      await Promise.resolve()
-    })
+    delivery?.then(() => { delivered = true })
+    await act(async () => { await Promise.resolve() })
     expect(delivered).toBe(false)
 
     Object.defineProperties(portraitCardImage, {
@@ -1407,7 +1371,7 @@ describe('OverlayPage', () => {
   it.each([
     { label: '通常表示', query: '' },
     { label: '画像のみ表示', query: '?imageOnly=true' },
-  ])('ウォッチドッグ後に遅延画像が復帰すると代替表示を外す($label)', async ({ query }) => {
+  ])('画像準備タイムアウト後に遅延画像が復帰すると代替表示を外す($label)', async ({ query }) => {
     vi.useFakeTimers()
     window.history.replaceState({}, '', `/overlay/streamer-1${query}`)
 
@@ -1450,14 +1414,14 @@ describe('OverlayPage', () => {
     })
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(100)
+      await vi.advanceTimersByTimeAsync(1600)
     })
     const imageBeforeFallback = screen.getByAltText('Slow Recovery')
 
-    // The watchdog paints a visible fallback, but it must not unmount the
+    // The preparation timeout paints a fallback, but it must not unmount the
     // underlying image element because a slow CDN response can still recover.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(4500)
+      await vi.advanceTimersByTimeAsync(200)
     })
     expect(screen.getByLabelText(/Slow Recovery の画像を表示できないため代替表示/))
       .toHaveAttribute('data-overlay-card-fallback', 'true')
@@ -1521,15 +1485,14 @@ describe('OverlayPage', () => {
     })
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(100)
+      await vi.advanceTimersByTimeAsync(1600)
     })
     expect(screen.getByAltText('Short Window')).toBeInTheDocument()
 
-    // displayDuration=2 expires before the 4.5s watchdog. The fallback must
-    // be committed while this card is still mounted, so this exchange resolves
-    // once without a transport retry.
+    // The fallback must be committed during its full two-second display
+    // window, so this exchange resolves once without a transport retry.
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000)
+      await vi.advanceTimersByTimeAsync(1000)
     })
     expect(screen.getByLabelText(/Short Window の画像を表示できないため代替表示/))
       .toHaveAttribute('data-overlay-card-fallback', 'true')
@@ -1537,15 +1500,14 @@ describe('OverlayPage', () => {
       .toHaveClass('opacity-100')
     await expect(delivery).resolves.toBe(true)
 
-    // A same-turn display-expiry callback must leave the fallback painted for
-    // a bounded frame window before making the outgoing card transparent.
+    // Preparation time must not shorten the fallback display window.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(249)
     })
     expect(document.querySelector('[data-overlay-card="true"]'))
       .toHaveClass('opacity-100')
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(500)
+      await vi.advanceTimersByTimeAsync(1000)
     })
     expect(document.querySelector('[data-overlay-card="true"]'))
       .toHaveClass('opacity-0')
@@ -1707,6 +1669,15 @@ describe('OverlayPage', () => {
   // 「setTimeoutコールバックの中で起きた例外」を確実に再現する。
   it('setTimeoutでスケジュールされる表示チェーン内の例外でもロックが残らない(Issue #999レビュー指摘#1回帰)', async () => {
     vi.useFakeTimers()
+    class PreparedImage {
+      width = 640
+      height = 480
+      onload: (() => void) | null = null
+      onerror: (() => void) | null = null
+      set src(_value: string) { queueMicrotask(() => this.onload?.()) }
+    }
+    vi.stubGlobal('Image', PreparedImage)
+
     window.history.replaceState({}, '', '/overlay/streamer-1?duration=2')
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
@@ -1953,16 +1924,11 @@ describe('OverlayPage', () => {
     act(() => {
       onGachaResult?.({ type: 'gacha', card: cards[0], cards, userTwitchUsername: 'Viewer' })
     })
-    // The image watchdog renders its fallback at 4.5s. Flush that state
-    // update before advancing the normal 6s display window so the test models
-    // the browser's separate timer tasks rather than batching both deadlines.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(4500)
-    })
+    // The first preloader succeeds; the mounted image watchdog owns its ACK.
+    await act(async () => { await vi.advanceTimersByTimeAsync(100) })
+    await act(async () => { await vi.advanceTimersByTimeAsync(4400) })
     expect(document.querySelector('[data-overlay-card-fallback="true"]')).not.toBeNull()
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2100)
-    })
+    await act(async () => { await vi.advanceTimersByTimeAsync(2100) })
     expect(imageInstances).toHaveLength(2)
     const playsBeforeUnmount = playMock.mock.calls.length
 


### PR DESCRIPTION
配信オーバーレイでカード枠だけが先に現れ、画像が遅れて表示されるため、画像の読み込み・デコード完了を待ってからカードを表示します。縦長レイアウトも表示開始前に確定し、読み込み待ち時間を設定された表示時間に含めません。

画像準備は最大1.5秒とし、失敗・タイムアウト時は既存の代替表示でキューを継続します。実画像が後から読み込めた場合の復帰、表示済み確認によるACK、画面切り替え・unmount時の旧処理破棄を維持しています。ネットワーク速度自体を改善する変更ではありません。

検証:
- 変更前に画像待機中も枠が表示されることを回帰テストで再現（4ケース失敗）。
- オーバーレイの表示・実Realtime ACK・Worker/契約/cursor関連: 6ファイル119テスト成功。
- load後のdecode待機、decode失敗/停止、timeout/error、全表示時間確保、連続カード、縦長、遅延復帰、cleanupを確認。
- TypeScript型チェック成功。変更ファイルのESLintはエラー0（既存のcleanup ref警告2件）。diff check成功。
- ユーザー指示に従いサブエージェントは使わず、主担当が自己レビュー実施。

未実施: ビルド、固定preview/OBSでの実表示、本番配備。docs/QA.mdのoverlay行に基づくpreview実経路ゲート（複数引き換え、表示順序、chat、ログ、WS/polling gap recovery）は、本番昇格前に必要です。上記unitテストを実経路検証の代替とは扱っていません。
