### PR TITLE
docs(test): storage message互換テストの変更判断基準を明記

### DIFF
--- a/tests/unit/storage-status-api.test.ts
+++ b/tests/unit/storage-status-api.test.ts
@@ -41,6 +41,8 @@ async function getSuccessfulStorageStatusBody(overrides: Partial<StorageUsage> =
 
 // 互換契約の退行を検知するため、production の定数を参照せず期待文字列をリテラルで固定する。
 // 定数側の文言変更へテストも同時追従すると、未知クライアント向け message の意図しない変更を検知できない。
+// この契約が失敗した場合はテストを機械的に追従させず、まず production 側の意図しない互換破壊として戻すかを確認する。
+// 変更が意図的なら外部互換性を評価・記録した契約変更として、production と期待値を同時に更新する（#1352）。
 describe('GET /api/storage-status message compatibility', () => {
   beforeEach(() => {
     vi.clearAllMocks()


### PR DESCRIPTION
## 概要

Issue #1352 の未完了フォローアップから、storage-status の互換 `message` 契約テストが失敗した際の扱いをテスト近傍コメントへ明記します。

## 変更

- 契約失敗時に期待値を機械的に追従させないことを明記
- まず production 側の意図しない互換破壊として戻すか確認することを明記
- 意図的変更なら外部互換性を評価・記録した契約変更として production と期待値を同時更新する方針を明記
- runtime / assertion / API 挙動は変更しない

## 重複回避

既存のリテラル固定理由コメントを置き換えず、その判断基準だけを補足します。#1345 の `message` 削除可否や401→403などの互換性判断には踏み込みません。

## 検証

コメントのみの差分。CI / Release PR template contract を確認します。

Refs #1352