### PR TITLE
refactor: production/preview の環境判定を共通化

### DIFF
--- a/src/app/api/admin/eventsub-health/route.ts
+++ b/src/app/api/admin/eventsub-health/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
+import { resolveAppEnvironment } from "@/lib/app-environment";
 import { ERROR_MESSAGES } from "@/lib/constants";
 import { checkRateLimit, rateLimits, getRateLimitIdentifier } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger.server";
@@ -148,14 +149,6 @@ function buildFetchFailedAlertMessage(environment: "production" | "preview"): st
   return `[EventSub Health][${environment}] Failed to check EventSub subscription health`;
 }
 
-/** `process.env.NEXT_PUBLIC_APP_URL` から environment を判定する。
- * `src/lib/sentry/error-handler.ts` の persistErrorToDatabase と同じロジック
- * （errors.environment 列の算出方法と一致させておく必要があるため、意図的な
- * 重複実装。フォローアップissueで共通化を検討）。 */
-function resolveEnvironment(): "production" | "preview" {
-  return (process.env.NEXT_PUBLIC_APP_URL || "").includes("preview") ? "preview" : "production";
-}
-
 /** KV上のアラート状態キーのprefix。root wrangler.tomlのRATE_LIMIT_KVコメント
  * が列挙する既存用途（レート制限・maintenance EventSub parking・OBSデモ
  * イベント・Twitch app tokenキャッシュ）と衝突しないdisjointな新規prefix。 */
