### PR TITLE
chore: RATE_LIMIT_KV binding取得の不要な any cast を除去

### DIFF
--- a/src/lib/cloudflare-kv.ts
+++ b/src/lib/cloudflare-kv.ts
@@ -43,8 +43,7 @@ export async function getKvBinding(): Promise<KVNamespaceLike | null> {
   try {
     const { getCloudflareContext } = await import("@opennextjs/cloudflare")
     const ctx = await getCloudflareContext({ async: true })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const binding = (ctx.env as any)[KV_BINDING_NAME] as KVNamespaceLike | undefined
+    const binding = (ctx.env as unknown as Record<string, unknown>)[KV_BINDING_NAME] as KVNamespaceLike | undefined
     return binding ?? null
   } catch {
     return null


### PR DESCRIPTION
## 概要

`src/lib/cloudflare-kv.ts#getKvBinding()` に残っていた `ctx.env as any` と局所 `no-explicit-any` lint suppression を削除し、PR #1537 の R2 binding と同じ `unknown` → `Record<string, unknown>` の明示的な narrowing に揃えます。

## 変更

- `ctx.env as any` を `ctx.env as unknown as Record<string, unknown>` に置換
- `eslint-disable-next-line @typescript-eslint/no-explicit-any` を削除
- `RATE_LIMIT_KV` 固定 binding 名、`KVNamespaceLike`、Workers 外/取得失敗時の `null` fallback は変更なし

## 安全性

- runtime の property lookup は同一
- wrangler / namespace / TTL / key prefix / 公開API / secrets の変更なし
- 1ファイル +1/-2 の型整理のみ
- `docs/QA.md` の Preview 実経路対象となる runtime 挙動変更はありません

## 確認

- CI / typecheck で型整合を確認する
- latest exact HEAD へ手動 formal review を付与する

Refs #1538