### PR TITLE
chore(release): main直PRの通常fallback警告を抑制

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -171,10 +171,9 @@ jobs:
                   with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as env:
                       env.write("PROMOTION_SUMMARY_MISSING=true" + chr(10))
               else:
-                  print(
-                      "::warning::Merged PR is missing a non-empty promotion summary; using PR title in Discord.",
-                      file=sys.stderr,
-                  )
+                  # A direct-to-main merge has no promotion-summary contract.
+                  # Falling back to the sanitized PR title is the expected path,
+                  # so do not emit a misleading warning for this normal case.
                   release_text = strip_markdown_links(
                       os.environ.get("PR_TITLE", "").strip()
                   ).strip()


### PR DESCRIPTION
## 概要

Issue #1113 の軽量フォローアップです。preview→main 昇格ではない通常の main 直PRについて、リリース要約が無い場合にPRタイトルへfallbackする既存挙動を維持しつつ、正常系なのに `::warning::` を出していたログノイズだけを抑制します。

## 変更

- preview→main 昇格PRの要約必須契約・warning・失敗挙動は変更しない
- main直PR / 非昇格PRで要約が無い場合は、従来どおりsanitized PR titleへfallback
- そのfallbackは正常系として扱い、誤解を招くwarningを出さない
- webhook、権限、Secret、Discord payload、文字数制限、昇格判定には変更なし

## 重複回避

- 現在の preview 向け open PR #1491 / #1493 と変更領域は重複しない
- #1113 の既存対応済み項目（reopened / ready_for_review / GITHUB_REPOSITORY整理等）には再着手しない

## QA

workflowのログ出力だけを変更するため runtime アプリのPreview実経路ゲート対象外。GitHub Actions CI と exact HEAD の手動レビューで確認します。

Refs #1113