### PR TITLE
test: plan driver parity の想定外テーブル参照をfail-fastにする

### DIFF
--- a/tests/unit/plan-driver-parity.test.ts
+++ b/tests/unit/plan-driver-parity.test.ts
@@ -42,8 +42,14 @@ function createDrizzleDbMock(config: {
       from: vi.fn((table: unknown) => {
         const call: DrizzleCallRecord = { table }
         calls.push(call)
-        const isLicenseQuery = table === userLicensesTable
-        const rows = isLicenseQuery ? (config.licenseRows ?? []) : (config.userRows ?? [])
+        let rows: Array<{ plan_type: string }> | Array<{ twitch_has_sub: boolean | null }>
+        if (table === userLicensesTable) {
+          rows = config.licenseRows ?? []
+        } else if (table === usersTable) {
+          rows = config.userRows ?? []
+        } else {
+          throw new Error('Unexpected table in plan driver parity mock')
+        }
         const projected = rows.map((row) =>
           Object.fromEntries(
             Object.keys(fields).map((key) => [key, (row as Record<string, unknown>)[key] ?? null])


### PR DESCRIPTION
## 概要

`tests/unit/plan-driver-parity.test.ts` のDrizzle fixtureが、`userLicensesTable` 以外の任意テーブルを暗黙に `usersTable` として扱っていたため、想定外のquery追加を見逃し得る状態をfail-fastにします。

## 変更

- `userLicensesTable` → `licenseRows` を明示
- `usersTable` → `userRows` を明示
- それ以外のテーブルはfixture側でthrow

runtimeコード、DB schema、実クエリ、既存assertionは変更しません。test-onlyの回帰網強化です。

Refs #1550