### PR TITLE
コレクション一覧の誤ったコンプリート表示を修正

### DIFF
--- a/src/lib/dashboard-data.ts
+++ b/src/lib/dashboard-data.ts
@@ -2195,14 +2195,10 @@ export interface ActiveCardCountForStreamer {
 /**
  * getActiveCardCountsForStreamers の Drizzle（pg 直結）実装 (#571)
  *
- * 前処理（重複除去・空入力の早期 return）と JS 側集計は経路非依存だが、
- * 「関数冒頭でのフラグ分岐 + 既存実装無変更」の規約を守るため、pg 版にも
- * 同じ前処理を意図的に複製している（挙動パリティの検証容易性を優先）。
- *
- * 暗黙に打ち切られる。この関数は複数配信者のアクティブカードを合算で取得する
- * ため、コレクションの多いユーザーでは 1000 行超が現実に起こりうる。ここで
- * LIMIT を外すと pg 経路だけカウントが変わってしまうため、明示 LIMIT 1000 で
- * 既存挙動（打ち切りによる過少カウントも含めて）を再現する。
+ * 複数配信者の進捗は、対象となる全アクティブカードのIDで集計する。
+ * 合算にLIMITを掛けると後方の配信者が一部のカードだけで100%と判定されるため、
+ * pg直結では件数を打ち切らない。取得列はIDと配信者IDのみに絞り、
+ * 配信者ごとのN+1クエリを避けながら分母と所有カードとの交差を正確に保つ。
  * エラー時は既存実装と同じく reportError + 全ゼロの counts を返す。
  */
 async function getActiveCardCountsForStreamersPg(
@@ -2233,8 +2229,7 @@ async function getActiveCardCountsForStreamersPg(
               inArray(cardsTable.streamer_id, uniqueStreamerIds),
               eq(cardsTable.is_active, true),
             )
-          )
-          .limit(1000);
+          );
       },
       "getActiveCardCountsForStreamers",
       { idempotent: true },

--- a/tests/unit/dashboard-active-card-counts.test.ts
+++ b/tests/unit/dashboard-active-card-counts.test.ts
@@ -4,6 +4,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getActiveCardCountsForStreamers } from '@/lib/dashboard-data'
+import { countOwnedActiveCardTypes } from '@/lib/collection-utils'
 import { getDb } from '@/lib/db/client'
 import { cards as cardsTable } from '@/lib/db/schema'
 
@@ -25,8 +26,7 @@ describe('getActiveCardCountsForStreamers', () => {
       { id: 'card-2', streamer_id: 'streamer-a' },
       { id: 'card-3', streamer_id: 'streamer-b' },
     ]
-    const limit = vi.fn().mockResolvedValue(rows)
-    const where = vi.fn(() => ({ limit }))
+    const where = vi.fn().mockResolvedValue(rows)
     const from = vi.fn(() => ({ where }))
     const select = vi.fn(() => ({ from }))
     vi.mocked(getDb).mockResolvedValue({
@@ -47,7 +47,6 @@ describe('getActiveCardCountsForStreamers', () => {
       streamer_id: cardsTable.streamer_id,
     })
     expect(from).toHaveBeenCalledWith(cardsTable)
-    expect(limit).toHaveBeenCalledWith(1000)
     expect(result.get('streamer-a')).toEqual({
       totalActive: 2,
       activeCardIds: new Set(['card-1', 'card-2']),
@@ -56,6 +55,36 @@ describe('getActiveCardCountsForStreamers', () => {
       totalActive: 1,
       activeCardIds: new Set(['card-3']),
     })
+  })
+
+  it('合計1000種類を超えても後方の配信者を4/4と誤判定しない', async () => {
+    // 先行配信者996種類に続く139種類のうち102種類を所有。
+    // SQL LIMITを適用する境界を再現し、旧実装では4/4になる配置にする。
+    const targetRows = Array.from({ length: 139 }, (_, i) => ({
+      id: `target-${i}`, streamer_id: 'target',
+    }))
+    const rows = [
+      ...Array.from({ length: 996 }, (_, i) => ({
+        id: `other-${i}`, streamer_id: 'other',
+      })),
+      ...targetRows,
+    ]
+    const query = Object.assign(Promise.resolve(rows), {
+      limit: (count: number) => Promise.resolve(rows.slice(0, count)),
+    })
+    vi.mocked(getDb).mockResolvedValue({
+      db: { select: () => ({ from: () => ({ where: () => query }) }) },
+      sql: {},
+    } as any)
+
+    const result = await getActiveCardCountsForStreamers(['other', 'target'])
+    const target = result.get('target')!
+    const owned = countOwnedActiveCardTypes(targetRows.slice(0, 102), target.activeCardIds)
+    expect(target.totalActive).toBe(139)
+    expect(owned).toBe(102)
+    expect(Math.round(owned / target.totalActive * 100)).toBe(73)
+    expect(owned >= target.totalActive).toBe(false)
+    expect(result.get('other')?.totalActive).toBe(996)
   })
 
   it('空入力ではDB接続を取得せず空Mapを返す', async () => {


### PR DESCRIPTION
複数配信者のカードを集めていると、コレクション一覧が未達成でもコンプリートの勲章と満タンのバーを表示する不具合を修正します。

一覧のアクティブカード取得が全配信者合算で1,000件に打ち切られ、後方の配信者では一部だけを分母・分子にしていました。この上限を取り除き、対象のカードIDをすべて集計します。取得列はカードID・配信者IDのみで、問い合わせは1回を維持します。

検証:
- 先行996種類＋対象139種類・所有102種類の回帰テストで、修正前は分母4となる失敗を確認。修正後は102/139・73%、未コンプリート。
- 関連4ファイル・55テスト通過。
- TypeScript型チェック、変更ファイルのESLint、git diff --check通過。
- 主担当による自己レビュー実施。ユーザー指定によりサブエージェント・外部エージェントは使用していません。

本番実データでの原因照合、previewブラウザー確認、本番反映は未実施です。
