### PR TITLE
test(next): Cloudflare adapter pin契約をpackage.json参照へ寄せる

### DIFF
--- a/tests/unit/cloudflare-proxy-migration.test.ts
+++ b/tests/unit/cloudflare-proxy-migration.test.ts
@@ -12,13 +12,19 @@ describe("Cloudflare proxy migration policy", () => {
     expect(existsSync(join(process.cwd(), "src/proxy.ts"))).toBe(false);
   });
 
-  it("documents the current pin, upstream support, and verification gate", () => {
+  it("documents the current package pin, upstream support, and verification gate", () => {
     const doc = readSource("docs/cloudflare-proxy-migration.md");
     const middleware = readSource("src/middleware.ts");
+    const packageJson = JSON.parse(readSource("package.json")) as {
+      devDependencies?: Record<string, string>;
+    };
+    const adapterVersion = packageJson.devDependencies?.["@opennextjs/cloudflare"];
 
     // Keep this contract on observable migration gates, not prose copied from
-    // the policy document. Wording changes must not require a test rewrite.
-    expect(doc).toContain("@opennextjs/cloudflare` 1.20.2");
+    // the policy document. Wording and future package pin changes should not
+    // require duplicating the same version literal in this test.
+    expect(adapterVersion).toBeDefined();
+    expect(doc).toContain(`@opennextjs/cloudflare\` ${adapterVersion}`);
     expect(doc).toContain("opennextjs-cloudflare#1309");
     expect(doc).toContain("1.20.3");
     expect(doc).toContain("Upstream status last checked");


### PR DESCRIPTION
## 概要

Issue #1321 の軽量フォローアップとして、Cloudflare Proxy移行方針テストが現在の adapter pin をテスト内へ重複ハードコードしないよう整理します。

## 変更内容

- `package.json` の `@opennextjs/cloudflare` devDependency をテスト時に読み取る
- docs がその現在pinを記録していることを検証する
- upstream #1309 / 1.20.3 / `workers:build` など移行ゲートの契約は維持する
- runtime / dependency / middleware / deploy設定は変更しない

## QA

テストのみの変更のため Preview 実経路ゲート対象外です。通常CIと latest exact HEAD の手動レビューで確認します。

Refs #1321