### PR TITLE
test: basic sound fixture の不要な any cast を除去

### DIFF
--- a/tests/unit/streamer-settings-basic-sound-mirror.test.ts
+++ b/tests/unit/streamer-settings-basic-sound-mirror.test.ts
@@ -82,17 +82,17 @@ describe("streamer settings basic-plan sound legacy mirror (#991)", () => {
       broadcasterType: "affiliate",
       expiresAt: Date.UTC(2100, 0, 1),
       version: 1,
-    } as any);
+    });
     mockCanUseStreamerFeatures.mockReturnValue(true);
     mockCheckRateLimit.mockResolvedValue({
       success: true,
       limit: 10,
       remaining: 9,
       reset: Date.UTC(2100, 0, 1),
-    } as any);
-    mockValidateCSRFToken.mockResolvedValue({ valid: true } as any);
+    });
+    mockValidateCSRFToken.mockResolvedValue({ valid: true });
     mockValidateContentType.mockReturnValue(null);
-    mockGetUserPlan.mockResolvedValue("basic" as any);
+    mockGetUserPlan.mockResolvedValue("basic");
   });
 
   it("derives gacha_sound_url/enabled from the post-gate rules, not the submitted gated fields", async () => {


### PR DESCRIPTION
## 概要

Issue #1546 のとおり、`tests/unit/streamer-settings-basic-sound-mirror.test.ts` のdefault dependency fixtureから不要な `as any` を除去します。

## 変更

- `getSession` fixture の `as any` を除去
- `checkRateLimit` fixture の `as any` を除去
- `validateCSRFToken` fixture の `as any` を除去
- `getUserPlan` fixture の `as any` を除去

DB builder / partial DB mockを成立させるためのcastは本PRでは変更しません。

## 影響

test-only、1ファイル +4/-4。runtime・API・assertion・fixture値は変更せず、依存関数の実際の戻り値型にfixtureを直接検査させます。

Refs #1546