### PR TITLE
test(discord): fork PR本文の通知入力遮断を固定

### DIFF
--- a/tests/unit/discord-promotion-fork-guard.test.ts
+++ b/tests/unit/discord-promotion-fork-guard.test.ts
@@ -80,15 +80,10 @@ describe("Discord promotion validation fork guard", () => {
       'body = os.environ.get("PR_BODY", "").replace'
     );
     const forkGuard = workflow.indexOf(
-      'if os.environ.get("HEAD_REPOSITORY") != os.environ.get("GITHUB_REPOSITORY"): ',
-      notifyBodyStart
-    );
-    const forkGuardWithoutTrailingSpace = workflow.indexOf(
       'if os.environ.get("HEAD_REPOSITORY") != os.environ.get("GITHUB_REPOSITORY"):',
       notifyBodyStart
     );
-    const effectiveForkGuard = forkGuard >= 0 ? forkGuard : forkGuardWithoutTrailingSpace;
-    const discardBody = workflow.indexOf('body = ""', effectiveForkGuard);
+    const discardBody = workflow.indexOf('body = ""', forkGuard);
     const sanitizeBody = workflow.indexOf(
       'body = re.sub(r"<!--.*?(?:-->|$)", "", body, flags=re.DOTALL)',
       discardBody
@@ -96,8 +91,8 @@ describe("Discord promotion validation fork guard", () => {
     const splitBody = workflow.indexOf("lines = body.splitlines()", sanitizeBody);
 
     expect(notifyBodyStart).toBeGreaterThan(-1);
-    expect(effectiveForkGuard).toBeGreaterThan(notifyBodyStart);
-    expect(discardBody).toBeGreaterThan(effectiveForkGuard);
+    expect(forkGuard).toBeGreaterThan(notifyBodyStart);
+    expect(discardBody).toBeGreaterThan(forkGuard);
     expect(sanitizeBody).toBeGreaterThan(discardBody);
     expect(splitBody).toBeGreaterThan(sanitizeBody);
   });

--- a/tests/unit/discord-promotion-fork-guard.test.ts
+++ b/tests/unit/discord-promotion-fork-guard.test.ts
@@ -74,4 +74,31 @@ describe("Discord promotion validation fork guard", () => {
     expect(directToMain).not.toContain("::warning::");
     expect(directToMain).not.toContain("PROMOTION_SUMMARY_MISSING=true");
   });
+
+  it("discards fork PR bodies before parsing notification summary text", () => {
+    const notifyBodyStart = workflow.indexOf(
+      'body = os.environ.get("PR_BODY", "").replace'
+    );
+    const forkGuard = workflow.indexOf(
+      'if os.environ.get("HEAD_REPOSITORY") != os.environ.get("GITHUB_REPOSITORY"): ',
+      notifyBodyStart
+    );
+    const forkGuardWithoutTrailingSpace = workflow.indexOf(
+      'if os.environ.get("HEAD_REPOSITORY") != os.environ.get("GITHUB_REPOSITORY"):',
+      notifyBodyStart
+    );
+    const effectiveForkGuard = forkGuard >= 0 ? forkGuard : forkGuardWithoutTrailingSpace;
+    const discardBody = workflow.indexOf('body = ""', effectiveForkGuard);
+    const sanitizeBody = workflow.indexOf(
+      'body = re.sub(r"<!--.*?(?:-->|$)", "", body, flags=re.DOTALL)',
+      discardBody
+    );
+    const splitBody = workflow.indexOf("lines = body.splitlines()", sanitizeBody);
+
+    expect(notifyBodyStart).toBeGreaterThan(-1);
+    expect(effectiveForkGuard).toBeGreaterThan(notifyBodyStart);
+    expect(discardBody).toBeGreaterThan(effectiveForkGuard);
+    expect(sanitizeBody).toBeGreaterThan(discardBody);
+    expect(splitBody).toBeGreaterThan(sanitizeBody);
+  });
 });


### PR DESCRIPTION
## 概要

Issue #1113 の軽量フォローアップとして、`pull_request_target` で動く Discord main マージ通知が fork PR の本文を通知要約として扱わない既存セキュリティ契約を静的回帰テストで固定します。

## 変更内容

- notify 側の `PR_BODY` 読み込み位置を起点に、fork 判定がその後に存在することを確認
- fork の場合に `body = ""` へ落とすことを確認
- その遮断が HTML コメント除去・セクション抽出より前に行われることを順序込みで確認
- workflow / runtime / permissions / webhook 処理自体は変更しない

## QA

テストのみの変更のため Preview 実経路ゲート対象外です。通常 CI と latest exact HEAD の手動レビューで確認します。

Refs #1113