### PR TITLE
test(storage): handleApiErrorの委譲引数を将来拡張可能にする

### DIFF
--- a/tests/unit/storage-status-error.test.ts
+++ b/tests/unit/storage-status-error.test.ts
@@ -64,7 +64,12 @@ describe('GET /api/storage-status: error delegation (#1356)', () => {
       SESSION.twitchUserId
     );
     expect(mockHandleApiError).toHaveBeenCalledTimes(1);
-    expect(mockHandleApiError).toHaveBeenCalledWith(error, 'Storage Status API');
+    // route が保証するのは元例外と context の伝播まで。将来 additionalInfo を
+    // 追加しても委譲契約の退行ではないため、先頭2引数だけを固定する。
+    expect(mockHandleApiError.mock.calls[0]?.slice(0, 2)).toEqual([
+      error,
+      'Storage Status API',
+    ]);
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({ error: 'handled-storage-error' });
   });


### PR DESCRIPTION
## 概要

Issue #1352 の未完了フォローアップとして、`storage-status` route の `handleApiError` 委譲テストが第3引数 `additionalInfo` の将来追加まで退行扱いしないよう、route が保証する先頭2引数だけを固定します。

## 変更

- `handleApiError(error, 'Storage Status API')` の厳密な全引数一致をやめる
- mock call の先頭2引数だけを検証し、将来 `additionalInfo` が追加されても route の委譲契約が維持されていればテストを通す
- なぜ先頭2引数だけを固定するかをテスト近傍コメントで明記
- runtime / API挙動は変更しない

## 重複回避

#1357 / #1496 が固定した例外委譲・実 `handleApiError` の500契約は維持します。本PRはテストの過剰な引数厳密性だけを緩和します。

## 検証

CI / Release PR template contract で確認します。

Refs #1352