### PR TITLE
docs(next): Proxy移行の上流確認日を更新

### DIFF
--- a/docs/cloudflare-proxy-migration.md
+++ b/docs/cloudflare-proxy-migration.md
@@ -36,7 +36,8 @@ was closed on 2026-08-25 when
 merged. `@opennextjs/cloudflare` 1.20.3, published on 2026-08-26, includes that
 experimental `proxy.ts` support.
 
-Upstream status last checked: **2026-09-05**. TwiCa is still pinned to
+Upstream status last checked: **2026-09-09**. The recheck confirms #1277 remains
+closed and #1309 remains merged. TwiCa is still pinned to
 `@opennextjs/cloudflare` 1.20.2, so the upstream fix has not yet changed the
 repository's verified deployment contract.
 


### PR DESCRIPTION
## 概要

Issue #1321 の判断不要な追跡性フォローアップとして、Cloudflare Proxy移行方針の上流状況を2026-09-09時点で再確認し、確認日と確認結果を更新します。

## 変更内容

- `opennextjs-cloudflare#1277` が引き続き closed であることを確認
- `opennextjs-cloudflare#1309` が引き続き merged であることを確認
- TwiCa の `@opennextjs/cloudflare` が引き続き 1.20.2 pin であることを確認
- `docs/cloudflare-proxy-migration.md` の `Upstream status last checked` を 2026-09-09 に更新

## スコープ

docs 1ファイルのみ。依存更新、`middleware.ts` / `proxy.ts`、runtime、API、DB、権限、Secret は変更しません。既存の移行判断自体も変更しません。

## QA

docs-only のため Preview 実経路ゲート対象外。既存の `cloudflare-proxy-migration` 契約テストと通常CI、latest exact HEAD の手動レビューで確認します。

Refs #1321 #417