### PR TITLE
promotion検証の重複fork判定を整理

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -25,14 +25,10 @@ jobs:
         shell: bash
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
-          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
           python3 - <<'PY'
           import os
           import re
-
-          if os.environ["HEAD_REPOSITORY"] != os.environ["GITHUB_REPOSITORY"]:
-              raise SystemExit("Promotion PR must originate from the repository preview branch")
 
           body = os.environ.get("PR_BODY", "")
           body = re.sub(r"<!--.*?(?:-->|$)", "", body, flags=re.DOTALL)


### PR DESCRIPTION
## 概要

Issue #1113 のノンブロッキング整理として、main 昇格サマリー検証の same-repository 判定を1箇所へ集約します。

`validate-promotion-summary` job は job-level `if` で既に `head.repo.full_name == github.repository` と `head.ref == 'preview'` を要求しているため、その後の Python step 内で同じ `HEAD_REPOSITORY != GITHUB_REPOSITORY` 判定を再実行する必要がありません。validate step 専用の `HEAD_REPOSITORY` env と重複チェックだけを削除しました。

## 安全性

- canonical な fork guard は job-level `if` に維持
- notify job 側の `HEAD_REPOSITORY` と fork body discard / promotion 判定は変更なし
- permissions / trigger / secret / webhook / release summary parsing は変更なし
- runtime / API / DB / Cloudflare デプロイ設定は変更なし
- `tests/unit/discord-promotion-fork-guard.test.ts` が job-level same-repository guard と notify-side fork guard を既に契約固定していることを確認済み

CI と最新 exact HEAD のレビューを確認してから収束判断します。

Refs #1113