### PR TITLE
test: storage-status の crypto mock を automock に揃える

### DIFF
--- a/tests/unit/storage-status-api.test.ts
+++ b/tests/unit/storage-status-api.test.ts
@@ -9,9 +9,7 @@ vi.mock('@/lib/storage-usage', () => ({
   getStorageUsage: vi.fn(),
   formatBytes: vi.fn(),
 }))
-vi.mock('@/lib/crypto-utils', () => ({
-  sha256Prefix: vi.fn(),
-}))
+vi.mock('@/lib/crypto-utils')
 
 const mockGetSession = vi.mocked(getSession)
 const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)

--- a/tests/unit/storage-status-error.test.ts
+++ b/tests/unit/storage-status-error.test.ts
@@ -20,9 +20,7 @@ vi.mock('@/lib/storage-usage', () => ({
   getStorageUsage: vi.fn(),
   formatBytes: vi.fn(),
 }));
-vi.mock('@/lib/crypto-utils', () => ({
-  sha256Prefix: vi.fn(),
-}));
+vi.mock('@/lib/crypto-utils');
 vi.mock('@/lib/error-handler', () => ({
   handleApiError: vi.fn(),
 }));

--- a/tests/unit/storage-status-format-bytes.test.ts
+++ b/tests/unit/storage-status-format-bytes.test.ts
@@ -9,9 +9,7 @@ vi.mock('@/lib/storage-usage', () => ({
   getStorageUsage: vi.fn(),
   formatBytes: vi.fn(),
 }))
-vi.mock('@/lib/crypto-utils', () => ({
-  sha256Prefix: vi.fn(),
-}))
+vi.mock('@/lib/crypto-utils')
 
 const mockGetSession = vi.mocked(getSession)
 const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)

--- a/tests/unit/storage-status-upload-disabled.test.ts
+++ b/tests/unit/storage-status-upload-disabled.test.ts
@@ -9,9 +9,7 @@ vi.mock('@/lib/storage-usage', () => ({
   getStorageUsage: vi.fn(),
   formatBytes: vi.fn(),
 }))
-vi.mock('@/lib/crypto-utils', () => ({
-  sha256Prefix: vi.fn(),
-}))
+vi.mock('@/lib/crypto-utils')
 
 const mockGetSession = vi.mocked(getSession)
 const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)

--- a/tests/unit/storage-status-usage-args.test.ts
+++ b/tests/unit/storage-status-usage-args.test.ts
@@ -9,9 +9,7 @@ vi.mock('@/lib/storage-usage', () => ({
   getStorageUsage: vi.fn(),
   formatBytes: vi.fn(),
 }))
-vi.mock('@/lib/crypto-utils', () => ({
-  sha256Prefix: vi.fn(),
-}))
+vi.mock('@/lib/crypto-utils')
 
 const mockGetSession = vi.mocked(getSession)
 const mockCanUseStreamerFeatures = vi.mocked(canUseStreamerFeatures)


### PR DESCRIPTION
## 概要

Issue #1352 の軽量フォローアップとして、storage-status 系 unit test で `@/lib/crypto-utils` を factory 全置換していた5箇所を Vitest の automock に揃えます。

既存の `storage-status-auth.test.ts` はすでに `vi.mock('@/lib/crypto-utils')` を使っており、今回の対象も `sha256Prefix` を `vi.mocked()` して個別に戻り値を設定する契約は維持します。これにより将来 `crypto-utils` に export が増えた際、テスト用 factory がモジュール形状を不必要に狭めるリスクを減らします。

## 変更

- `storage-status-api.test.ts`
- `storage-status-error.test.ts`
- `storage-status-format-bytes.test.ts`
- `storage-status-upload-disabled.test.ts`
- `storage-status-usage-args.test.ts`

各ファイルの `vi.mock('@/lib/crypto-utils', () => ({ sha256Prefix: vi.fn() }))` を `vi.mock('@/lib/crypto-utils')` に置換しただけで、runtime / API / DB / assertion の変更はありません。

## 確認

- 差分は5ファイル、各 `+1/-3` の mock 宣言のみ
- runtime / API / DB / UI 変更なし
- CI と exact HEAD のレビュー記録を確認してから収束する

Refs #1352