### PR TITLE
chore(twitch): bootstrapのtoken診断コメントをJSDoc参照へ整理

### DIFF
--- a/src/app/api/twitch/channel-point-bootstrap/route.ts
+++ b/src/app/api/twitch/channel-point-bootstrap/route.ts
@@ -477,8 +477,7 @@ export async function GET(request: NextRequest) {
         { status: 401 }
       );
     }
-    // Issue #670: refresh失敗(REFRESH_FAILED)の場合、diagnostics(status/kind)を
-    // auto-generated bug reportのContextへ載せる(twitchTokenErrorReportContext参照)。
+    // refresh診断の永続化・非二重報告契約は twitchTokenErrorReportContext のJSDocを参照。
     return handleApiError(error, "Channel Point Bootstrap API", twitchTokenErrorReportContext(error));
   } finally {
     logPerf("api", "channel-point-bootstrap", startedAt, { diagnostics });


### PR DESCRIPTION
## 概要

Issue #1088 の軽量フォローアップとして、`channel-point-bootstrap` の汎用catchに残っていた refresh診断コメントを、rewards / emotes と同じ `twitchTokenErrorReportContext` JSDoc参照へ揃えます。

## 変更内容

- `src/app/api/twitch/channel-point-bootstrap/route.ts` のコメント2行を共通表現1行へ整理
- runtime / API応答 / 認証 / token処理 / DB / rate limit / 権限は変更しない
- 恒久失効時の401経路と `recordApiError` の説明は固有契約なので変更しない

## QA

コメントのみのため Preview 実経路ゲート対象外です。通常CIと latest exact HEAD の手動レビューで確認します。

Refs #1088