### PR TITLE
test: storage-status 成功helperの責務を明示する

### DIFF
--- a/tests/unit/storage-status-api.test.ts
+++ b/tests/unit/storage-status-api.test.ts
@@ -30,7 +30,9 @@ const baseUsage: StorageUsage = {
   planOverLimit: false,
 }
 
-async function getStorageStatus(overrides: Partial<StorageUsage> = {}) {
+// このsuiteは200応答の本文互換だけを検証するため、成功statusのassertionはhelperに集約する。
+// 401/500のstatus契約は専用suiteで固定し、各テストはmessage優先順位へ集中させる（#1352）。
+async function getSuccessfulStorageStatusBody(overrides: Partial<StorageUsage> = {}) {
   mockGetStorageUsage.mockResolvedValue({ ...baseUsage, ...overrides })
   const response = await GET()
   expect(response.status).toBe(200)
@@ -57,7 +59,7 @@ describe('GET /api/storage-status message compatibility', () => {
   })
 
   it('planOverLimit を最優先の互換 message として返す', async () => {
-    const body = await getStorageStatus({
+    const body = await getSuccessfulStorageStatusBody({
       planOverLimit: true,
       globalLimitReached: true,
       userLimitReached: true,
@@ -69,7 +71,7 @@ describe('GET /api/storage-status message compatibility', () => {
   })
 
   it('globalLimitReached を userLimitReached より優先する', async () => {
-    const body = await getStorageStatus({
+    const body = await getSuccessfulStorageStatusBody({
       globalLimitReached: true,
       userLimitReached: true,
     })
@@ -78,7 +80,7 @@ describe('GET /api/storage-status message compatibility', () => {
   })
 
   it('userLimitReached の互換 message を返す', async () => {
-    const body = await getStorageStatus({ userLimitReached: true })
+    const body = await getSuccessfulStorageStatusBody({ userLimitReached: true })
 
     expect(body.message).toBe(
       '画像のアップロード上限は現在一アカウントにつき10MBです。上限を超える場合は、既存の画像を削除してから再度お試しください。'
@@ -86,7 +88,7 @@ describe('GET /api/storage-status message compatibility', () => {
   })
 
   it('制限に達していなければ message は null を返す', async () => {
-    const body = await getStorageStatus()
+    const body = await getSuccessfulStorageStatusBody()
 
     expect(body.message).toBeNull()
   })

--- a/tests/unit/storage-status-upload-disabled.test.ts
+++ b/tests/unit/storage-status-upload-disabled.test.ts
@@ -34,7 +34,9 @@ type StorageStatusBody = Pick<
   uploadDisabled: boolean
 }
 
-async function getStorageStatus(
+// このsuiteは200応答のmachine-readable body契約が対象なので、成功statusはhelperで固定する。
+// auth/errorのstatus契約は専用テストへ分離し、各ケースは制限フラグのOR契約へ集中させる（#1352）。
+async function getSuccessfulStorageStatusBody(
   overrides: Partial<StorageUsage> = {}
 ): Promise<StorageStatusBody> {
   mockGetStorageUsage.mockResolvedValue({ ...baseUsage, ...overrides })
@@ -66,7 +68,7 @@ describe('GET /api/storage-status uploadDisabled contract (#1352)', () => {
   })
 
   it('制限フラグがすべて false なら uploadDisabled は false', async () => {
-    const body = await getStorageStatus()
+    const body = await getSuccessfulStorageStatusBody()
 
     expect(body).toMatchObject({
       userLimitReached: false,
@@ -77,7 +79,7 @@ describe('GET /api/storage-status uploadDisabled contract (#1352)', () => {
   })
 
   it('userLimitReached が true なら uploadDisabled は true', async () => {
-    const body = await getStorageStatus({ userLimitReached: true })
+    const body = await getSuccessfulStorageStatusBody({ userLimitReached: true })
 
     expect(body).toMatchObject({
       userLimitReached: true,
@@ -88,7 +90,7 @@ describe('GET /api/storage-status uploadDisabled contract (#1352)', () => {
   })
 
   it('globalLimitReached が true なら uploadDisabled は true', async () => {
-    const body = await getStorageStatus({ globalLimitReached: true })
+    const body = await getSuccessfulStorageStatusBody({ globalLimitReached: true })
 
     expect(body).toMatchObject({
       userLimitReached: false,
@@ -99,7 +101,7 @@ describe('GET /api/storage-status uploadDisabled contract (#1352)', () => {
   })
 
   it('planOverLimit が true なら uploadDisabled は true', async () => {
-    const body = await getStorageStatus({ planOverLimit: true })
+    const body = await getSuccessfulStorageStatusBody({ planOverLimit: true })
 
     expect(body).toMatchObject({
       userLimitReached: false,


### PR DESCRIPTION
## 概要

Issue #1352 の軽量フォローアップとして、`storage-status` の200応答本文を検証する2つの unit test で、成功status assertion を内包する helper の責務を名前とコメントで明示します。

従来の `getStorageStatus` は helper 内で `response.status === 200` まで検証していましたが、名前だけでは「成功応答専用」であることが分かりにくい状態でした。`getSuccessfulStorageStatusBody` へ揃え、200 assertion を helper に置く理由をコメントとして残します。401/500 は既存の auth/error 専用suiteへ分離されているため、各本文テストは message / uploadDisabled の契約へ集中させます。

## 変更

- `tests/unit/storage-status-api.test.ts`
  - `getStorageStatus` → `getSuccessfulStorageStatusBody`
  - 200 status assertion を helper に集約する理由をコメント化
- `tests/unit/storage-status-upload-disabled.test.ts`
  - 同じ helper 名・責務へ統一

runtime / API / DB / UI / assertion の意味は変更しません。

## 確認

- 差分は test 2ファイルのみ
- `preview` exact HEAD `1bb40f47494c58c02391116c90be830c03b03182` から分岐
- CI と latest exact HEAD のレビュー記録を確認してから収束する

Refs #1352