### PR TITLE
docs(workflow): リリース要約の正本契約をコメント化

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -102,6 +102,9 @@ jobs:
           # Promotion PRs keep the human-facing release summary in the first
           # `## このリリースで変わること` section. Reuse that text directly
           # instead of rediscovering component PRs through the GitHub API.
+          # The promotion PR body is intentionally the notification source of truth:
+          # this workflow does not reconstruct the summary from component diffs, so
+          # summary-vs-diff accuracy remains a normal promotion-PR review responsibility.
           content=$(python3 - <<'PY'
           import os
           import re


### PR DESCRIPTION
## 概要

Issue #1113 のノンブロッキング改善として、main マージ通知が preview→main 昇格PR本文の `## このリリースで変わること` を通知文の正本として扱う設計トレードオフを workflow コメントへ明記します。

## 変更内容

- `.github/workflows/notify-discord-main-merge.yml` のコメント3行のみ追加
- component PR の差分から通知要約を自動再構築しないことを明示
- 要約と実差分の整合性は昇格PRレビューで担保する契約を明示

runtime / trigger / validation / Discord通知内容の挙動は変更しません。

Refs #1113