### PR TITLE
chore: sound URL allowlist の到達不能な same-origin 分岐を整理

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -87,7 +87,7 @@ R2_SOUND_PUBLIC_URL=https://your-sound-bucket.your-domain.com
 # Cloudflare Web Analytics (optional)
 # CloudflareダッシュボードでWeb Analyticsを有効にしてトークンを取得
 # 設定しない場合、アナリティクスは無効になります
-NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_analytics_token
+NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
 
 # runtime の DB 接続先は PlanetScale 固定。旧ドライバ切替変数は使用しない。
 

--- a/.env.local.example
+++ b/.env.local.example
@@ -81,13 +81,13 @@ R2_SOUND_PUBLIC_URL=https://your-sound-bucket.your-domain.com
 # HTTPS は常に必須。R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL 由来ホストとの和集合で判定する。
 # R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL / ALLOWED_SOUND_HOSTS の3系統がすべて未設定なら、
 # 後方互換のため任意の HTTPS URL を許可する。3系統のどれか1つでも設定されていればこの fallback は無効になる。
-# いずれか設定時も HTTPS の同一オリジンは許可する。
+# いずれか設定時は、上記の許可ホスト集合との hostname 完全一致で判定する。
 # ALLOWED_SOUND_HOSTS=cdn.example.com,media.example.com
 
 # Cloudflare Web Analytics (optional)
 # CloudflareダッシュボードでWeb Analyticsを有効にしてトークンを取得
 # 設定しない場合、アナリティクスは無効になります
-NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_web_analytics_token
+NEXT_PUBLIC_CF_WEB_ANALYTICS_TOKEN=your_cloudflare_analytics_token
 
 # runtime の DB 接続先は PlanetScale 固定。旧ドライバ切替変数は使用しない。
 

--- a/docs/gacha-sound-url-allowlist.md
+++ b/docs/gacha-sound-url-allowlist.md
@@ -14,8 +14,7 @@
    - `ALLOWED_SOUND_HOSTS` のカンマ区切り hostname
 4. 許可ホスト集合が空の場合は、後方互換として HTTPS URL を許可する。
 5. 許可ホスト集合がある場合は、対象 URL の hostname が集合に含まれていれば許可する。
-6. ブラウザ環境で `location` が存在する場合は、同一 origin の HTTPS URL も許可する。
-7. それ以外は拒否する。
+6. それ以外は拒否する。
 
 ## hostname の正規化
 
@@ -47,12 +46,12 @@ R2 由来ホストと `ALLOWED_SOUND_HOSTS` の双方から 1 件も hostname �
 
 これは「任意 URL を常に許可する」という意味ではない。いずれかの許可ホストが 1 件でも設定・導出されると hostname 制限が有効になる。
 
-## same-origin 分岐
+## ブラウザでの相対 URL 解釈
 
-同一 origin の例外は `location` が存在するブラウザ環境でのみ評価される。サーバー側で `location` が存在しない実行では、この分岐には入らない。
+ブラウザ環境では相対 URL を解釈するために `location.origin` を `new URL()` の base として使う。ただし、`location.origin` 自体を allowlist の追加許可としては扱わない。
 
-この分岐は `parsed.origin === location.origin` で判定するため、allowlist の hostname 比較とは異なり scheme / hostname / port を含む origin 全体が一致する必要がある。
+`R2_SOUND_PUBLIC_URL` / `R2_PUBLIC_URL` / `ALLOWED_SOUND_HOSTS` はいずれも `NEXT_PUBLIC_` ではないためクライアントバンドルへ公開されず、通常のブラウザ経路では許可ホスト集合が空になって HTTPS fallback が先に成立する。一方、サーバー経路には `location` がない。このため従来の「allowlist 不一致でも同一 origin なら許可する」末尾分岐は、サポートしている実行経路では到達不能だったため Issue #1375 で撤去した。
 
-この分岐が各実利用経路で実際に必要か、削除・責務整理すべきかは Issue #1375 の別フォローアップとして扱い、本書では現行挙動だけを記録する。
+相対 URL を絶対 URL へ解釈するための `location.origin` 利用は維持しているため、この整理によってブラウザ上の相対 HTTPS URL の扱いは変わらない。
 
 Refs #1375 #1374 #1342 #837

