### PR TITLE
test: chat retry契約テストの責務を明確化

### DIFF
--- a/tests/unit/post-redemption-notify-chat-retry.test.ts
+++ b/tests/unit/post-redemption-notify-chat-retry.test.ts
@@ -23,6 +23,10 @@ import {
  * 呼ばれないかを固定する:
  * - 'pending'（自動再試行予定）: reportErrorを呼ばずinfoログのみ
  * - 'dead'（再試行を使い切った）: 従来通りreportErrorを呼ぶ
+ *
+ * EventSub/DB driver parity suite は署名付きroute全体とDB境界を検証する一方、
+ * このsuiteは補助DB参照を通さず retryState→reportError/log 契約を直接固定する。
+ * 責務が異なるため、pendingケースはここへ集約し parity test とは統合しない（#1037）。
  */
 
 vi.mock('@/lib/services/chat-notification-outbox', () => ({


### PR DESCRIPTION
## 概要

Issue #1037 の pending ケースと既存 driver parity テストの役割重複について整理します。

`post-redemption-notify-chat-retry.test.ts` は補助DB参照を通さず `retryState -> reportError/log` の契約を直接固定する focused suite であり、署名付き EventSub route と DB driver 境界を検証する parity suite とは責務が異なります。そのため pending ケースを parity suite へ統合せず、この focused suite に集約する方針をテスト近傍へ明記しました。

- runtime変更なし
- assertion / fixture変更なし
- テストコメントのみ
- #1491 / #1493 の変更領域とは非重複

Refs #1037