### PR TITLE
chore: URL fallback コメントを恒久理由へ整理

### DIFF
--- a/src/lib/url-utils.ts
+++ b/src/lib/url-utils.ts
@@ -58,8 +58,8 @@ function resolveFallbackOrigin(): string {
   const raw = process.env.NEXT_PUBLIC_APP_URL
   if (!raw) {
     if (process.env.NODE_ENV === 'production') {
-      // サイレントに localhost へ倒すと OAuth redirect_uri が全滅し、気付く手段が
-      // 無い。設定ミスはリクエスト時に即座に検知する（#836 レビュー指摘）。
+      // サイレントに localhost へ倒すと OAuth redirect_uri が全滅して設定ミスを
+      // 検知できないため、production ではリクエスト時に即座に失敗させる。
       throw new Error('NEXT_PUBLIC_APP_URL is required in production')
     }
     return 'http://localhost:8787'


### PR DESCRIPTION
## 概要

`resolveFallbackOrigin()` の production 未設定分岐に残っていたレビュー履歴の表現を外し、現在も有効な設計理由だけをコード近傍へ残します。

## 変更

- `NEXT_PUBLIC_APP_URL` 未設定を production で fail-loud にする理由を「localhost fallback では OAuth redirect_uri が壊れ、設定ミスを検知できないため」と恒久的な説明へ整理
- runtime、throw条件、例外文言、allowlist、テスト契約は変更しない

## 差分

- 1 file / +2 -2
- コメントのみ

Refs #1523