### PR TITLE
chore(workflow): main向け通知の冗長なbase ref判定を削除

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -80,7 +80,6 @@ jobs:
       PR_URL: ${{ github.event.pull_request.html_url }}
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
       HEAD_REF: ${{ github.event.pull_request.head.ref }}
-      BASE_REF: ${{ github.event.pull_request.base.ref }}
       HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
 
     steps:
@@ -113,9 +112,9 @@ jobs:
           limit = 2000
           section_heading = "## このリリースで変わること"
           # Only the canonical preview -> main path is a release promotion.
-          # Keep the branch names explicit here so direct-to-main merges use the title fallback.
+          # The workflow itself is already scoped to PRs targeting main, so only
+          # the head ref and repository identity need to be checked here.
           promotion_source_ref = "preview"
-          promotion_target_ref = "main"
           body = os.environ.get("PR_BODY", "").replace("\r\n", "\n").replace("\r", "\n")
           # Only same-repository promotion text is trusted as notification input.
           # Fork PRs fall back to a sanitized title below.
@@ -156,8 +155,7 @@ jobs:
           release_text = strip_markdown_links(chr(10).join(release_lines)).strip()
           if not release_text or not re.search("[0-9A-Za-zぁ-んァ-ヶ一-龠]", release_text):
               is_promotion = (
-                  os.environ.get("BASE_REF") == promotion_target_ref
-                  and os.environ.get("HEAD_REF") == promotion_source_ref
+                  os.environ.get("HEAD_REF") == promotion_source_ref
                   and os.environ.get("HEAD_REPOSITORY") == os.environ.get("GITHUB_REPOSITORY")
               )
               if is_promotion:


### PR DESCRIPTION
## 概要

Issue #1113 のノンブロッキング改善として、Discord mainマージ通知 workflow から冗長な `BASE_REF` メタデータと promotion 判定を削除します。

## 変更内容

- workflow 自体が `pull_request_target.branches: [main]` に限定されているため、notify側の `BASE_REF == main` 再判定を削除
- 不要になった `BASE_REF` env と `promotion_target_ref` を削除
- promotion 判定は `HEAD_REF == preview` かつ same-repository の既存条件だけに整理

通知内容、promotion summary の必須契約、fork fallback、Discord送信、権限・triggerには変更ありません。

Refs #1113