### PR TITLE
test: handleApiError の500応答と記録契約を固定

### DIFF
--- a/tests/unit/error-handler-api-contract.test.ts
+++ b/tests/unit/error-handler-api-contract.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { logErrorFromLoggerMock } = vi.hoisted(() => ({
+  logErrorFromLoggerMock: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/sentry/error-handler', () => ({
+  logErrorFromLogger: logErrorFromLoggerMock,
+}))
+
+import { ERROR_MESSAGES } from '@/lib/constants'
+import { handleApiError } from '@/lib/error-handler'
+
+/**
+ * Issue #1352: route-level tests intentionally mock handleApiError and only pin
+ * delegation at the API boundary. This suite fixes the complementary common
+ * handler contract: an unclassified API exception is durably recorded before
+ * returning the stable 500 response consumed by those routes.
+ */
+describe('handleApiError common 500 contract (#1352)', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('records the original error/context and returns the stable internal-error response', async () => {
+    const error = new Error('storage lookup failed')
+    const additionalInfo = { operation: 'storage-status' }
+
+    const response = await handleApiError(error, 'Storage Status API', additionalInfo)
+
+    expect(logErrorFromLoggerMock).toHaveBeenCalledTimes(1)
+    expect(logErrorFromLoggerMock).toHaveBeenCalledWith('Storage Status API:', [
+      error,
+      additionalInfo,
+    ])
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ error: ERROR_MESSAGES.INTERNAL_ERROR })
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1352 の未完了フォローアップから、route 側の委譲テストとは別に、実 `handleApiError` の共通500契約を最小の unit test で固定します。

## 変更

- `handleApiError` が元の error / context / additionalInfo を durable writer (`logErrorFromLogger`) へ1回渡すことを検証
- 記録完了後に status 500 と `ERROR_MESSAGES.INTERNAL_ERROR` の安定した本文を返すことを検証
- production/runtime コードは変更しない

## 重複回避

`tests/unit/storage-status-error.test.ts` は route → `handleApiError` の委譲境界だけを固定しており、本PRは実ハンドラ側の契約だけを扱います。

## 検証

GitHub CI / unit test の結果を確認します。

Refs #1352