### PR TITLE
test(storage): プランダウングレード時の複合制限を回帰固定

### DIFF
--- a/tests/unit/storage-status-upload-disabled.test.ts
+++ b/tests/unit/storage-status-upload-disabled.test.ts
@@ -108,4 +108,18 @@ describe('GET /api/storage-status uploadDisabled contract (#1352)', () => {
       uploadDisabled: true,
     })
   })
+
+  it('プランダウングレードで userLimitReached と planOverLimit が同時に true でも uploadDisabled は true', async () => {
+    const body = await getSuccessfulStorageStatusBody({
+      userLimitReached: true,
+      planOverLimit: true,
+    })
+
+    expect(body).toMatchObject({
+      userLimitReached: true,
+      globalLimitReached: false,
+      planOverLimit: true,
+      uploadDisabled: true,
+    })
+  })
 })


### PR DESCRIPTION
## 概要

Issue #1352 のノンブロッキング改善として、`storage-status` の `uploadDisabled` 契約に、`userLimitReached=true` と `planOverLimit=true` が同時に成立するプランダウングレード相当ケースを追加します。

## 変更内容

- `tests/unit/storage-status-upload-disabled.test.ts` のみ変更
- 既存の各OR項の独立検証は維持
- `userLimitReached` と `planOverLimit` が同時に true の場合も、両フラグを保持したまま `uploadDisabled=true` を返すことを固定

runtime / API / DB / 認証挙動は変更しません。

## 検証

GitHub CI / Release PR template contract で確認します。

Refs #1352