### PR TITLE
chore: EventSub park KV binding の any cast を除去

### DIFF
--- a/src/lib/maintenance/eventsub-park.ts
+++ b/src/lib/maintenance/eventsub-park.ts
@@ -156,8 +156,9 @@ export async function getMaintenanceKvBinding(): Promise<KVNamespaceLike | null>
     // （db/client.ts, r2-client.ts と同じ理由）
     const { getCloudflareContext } = await import('@opennextjs/cloudflare')
     const { env } = await getCloudflareContext({ async: true })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const binding = (env as any)[KV_BINDING_NAME] as KVNamespaceLike | undefined
+    const binding = (env as unknown as Record<string, unknown>)[KV_BINDING_NAME] as
+      | KVNamespaceLike
+      | undefined
     return binding ?? null
   } catch {
     // Cloudflare Workers 環境ではない（next dev / Node / テスト）


### PR DESCRIPTION
## 概要

`src/lib/maintenance/eventsub-park.ts#getMaintenanceKvBinding()` に残っていた `env as any` と局所 `no-explicit-any` lint suppression を削除し、PR #1537 / #1539 と同じ `unknown` → `Record<string, unknown>` の明示的な narrowing に揃えます。

## 変更

- `env as any` を `env as unknown as Record<string, unknown>` に置換
- `eslint-disable-next-line @typescript-eslint/no-explicit-any` を削除
- `RATE_LIMIT_KV` 固定 binding 名、`KVNamespaceLike`、Workers 外/取得失敗時の `null` fallback は変更なし

## 安全性

- runtime の property lookup は同一
- maintenance/EventSub の保存・replay契約、TTL、key prefix、wrangler、namespace、公開API、secret は変更なし
- 1ファイルの型整理のみ
- 追加の Preview 実経路ゲートを必要とする runtime 挙動変更はありません

## 確認

- CI / typecheck で型整合を確認する
- latest exact HEAD へ手動 formal review を付与する

Refs #1540