### PR TITLE
test(discord): metadata overflow fallback を固定

### DIFF
--- a/tests/unit/discord-promotion-fork-guard.test.ts
+++ b/tests/unit/discord-promotion-fork-guard.test.ts
@@ -96,4 +96,32 @@ describe("Discord promotion validation fork guard", () => {
     expect(sanitizeBody).toBeGreaterThan(discardBody);
     expect(splitBody).toBeGreaterThan(sanitizeBody);
   });
+
+  it("falls back to bounded metadata before trimming release text", () => {
+    const metadataOverflowGuard = workflow.indexOf(
+      "if discord_length(prefix + marker + suffix) > limit:"
+    );
+    const fallbackPrefix = workflow.indexOf(
+      'prefix = "🚀 **リポジトリが更新されました**\\n\\n"',
+      metadataOverflowGuard
+    );
+    const fallbackSuffix = workflow.indexOf(
+      'suffix = f"\\n\\n🔗 {os.environ[\'PR_URL\']}"',
+      fallbackPrefix
+    );
+    const contentBuild = workflow.indexOf(
+      "content = prefix + release_text + suffix",
+      fallbackSuffix
+    );
+    const releaseTextTrim = workflow.indexOf(
+      "if discord_length(content) > limit:",
+      contentBuild
+    );
+
+    expect(metadataOverflowGuard).toBeGreaterThan(-1);
+    expect(fallbackPrefix).toBeGreaterThan(metadataOverflowGuard);
+    expect(fallbackSuffix).toBeGreaterThan(fallbackPrefix);
+    expect(contentBuild).toBeGreaterThan(fallbackSuffix);
+    expect(releaseTextTrim).toBeGreaterThan(contentBuild);
+  });
 });


### PR DESCRIPTION
## 概要

Discord mainマージ通知で、repository/user/ref などのmetadataだけで Discord の2000 UTF-16 unit上限へ近づいた場合に、release textの切り詰めより先に bounded metadata fallback へ切り替える既存契約を回帰テストで固定します。

- runtime / workflow / webhook / permissions は変更しません
- `tests/unit/discord-promotion-fork-guard.test.ts` のみ変更します
- fallback guard → bounded prefix/suffix → content組み立て → release text切り詰め、の順序を固定します

Refs #1113