### PR TITLE
test(release): direct-to-main通知fallback契約を固定

### DIFF
--- a/tests/unit/discord-promotion-fork-guard.test.ts
+++ b/tests/unit/discord-promotion-fork-guard.test.ts
@@ -42,4 +42,16 @@ describe("Discord promotion validation fork guard", () => {
     expect(eventTypes).toContain("reopened");
     expect(eventTypes).toContain("ready_for_review");
   });
+
+  it("keeps missing-summary warnings and failures limited to preview promotions", () => {
+    expect(workflow).toContain(
+      'is_promotion = (\n                  os.environ.get("HEAD_REF") == promotion_source_ref\n                  and os.environ.get("HEAD_REPOSITORY") == os.environ.get("GITHUB_REPOSITORY")\n              )'
+    );
+    expect(workflow).toContain(
+      'if is_promotion:\n                  print(\n                      "::warning::Promotion PR summary missing after sanitization; "'
+    );
+    expect(workflow).toContain(
+      'else:\n                  # A direct-to-main merge has no promotion-summary contract.'
+    );
+  });
 });

--- a/tests/unit/discord-promotion-fork-guard.test.ts
+++ b/tests/unit/discord-promotion-fork-guard.test.ts
@@ -24,6 +24,19 @@ function pullRequestTargetTypes(source: string): string[] {
   );
 }
 
+function missingSummaryBranches(source: string): {
+  promotion: string;
+  directToMain: string;
+} {
+  const match = source.match(
+    /if is_promotion:\n([\s\S]*?)\n\s+else:\n([\s\S]*?)\n\s+prefix =/
+  );
+  return {
+    promotion: match?.[1] ?? "",
+    directToMain: match?.[2] ?? "",
+  };
+}
+
 describe("Discord promotion validation fork guard", () => {
   it("skips the validation job for fork-owned preview branches", () => {
     const condition = validationCondition(workflow);
@@ -45,13 +58,20 @@ describe("Discord promotion validation fork guard", () => {
 
   it("keeps missing-summary warnings and failures limited to preview promotions", () => {
     expect(workflow).toContain(
-      'is_promotion = (\n                  os.environ.get("HEAD_REF") == promotion_source_ref\n                  and os.environ.get("HEAD_REPOSITORY") == os.environ.get("GITHUB_REPOSITORY")\n              )'
+      'os.environ.get("HEAD_REF") == promotion_source_ref'
     );
     expect(workflow).toContain(
-      'if is_promotion:\n                  print(\n                      "::warning::Promotion PR summary missing after sanitization; "'
+      'os.environ.get("HEAD_REPOSITORY") == os.environ.get("GITHUB_REPOSITORY")'
     );
-    expect(workflow).toContain(
-      'else:\n                  # A direct-to-main merge has no promotion-summary contract.'
+
+    const { promotion, directToMain } = missingSummaryBranches(workflow);
+
+    expect(promotion).toContain("::warning::Promotion PR summary missing");
+    expect(promotion).toContain("PROMOTION_SUMMARY_MISSING=true");
+    expect(directToMain).toContain(
+      "A direct-to-main merge has no promotion-summary contract."
     );
+    expect(directToMain).not.toContain("::warning::");
+    expect(directToMain).not.toContain("PROMOTION_SUMMARY_MISSING=true");
   });
 });


### PR DESCRIPTION
## 概要

Issue #1113 の軽量フォローアップとして、direct-to-main PR では promotion summary 欠落を warning / failure 扱いせず、PRタイトルへフォールバックする現行契約を静的回帰テストで固定します。

## 変更内容

- `tests/unit/discord-promotion-fork-guard.test.ts` に1ケース追加
- `is_promotion` が same-repository `preview` 起点だけを対象とすることを固定
- warning / `PROMOTION_SUMMARY_MISSING` 系の失敗契約が promotion 分岐に限定され、direct-to-main は通常fallbackへ進む構造を固定
- workflow/runtime/通知内容/権限/秘密情報は変更しない

## QA

テストのみのため Preview 実経路ゲート対象外です。通常CIと latest exact HEAD の手動レビューで確認します。

Refs #1113