### PR TITLE
test(ci): production Workers Build guard を回帰固定

### DIFF
--- a/tests/unit/cloudflare-build-cost-guard.test.ts
+++ b/tests/unit/cloudflare-build-cost-guard.test.ts
@@ -38,17 +38,20 @@ describe("Cloudflare Workers Build cost guard", () => {
     expect(result.stdout).toContain("Skipping OpenNext build");
   });
 
-  it("skips preview deploy/upload on feature branches in Workers CI", () => {
-    for (const mode of ["deploy", "upload"] as const) {
-      const result = spawnSync("bash", [deployGuard, "preview", mode], {
-        cwd: repositoryRoot,
-        env: workersCiEnv("feature/cost-test"),
-        encoding: "utf8",
-      });
+  it("skips deploy/upload for both deployment targets on feature branches in Workers CI", () => {
+    for (const target of ["production", "preview"] as const) {
+      const expectedBranch = target === "production" ? "main" : "preview";
+      for (const mode of ["deploy", "upload"] as const) {
+        const result = spawnSync("bash", [deployGuard, target, mode], {
+          cwd: repositoryRoot,
+          env: workersCiEnv("feature/cost-test"),
+          encoding: "utf8",
+        });
 
-      expect(result.status).toBe(0);
-      expect(result.stdout).toContain("Skipping Cloudflare");
-      expect(result.stdout).toContain("only 'preview' is deployable");
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain("Skipping Cloudflare");
+        expect(result.stdout).toContain(`only '${expectedBranch}' is deployable`);
+      }
     }
   });
 });


### PR DESCRIPTION
## 概要

PR #1542 で追加した Workers Build cost guard のうち、既存テストが直接固定していなかった `production` target の feature-branch skip を回帰テストへ追加します。

## 変更

- `tests/unit/cloudflare-build-cost-guard.test.ts` の deploy/upload guard テストを `production` / `preview` の両targetへ拡張
- production は `main`、preview は `preview` だけが deployable という既存メッセージ契約を確認
- runtime script / Cloudflare設定 / deploy挙動は変更しない

## 非スコープ

Cloudflare Dashboard の Branch control / Build cache / watch paths の実設定は #1543 で扱います。

Refs #1544 #1542 #1543