### PR TITLE
chat retryのpendingログコメントを実装へ同期

### DIFF
--- a/src/lib/services/eventsub-redemption.ts
+++ b/src/lib/services/eventsub-redemption.ts
@@ -613,7 +613,7 @@ export async function postRedemptionNotify(
   // Note: publishCommittedGachaBatch (i=0) は失敗を結果へ閉じ込め、polling回収へ
   // 委ねる設計のため rejected にならない。詳細はpublisher側の構造化warnで追跡する。
   // chatAnnouncement (i=1): retryable outcome経由でretryChatNotificationが'pending'を
-  // 返した場合はchatTask内でwarnログのみに留めて正常終了するため、ここには到達しない
+  // 返した場合はchatTask内でinfoログのみに留めて正常終了するため、ここには到達しない
   // （Issue #1033）。一方、sendChatAnnouncement自体が予期せずthrowした場合の catch
   // ブロックは、行を'pending'へ戻したうえでそのままrethrowする契約を維持しており
   // （呼び出し元コード自体のバグを揉み消さないため）、この経路はoutbox行がpendingで


### PR DESCRIPTION
## 概要
Issue #1037 の軽量フォローアップです。`postRedemptionNotify` の `Promise.allSettled` 後コメントに残っていた「pending は warn ログ」という古い記述を、現行実装・テストどおり `info` へ同期します。

## 変更
- `warnログ` → `infoログ` のコメント1行のみ
- runtime / logger呼び出し / assertion / fixture / 設定は変更なし
- 既存 open PR #1491 / #1493 の変更ファイルとは非重複

## 検証観点
- `retryState === 'pending'` の実装は引き続き `logger.info`
- focused retry test の契約記述も `infoログのみ`
- 実行経路を変えないため、新たなPreview実経路QA証跡は不要

Refs #1037