### PR TITLE
chore: app token コメントを恒久理由へ整理

### DIFF
--- a/src/lib/twitch/app-token.ts
+++ b/src/lib/twitch/app-token.ts
@@ -51,7 +51,7 @@ async function issueAppAccessToken(): Promise<CachedAppToken> {
   const data = (await response.json()) as { access_token?: string; expires_in?: number };
   if (typeof data.access_token !== "string" || data.access_token.length === 0) {
     // 200 でも access_token 欠落のボディが返る異常系。不正値を KV へ4時間
-    // キャッシュしない（#739 レビュー指摘）。
+    // キャッシュしない。
     throw new Error("App access token response is missing access_token");
   }
   // expires_in 欠落・不正値（0以下 / NaN）は上限TTLへフォールバックする
@@ -173,7 +173,7 @@ export async function fetchTwitchApi(
   if (response.status === 401) {
     await invalidateTwitchAppToken();
     // 強制再発行: KV の delete がエッジへ伝播していない場合でも、キャッシュを
-    // 読み戻さず新トークンを発行してリトライする（#739 レビュー指摘）。
+    // 読み戻さず新トークンを発行してリトライする。
     return doFetch(await getTwitchAppAccessToken({ forceRefresh: true }));
   }
   return response;


### PR DESCRIPTION
## 概要

`src/lib/twitch/app-token.ts` に残っていた `#739 レビュー指摘` という履歴依存表現を外し、既に本文で説明されている現在の設計理由だけを残します。

## 変更

- 200応答で `access_token` が欠落した場合にKVへキャッシュしない理由コメントからレビュー履歴表現を除去
- 401自己回復でキャッシュを読み戻さず強制再発行する理由コメントからレビュー履歴表現を除去
- runtime、分岐、例外文言、KVキー/TTL、401再試行契約、テストは変更しない

## 差分

- 1 file / +2 -2
- コメントのみ

Refs #1525