### PR TITLE
test(release): 昇格PR再検証triggerを回帰固定

### DIFF
--- a/tests/unit/discord-promotion-fork-guard.test.ts
+++ b/tests/unit/discord-promotion-fork-guard.test.ts
@@ -14,6 +14,16 @@ function validationCondition(source: string): string {
   return match?.[1] ?? "";
 }
 
+function pullRequestTargetTypes(source: string): string[] {
+  const match = source.match(/pull_request_target:\n\s+types: \[([^\]]+)\]/);
+  return (
+    match?.[1]
+      ?.split(",")
+      .map((type) => type.trim())
+      .filter(Boolean) ?? []
+  );
+}
+
 describe("Discord promotion validation fork guard", () => {
   it("skips the validation job for fork-owned preview branches", () => {
     const condition = validationCondition(workflow);
@@ -24,5 +34,12 @@ describe("Discord promotion validation fork guard", () => {
     expect(condition).toContain(
       "github.event.pull_request.head.ref == 'preview'"
     );
+  });
+
+  it("revalidates promotion summaries after reopen and ready-for-review transitions", () => {
+    const eventTypes = pullRequestTargetTypes(workflow);
+
+    expect(eventTypes).toContain("reopened");
+    expect(eventTypes).toContain("ready_for_review");
   });
 });


### PR DESCRIPTION
## 概要

Issue #1113 の判断不要な軽量フォローアップとして、preview→main 昇格PRの要約検証が `reopened` / `ready_for_review` でも再実行される契約を静的回帰テストで固定します。

## 変更内容

- `.github/workflows/notify-discord-main-merge.yml` の `pull_request_target.types` をテストから読み取る小さな helper を追加
- `reopened` と `ready_for_review` が維持されることを明示的に検証
- workflow 自体、通知本文、権限、Secret、runtime/API/DB の挙動は変更しない

## 重複回避

- `reopened` の実装は PR #1303、`ready_for_review` の実装は PR #1317 で既に完了済み
- 本PRはその2つのトリガが将来のworkflow整理で脱落しないための回帰ガードだけを追加
- open PR #1491 / #1493 と変更領域は重複しない

## QA

テストのみの変更で Preview 実経路ゲート対象外。GitHub CI と exact HEAD の手動レビューで確認します。

Refs #1113 #1303 #1317