@@ -300,7 +293,7 @@ export async function GET(request: NextRequest) {
     // Worker側secretだけ先に設定されアプリ側が未設定、という一時的な
     // デプロイ順序の過渡期でも5分毎に呼ばれうるため、他の通知経路と同じ
     // クールダウンゲートを通す（PR #1009 3回目のレビュー指摘・必須）。
-    const environment = resolveEnvironment();
+    const environment = resolveAppEnvironment();
     const kv = await getKvBinding();
     const kvKey = alertStateKvKey("secret-missing", environment);
     const now = Date.now();
@@ -338,7 +331,7 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const environment = resolveEnvironment();
+  const environment = resolveAppEnvironment();
   const kv = await getKvBinding();
 
   try {

--- a/src/lib/app-environment.ts
+++ b/src/lib/app-environment.ts
@@ -1,0 +1,12 @@
+export type AppEnvironment = 'production' | 'preview'
+
+/**
+ * TwiCa の論理環境名を既存契約どおり解決する。
+ * `NEXT_PUBLIC_APP_URL` に `preview` を含む場合だけ preview、それ以外
+ * （未設定を含む）は production とする。
+ */
+export function resolveAppEnvironment(
+  appUrl: string | undefined = process.env.NEXT_PUBLIC_APP_URL,
+): AppEnvironment {
+  return (appUrl || '').includes('preview') ? 'preview' : 'production'
+}

--- a/src/lib/sentry/error-handler.ts
+++ b/src/lib/sentry/error-handler.ts
@@ -36,6 +36,7 @@ import 'server-only'
  *   (logger) and the database pipeline use the same redaction policy.
  */
 
+import { resolveAppEnvironment } from '@/lib/app-environment'
 import {
   sanitizeContext,
   sanitizeErrorStack,
@@ -153,9 +154,7 @@ async function persistErrorToDatabase(
   context: Record<string, unknown>
 ): Promise<void> {
   try {
-    // 環境判定: NEXT_PUBLIC_APP_URL に 'preview' が含まれるかで判定
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL || ''
-    const environment = appUrl.includes('preview') ? 'preview' : 'production'
+    const environment = resolveAppEnvironment()
     const values = {
       error_type: errorType,
       // message/context は最終書き込み境界でも再検閲する。stack は Error 境界で

--- a/tests/unit/app-environment.test.ts
+++ b/tests/unit/app-environment.test.ts
@@ -1,23 +1,23 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { resolveAppEnvironment } from '@/lib/app-environment'
 
 describe('resolveAppEnvironment', () => {
   afterEach(() => {
-    delete process.env.NEXT_PUBLIC_APP_URL
+    vi.unstubAllEnvs()
   })
 
   it('NEXT_PUBLIC_APP_URL が未設定なら production を返す', () => {
-    delete process.env.NEXT_PUBLIC_APP_URL
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', undefined)
     expect(resolveAppEnvironment()).toBe('production')
   })
 
   it('production URL なら production を返す', () => {
-    process.env.NEXT_PUBLIC_APP_URL = 'https://twica.example.com'
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica.example.com')
     expect(resolveAppEnvironment()).toBe('production')
   })
 
   it('preview を含む URL なら preview を返す', () => {
-    process.env.NEXT_PUBLIC_APP_URL = 'https://twica-preview.example.workers.dev'
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://twica-preview.example.workers.dev')
     expect(resolveAppEnvironment()).toBe('preview')
   })
 })

--- a/tests/unit/app-environment.test.ts
+++ b/tests/unit/app-environment.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { resolveAppEnvironment } from '@/lib/app-environment'
+
+describe('resolveAppEnvironment', () => {
+  it('NEXT_PUBLIC_APP_URL が未設定なら production を返す', () => {
+    expect(resolveAppEnvironment(undefined)).toBe('production')
+  })
+
+  it('production URL なら production を返す', () => {
+    expect(resolveAppEnvironment('https://twica.example.com')).toBe('production')
+  })
+
+  it('preview を含む URL なら preview を返す', () => {
+    expect(resolveAppEnvironment('https://twica-preview.example.workers.dev')).toBe('preview')
+  })
+})

--- a/tests/unit/app-environment.test.ts
+++ b/tests/unit/app-environment.test.ts
@@ -1,16 +1,23 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { resolveAppEnvironment } from '@/lib/app-environment'
 
 describe('resolveAppEnvironment', () => {
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+  })
+
   it('NEXT_PUBLIC_APP_URL が未設定なら production を返す', () => {
-    expect(resolveAppEnvironment(undefined)).toBe('production')
+    delete process.env.NEXT_PUBLIC_APP_URL
+    expect(resolveAppEnvironment()).toBe('production')
   })
 
   it('production URL なら production を返す', () => {
-    expect(resolveAppEnvironment('https://twica.example.com')).toBe('production')
+    process.env.NEXT_PUBLIC_APP_URL = 'https://twica.example.com'
+    expect(resolveAppEnvironment()).toBe('production')
   })
 
   it('preview を含む URL なら preview を返す', () => {
-    expect(resolveAppEnvironment('https://twica-preview.example.workers.dev')).toBe('preview')
+    process.env.NEXT_PUBLIC_APP_URL = 'https://twica-preview.example.workers.dev'
+    expect(resolveAppEnvironment()).toBe('preview')
   })
 })


### PR DESCRIPTION
## 概要

Issue #1531 のとおり、`NEXT_PUBLIC_APP_URL` から `production | preview` を決める重複ロジックを共通 helper へ集約します。

## 変更

- `src/lib/app-environment.ts` に `resolveAppEnvironment` を追加
- `src/lib/sentry/error-handler.ts` の `errors.environment` 算出を共通 helper へ移行
- EventSub health route のアラート署名/コンテキスト用 environment も同じ helper を使用
- 未設定 / production URL / preview URL の3ケースを unit test で固定

## 互換性

判定仕様は変更しません。URLに `preview` を含む場合だけ `preview`、それ以外（未設定を含む）は `production` のままです。alert message、DB schema、公開API、環境変数名は変更しません。

既存 `eventsub-health-route.test.ts` は production/preview のメッセージ分離と context の environment を、`sentry-error-handler.test.ts` は preview 時の `errors.environment` を既に検証しているため、共通 helper の3ケーステストと合わせて両利用側の契約を維持します。

Refs #1531