### PR TITLE
chore: Proxy移行ポリシーのmiddlewareコメントを正本参照へ縮約

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,13 +21,8 @@ const maintenanceWriteSurfaces = maintenanceWriteSurfacesJson as MaintenanceWrit
 /** maintenance write block の対象となる HTTP メソッド（読み取り系は対象外）。 */
 const MAINTENANCE_GUARDED_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
-// Next.js 16 recommends proxy.ts, but Proxy runs as Node.js middleware.
-// TwiCa remains on src/middleware.ts while @opennextjs/cloudflare is pinned
-// to 1.20.2, whose workers:build rejects that Node.js middleware output.
-// Upstream proxy.ts support shipped in @opennextjs/cloudflare 1.20.3+, so
-// migration is now gated by dependency upgrade and TwiCa-specific verification,
-// not by an open upstream blocker. Keep this file edge-compatible until the
-// proxy build and existing session/routing contracts pass.
+// Keep this Edge Middleware entrypoint until the Cloudflare Proxy migration
+// passes TwiCa's build and session/routing verification gates.
 // Source of truth: docs/cloudflare-proxy-migration.md (#1321).
 
 /**


### PR DESCRIPTION
## 概要

Issue #1321 の軽量フォローアップとして、`src/middleware.ts` に重複していた Cloudflare Proxy 移行のバージョン履歴説明を、恒久的な実装理由と正本ドキュメント参照だけへ縮約します。

- runtime / middleware 挙動 / matcher / dependency は変更しません
- `docs/cloudflare-proxy-migration.md` を移行判断の正本として維持します
- package version / upstream status のような時間経過で陳腐化する情報は middleware コメントへ重複させません

## 検証

- `preview` exact HEAD `8a0bf98c13b4c89cc965827c86bfed4f60d933d7` から分岐
- net diff: `src/middleware.ts` のコメントのみ（+2/-7）
- 既存 `tests/unit/cloudflare-proxy-migration.test.ts` が要求する `Source of truth: docs/cloudflare-proxy-migration.md (#1321).` は維持

Refs #1321