### PR TITLE
test(storage): error経路の入力伝播を明示する

### DIFF
--- a/tests/unit/storage-status-error.test.ts
+++ b/tests/unit/storage-status-error.test.ts
@@ -40,13 +40,14 @@ const SESSION: SessionPayload = {
   expiresAt: 4_102_444_800_000,
   version: 1,
 };
+const STORAGE_PREFIX = 'storage-error-prefix';
 
 describe('GET /api/storage-status: error delegation (#1356)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue(SESSION);
     mockCanUseStreamerFeatures.mockReturnValue(true);
-    mockSha256Prefix.mockResolvedValue('storage-error-prefix');
+    mockSha256Prefix.mockResolvedValue(STORAGE_PREFIX);
     mockHandleApiError.mockResolvedValue(
       NextResponse.json({ error: 'handled-storage-error' }, { status: 500 })
     );
@@ -59,7 +60,7 @@ describe('GET /api/storage-status: error delegation (#1356)', () => {
     const response = await GET();
 
     expect(mockGetStorageUsage).toHaveBeenCalledWith(
-      'storage-error-prefix',
+      STORAGE_PREFIX,
       SESSION.twitchUserId
     );
     expect(mockHandleApiError).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## 概要

Issue #1352 の任意フォローアップとして、`storage-status-error.test.ts` の `getStorageUsage` 引数期待値を、モック入力からの伝播を表現する形へ揃えます。

- `sha256Prefix` の戻り値を `STORAGE_PREFIX` fixture として定義
- `getStorageUsage` の期待値も同じ fixture と `SESSION.twitchUserId` を参照
- runtime / API / assertion の意味は変更しない

## 確認

- test-only の最小差分
- `preview` の最新 HEAD `1194639de857cd06b0a27f15ec3822a14dc6d972` から分岐

Refs #1352