### PR TITLE
test: Proxy移行方針テストを本質的な契約へ絞る

### DIFF
--- a/tests/unit/cloudflare-proxy-migration.test.ts
+++ b/tests/unit/cloudflare-proxy-migration.test.ts
@@ -22,15 +22,14 @@ describe("Cloudflare proxy migration policy", () => {
 
     // Keep this contract on observable migration gates, not prose copied from
     // the policy document. Wording and future package pin changes should not
-    // require duplicating the same version literal in this test.
+    // require duplicating the same version literal or explanatory sentence here.
     expect(adapterVersion).toBeDefined();
     expect(doc).toContain(`@opennextjs/cloudflare\` ${adapterVersion}`);
     expect(doc).toContain("opennextjs-cloudflare#1309");
-    expect(doc).toContain("1.20.3");
     expect(doc).toContain("Upstream status last checked");
     expect(doc).toContain("npm run workers:build");
     expect(middleware).toContain("export async function middleware");
     expect(middleware).not.toContain("export async function proxy");
-    expect(middleware).toContain("Source of truth: docs/cloudflare-proxy-migration.md (#1321).");
+    expect(middleware).toContain("docs/cloudflare-proxy-migration.md");
   });
 });


### PR DESCRIPTION
## 概要

Issue #1321 の残件として、`tests/unit/cloudflare-proxy-migration.test.ts` が説明文の完全一致へ強く結合しないよう、契約の本質だけを固定する形へ整理します。

- docs の adapter version は `package.json` の現在値との一致だけを確認し、同じ `1.20.3` を別assertionで二重固定しない
- middleware 側は正本文書への参照先を固定し、説明文の完全一致は要求しない
- Edge Middleware維持、Proxy未採用、upstream #1309、確認日、`workers:build` gate の契約は維持
- runtime / docs / package /権限 / deploy設定は変更しない

既存open PR #1491 / #1493 の変更ファイルとは非重複です。

Refs #1321