### PR TITLE
ci: Workers Build Minutes の無駄なfeature branch消費を抑止

### DIFF
--- a/docs/cloudflare-workers-builds.md
+++ b/docs/cloudflare-workers-builds.md
@@ -19,6 +19,37 @@ GitHub Actions はアプリ本体を二重デプロイせず、PlanetScale migra
 - DB は production / preview とも `HYPERDRIVE_PLANETSCALE` binding が唯一の runtime 経路です。
   connection string を Workers Builds の変数として複製しません。
 
+### Build Minutes のコスト制御
+
+TwiCa は `main` / `preview` という長期ブランチでのみ Cloudflare へデプロイします。feature branch ごとの
+Commit Preview は運用上不要で、OpenNext のフルビルドを各 push で実行すると Workers Build Minutes を
+大量消費するため、Cloudflare Dashboard の **Settings > Build** は次の状態を正本とします。
+
+| Worker | Production branch | Builds for non-production branches | Build cache |
+| --- | --- | --- | --- |
+| `twica` | `main` | **OFF** | **ON** |
+| `twica-preview` | `preview` | **OFF** | **ON** |
+
+Build watch paths では、少なくとも deploy artifact を変えない次の変更を除外します。
+
+```text
+.github/*
+docs/*
+tests/*
+AGENTS.md
+README.md
+```
+
+複数種類のファイルを同じ push で変更した場合、上記以外の deploy 対象ファイルが1つでも含まれれば
+build は通常どおり起動します。`scripts/`、`src/`、`workers/`、`package*.json`、Wrangler/OpenNext設定は
+build/deploy契約に影響し得るため除外しません。
+
+`scripts/cloudflare-workers-build.sh` と `scripts/cloudflare-workers-build-deploy.sh` にも
+`WORKERS_CI_BRANCH` を使った防御を置いています。Cloudflare 側の Branch control が誤って再度
+非production branchを対象にしても、`main` / `preview` 以外では重い OpenNext build と deploy/upload を
+実行しません。ただし、repo側ガードは Build 自体の起動を止められないため、**Branch control と watch paths が
+一次対策**です。
+
 Cloudflare Workers Builds を有効にするリポジトリ変数は
 `CLOUDFLARE_WORKERS_BUILDS_ENABLED=true` です。有効時、
 `.github/workflows/deploy-cloudflare.yml` の legacy app deploy は意図的に skip されます。

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:unit:ui": "vitest ui",
     "test:cleanup": "pkill -9 -f vitest || true",
     "test:agent": "npm run test:cleanup && vitest run --no-watch --no-file-parallelism --pool=forks --poolOptions.forks.singleFork=true --bail 1 && npm run test:cleanup",
-    "workers:build": "npx opennextjs-cloudflare build",
+    "workers:build": "bash scripts/cloudflare-workers-build.sh",
     "workers:dev": "npx wrangler dev",
     "workers:deploy": "npx opennextjs-cloudflare deploy",
     "workers:deploy:preview": "npx opennextjs-cloudflare deploy --env preview",

--- a/scripts/cloudflare-workers-build-deploy.sh
+++ b/scripts/cloudflare-workers-build-deploy.sh
@@ -30,27 +30,33 @@ case "$target:$mode" in
     deploy_command=(npm run workers:deploy:preview)
     ;;
   production:upload)
-    expected_branch=""
+    expected_branch="main"
     deploy_command=(npx opennextjs-cloudflare upload)
     ;;
   preview:upload)
-    expected_branch=""
+    expected_branch="preview"
     deploy_command=(npx opennextjs-cloudflare upload --env preview)
     ;;
 esac
 
-if [[ "$mode" == "deploy" ]]; then
-  if [[ "$branch" != "$expected_branch" ]]; then
-    if [[ "$target" == "preview" ]]; then
-      echo "Uploading preview version for non-preview branch '$branch' instead of deploying." >&2
-      deploy_command=(npx opennextjs-cloudflare upload --env preview)
-      "${deploy_command[@]}"
-      exit 0
-    fi
+# Branch control in Cloudflare is the primary cost control. This guard remains
+# as defense-in-depth so a future dashboard drift cannot make feature branches
+# upload or deploy a Worker after the build-side guard skipped OpenNext.
+if [[ "${WORKERS_CI:-}" == "1" && "$branch" != "$expected_branch" ]]; then
+  echo "Skipping Cloudflare $mode for $target on Workers Builds branch '$branch'; only '$expected_branch' is deployable."
+  exit 0
+fi
 