--- a/src/lib/gacha-sound-rules.ts
+++ b/src/lib/gacha-sound-rules.ts
@@ -46,7 +46,7 @@ export const createRuleId = (): string => (
  * アプリ自身がアップロード済み効果音／画像の公開URLとして実際に使っている
  * R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL（いずれも src/lib/r2-client.ts が使う
  * サーバー専用の環境変数。NEXT_PUBLIC_ プレフィックスが無いためクライアント
- * バンドルには埋め込まれない = ブラウザ側で呼ばれても値は取れず安全側に倒れる）
+ * バンドルには埋め込まれず、ブラウザ側の判定ではこれらの値を前提にしない）
  * のホスト名を許可リストとして導出する。正規に保存された効果音は必ずこの
  * いずれかのホストに置かれているため、既存の保存済みルールが誤って弾かれる
  * ことはない。
@@ -71,7 +71,6 @@ function getDefaultAllowedSoundHosts(): string[] {
  *   1. R2_SOUND_PUBLIC_URL / R2_PUBLIC_URL から導出したホスト（アプリが
  *      実際にアップロード先として使っているホスト。上記 getDefaultAllowedSoundHosts 参照）
  *   2. process.env.ALLOWED_SOUND_HOSTS（カンマ区切りホスト名、任意の追加許可）
- *   または同一オリジンのみ許可
  * - 上記いずれも未設定の場合（ローカル開発でR2環境変数が無い等）は
  *   後方互換のため HTTPS チェックのみで素通しする
  */
@@ -102,11 +101,6 @@ export function isAllowedSoundUrl(rawUrl: string): boolean {
   const hostname = parsed.hostname.toLowerCase();
   if (allowList.includes(hostname)) return true;
 
-  // 同一オリジンは常に許可
-  if (typeof location !== "undefined" && parsed.origin === location.origin) {
-    return true;
-  }
-
   return false;
 }
 
@@ -123,7 +117,7 @@ function normalizeRule(value: unknown): GachaSoundRule | null {
   const url = sanitizeText(raw.url, 2048);
   if (!url) return null;
 
-  // URL allowlist: HTTPS 必須 + 許可ホスト／同一オリジン制限
+  // URL allowlist: HTTPS 必須 + 許可ホスト制限
   // 任意の外部 URL を配信オーバーレイで再生させない（SSRF/不正音声対策）
   if (!isAllowedSoundUrl(url)) return null;
 


### PR DESCRIPTION
## 概要

Issue #1375 の残件だった `isAllowedSoundUrl` の browser-only same-origin 分岐を実行経路から再評価し、サポート対象の実行経路では到達不能であることを確認したため撤去します。

## 変更

- `isAllowedSoundUrl` 末尾の `location.origin` same-origin 例外を削除
- 相対URL解釈のための `location.origin` base は維持
- allowlist JSDoc / `normalizeRule` コメントを現行判定へ同期
- `docs/gacha-sound-url-allowlist.md` から同一origin例外を削除し、到達不能だった理由と相対URLへの影響がないことを記録
- `.env.local.example` の同一origin例外説明も現行の hostname 完全一致契約へ同期

## 判断根拠

- サーバー経路では `location` が存在しないため same-origin 分岐へ入らない
- ブラウザ経路では `R2_SOUND_PUBLIC_URL` / `R2_PUBLIC_URL` / `ALLOWED_SOUND_HOSTS` は `NEXT_PUBLIC_` ではなく、通常のクライアントバンドルへ公開されないため allowlist は空になり、既存の HTTPS fallback が same-origin 判定より先に成立する
- したがって末尾の same-origin 例外は、サポートしている server/browser 経路のどちらでも判定結果へ寄与していない
- 相対URLの `new URL(rawUrl, location.origin)` は残すのでブラウザ上の相対HTTPS URL解釈は変えない

## 影響範囲

3 files の低リスク整理です。秘密情報・環境変数・allowlist値・HTTPS fallback・hostname正規化・runtime API contract は変更しません。既存の allowlist normalization tests が有効な判定経路を引き続き固定します。

Refs #1375