### PR TITLE
chore: R2 binding取得の不要な any cast を除去

### DIFF
--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -243,7 +243,6 @@ export async function uploadSoundToR2(
       await binding.put(fileName, buffer, { httpMetadata: { contentType } });
     } else {
       // S3 SDK fallback for local development
-      // ローカル開発用S3 SDKフォールバック
       const bucket = process.env.R2_SOUND_BUCKET_NAME;
       if (!bucket) throw new Error('Missing R2_SOUND_BUCKET_NAME environment variable');
       await s3Upload(bucket, fileName, buffer, contentType, 'sounds');
@@ -271,7 +270,6 @@ export async function deleteFromR2(fileName: string): Promise<void> {
       await binding.delete(fileName);
     } else {
       // S3 SDK fallback for local development
-      // ローカル開発用S3 SDKフォールバック
       const bucket = process.env.R2_BUCKET_NAME;
       if (!bucket) throw new Error('Missing R2_BUCKET_NAME environment variable');
       await s3Delete(bucket, fileName, 'images');
@@ -296,7 +294,6 @@ export async function deleteSoundFromR2(fileName: string): Promise<void> {
       await binding.delete(fileName);
     } else {
       // S3 SDK fallback for local development
-      // ローカル開発用S3 SDKフォールバック
       const bucket = process.env.R2_SOUND_BUCKET_NAME;
       if (!bucket) throw new Error('Missing R2_SOUND_BUCKET_NAME environment variable');
       await s3Delete(bucket, fileName, 'sounds');

--- a/src/lib/r2-client.ts
+++ b/src/lib/r2-client.ts
@@ -43,8 +43,7 @@ async function getR2Binding(bindingName: 'R2_IMAGES' | 'R2_SOUNDS'): Promise<R2B
     // ローカル開発時に@opennextjs/cloudflareをバンドルしないよう動的インポート
     const { getCloudflareContext } = await import('@opennextjs/cloudflare');
     const ctx = await getCloudflareContext({ async: true });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const binding = (ctx.env as any)[bindingName] as R2BucketLike | undefined;
+    const binding = (ctx.env as unknown as Record<string, unknown>)[bindingName] as R2BucketLike | undefined;
     return binding ?? null;
   } catch {
     // Not running in Cloudflare Workers environment
@@ -244,6 +243,7 @@ export async function uploadSoundToR2(
       await binding.put(fileName, buffer, { httpMetadata: { contentType } });
     } else {
       // S3 SDK fallback for local development
+      // ローカル開発用S3 SDKフォールバック
       const bucket = process.env.R2_SOUND_BUCKET_NAME;
       if (!bucket) throw new Error('Missing R2_SOUND_BUCKET_NAME environment variable');
       await s3Upload(bucket, fileName, buffer, contentType, 'sounds');
@@ -271,6 +271,7 @@ export async function deleteFromR2(fileName: string): Promise<void> {
       await binding.delete(fileName);
     } else {
       // S3 SDK fallback for local development
+      // ローカル開発用S3 SDKフォールバック
       const bucket = process.env.R2_BUCKET_NAME;
       if (!bucket) throw new Error('Missing R2_BUCKET_NAME environment variable');
       await s3Delete(bucket, fileName, 'images');
@@ -295,6 +296,7 @@ export async function deleteSoundFromR2(fileName: string): Promise<void> {
       await binding.delete(fileName);
     } else {
       // S3 SDK fallback for local development
+      // ローカル開発用S3 SDKフォールバック
       const bucket = process.env.R2_SOUND_BUCKET_NAME;
       if (!bucket) throw new Error('Missing R2_SOUND_BUCKET_NAME environment variable');
       await s3Delete(bucket, fileName, 'sounds');


### PR DESCRIPTION
## 概要

`src/lib/r2-client.ts` の `getR2Binding()` に残っていた `ctx.env as any` と局所 lint disable を除去します。

## 変更

- `ctx.env` を `unknown` 経由で `Record<string, unknown>` として固定 binding 名をlookup
- `@typescript-eslint/no-explicit-any` のdisableを削除

binding名 (`R2_IMAGES` / `R2_SOUNDS`)、dynamic import、native R2 binding優先、Workers外での `null`、S3 fallbackを含むruntime挙動は変更しません。最終diffは1ファイル +1/-2です。

型付けだけの変更でAPI/DB/OAuth/Worker経路やユーザー可視挙動を変えないため、このPR単独で追加のPreview実経路QAは不要と判断します。

Refs #1536