### PR TITLE
chore(twitch): token診断コメントをJSDoc参照へ整理

### DIFF
--- a/src/app/api/twitch/emotes/route.ts
+++ b/src/app/api/twitch/emotes/route.ts
@@ -42,7 +42,7 @@ async function getTwitchAccessTokenOrError(twitchUserId: string): Promise<string
 /**
  * GET /api/twitch/emotes
  * Fetches the broadcaster's channel emotes from Twitch API
- * 配信者のチャネルエモートを取得
+ * 配信者のチャネルエモートをTwitch APIから取得
  */
 export async function GET(request: Request) {
   const session = await getSession();

--- a/src/app/api/twitch/emotes/route.ts
+++ b/src/app/api/twitch/emotes/route.ts
@@ -42,7 +42,7 @@ async function getTwitchAccessTokenOrError(twitchUserId: string): Promise<string
 /**
  * GET /api/twitch/emotes
  * Fetches the broadcaster's channel emotes from Twitch API
- * 配信者のチャネルエモートをTwitch APIから取得
+ * 配信者のチャネルエモートを取得
  */
 export async function GET(request: Request) {
   const session = await getSession();
@@ -116,8 +116,7 @@ export async function GET(request: Request) {
         { status: 401 }
       );
     }
-    // refresh診断の永続化責任はAPI境界。additionalInfoへの安全な橋渡しと非二重報告の理由は
-    // twitchTokenErrorReportContext のJSDocを参照。
+    // refresh診断の永続化・非二重報告契約は twitchTokenErrorReportContext のJSDocを参照。
     return handleApiError(error, "Twitch emotes fetch", twitchTokenErrorReportContext(error));
   }
 }

--- a/src/app/api/twitch/rewards/route.ts
+++ b/src/app/api/twitch/rewards/route.ts
@@ -80,8 +80,7 @@ export async function GET(request: Request) {
         { status: 401 }
       );
     }
-    // token-manager側はrefresh障害を二重報告しない。永続化責任はAPI境界のhandleApiErrorにあり、
-    // ここで安全なrefresh診断だけをadditionalInfoへ明示的に橋渡しする。
+    // refresh診断の永続化・非二重報告契約は twitchTokenErrorReportContext のJSDocを参照。
     return handleApiError(error, "Twitch rewards fetch", twitchTokenErrorReportContext(error));
   }
 }
@@ -155,8 +154,7 @@ export async function POST(request: Request) {
         { status: 401 }
       );
     }
-    // token-manager側はrefresh障害を二重報告しない。永続化責任はAPI境界のhandleApiErrorにあり、
-    // ここで安全なrefresh診断だけをadditionalInfoへ明示的に橋渡しする。
+    // refresh診断の永続化・非二重報告契約は twitchTokenErrorReportContext のJSDocを参照。
     return handleApiError(error, "Twitch reward creation", twitchTokenErrorReportContext(error));
   }
 }


### PR DESCRIPTION
## 概要

Issue #1088 の判断不要なコメント整理として、`twitchTokenErrorReportContext` を使う rewards / emotes の catch 近傍に重複していた説明を、helper の JSDoc を正本として参照する短い恒久コメントへ揃えます。

## 変更内容

- rewards GET / POST の refresh診断コメントを同一の JSDoc 参照へ統一
- emotes GET の同種コメントも同じ表現へ統一
- runtime / API応答 / 認証 / token処理 / DB / rate limit / 権限は変更しない

## QA

コメントのみのため Preview 実経路ゲート対象外です。通常CIと latest exact HEAD の手動レビューで確認します。

Refs #1088