### PR TITLE
refactor: OBSデモのKV binding取得を共通helperへ寄せる

### DIFF
--- a/src/lib/overlay/demo-event-store.ts
+++ b/src/lib/overlay/demo-event-store.ts
@@ -1,6 +1,6 @@
+import { getKvBinding } from '@/lib/cloudflare-kv'
 import type { Card } from '@/types/database'
 
-const KV_BINDING_NAME = 'RATE_LIMIT_KV'
 const KEY_PREFIX = 'overlay:demo:'
 // A healthy overlay performs a full HTTP reconciliation every 10 minutes, and
 // realtime liveness detection plus bounded reconnect retries can consume a
@@ -14,11 +14,6 @@ type OverlayDemoCard = Pick<
   Card,
   'id' | 'name' | 'description' | 'image_url' | 'image_padding_color' | 'rarity'
 >
-
-interface KVNamespaceLike {
-  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>
-  get(key: string): Promise<string | null>
-}
 
 export interface OverlayDemoEvent {
   readonly id: string
@@ -48,17 +43,6 @@ function requireLocalFallback(): void {
     throw new Error(
       '[overlay-demo] RATE_LIMIT_KV is required in production; refusing process-local delivery'
     )
-  }
-}
-
-async function getKvBinding(): Promise<KVNamespaceLike | null> {
-  try {
-    const { getCloudflareContext } = await import('@opennextjs/cloudflare')
-    const { env } = await getCloudflareContext({ async: true })
-    const binding = (env as unknown as Record<string, unknown>)[KV_BINDING_NAME]
-    return (binding as KVNamespaceLike | undefined) ?? null
-  } catch {
-    return null
   }
 }
 


### PR DESCRIPTION
## 概要

OBSデモevent storeに重複していた `RATE_LIMIT_KV` binding解決を、既存の `src/lib/cloudflare-kv.ts#getKvBinding()` へ寄せます。

## 変更

- `demo-event-store.ts` 独自の `KV_BINDING_NAME` を削除
- 重複した `KVNamespaceLike` interfaceを削除
- 独自の `getCloudflareContext()` / `getKvBinding()` 実装を削除
- 既存共通 `getKvBinding()` をimportして利用

15分TTL、key prefix、productionでbinding欠落時にprocess-local fallbackを拒否する挙動、local/test時のmemory fallback、公開APIは変更しません。既存 `overlay-demo-event-store` unit testが同じKV/fallback契約を引き続き検証します。

Refs #1533