### PR TITLE
chore(workflow): Discord通知のメタデータ超過時fallbackを追加

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -199,9 +199,17 @@ jobs:
                   used += units
               return "".join(result)
 
+          # GitHub currently bounds repository/user/ref metadata far below Discord's
+          # 2000 UTF-16-unit limit, but keep delivery fail-safe if those contracts or
+          # event payloads ever change. In that pathological case, discard optional
+          # metadata before trimming the user-facing release text.
+          marker = "\n\n…"
+          if discord_length(prefix + marker + suffix) > limit:
+              prefix = "🚀 **リポジトリが更新されました**\n\n"
+              suffix = f"\n\n🔗 {os.environ['PR_URL']}"
+
           content = prefix + release_text + suffix
           if discord_length(content) > limit:
-              marker = "\n\n…"
               available = limit - discord_length(prefix + marker + suffix)
               release_text = truncate_utf16(release_text, max(0, available)).rstrip()
               content = prefix + release_text + marker + suffix


### PR DESCRIPTION
## 概要

Issue #1113 のノンブロッキング改善として、Discord通知の prefix / suffix だけで 2000 UTF-16 units を超える極端なイベント入力でも、本文送信そのものを失敗させない防御的 fallback を追加します。

## 変更内容

- 通常時の通知形式・release summary切り詰め契約は変更しない
- prefix + marker + suffix だけで2000 unitsを超える場合に限り、リポジトリ名・branch・authorを省いた短い固定prefix/suffixへ縮退
- PR URLは維持し、ユーザー向け release text を従来のUTF-16単位ロジックで可能な範囲まで残す

GitHubの現行メタデータ上限では通常到達しない防御経路で、runtimeアプリ・権限・trigger・promotion summary契約には変更ありません。

Refs #1113