### PR TITLE
test(middleware): 400応答契約の意図を明記

### DIFF
--- a/tests/unit/middleware-overlay-events-validation.test.ts
+++ b/tests/unit/middleware-overlay-events-validation.test.ts
@@ -3,6 +3,8 @@ import { NextRequest } from 'next/server'
 import { middleware } from '@/middleware'
 
 describe('middleware overlay events validation', () => {
+  // Regression contract from #1320/#1322: keep this early 400 body stable across
+  // middleware/proxy refactors instead of letting unrelated work silently rewrite it.
   it('不正なstreamerIdを400の固定JSON本文で拒否する', async () => {
     const response = await middleware(
       new NextRequest('https://example.com/api/overlay/not-a-uuid/events')


### PR DESCRIPTION
## 概要

Issue #1321 で残っていた軽量フォローアップとして、`tests/unit/middleware-overlay-events-validation.test.ts` が固定している不正 `streamerId` の早期400 JSON契約について、なぜこのテストを維持するのかを恒久コメントで明記します。

- `#1320/#1322` で確認された「無関係なmiddleware/proxy変更で400本文が意図せず変わる」退行の再発防止意図を記録
- runtime / middleware / API / security header / assertion は変更しません
- テストファイルのコメント2行のみの差分です

Refs #1321