-    echo "Refusing to deploy $target from branch '$branch'; expected '$expected_branch'." >&2
-    exit 1
+if [[ "$mode" == "deploy" && "$branch" != "$expected_branch" ]]; then
+  if [[ "$target" == "preview" ]]; then
+    echo "Uploading preview version for non-preview branch '$branch' instead of deploying." >&2
+    deploy_command=(npx opennextjs-cloudflare upload --env preview)
+    "${deploy_command[@]}"
+    exit 0
   fi
+
+  echo "Refusing to deploy $target from branch '$branch'; expected '$expected_branch'." >&2
+  exit 1
 fi
 
 "${deploy_command[@]}"

--- a/scripts/cloudflare-workers-build.sh
+++ b/scripts/cloudflare-workers-build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Workers Builds used to run the full OpenNext build for every feature-branch
+# push. TwiCa has dedicated long-lived deployment branches (`main` and
+# `preview`), so feature branches do not need a Cloudflare build artifact.
+#
+# Keep this as a repository-side safety net even after Branch control is fixed
+# in Cloudflare. Branch control prevents the build from starting at all (and is
+# therefore the primary cost control); this guard prevents an accidental future
+# dashboard change from turning every PR push back into a full OpenNext build.
+if [[ "${WORKERS_CI:-}" == "1" ]]; then
+  branch="${WORKERS_CI_BRANCH:-}"
+  if [[ "$branch" != "main" && "$branch" != "preview" ]]; then
+    echo "Skipping OpenNext build on Workers Builds branch '${branch:-unknown}'. Only main/preview are deployable."
+    exit 0
+  fi
+fi
+
+exec npx opennextjs-cloudflare build

--- a/tests/unit/cloudflare-build-cost-guard.test.ts
+++ b/tests/unit/cloudflare-build-cost-guard.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const buildGuard = join(repositoryRoot, "scripts/cloudflare-workers-build.sh");
+const deployGuard = join(repositoryRoot, "scripts/cloudflare-workers-build-deploy.sh");
+
+function workersCiEnv(branch: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    WORKERS_CI: "1",
+    WORKERS_CI_BRANCH: branch,
+  };
+}
+
+describe("Cloudflare Workers Build cost guard", () => {
+  it("keeps the package build command behind the repository guard", () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(repositoryRoot, "package.json"), "utf8")
+    ) as { scripts: Record<string, string> };
+
+    expect(packageJson.scripts["workers:build"]).toBe(
+      "bash scripts/cloudflare-workers-build.sh"
+    );
+  });
+
+  it("skips the expensive OpenNext build on feature branches in Workers CI", () => {
+    const result = spawnSync("bash", [buildGuard], {
+      cwd: repositoryRoot,
+      env: workersCiEnv("feature/cost-test"),
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Skipping OpenNext build");
+  });
+
+  it("skips preview deploy/upload on feature branches in Workers CI", () => {
+    for (const mode of ["deploy", "upload"] as const) {
+      const result = spawnSync("bash", [deployGuard, "preview", mode], {
+        cwd: repositoryRoot,
+        env: workersCiEnv("feature/cost-test"),
+        encoding: "utf8",
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Skipping Cloudflare");
+      expect(result.stdout).toContain("only 'preview' is deployable");
+    }
+  });
+});


### PR DESCRIPTION
## 概要

Cloudflare Workers Builds が feature branch の各pushでも OpenNext フルビルドを実行し、Build Minutesを大量消費しているため、repo側にコストガードを追加します。

## 変更

- Workers Builds 上では `main` / `preview` 以外の `npm run workers:build` を即skip
- Workers Builds 上では非対象branchからの deploy/upload も即skip
- ローカル/GitHub CIでは従来どおり OpenNext build を実行
- 手動の非Workers-CI preview upload挙動は維持
- Cloudflare Dashboardの正本設定を文書化
  - `twica`: production=`main`, non-production builds=OFF, cache=ON
  - `twica-preview`: production=`preview`, non-production builds=OFF, cache=ON
  - docs/tests/workflows等をBuild watch pathsから除外
- feature branchで重いbuild/deployが起動しない回帰テストを追加

## ねらい

Cloudflare側のBranch controlが一次対策ですが、設定ドリフト時にも全PR pushでOpenNextを再実行しない防御をrepo側に残します。feature branch build自体が誤って起動しても、重い処理とdeploy/uploadは実行しません。

## 検証

通常CI / unit / typecheck / Workers Buildsの結果を確認します。実行時API・DB・Twitch経路の変更はありません。
