### PR TITLE
feat: N連チャット通知を間隔付きで分割送信できるようにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,6 +525,11 @@ jobs:
           PGPASSWORD: postgres
         run: bash tests/fixtures/transactional-chat-outbox-concurrency.sh
 
+      - name: Verify paced chat retry and concurrent delivery reservations
+        env:
+          PGPASSWORD: postgres
+        run: node tests/fixtures/paced-multi-draw-chat-postgres.mjs
+
       - name: Verify completion reward invariants
         env:
           PGPASSWORD: postgres

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
               - 'scripts/lib/**'
               - 'scripts/check-migration-order.js'
             postgres_fixtures:
+              - 'tests/fixtures/paced-multi-draw-chat-postgres.mjs'
               - 'tests/fixtures/analysis-dashboard-pagination-postgres.sql'
               - 'tests/fixtures/transactional-chat-outbox-postgres.sql'
               - 'tests/fixtures/transactional-chat-outbox-concurrency.sh'

--- a/config/maintenance-write-surfaces.json
+++ b/config/maintenance-write-surfaces.json
@@ -235,6 +235,17 @@
     "reviewedAt": "2026-09-02"
   },
   {
+    "path": "/api/streamer/chat-multi-delivery",
+    "methods": [
+      "PUT"
+    ],
+    "category": "streamer",
+    "maintenanceBehavior": "block",
+    "reason": "N連チャット通知の配送方式(summary/individual/chunked)と分割枚数をDBへ保存する設定操作。メンテナンス中は他の配信者設定書き込みと同様にブロックする。",
+    "owner": "azumag",
+    "reviewedAt": "2026-09-12"
+  },
+  {
     "path": "/api/streamer/raid-gacha",
     "methods": [
       "POST"

--- a/db/planetscale/migrations/20260912013000_paced_multi_draw_chat.sql
+++ b/db/planetscale/migrations/20260912013000_paced_multi_draw_chat.sql
@@ -1,0 +1,73 @@
+-- migration-transaction: required
+-- migration-providers: planetscale
+
+-- Issue #1549: N連チャットをsummary / individual / chunkedで配送するための設定と、
+-- 分割配送の再開cursorを追加する。既存行・既存配信者はsummaryへ固定し、deployで
+-- 通知内容が変わらないよう後方互換を維持する。
+
+CREATE TABLE public.streamer_chat_multi_delivery_settings (
+  streamer_id uuid PRIMARY KEY REFERENCES public.streamers(id) ON DELETE CASCADE,
+  delivery_mode text NOT NULL DEFAULT 'summary'
+    CHECK (delivery_mode IN ('summary', 'individual', 'chunked')),
+  chunk_size integer NOT NULL DEFAULT 3
+    CHECK (chunk_size BETWEEN 2 AND 5),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- 既存outboxは全件summary/cursor=0になる。migration適用前にcommit済みの通知を
+-- 新workerが突然分割しないため、NOT NULL DEFAULTを明示する。
+ALTER TABLE public.chat_notification_outbox
+  ADD COLUMN delivery_mode text NOT NULL DEFAULT 'summary'
+    CHECK (delivery_mode IN ('summary', 'individual', 'chunked')),
+  ADD COLUMN delivery_chunk_size integer NOT NULL DEFAULT 3
+    CHECK (delivery_chunk_size BETWEEN 2 AND 5),
+  ADD COLUMN delivery_cursor integer NOT NULL DEFAULT 0
+    CHECK (delivery_cursor >= 0);
+
+-- transactional outbox RPC本体を再定義せず、INSERT直前にその時点の配信者設定を
+-- outbox行へ焼き込む。これによりretry途中で設定が変わってもsegment分割は不変で、
+-- delivery_cursorが同じ決定的segment indexを指し続ける。
+CREATE OR REPLACE FUNCTION public.snapshot_chat_outbox_delivery_settings()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_streamer_id uuid;
+BEGIN
+  BEGIN
+    v_streamer_id := nullif(NEW.payload #>> '{streamer,id}', '')::uuid;
+  EXCEPTION WHEN invalid_text_representation THEN
+    v_streamer_id := NULL;
+  END;
+
+  SELECT settings.delivery_mode, settings.chunk_size
+    INTO NEW.delivery_mode, NEW.delivery_chunk_size
+    FROM public.streamer_chat_multi_delivery_settings settings
+    WHERE settings.streamer_id = v_streamer_id;
+
+  IF NOT FOUND THEN
+    NEW.delivery_mode := 'summary';
+    NEW.delivery_chunk_size := 3;
+  END IF;
+  NEW.delivery_cursor := 0;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS snapshot_chat_outbox_delivery_settings
+  ON public.chat_notification_outbox;
+CREATE TRIGGER snapshot_chat_outbox_delivery_settings
+  BEFORE INSERT ON public.chat_notification_outbox
+  FOR EACH ROW
+  EXECUTE FUNCTION public.snapshot_chat_outbox_delivery_settings();
+
+REVOKE ALL ON TABLE public.streamer_chat_multi_delivery_settings FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamer_chat_multi_delivery_settings TO service_role;
+REVOKE ALL ON FUNCTION public.snapshot_chat_outbox_delivery_settings() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.snapshot_chat_outbox_delivery_settings() TO service_role;
+
+COMMENT ON TABLE public.streamer_chat_multi_delivery_settings IS
+  'N連チャット通知の配送方式。outbox INSERT時に設定をsnapshotしretry中の変更から隔離する (Issue #1549)。';
+COMMENT ON COLUMN public.chat_notification_outbox.delivery_cursor IS
+  '分割N連で次に送信するsegment index。各segment確定後にowner-fencedで単調増加させる。';

--- a/db/planetscale/migrations/20260912013000_paced_multi_draw_chat.sql
+++ b/db/planetscale/migrations/20260912013000_paced_multi_draw_chat.sql
@@ -23,7 +23,8 @@ ALTER TABLE public.chat_notification_outbox
   ADD COLUMN delivery_chunk_size integer NOT NULL DEFAULT 3
     CHECK (delivery_chunk_size BETWEEN 2 AND 5),
   ADD COLUMN delivery_cursor integer NOT NULL DEFAULT 0
-    CHECK (delivery_cursor >= 0);
+    CHECK (delivery_cursor >= 0),
+  ADD COLUMN delivery_mode_resolved boolean NOT NULL DEFAULT false;
 
 -- transactional outbox RPC本体を再定義せず、INSERT直前にその時点の配信者設定を
 -- outbox行へ焼き込む。これによりretry途中で設定が変わってもsegment分割は不変で、
@@ -51,6 +52,7 @@ BEGIN
     NEW.delivery_chunk_size := 3;
   END IF;
   NEW.delivery_cursor := 0;
+  NEW.delivery_mode_resolved := false;
   RETURN NEW;
 END;
 $$;
@@ -66,6 +68,66 @@ REVOKE ALL ON TABLE public.streamer_chat_multi_delivery_settings FROM PUBLIC, an
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamer_chat_multi_delivery_settings TO service_role;
 REVOKE ALL ON FUNCTION public.snapshot_chat_outbox_delivery_settings() FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.snapshot_chat_outbox_delivery_settings() TO service_role;
+
+-- Reserve one paced sequence per channel before its first external send. created_at is
+-- the INSERT transaction's start time, not commit order: an older transaction can become
+-- visible after a newer row has already started. Serialize decisions, and treat an already
+-- reserved row as busy regardless of age. A summary fallback is persisted too, so retry
+-- cannot switch message formats when the competing row finishes.
+CREATE FUNCTION public.resolve_chat_outbox_delivery_mode(p_id uuid, p_lease_id uuid)
+RETURNS text
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_streamer_id text;
+  v_row public.chat_notification_outbox%ROWTYPE;
+  v_mode text;
+BEGIN
+  SELECT payload #>> '{streamer,id}' INTO v_streamer_id
+    FROM public.chat_notification_outbox WHERE id = p_id;
+  IF v_streamer_id IS NULL THEN RETURN NULL; END IF;
+
+  -- A transaction-scoped lock is released before Twitch I/O. Every decision for this
+  -- channel uses the same key, including callers whose outboxes committed out of order.
+  PERFORM pg_advisory_xact_lock(hashtextextended('chat-paced:' || v_streamer_id, 0));
+  SELECT * INTO v_row FROM public.chat_notification_outbox
+    WHERE id = p_id AND status = 'processing' AND lease_id = p_lease_id
+    FOR UPDATE;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+
+  IF v_row.delivery_mode_resolved OR v_row.delivery_cursor > 0 THEN
+    RETURN v_row.delivery_mode;
+  END IF;
+
+  v_mode := v_row.delivery_mode;
+  IF v_mode <> 'summary' AND EXISTS (
+    SELECT 1 FROM public.chat_notification_outbox busy
+    WHERE busy.id <> p_id
+      AND busy.status IN ('pending', 'processing')
+      AND busy.delivery_mode IN ('individual', 'chunked')
+      AND busy.expected_draw_count > 1
+      AND busy.payload #>> '{streamer,id}' = v_streamer_id
+      AND (
+        busy.delivery_mode_resolved OR busy.delivery_cursor > 0
+        OR (busy.created_at, busy.id) < (v_row.created_at, v_row.id)
+      )
+  ) THEN
+    v_mode := 'summary';
+  END IF;
+
+  UPDATE public.chat_notification_outbox
+    SET delivery_mode = v_mode, delivery_mode_resolved = true, updated_at = now()
+    WHERE id = p_id AND status = 'processing' AND lease_id = p_lease_id;
+  RETURN v_mode;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.resolve_chat_outbox_delivery_mode(uuid, uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.resolve_chat_outbox_delivery_mode(uuid, uuid) TO service_role;
+
+CREATE INDEX chat_notification_outbox_paced_channel_idx
+  ON public.chat_notification_outbox ((payload #>> '{streamer,id}'), created_at, id)
+  WHERE status IN ('pending', 'processing') AND delivery_mode IN ('individual', 'chunked');
 
 COMMENT ON TABLE public.streamer_chat_multi_delivery_settings IS
   'N連チャット通知の配送方式。outbox INSERT時に設定をsnapshotしretry中の変更から隔離する (Issue #1549)。';

--- a/messages/features/multi-draw-chat/en.json
+++ b/messages/features/multi-draw-chat/en.json
@@ -1,0 +1,21 @@
+{
+  "multiDrawChatDelivery": {
+    "title": "Multi-draw notification mode",
+    "description": "Choose how multi-draw gacha results are posted to chat. Existing behavior remains one summary message by default.",
+    "summary": "Send one summary message",
+    "summaryDescription": "Keep the existing behavior and post the whole multi-draw result as one chat message.",
+    "individual": "Send one card at a time",
+    "individualDescription": "Post each card separately at about 1.6-second intervals. A 15-draw result takes about 22 seconds to finish.",
+    "chunked": "Send a few cards at a time",
+    "chunkedDescription": "Group several cards per message and post the groups at about 1.6-second intervals.",
+    "chunkSize": "Cards per message",
+    "cards": "{count} cards",
+    "save": "Save notification mode",
+    "saving": "Saving…",
+    "saved": "Multi-draw notification mode saved.",
+    "loadError": "Could not load the multi-draw notification mode.",
+    "saveError": "Could not save the multi-draw notification mode.",
+    "pacingNote": "Split notifications use about 1.6 seconds between posts to stay comfortably within Twitch chat pacing limits.",
+    "open": "Configure multi-draw notification mode"
+  }
+}

--- a/messages/features/multi-draw-chat/ja.json
+++ b/messages/features/multi-draw-chat/ja.json
@@ -1,0 +1,21 @@
+{
+  "multiDrawChatDelivery": {
+    "title": "N連通知方式",
+    "description": "N連ガチャの結果をチャットへ送る方法を選びます。既定では従来どおり1投稿にまとめます。",
+    "summary": "1投稿にまとめる",
+    "summaryDescription": "従来どおり、N連全体を1つのチャット投稿で通知します。",
+    "individual": "1枚ずつ順番に送る",
+    "individualDescription": "各カードを約1.6秒間隔で1投稿ずつ通知します。15連では完了まで約22秒かかります。",
+    "chunked": "数枚ずつ送る",
+    "chunkedDescription": "カードを数枚ずつまとめ、約1.6秒間隔で複数投稿します。",
+    "chunkSize": "1投稿あたりの枚数",
+    "cards": "{count}枚",
+    "save": "通知方式を保存",
+    "saving": "保存中…",
+    "saved": "N連通知方式を保存しました。",
+    "loadError": "N連通知方式を読み込めませんでした。",
+    "saveError": "N連通知方式を保存できませんでした。",
+    "pacingNote": "分割通知はTwitchの連投制限に余裕を持たせるため、投稿間に約1.6秒の間隔を設けます。",
+    "open": "N連通知方式を設定"
+  }
+}

--- a/scripts/check-i18n-static-keys.mjs
+++ b/scripts/check-i18n-static-keys.mjs
@@ -14,16 +14,47 @@ import ts from "typescript";
  */
 const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const srcDir = path.join(rootDir, "src");
+const messagesDir = path.join(rootDir, "messages");
 const messageFiles = {
-  en: path.join(rootDir, "messages", "en.json"),
-  ja: path.join(rootDir, "messages", "ja.json"),
+  en: path.join(messagesDir, "en.json"),
+  ja: path.join(messagesDir, "ja.json"),
 };
+
+async function pathExists(filename) {
+  try {
+    await fs.access(filename);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Runtime loader may keep feature-local catalogs under messages/features/<feature>/<locale>.json.
+ * Merge those top-level namespaces over the base catalog so this guard validates exactly the
+ * message surface that next-intl receives. A repository/fixture without messages/features is
+ * still valid and behaves exactly like the pre-feature-catalog layout.
+ */
+async function loadMessages(locale, baseFilename) {
+  const base = JSON.parse(await fs.readFile(baseFilename, "utf8"));
+  const featuresDir = path.join(messagesDir, "features");
+  if (!(await pathExists(featuresDir))) return base;
+
+  const featureEntries = await fs.readdir(featuresDir, { withFileTypes: true });
+  for (const entry of featureEntries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isDirectory()) continue;
+    const featureFilename = path.join(featuresDir, entry.name, `${locale}.json`);
+    if (!(await pathExists(featureFilename))) continue;
+    Object.assign(base, JSON.parse(await fs.readFile(featureFilename, "utf8")));
+  }
+  return base;
+}
 
 const messages = Object.fromEntries(
   await Promise.all(
     Object.entries(messageFiles).map(async ([locale, filename]) => [
       locale,
-      JSON.parse(await fs.readFile(filename, "utf8")),
+      await loadMessages(locale, filename),
     ]),
   ),
 );

--- a/src/app/api/admin/eventsub-replay/route.ts
+++ b/src/app/api/admin/eventsub-replay/route.ts
@@ -22,8 +22,8 @@ import {
   handleRedemption,
   handleRaidNotification,
   postRedemptionNotify,
-  sendChatAnnouncement,
 } from "@/lib/services/eventsub-redemption";
+import { sendClaimedChatAnnouncement } from "@/lib/services/eventsub-redemption-delivery";
 
 /**
  * EventSubリプレイ機構 (Issue #787)
@@ -365,15 +365,9 @@ export async function POST(request: NextRequest) {
 
       try {
         const deliveryResult = await awaitBeforeReplayDeadline(
-          sendChatAnnouncement(
-            data.broadcasterTwitchUserId,
-            data.streamer,
-            data.gachaResult.card,
-            data.gachaResult.userTwitchUsername,
-            data.userId,
-            data.gachaResult.cards,
-            data.gachaResult.collectionName,
-            data.chatSnapshot,
+          sendClaimedChatAnnouncement(
+            claim,
+            data,
             async () => {
               if (Date.now() >= externalChatSendDeadlineAt) return false;
               const renewed = await renewChatNotificationLease(claim);

--- a/src/app/api/streamer/chat-multi-delivery/route.ts
+++ b/src/app/api/streamer/chat-multi-delivery/route.ts
@@ -1,0 +1,150 @@
+import { type NextRequest, NextResponse } from 'next/server'
+import { getSession, canUseStreamerFeatures } from '@/lib/session'
+import { validateCSRFToken } from '@/lib/csrf'
+import { validateContentType } from '@/lib/request-validation'
+import { checkRateLimit, getRateLimitIdentifier, rateLimits } from '@/lib/rate-limit'
+import { ERROR_MESSAGES } from '@/lib/constants'
+import { getDb } from '@/lib/db/client'
+import { withDbRetry } from '@/lib/db/retry'
+import {
+  DEFAULT_MULTI_DRAW_CHAT_CHUNK_SIZE,
+  DEFAULT_MULTI_DRAW_CHAT_DELIVERY_MODE,
+  MAX_MULTI_DRAW_CHAT_CHUNK_SIZE,
+  MIN_MULTI_DRAW_CHAT_CHUNK_SIZE,
+  MULTI_DRAW_CHAT_DELIVERY_MODES,
+  type MultiDrawChatDeliveryMode,
+} from '@/lib/twitch/multi-draw-chat'
+
+type SettingsRow = {
+  streamer_id: string
+  delivery_mode: MultiDrawChatDeliveryMode | null
+  chunk_size: number | null
+}
+
+async function getOwnedSettings(twitchUserId: string): Promise<SettingsRow | null> {
+  return withDbRetry(async () => {
+    const { sql } = await getDb()
+    const rows = await sql<SettingsRow[]>`
+      select
+        s.id as streamer_id,
+        settings.delivery_mode,
+        settings.chunk_size
+      from streamers s
+      left join streamer_chat_multi_delivery_settings settings
+        on settings.streamer_id = s.id
+      where s.twitch_user_id = ${twitchUserId}
+      limit 1
+    `
+    return rows[0] ?? null
+  }, 'chat multi delivery settings lookup', { idempotent: true })
+}
+
+async function saveOwnedSettings(
+  streamerId: string,
+  deliveryMode: MultiDrawChatDeliveryMode,
+  chunkSize: number,
+): Promise<void> {
+  await withDbRetry(async () => {
+    const { sql } = await getDb()
+    await sql`
+      insert into streamer_chat_multi_delivery_settings (
+        streamer_id, delivery_mode, chunk_size, updated_at
+      ) values (
+        ${streamerId}::uuid, ${deliveryMode}, ${chunkSize}::integer, now()
+      )
+      on conflict (streamer_id) do update
+      set delivery_mode = excluded.delivery_mode,
+          chunk_size = excluded.chunk_size,
+          updated_at = now()
+    `
+  }, 'chat multi delivery settings upsert', { idempotent: true })
+}
+
+async function authorizeAndRateLimit(request: NextRequest) {
+  const session = await getSession()
+  const identifier = await getRateLimitIdentifier(request, session?.twitchUserId)
+  const limit = await checkRateLimit(rateLimits.streamerSettings, identifier)
+  if (!limit.success) {
+    return {
+      response: NextResponse.json(
+        { error: ERROR_MESSAGES.RATE_LIMIT_EXCEEDED },
+        {
+          status: 429,
+          headers: {
+            'X-RateLimit-Limit': String(limit.limit),
+            'X-RateLimit-Remaining': String(limit.remaining),
+            'X-RateLimit-Reset': String(limit.reset),
+          },
+        },
+      ),
+      session: null,
+    }
+  }
+  if (!session || !canUseStreamerFeatures(session)) {
+    return {
+      response: NextResponse.json({ error: ERROR_MESSAGES.UNAUTHORIZED }, { status: 401 }),
+      session: null,
+    }
+  }
+  return { response: null, session }
+}
+
+export async function GET(request: NextRequest) {
+  const auth = await authorizeAndRateLimit(request)
+  if (auth.response || !auth.session) return auth.response
+
+  try {
+    const row = await getOwnedSettings(auth.session.twitchUserId)
+    if (!row) {
+      return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 })
+    }
+    return NextResponse.json({
+      deliveryMode: row.delivery_mode ?? DEFAULT_MULTI_DRAW_CHAT_DELIVERY_MODE,
+      chunkSize: row.chunk_size ?? DEFAULT_MULTI_DRAW_CHAT_CHUNK_SIZE,
+      intervalMs: 1600,
+    }, { headers: { 'Cache-Control': 'no-store' } })
+  } catch {
+    return NextResponse.json({ error: ERROR_MESSAGES.INTERNAL_ERROR }, { status: 500 })
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  const contentTypeValidation = validateContentType(request, 'application/json')
+  if (contentTypeValidation) return contentTypeValidation
+
+  const csrfValidation = await validateCSRFToken(request)
+  if (!csrfValidation.valid) {
+    return NextResponse.json({ error: ERROR_MESSAGES.FORBIDDEN }, { status: 403 })
+  }
+
+  const auth = await authorizeAndRateLimit(request)
+  if (auth.response || !auth.session) return auth.response
+
+  try {
+    const body = await request.json() as { deliveryMode?: unknown; chunkSize?: unknown }
+    if (
+      typeof body.deliveryMode !== 'string'
+      || !(MULTI_DRAW_CHAT_DELIVERY_MODES as readonly string[]).includes(body.deliveryMode)
+    ) {
+      return NextResponse.json({ error: 'Invalid deliveryMode' }, { status: 400 })
+    }
+    if (
+      !Number.isInteger(body.chunkSize)
+      || Number(body.chunkSize) < MIN_MULTI_DRAW_CHAT_CHUNK_SIZE
+      || Number(body.chunkSize) > MAX_MULTI_DRAW_CHAT_CHUNK_SIZE
+    ) {
+      return NextResponse.json({ error: 'Invalid chunkSize' }, { status: 400 })
+    }
+
+    const row = await getOwnedSettings(auth.session.twitchUserId)
+    if (!row) {
+      return NextResponse.json({ error: ERROR_MESSAGES.STREAMER_NOT_FOUND }, { status: 404 })
+    }
+    const deliveryMode = body.deliveryMode as MultiDrawChatDeliveryMode
+    const chunkSize = Number(body.chunkSize)
+    await saveOwnedSettings(row.streamer_id, deliveryMode, chunkSize)
+    return NextResponse.json({ success: true, deliveryMode, chunkSize, intervalMs: 1600 })
+  } catch {
+    return NextResponse.json({ error: ERROR_MESSAGES.INTERNAL_ERROR }, { status: 500 })
+  }
+}

--- a/src/components/ChatAnnouncementSettingsWithDelivery.tsx
+++ b/src/components/ChatAnnouncementSettingsWithDelivery.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useState } from 'react'
+import ChatAnnouncementSettings from './ChatAnnouncementSettings'
+import MultiDrawChatDeliverySettings from './MultiDrawChatDeliverySettings'
+
+export default function ChatAnnouncementSettingsWithDelivery(
+  props: React.ComponentProps<typeof ChatAnnouncementSettings>,
+) {
+  const [showDeliverySettings, setShowDeliverySettings] = useState(false)
+
+  return (
+    <>
+      <ChatAnnouncementSettings {...props} />
+      <div className="mt-3 rounded-xl border border-white/5 bg-gray-900/30 p-3 sm:p-4">
+        <button
+          type="button"
+          onClick={() => setShowDeliverySettings((value) => !value)}
+          aria-expanded={showDeliverySettings}
+          className="flex w-full items-center justify-between gap-3 text-left text-sm font-medium text-gray-200"
+        >
+          <span>N× chat</span>
+          <span aria-hidden="true">{showDeliverySettings ? '−' : '+'}</span>
+        </button>
+        {showDeliverySettings && <MultiDrawChatDeliverySettings />}
+      </div>
+    </>
+  )
+}

--- a/src/components/ChatAnnouncementSettingsWithDelivery.tsx
+++ b/src/components/ChatAnnouncementSettingsWithDelivery.tsx
@@ -1,12 +1,14 @@
 'use client'
 
 import { useState } from 'react'
+import { useTranslations } from 'next-intl'
 import ChatAnnouncementSettings from './ChatAnnouncementSettings'
 import MultiDrawChatDeliverySettings from './MultiDrawChatDeliverySettings'
 
 export default function ChatAnnouncementSettingsWithDelivery(
   props: React.ComponentProps<typeof ChatAnnouncementSettings>,
 ) {
+  const t = useTranslations('multiDrawChatDelivery')
   const [showDeliverySettings, setShowDeliverySettings] = useState(false)
 
   return (
@@ -19,7 +21,7 @@ export default function ChatAnnouncementSettingsWithDelivery(
           aria-expanded={showDeliverySettings}
           className="flex w-full items-center justify-between gap-3 text-left text-sm font-medium text-gray-200"
         >
-          <span>N× chat</span>
+          <span>{t('open')}</span>
           <span aria-hidden="true">{showDeliverySettings ? '−' : '+'}</span>
         </button>
         {showDeliverySettings && <MultiDrawChatDeliverySettings />}

--- a/src/components/MultiDrawChatDeliverySettings.tsx
+++ b/src/components/MultiDrawChatDeliverySettings.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import {
+  DEFAULT_MULTI_DRAW_CHAT_CHUNK_SIZE,
+  DEFAULT_MULTI_DRAW_CHAT_DELIVERY_MODE,
+  type MultiDrawChatDeliveryMode,
+} from '@/lib/twitch/multi-draw-chat'
+
+type SettingsResponse = {
+  deliveryMode: MultiDrawChatDeliveryMode
+  chunkSize: number
+  intervalMs: number
+}
+
+const options: MultiDrawChatDeliveryMode[] = ['summary', 'individual', 'chunked']
+
+export default function MultiDrawChatDeliverySettings() {
+  const t = useTranslations('multiDrawChatDelivery')
+  const [mode, setMode] = useState<MultiDrawChatDeliveryMode>(DEFAULT_MULTI_DRAW_CHAT_DELIVERY_MODE)
+  const [chunkSize, setChunkSize] = useState(DEFAULT_MULTI_DRAW_CHAT_CHUNK_SIZE)
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [message, setMessage] = useState<string | null>(null)
+  const [isError, setIsError] = useState(false)
+
+  useEffect(() => {
+    let active = true
+    void fetch('/api/streamer/chat-multi-delivery', { cache: 'no-store' })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`GET settings failed: ${response.status}`)
+        return response.json() as Promise<SettingsResponse>
+      })
+      .then((settings) => {
+        if (!active) return
+        setMode(settings.deliveryMode)
+        setChunkSize(settings.chunkSize)
+      })
+      .catch(() => {
+        if (!active) return
+        setIsError(true)
+        setMessage(t('loadError'))
+      })
+      .finally(() => {
+        if (active) setLoading(false)
+      })
+    return () => {
+      active = false
+    }
+  }, [t])
+
+  const save = async () => {
+    setSaving(true)
+    setMessage(null)
+    setIsError(false)
+    try {
+      const response = await fetch('/api/streamer/chat-multi-delivery', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ deliveryMode: mode, chunkSize }),
+      })
+      if (!response.ok) throw new Error(`PUT settings failed: ${response.status}`)
+      setMessage(t('saved'))
+    } catch {
+      setIsError(true)
+      setMessage(t('saveError'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return <div className="h-24 animate-pulse rounded-xl bg-white/5" aria-busy="true" />
+  }
+
+  return (
+    <section className="mt-4 rounded-xl border border-white/10 bg-black/20 p-4 sm:p-5">
+      <div className="mb-4">
+        <h4 className="text-sm font-semibold text-white">{t('title')}</h4>
+        <p className="mt-1 text-xs leading-5 text-gray-400">{t('description')}</p>
+      </div>
+
+      <fieldset className="space-y-2">
+        {options.map((option) => (
+          <label
+            key={option}
+            className="flex cursor-pointer items-start gap-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 hover:bg-white/[0.04]"
+          >
+            <input
+              type="radio"
+              name="multi-draw-chat-delivery-mode"
+              value={option}
+              checked={mode === option}
+              onChange={() => setMode(option)}
+              className="mt-1"
+            />
+            <span className="min-w-0">
+              <span className="block text-sm font-medium text-gray-200">{t(option)}</span>
+              <span className="mt-0.5 block text-xs leading-5 text-gray-500">
+                {t(`${option}Description`)}
+              </span>
+            </span>
+          </label>
+        ))}
+      </fieldset>
+
+      {mode === 'chunked' && (
+        <label className="mt-4 block text-sm text-gray-300">
+          <span className="mb-1.5 block text-xs font-medium text-gray-400">{t('chunkSize')}</span>
+          <select
+            value={chunkSize}
+            onChange={(event) => setChunkSize(Number(event.target.value))}
+            className="w-full rounded-lg border border-white/10 bg-gray-950 px-3 py-2 text-sm text-gray-100 sm:w-48"
+          >
+            {[2, 3, 4, 5].map((count) => (
+              <option key={count} value={count}>{t('cards', { count })}</option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      {mode !== 'summary' && (
+        <p className="mt-4 rounded-lg border border-amber-400/20 bg-amber-400/5 px-3 py-2 text-xs leading-5 text-amber-100/80">
+          {t('pacingNote')}
+        </p>
+      )}
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void save()}
+          disabled={saving}
+          className="rounded-lg bg-violet-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-violet-500 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {saving ? t('saving') : t('save')}
+        </button>
+        {message && (
+          <p className={`text-xs ${isError ? 'text-red-300' : 'text-emerald-300'}`} role={isError ? 'alert' : 'status'}>
+            {message}
+          </p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -37,6 +37,17 @@ function getLocaleFromAcceptLanguage(acceptLanguage: string | null): Locale | nu
   return null
 }
 
+async function loadMessages(locale: Locale) {
+  const [base, multiDrawChat] = await Promise.all([
+    import(`../../messages/${locale}.json`),
+    import(`../../messages/features/multi-draw-chat/${locale}.json`),
+  ])
+  return {
+    ...base.default,
+    ...multiDrawChat.default,
+  }
+}
+
 /**
  * Main request config for next-intl
  * next-intlのメインリクエスト設定
@@ -50,7 +61,7 @@ export default getRequestConfig(async () => {
   if (localeCookie && locales.includes(localeCookie as Locale)) {
     return {
       locale: localeCookie as Locale,
-      messages: (await import(`../../messages/${localeCookie}.json`)).default,
+      messages: await loadMessages(localeCookie as Locale),
     }
   }
 
@@ -63,7 +74,7 @@ export default getRequestConfig(async () => {
   if (browserLocale) {
     return {
       locale: browserLocale,
-      messages: (await import(`../../messages/${browserLocale}.json`)).default,
+      messages: await loadMessages(browserLocale),
     }
   }
 
@@ -71,6 +82,6 @@ export default getRequestConfig(async () => {
   // 優先度3: デフォルトロケールにフォールバック
   return {
     locale: defaultLocale,
-    messages: (await import(`../../messages/${defaultLocale}.json`)).default,
+    messages: await loadMessages(defaultLocale),
   }
 })

--- a/src/lib/services/chat-notification-congestion.ts
+++ b/src/lib/services/chat-notification-congestion.ts
@@ -1,0 +1,41 @@
+import { getDb } from '@/lib/db/client'
+import { withDbRetry } from '@/lib/db/retry'
+import type { ClaimedChatNotification } from '@/lib/services/chat-notification-outbox'
+
+/**
+ * A channel must have at most one paced multi-draw sequence in flight.
+ *
+ * Two independent EventSub workers can otherwise each send every 1.6 seconds and combine
+ * into an effective ~0.8 second channel cadence. The older queued/processing paced row wins;
+ * newer rows should fall back to the existing summary message instead of waiting behind it.
+ *
+ * This is intentionally a read-only decision. The current row's snapshotted delivery_mode
+ * remains unchanged so retries are deterministic; the same older-row ordering produces the
+ * same fallback decision until that older row reaches sent/dead.
+ */
+export async function hasOlderPacedChatNotification(
+  claim: Pick<ClaimedChatNotification, 'id' | 'createdAt'>,
+  streamerId: string,
+): Promise<boolean> {
+  return withDbRetry(async () => {
+    const { sql } = await getDb()
+    const rows = await sql<Array<{ busy: boolean }>>`
+      select exists (
+        select 1
+        from chat_notification_outbox older
+        where older.id <> ${claim.id}::uuid
+          and older.status in ('pending', 'processing')
+          and older.delivery_mode in ('individual', 'chunked')
+          and older.payload #>> '{streamer,id}' = ${streamerId}
+          and (
+            older.created_at < ${claim.createdAt}::timestamptz
+            or (
+              older.created_at = ${claim.createdAt}::timestamptz
+              and older.id::text < ${claim.id}
+            )
+          )
+      ) as busy
+    `
+    return rows[0]?.busy === true
+  }, 'chat outbox paced congestion check', { idempotent: true })
+}

--- a/src/lib/services/chat-notification-congestion.ts
+++ b/src/lib/services/chat-notification-congestion.ts
@@ -1,41 +1,24 @@
 import { getDb } from '@/lib/db/client'
 import { withDbRetry } from '@/lib/db/retry'
 import type { ClaimedChatNotification } from '@/lib/services/chat-notification-outbox'
+import { MULTI_DRAW_CHAT_DELIVERY_MODES, type MultiDrawChatDeliveryMode } from '@/lib/twitch/multi-draw-chat'
 
 /**
- * A channel must have at most one paced multi-draw sequence in flight.
- *
- * Two independent EventSub workers can otherwise each send every 1.6 seconds and combine
- * into an effective ~0.8 second channel cadence. The older queued/processing paced row wins;
- * newer rows should fall back to the existing summary message instead of waiting behind it.
- *
- * This is intentionally a read-only decision. The current row's snapshotted delivery_mode
- * remains unchanged so retries are deterministic; the same older-row ordering produces the
- * same fallback decision until that older row reaches sent/dead.
+ * Resolve and persist the first delivery decision under a per-channel DB lock.
+ * The RPC reads the channel from the stored payload and fences the decision by lease.
+ * Persisting both a paced reservation and a summary fallback makes retries deterministic,
+ * including when an older INSERT transaction commits after another row starts delivery.
  */
-export async function hasOlderPacedChatNotification(
-  claim: Pick<ClaimedChatNotification, 'id' | 'createdAt'>,
-  streamerId: string,
-): Promise<boolean> {
+export async function resolveChatNotificationDeliveryMode(
+  claim: Pick<ClaimedChatNotification, 'id' | 'leaseId'>,
+): Promise<MultiDrawChatDeliveryMode | null> {
   return withDbRetry(async () => {
     const { sql } = await getDb()
-    const rows = await sql<Array<{ busy: boolean }>>`
-      select exists (
-        select 1
-        from chat_notification_outbox older
-        where older.id <> ${claim.id}::uuid
-          and older.status in ('pending', 'processing')
-          and older.delivery_mode in ('individual', 'chunked')
-          and older.payload #>> '{streamer,id}' = ${streamerId}
-          and (
-            older.created_at < ${claim.createdAt}::timestamptz
-            or (
-              older.created_at = ${claim.createdAt}::timestamptz
-              and older.id::text < ${claim.id}
-            )
-          )
-      ) as busy
+    const rows = await sql<Array<{ mode: MultiDrawChatDeliveryMode | null }>>`
+      select public.resolve_chat_outbox_delivery_mode(${claim.id}::uuid, ${claim.leaseId}::uuid) as mode
     `
-    return rows[0]?.busy === true
-  }, 'chat outbox paced congestion check', { idempotent: true })
+    const mode = rows[0]?.mode
+    // Empty/unknown responses must never be interpreted as permission to send.
+    return mode && MULTI_DRAW_CHAT_DELIVERY_MODES.includes(mode) ? mode : null
+  }, 'chat outbox delivery mode reservation', { idempotent: true })
 }

--- a/src/lib/services/chat-notification-outbox.ts
+++ b/src/lib/services/chat-notification-outbox.ts
@@ -33,10 +33,11 @@ export interface ClaimedChatNotification {
   leaseId: string
   attemptCount: number
   createdAt: string
-  deliveryMode: MultiDrawChatDeliveryMode
-  deliveryChunkSize: number
+  /** Issue #1549 additive fields. Optional keeps legacy test doubles/source-compatible. */
+  deliveryMode?: MultiDrawChatDeliveryMode
+  deliveryChunkSize?: number
   /** 次に送るsegment index。summary/旧行は常に0。 */
-  deliveryCursor: number
+  deliveryCursor?: number
 }
 
 export interface ChatNotificationOutboxWorkItem {
@@ -53,13 +54,13 @@ interface ClaimedRow {
   lease_id: string
   attempt_count: number
   created_at: string
-  delivery_mode: MultiDrawChatDeliveryMode
-  delivery_chunk_size: number
-  delivery_cursor: number
+  delivery_mode?: MultiDrawChatDeliveryMode
+  delivery_chunk_size?: number
+  delivery_cursor?: number
 }
 
 function toClaimed(row: ClaimedRow): ClaimedChatNotification {
-  return {
+  const claim: ClaimedChatNotification = {
     id: row.id,
     batchId: row.batch_id,
     payloadVersion: Number(row.payload_version),
@@ -67,10 +68,13 @@ function toClaimed(row: ClaimedRow): ClaimedChatNotification {
     leaseId: row.lease_id,
     attemptCount: Number(row.attempt_count),
     createdAt: row.created_at,
-    deliveryMode: row.delivery_mode,
-    deliveryChunkSize: Number(row.delivery_chunk_size),
-    deliveryCursor: Number(row.delivery_cursor),
   }
+  // Production rows always carry these columns after the migration. Keep them additive
+  // here so older unit fixtures that mock the pre-#1549 row shape retain exact equality.
+  if (row.delivery_mode !== undefined) claim.deliveryMode = row.delivery_mode
+  if (row.delivery_chunk_size !== undefined) claim.deliveryChunkSize = Number(row.delivery_chunk_size)
+  if (row.delivery_cursor !== undefined) claim.deliveryCursor = Number(row.delivery_cursor)
+  return claim
 }
 
 function isGachaCard(value: unknown): boolean {

--- a/src/lib/services/chat-notification-outbox.ts
+++ b/src/lib/services/chat-notification-outbox.ts
@@ -224,7 +224,11 @@ async function maintainChatNotificationOutbox(): Promise<void> {
   `
 }
 
-/** ライブEventSub処理が、自分のbatchだけをclaimする。 */
+/**
+ * ライブEventSub処理が、自分のbatchだけをclaimする。
+ * RETURNING * deliberately avoids naming additive delivery columns: Workers Builds can
+ * deploy before migration. Old rows then omit those fields and remain on legacy summary.
+ */
 export async function claimChatNotificationBatch(
   batchId: string,
 ): Promise<ClaimedChatNotification | null> {
@@ -243,8 +247,7 @@ export async function claimChatNotificationBatch(
         (status = 'pending' and next_attempt_at <= now())
         or (status = 'processing' and lease_expires_at <= now())
       )
-    returning id, batch_id, payload_version, payload, lease_id, attempt_count, created_at,
-              delivery_mode, delivery_chunk_size, delivery_cursor
+    returning *
   `
   return rows[0] ? toClaimed(rows[0]) : null
 }
@@ -285,9 +288,7 @@ export async function claimDueChatNotifications(
         updated_at = now()
     from candidates
     where outbox.id = candidates.id
-    returning outbox.id, outbox.batch_id, outbox.payload_version, outbox.payload,
-              outbox.lease_id, outbox.attempt_count, outbox.created_at,
-              outbox.delivery_mode, outbox.delivery_chunk_size, outbox.delivery_cursor
+    returning outbox.*
   `
   return rows.map(toClaimed)
 }

--- a/src/lib/services/chat-notification-outbox.ts
+++ b/src/lib/services/chat-notification-outbox.ts
@@ -9,6 +9,7 @@
  */
 import { getDb } from '@/lib/db/client'
 import type { RedemptionNotifyData } from '@/lib/services/eventsub-redemption'
+import type { MultiDrawChatDeliveryMode } from '@/lib/twitch/multi-draw-chat'
 
 export const CHAT_OUTBOX_MAX_ATTEMPTS = 5
 // Helix送信は最大3試行（各試行timeout + backoff）を含むため、通常の最悪時間より
@@ -32,6 +33,10 @@ export interface ClaimedChatNotification {
   leaseId: string
   attemptCount: number
   createdAt: string
+  deliveryMode: MultiDrawChatDeliveryMode
+  deliveryChunkSize: number
+  /** 次に送るsegment index。summary/旧行は常に0。 */
+  deliveryCursor: number
 }
 
 export interface ChatNotificationOutboxWorkItem {
@@ -48,6 +53,9 @@ interface ClaimedRow {
   lease_id: string
   attempt_count: number
   created_at: string
+  delivery_mode: MultiDrawChatDeliveryMode
+  delivery_chunk_size: number
+  delivery_cursor: number
 }
 
 function toClaimed(row: ClaimedRow): ClaimedChatNotification {
@@ -59,6 +67,9 @@ function toClaimed(row: ClaimedRow): ClaimedChatNotification {
     leaseId: row.lease_id,
     attemptCount: Number(row.attempt_count),
     createdAt: row.created_at,
+    deliveryMode: row.delivery_mode,
+    deliveryChunkSize: Number(row.delivery_chunk_size),
+    deliveryCursor: Number(row.delivery_cursor),
   }
 }
 
@@ -228,7 +239,8 @@ export async function claimChatNotificationBatch(
         (status = 'pending' and next_attempt_at <= now())
         or (status = 'processing' and lease_expires_at <= now())
       )
-    returning id, batch_id, payload_version, payload, lease_id, attempt_count, created_at
+    returning id, batch_id, payload_version, payload, lease_id, attempt_count, created_at,
+              delivery_mode, delivery_chunk_size, delivery_cursor
   `
   return rows[0] ? toClaimed(rows[0]) : null
 }
@@ -270,7 +282,8 @@ export async function claimDueChatNotifications(
     from candidates
     where outbox.id = candidates.id
     returning outbox.id, outbox.batch_id, outbox.payload_version, outbox.payload,
-              outbox.lease_id, outbox.attempt_count, outbox.created_at
+              outbox.lease_id, outbox.attempt_count, outbox.created_at,
+              outbox.delivery_mode, outbox.delivery_chunk_size, outbox.delivery_cursor
   `
   return rows.map(toClaimed)
 }
@@ -290,6 +303,32 @@ export async function renewChatNotificationLease(
   const rows = await sql<{ id: string }[]>`
     update chat_notification_outbox
     set lease_expires_at = now() + (${CHAT_OUTBOX_LEASE_SECONDS}::integer * interval '1 second'),
+        updated_at = now()
+    where id = ${claim.id}::uuid
+      and status = 'processing'
+      and lease_id = ${claim.leaseId}::uuid
+    returning id
+  `
+  return rows.length === 1
+}
+
+/**
+ * 分割N連の1segmentがTwitch側で確定した直後にcursorを前進する。
+ *
+ * cursorを保存できないまま次segmentを送ると、worker停止/429後の再claimで既送信分を
+ * 再送してしまう。そのためowner-fenced UPDATEが成功した場合だけ呼び出し側は次へ進む。
+ * `greatest` によりcursorは単調増加し、古いworkerが後退させることもない。
+ */
+export async function advanceChatNotificationDeliveryCursor(
+  claim: Pick<ClaimedChatNotification, 'id' | 'leaseId'>,
+  nextCursor: number,
+): Promise<boolean> {
+  if (!Number.isInteger(nextCursor) || nextCursor < 0) return false
+  const { sql } = await getDb()
+  const rows = await sql<{ id: string }[]>`
+    update chat_notification_outbox
+    set delivery_cursor = greatest(delivery_cursor, ${nextCursor}::integer),
+        lease_expires_at = now() + (${CHAT_OUTBOX_LEASE_SECONDS}::integer * interval '1 second'),
         updated_at = now()
     where id = ${claim.id}::uuid
       and status = 'processing'

--- a/src/lib/services/eventsub-redemption-delivery.ts
+++ b/src/lib/services/eventsub-redemption-delivery.ts
@@ -1,0 +1,245 @@
+export {
+  handleRaidNotification,
+  handleRedemption,
+  runInBackground,
+  sendChatAnnouncement,
+} from './eventsub-redemption'
+export type {
+  ChatAnnouncementOutcome,
+  ChatAnnouncementSnapshot,
+  RedemptionNotifyData,
+  RedemptionOutcome,
+} from './eventsub-redemption'
+
+import { publishCommittedGachaBatch } from '@/lib/overlay-realtime/publisher'
+import { logger } from '@/lib/logger.server'
+import { reportError } from '@/lib/sentry/error-handler'
+import {
+  advanceChatNotificationDeliveryCursor,
+  claimChatNotificationBatch,
+  decodeChatNotificationPayload,
+  deadLetterChatNotification,
+  markChatNotificationSent,
+  renewChatNotificationLease,
+  retryChatNotification,
+  type ClaimedChatNotification,
+} from '@/lib/services/chat-notification-outbox'
+import {
+  postRedemptionNotify as legacyPostRedemptionNotify,
+  sendChatAnnouncement,
+  type ChatAnnouncementOutcome,
+  type RedemptionNotifyData,
+} from './eventsub-redemption'
+import { CHAT_SEND_TERMINAL_CODES } from '@/lib/twitch/chat-service'
+import { formatChatFailureReason } from '@/lib/twitch/chat-failure-reason'
+import { normalizeMultiDrawChatDeliveryMode } from '@/lib/twitch/multi-draw-chat'
+import { sendPacedMultiDrawChatAnnouncement } from '@/lib/twitch/paced-multi-draw-sender'
+
+async function reportNotificationError(
+  error: unknown,
+  context: Record<string, unknown>,
+): Promise<void> {
+  try {
+    await reportError(error, context)
+  } catch (reportingError) {
+    logger.warn('[EventSub] Failed to persist notification error', {
+      context: context.context,
+      error: reportingError instanceof Error
+        ? reportingError.message
+        : String(reportingError),
+    })
+  }
+}
+
+async function deliverClaimedChatNotification(
+  claim: ClaimedChatNotification,
+  data: RedemptionNotifyData,
+  options: { externalSendDeadlineAt?: number },
+): Promise<void> {
+  let deliveryStatePersisted = false
+  try {
+    const persistedData = decodeChatNotificationPayload(claim)
+    if (!persistedData) {
+      const persisted = await deadLetterChatNotification(
+        claim,
+        `transactional chat outbox payload v${claim.payloadVersion} is invalid`,
+      )
+      deliveryStatePersisted = true
+      throw new Error(
+        persisted
+          ? 'Chat announcement payload moved to DLQ'
+          : 'Chat announcement payload DLQ update lost its lease',
+      )
+    }
+
+    const beforeExternalSend = async () => {
+      if (
+        options.externalSendDeadlineAt !== undefined
+        && Date.now() >= options.externalSendDeadlineAt
+      ) {
+        return false
+      }
+      const renewed = await renewChatNotificationLease(claim)
+      return renewed && (
+        options.externalSendDeadlineAt === undefined
+        || Date.now() < options.externalSendDeadlineAt
+      )
+    }
+
+    const drawnCards = persistedData.gachaResult.cards
+      && persistedData.gachaResult.cards.length > 0
+      ? persistedData.gachaResult.cards
+      : [persistedData.gachaResult.card]
+    const mode = normalizeMultiDrawChatDeliveryMode(claim.deliveryMode)
+    const usePacedDelivery = drawnCards.length > 1 && mode !== 'summary'
+
+    const outcome: ChatAnnouncementOutcome = usePacedDelivery
+      ? await sendPacedMultiDrawChatAnnouncement(
+          persistedData.broadcasterTwitchUserId,
+          drawnCards,
+          persistedData.gachaResult.userTwitchUsername,
+          {
+            deliveryMode: mode,
+            chunkSize: claim.deliveryChunkSize,
+            startCursor: claim.deliveryCursor,
+            beforeExternalSend,
+            afterSegmentComplete: async (nextCursor) => {
+              const persisted = await advanceChatNotificationDeliveryCursor(claim, nextCursor)
+              if (persisted) {
+                claim.deliveryCursor = nextCursor
+              }
+              return persisted
+            },
+          },
+        )
+      : await sendChatAnnouncement(
+          persistedData.broadcasterTwitchUserId,
+          persistedData.streamer,
+          persistedData.gachaResult.card,
+          persistedData.gachaResult.userTwitchUsername,
+          persistedData.userId,
+          persistedData.gachaResult.cards,
+          persistedData.gachaResult.collectionName,
+          persistedData.chatSnapshot,
+          beforeExternalSend,
+        )
+
+    if (outcome.outcome === 'sent' || outcome.outcome === 'skipped') {
+      const persisted = await markChatNotificationSent(claim)
+      deliveryStatePersisted = true
+      if (!persisted) {
+        throw new Error(formatChatFailureReason(
+          'Chat announcement sent but outbox ack lost its lease',
+          outcome.degradation,
+        ))
+      }
+      if (outcome.degradation) {
+        logger.warn('[postRedemptionNotify] Chat sent using fallback sender', {
+          streamerId: data.streamer.id,
+          broadcasterTwitchUserId: data.broadcasterTwitchUserId,
+          degradation: outcome.degradation,
+        })
+        await reportNotificationError(
+          new Error(`Chat delivery used fallback sender: ${outcome.degradation.reason}`),
+          {
+            context: 'eventsub:postRedemptionNotify:chatDegradation',
+            streamerId: data.streamer.id,
+            broadcasterTwitchUserId: data.broadcasterTwitchUserId,
+            degradation: outcome.degradation,
+          },
+        )
+      }
+      return
+    }
+
+    const failureReason = formatChatFailureReason(outcome.reason, outcome.degradation)
+    if (outcome.outcome === 'terminal') {
+      const persisted = await deadLetterChatNotification(claim, failureReason)
+      deliveryStatePersisted = true
+      if (!persisted) {
+        throw new Error(`Chat announcement DLQ update lost its lease: ${failureReason}`)
+      }
+      if (outcome.code === CHAT_SEND_TERMINAL_CODES.MISSING_SCOPE) {
+        logger.warn('[postRedemptionNotify] chat announcement moved to DLQ pending Twitch reauthorization', {
+          code: outcome.code,
+          reason: outcome.reason,
+          streamerId: data.streamer.id,
+          broadcasterTwitchUserId: data.broadcasterTwitchUserId,
+          outboxId: claim.id,
+        })
+        return
+      }
+      throw new Error(`Chat announcement moved to DLQ: ${failureReason}`)
+    }
+    if (outcome.outcome === 'aborted') {
+      deliveryStatePersisted = true
+      throw new Error(`Chat announcement aborted: ${failureReason}`)
+    }
+
+    const retryState = await retryChatNotification(claim, failureReason)
+    deliveryStatePersisted = true
+    if (retryState === 'pending') {
+      logger.info('[postRedemptionNotify] chat announcement retry scheduled', {
+        streamerId: data.streamer.id,
+        broadcasterTwitchUserId: data.broadcasterTwitchUserId,
+        outboxId: claim.id,
+        deliveryCursor: claim.deliveryCursor,
+        reason: failureReason,
+      })
+      return
+    }
+    throw new Error(`Chat announcement ${retryState}: ${failureReason}`)
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error)
+    if (!deliveryStatePersisted) {
+      await retryChatNotification(claim, reason)
+    }
+    throw error
+  }
+}
+
+/**
+ * Delivery wrapper for Issue #1549. Summary mode stays on the existing message builder.
+ * Individual/chunked mode sends deterministic segments and checkpoints the next segment
+ * cursor after every Twitch-confirmed send, so retry resumes without replaying earlier cards.
+ */
+export async function postRedemptionNotify(
+  data: RedemptionNotifyData,
+  options: { externalSendDeadlineAt?: number } = {},
+): Promise<void> {
+  if (!data.streamer.chat_announcement_enabled) {
+    await legacyPostRedemptionNotify(data, options)
+    return
+  }
+
+  const chatTask = (async () => {
+    const claim = await claimChatNotificationBatch(data.batchId)
+    if (!claim) return
+    await deliverClaimedChatNotification(claim, data, options)
+  })()
+
+  const results = await Promise.allSettled([
+    publishCommittedGachaBatch(data.streamer.id, data.gachaResult, {
+      batchId: data.batchId,
+      maxRetries: 1,
+      retryDelay: 500,
+    }),
+    chatTask,
+  ])
+
+  for (const [index, result] of results.entries()) {
+    if (result.status !== 'rejected') continue
+    const { contextLabel, displayLabel } = index === 0
+      ? { contextLabel: 'broadcast', displayLabel: 'broadcast' }
+      : { contextLabel: 'chatAnnouncement', displayLabel: 'chat announcement' }
+    logger.warn(`[postRedemptionNotify] ${displayLabel} failed`, {
+      error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+      streamerId: data.streamer.id,
+    })
+    await reportNotificationError(result.reason, {
+      context: `eventsub:postRedemptionNotify:${contextLabel}`,
+      streamerId: data.streamer.id,
+      broadcasterTwitchUserId: data.broadcasterTwitchUserId,
+    })
+  }
+}

--- a/src/lib/services/eventsub-redemption-delivery.ts
+++ b/src/lib/services/eventsub-redemption-delivery.ts
@@ -101,7 +101,7 @@ async function deliverClaimedChatNotification(
           {
             deliveryMode: mode,
             chunkSize: claim.deliveryChunkSize,
-            startCursor: claim.deliveryCursor,
+            startCursor: claim.deliveryCursor ?? 0,
             beforeExternalSend,
             afterSegmentComplete: async (nextCursor) => {
               const persisted = await advanceChatNotificationDeliveryCursor(claim, nextCursor)
@@ -183,7 +183,7 @@ async function deliverClaimedChatNotification(
         streamerId: data.streamer.id,
         broadcasterTwitchUserId: data.broadcasterTwitchUserId,
         outboxId: claim.id,
-        deliveryCursor: claim.deliveryCursor,
+        deliveryCursor: claim.deliveryCursor ?? 0,
         reason: failureReason,
       })
       return

--- a/src/lib/services/eventsub-redemption-delivery.ts
+++ b/src/lib/services/eventsub-redemption-delivery.ts
@@ -14,6 +14,7 @@ export type {
 import { publishCommittedGachaBatch } from '@/lib/overlay-realtime/publisher'
 import { logger } from '@/lib/logger.server'
 import { reportError } from '@/lib/sentry/error-handler'
+import { hasOlderPacedChatNotification } from '@/lib/services/chat-notification-congestion'
 import {
   advanceChatNotificationDeliveryCursor,
   claimChatNotificationBatch,
@@ -91,7 +92,24 @@ async function deliverClaimedChatNotification(
       ? persistedData.gachaResult.cards
       : [persistedData.gachaResult.card]
     const mode = normalizeMultiDrawChatDeliveryMode(claim.deliveryMode)
-    const usePacedDelivery = drawnCards.length > 1 && mode !== 'summary'
+    let usePacedDelivery = drawnCards.length > 1 && mode !== 'summary'
+
+    // Only one paced sequence may occupy a broadcaster's chat at a time. Two EventSub
+    // workers sending every 1.6s would otherwise combine into an unsafe ~0.8s cadence.
+    // A sequence that already checkpointed at least one segment must continue paced on retry;
+    // only a not-yet-started newer sequence is eligible to collapse to the legacy summary.
+    if (usePacedDelivery && (claim.deliveryCursor ?? 0) === 0) {
+      const congested = await hasOlderPacedChatNotification(claim, persistedData.streamer.id)
+      if (congested) {
+        usePacedDelivery = false
+        logger.info('[postRedemptionNotify] collapsed paced multi-draw to summary due to channel congestion', {
+          streamerId: persistedData.streamer.id,
+          broadcasterTwitchUserId: persistedData.broadcasterTwitchUserId,
+          outboxId: claim.id,
+          configuredMode: mode,
+        })
+      }
+    }
 
     const outcome: ChatAnnouncementOutcome = usePacedDelivery
       ? await sendPacedMultiDrawChatAnnouncement(

--- a/src/lib/services/eventsub-redemption-delivery.ts
+++ b/src/lib/services/eventsub-redemption-delivery.ts
@@ -1,263 +1,70 @@
-export {
-  handleRaidNotification,
-  handleRedemption,
-  runInBackground,
-  sendChatAnnouncement,
-} from './eventsub-redemption'
-export type {
-  ChatAnnouncementOutcome,
-  ChatAnnouncementSnapshot,
-  RedemptionNotifyData,
-  RedemptionOutcome,
-} from './eventsub-redemption'
-
-import { publishCommittedGachaBatch } from '@/lib/overlay-realtime/publisher'
-import { logger } from '@/lib/logger.server'
-import { reportError } from '@/lib/sentry/error-handler'
-import { hasOlderPacedChatNotification } from '@/lib/services/chat-notification-congestion'
+import { resolveChatNotificationDeliveryMode } from '@/lib/services/chat-notification-congestion'
 import {
   advanceChatNotificationDeliveryCursor,
-  claimChatNotificationBatch,
-  decodeChatNotificationPayload,
-  deadLetterChatNotification,
-  markChatNotificationSent,
-  renewChatNotificationLease,
-  retryChatNotification,
   type ClaimedChatNotification,
 } from '@/lib/services/chat-notification-outbox'
 import {
-  postRedemptionNotify as legacyPostRedemptionNotify,
   sendChatAnnouncement,
   type ChatAnnouncementOutcome,
   type RedemptionNotifyData,
 } from './eventsub-redemption'
-import { CHAT_SEND_TERMINAL_CODES } from '@/lib/twitch/chat-service'
-import { formatChatFailureReason } from '@/lib/twitch/chat-failure-reason'
 import { normalizeMultiDrawChatDeliveryMode } from '@/lib/twitch/multi-draw-chat'
 import { sendPacedMultiDrawChatAnnouncement } from '@/lib/twitch/paced-multi-draw-sender'
 
-async function reportNotificationError(
-  error: unknown,
-  context: Record<string, unknown>,
-): Promise<void> {
-  try {
-    await reportError(error, context)
-  } catch (reportingError) {
-    logger.warn('[EventSub] Failed to persist notification error', {
-      context: context.context,
-      error: reportingError instanceof Error
-        ? reportingError.message
-        : String(reportingError),
-    })
-  }
-}
-
-async function deliverClaimedChatNotification(
+/**
+ * Live notifications and the outbox relay must use the same snapshotted delivery mode
+ * and cursor. Keep their existing ack, backoff and error reporting at the owning boundary;
+ * this helper only sends and checkpoints the next unsent segment under the current lease.
+ * The supplied fence runs immediately before each external send, after credential lookup.
+ */
+export async function sendClaimedChatAnnouncement(
   claim: ClaimedChatNotification,
   data: RedemptionNotifyData,
-  options: { externalSendDeadlineAt?: number },
-): Promise<void> {
-  let deliveryStatePersisted = false
-  try {
-    const persistedData = decodeChatNotificationPayload(claim)
-    if (!persistedData) {
-      const persisted = await deadLetterChatNotification(
-        claim,
-        `transactional chat outbox payload v${claim.payloadVersion} is invalid`,
-      )
-      deliveryStatePersisted = true
-      throw new Error(
-        persisted
-          ? 'Chat announcement payload moved to DLQ'
-          : 'Chat announcement payload DLQ update lost its lease',
-      )
+  beforeExternalSend: () => Promise<boolean>,
+): Promise<ChatAnnouncementOutcome> {
+  const drawnCards = data.gachaResult.cards?.length
+    ? data.gachaResult.cards
+    : [data.gachaResult.card]
+  let mode = normalizeMultiDrawChatDeliveryMode(claim.deliveryMode)
+  if (drawnCards.length > 1 && mode !== 'summary') {
+    // Persist any congestion fallback before sending. Retry must keep that decision even
+    // when the older sequence has completed, and a lost owner must not start a sequence.
+    const resolvedMode = await resolveChatNotificationDeliveryMode(claim)
+    if (resolvedMode === null) {
+      return { outcome: 'aborted', reason: 'Chat delivery mode update lost its lease' }
     }
-
-    const beforeExternalSend = async () => {
-      if (
-        options.externalSendDeadlineAt !== undefined
-        && Date.now() >= options.externalSendDeadlineAt
-      ) {
-        return false
-      }
-      const renewed = await renewChatNotificationLease(claim)
-      return renewed && (
-        options.externalSendDeadlineAt === undefined
-        || Date.now() < options.externalSendDeadlineAt
-      )
-    }
-
-    const drawnCards = persistedData.gachaResult.cards
-      && persistedData.gachaResult.cards.length > 0
-      ? persistedData.gachaResult.cards
-      : [persistedData.gachaResult.card]
-    const mode = normalizeMultiDrawChatDeliveryMode(claim.deliveryMode)
-    let usePacedDelivery = drawnCards.length > 1 && mode !== 'summary'
-
-    // Only one paced sequence may occupy a broadcaster's chat at a time. Two EventSub
-    // workers sending every 1.6s would otherwise combine into an unsafe ~0.8s cadence.
-    // A sequence that already checkpointed at least one segment must continue paced on retry;
-    // only a not-yet-started newer sequence is eligible to collapse to the legacy summary.
-    if (usePacedDelivery && (claim.deliveryCursor ?? 0) === 0) {
-      const congested = await hasOlderPacedChatNotification(claim, persistedData.streamer.id)
-      if (congested) {
-        usePacedDelivery = false
-        logger.info('[postRedemptionNotify] collapsed paced multi-draw to summary due to channel congestion', {
-          streamerId: persistedData.streamer.id,
-          broadcasterTwitchUserId: persistedData.broadcasterTwitchUserId,
-          outboxId: claim.id,
-          configuredMode: mode,
-        })
-      }
-    }
-
-    const outcome: ChatAnnouncementOutcome = usePacedDelivery
-      ? await sendPacedMultiDrawChatAnnouncement(
-          persistedData.broadcasterTwitchUserId,
-          drawnCards,
-          persistedData.gachaResult.userTwitchUsername,
-          {
-            deliveryMode: mode,
-            chunkSize: claim.deliveryChunkSize,
-            startCursor: claim.deliveryCursor ?? 0,
-            beforeExternalSend,
-            afterSegmentComplete: async (nextCursor) => {
-              const persisted = await advanceChatNotificationDeliveryCursor(claim, nextCursor)
-              if (persisted) {
-                claim.deliveryCursor = nextCursor
-              }
-              return persisted
-            },
-          },
-        )
-      : await sendChatAnnouncement(
-          persistedData.broadcasterTwitchUserId,
-          persistedData.streamer,
-          persistedData.gachaResult.card,
-          persistedData.gachaResult.userTwitchUsername,
-          persistedData.userId,
-          persistedData.gachaResult.cards,
-          persistedData.gachaResult.collectionName,
-          persistedData.chatSnapshot,
-          beforeExternalSend,
-        )
-
-    if (outcome.outcome === 'sent' || outcome.outcome === 'skipped') {
-      const persisted = await markChatNotificationSent(claim)
-      deliveryStatePersisted = true
-      if (!persisted) {
-        throw new Error(formatChatFailureReason(
-          'Chat announcement sent but outbox ack lost its lease',
-          outcome.degradation,
-        ))
-      }
-      if (outcome.degradation) {
-        logger.warn('[postRedemptionNotify] Chat sent using fallback sender', {
-          streamerId: data.streamer.id,
-          broadcasterTwitchUserId: data.broadcasterTwitchUserId,
-          degradation: outcome.degradation,
-        })
-        await reportNotificationError(
-          new Error(`Chat delivery used fallback sender: ${outcome.degradation.reason}`),
-          {
-            context: 'eventsub:postRedemptionNotify:chatDegradation',
-            streamerId: data.streamer.id,
-            broadcasterTwitchUserId: data.broadcasterTwitchUserId,
-            degradation: outcome.degradation,
-          },
-        )
-      }
-      return
-    }
-
-    const failureReason = formatChatFailureReason(outcome.reason, outcome.degradation)
-    if (outcome.outcome === 'terminal') {
-      const persisted = await deadLetterChatNotification(claim, failureReason)
-      deliveryStatePersisted = true
-      if (!persisted) {
-        throw new Error(`Chat announcement DLQ update lost its lease: ${failureReason}`)
-      }
-      if (outcome.code === CHAT_SEND_TERMINAL_CODES.MISSING_SCOPE) {
-        logger.warn('[postRedemptionNotify] chat announcement moved to DLQ pending Twitch reauthorization', {
-          code: outcome.code,
-          reason: outcome.reason,
-          streamerId: data.streamer.id,
-          broadcasterTwitchUserId: data.broadcasterTwitchUserId,
-          outboxId: claim.id,
-        })
-        return
-      }
-      throw new Error(`Chat announcement moved to DLQ: ${failureReason}`)
-    }
-    if (outcome.outcome === 'aborted') {
-      deliveryStatePersisted = true
-      throw new Error(`Chat announcement aborted: ${failureReason}`)
-    }
-
-    const retryState = await retryChatNotification(claim, failureReason)
-    deliveryStatePersisted = true
-    if (retryState === 'pending') {
-      logger.info('[postRedemptionNotify] chat announcement retry scheduled', {
-        streamerId: data.streamer.id,
-        broadcasterTwitchUserId: data.broadcasterTwitchUserId,
-        outboxId: claim.id,
-        deliveryCursor: claim.deliveryCursor ?? 0,
-        reason: failureReason,
-      })
-      return
-    }
-    throw new Error(`Chat announcement ${retryState}: ${failureReason}`)
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error)
-    if (!deliveryStatePersisted) {
-      await retryChatNotification(claim, reason)
-    }
-    throw error
-  }
-}
-
-/**
- * Delivery wrapper for Issue #1549. Summary mode stays on the existing message builder.
- * Individual/chunked mode sends deterministic segments and checkpoints the next segment
- * cursor after every Twitch-confirmed send, so retry resumes without replaying earlier cards.
- */
-export async function postRedemptionNotify(
-  data: RedemptionNotifyData,
-  options: { externalSendDeadlineAt?: number } = {},
-): Promise<void> {
-  if (!data.streamer.chat_announcement_enabled) {
-    await legacyPostRedemptionNotify(data, options)
-    return
+    mode = resolvedMode
   }
 
-  const chatTask = (async () => {
-    const claim = await claimChatNotificationBatch(data.batchId)
-    if (!claim) return
-    await deliverClaimedChatNotification(claim, data, options)
-  })()
-
-  const results = await Promise.allSettled([
-    publishCommittedGachaBatch(data.streamer.id, data.gachaResult, {
-      batchId: data.batchId,
-      maxRetries: 1,
-      retryDelay: 500,
-    }),
-    chatTask,
-  ])
-
-  for (const [index, result] of results.entries()) {
-    if (result.status !== 'rejected') continue
-    const { contextLabel, displayLabel } = index === 0
-      ? { contextLabel: 'broadcast', displayLabel: 'broadcast' }
-      : { contextLabel: 'chatAnnouncement', displayLabel: 'chat announcement' }
-    logger.warn(`[postRedemptionNotify] ${displayLabel} failed`, {
-      error: result.reason instanceof Error ? result.reason.message : String(result.reason),
-      streamerId: data.streamer.id,
-    })
-    await reportNotificationError(result.reason, {
-      context: `eventsub:postRedemptionNotify:${contextLabel}`,
-      streamerId: data.streamer.id,
-      broadcasterTwitchUserId: data.broadcasterTwitchUserId,
-    })
+  if (drawnCards.length > 1 && mode !== 'summary') {
+    return sendPacedMultiDrawChatAnnouncement(
+      data.broadcasterTwitchUserId,
+      drawnCards,
+      data.gachaResult.userTwitchUsername,
+      {
+        deliveryMode: mode,
+        chunkSize: claim.deliveryChunkSize,
+        startCursor: claim.deliveryCursor ?? 0,
+        beforeExternalSend,
+        afterSegmentComplete: async (nextCursor) => {
+          const persisted = await advanceChatNotificationDeliveryCursor(claim, nextCursor)
+          if (persisted) claim.deliveryCursor = nextCursor
+          return persisted
+        },
+      },
+    )
   }
+
+  // Preserve the legacy summary builder, including templates and card-list settings.
+  return sendChatAnnouncement(
+    data.broadcasterTwitchUserId,
+    data.streamer,
+    data.gachaResult.card,
+    data.gachaResult.userTwitchUsername,
+    data.userId,
+    data.gachaResult.cards,
+    data.gachaResult.collectionName,
+    data.chatSnapshot,
+    beforeExternalSend,
+  )
 }

--- a/src/lib/services/eventsub-redemption.ts
+++ b/src/lib/services/eventsub-redemption.ts
@@ -47,6 +47,7 @@ import {
   renewChatNotificationLease,
   retryChatNotification,
 } from "@/lib/services/chat-notification-outbox";
+import { sendClaimedChatAnnouncement } from "@/lib/services/eventsub-redemption-delivery";
 import type { GachaCard, EventSubStreamerInfo } from "@/lib/services/gacha";
 export { runInBackground } from "@/lib/background-task";
 // チャット通知プレースホルダと売り切れ設定を、ガチャ確定と同じPlanetScaleから
@@ -475,15 +476,9 @@ export async function postRedemptionNotify(
             : 'Chat announcement payload DLQ update lost its lease',
         );
       }
-      const outcome = await sendChatAnnouncement(
-        persistedData.broadcasterTwitchUserId,
-        persistedData.streamer,
-        persistedData.gachaResult.card,
-        persistedData.gachaResult.userTwitchUsername,
-        persistedData.userId,
-        persistedData.gachaResult.cards,
-        persistedData.gachaResult.collectionName,
-        persistedData.chatSnapshot,
+      const outcome = await sendClaimedChatAnnouncement(
+        claim,
+        persistedData,
         async () => {
           // replay routeが期限切れで応答を返した後に、遅れて資格情報解決が完了しても
           // Twitch送信を開始しない。期限内ならowner-fenced lease更新を最終送信許可にする。

--- a/src/lib/twitch/multi-draw-chat.ts
+++ b/src/lib/twitch/multi-draw-chat.ts
@@ -1,0 +1,114 @@
+import { TWITCH_CHAT_MESSAGE_MAX_CHARACTERS } from '@/lib/constants'
+import { truncateCharacters } from '@/lib/text-utils'
+import type { GachaCard } from '@/lib/services/gacha'
+
+export const MULTI_DRAW_CHAT_DELIVERY_MODES = ['summary', 'individual', 'chunked'] as const
+export type MultiDrawChatDeliveryMode = (typeof MULTI_DRAW_CHAT_DELIVERY_MODES)[number]
+
+export const DEFAULT_MULTI_DRAW_CHAT_DELIVERY_MODE: MultiDrawChatDeliveryMode = 'summary'
+export const DEFAULT_MULTI_DRAW_CHAT_CHUNK_SIZE = 3
+export const MIN_MULTI_DRAW_CHAT_CHUNK_SIZE = 2
+export const MAX_MULTI_DRAW_CHAT_CHUNK_SIZE = 5
+
+// Twitchの通常チャットは同一チャンネルで1秒に1件を超えないよう余裕を持たせる。
+// 15連をindividualで送っても 14 * 1.6s = 22.4s で完了する。
+export const MULTI_DRAW_CHAT_INTERVAL_MS = 1_600
+
+export interface MultiDrawChatSegment {
+  index: number
+  startDraw: number
+  endDraw: number
+  message: string
+}
+
+export function normalizeMultiDrawChatDeliveryMode(value: unknown): MultiDrawChatDeliveryMode {
+  return typeof value === 'string'
+    && (MULTI_DRAW_CHAT_DELIVERY_MODES as readonly string[]).includes(value)
+    ? value as MultiDrawChatDeliveryMode
+    : DEFAULT_MULTI_DRAW_CHAT_DELIVERY_MODE
+}
+
+export function normalizeMultiDrawChatChunkSize(value: unknown): number {
+  if (!Number.isInteger(value)) return DEFAULT_MULTI_DRAW_CHAT_CHUNK_SIZE
+  return Math.max(
+    MIN_MULTI_DRAW_CHAT_CHUNK_SIZE,
+    Math.min(MAX_MULTI_DRAW_CHAT_CHUNK_SIZE, Number(value)),
+  )
+}
+
+function rarityLabel(rarity: string): string {
+  const labels: Record<string, string> = {
+    common: 'コモン',
+    rare: 'レア',
+    epic: 'エピック',
+    legendary: 'レジェンダリー',
+  }
+  return labels[rarity] ?? rarity
+}
+
+function formatRarityCounts(cards: GachaCard[]): string {
+  const counts = new Map<string, number>()
+  for (const card of cards) {
+    counts.set(card.rarity, (counts.get(card.rarity) ?? 0) + 1)
+  }
+
+  const order = ['legendary', 'epic', 'rare', 'common']
+  return [...counts.entries()]
+    .sort(([a], [b]) => {
+      const ai = order.indexOf(a)
+      const bi = order.indexOf(b)
+      return (ai === -1 ? order.length : ai) - (bi === -1 ? order.length : bi)
+    })
+    .map(([rarity, count]) => `${rarityLabel(rarity)}x${count}`)
+    .join('、')
+}
+
+function fitSegmentMessage(message: string): string {
+  if (message.length === 0) return message
+  return truncateCharacters(message, TWITCH_CHAT_MESSAGE_MAX_CHARACTERS)
+}
+
+/**
+ * summaryは従来のsendChatAnnouncementに委ねるためsegmentを返さない。
+ * individual/chunkedはカード順序から決定的にmessage列を構築する。retry時に
+ * delivery_cursorだけで同じindexへ復帰できることが重要なので、時刻・乱数・外部状態を
+ * 一切参照しない。
+ */
+export function buildMultiDrawChatSegments(
+  cards: GachaCard[],
+  userName: string,
+  mode: MultiDrawChatDeliveryMode,
+  chunkSize: number = DEFAULT_MULTI_DRAW_CHAT_CHUNK_SIZE,
+): MultiDrawChatSegment[] {
+  if (mode === 'summary' || cards.length <= 1) return []
+
+  const total = cards.length
+  if (mode === 'individual') {
+    return cards.map((card, index) => ({
+      index,
+      startDraw: index + 1,
+      endDraw: index + 1,
+      message: fitSegmentMessage(
+        `@${userName} ${total}連 ${index + 1}/${total}: 【${rarityLabel(card.rarity)}】${card.name}`,
+      ),
+    }))
+  }
+
+  const safeChunkSize = normalizeMultiDrawChatChunkSize(chunkSize)
+  const segments: MultiDrawChatSegment[] = []
+  for (let offset = 0; offset < total; offset += safeChunkSize) {
+    const chunk = cards.slice(offset, offset + safeChunkSize)
+    const startDraw = offset + 1
+    const endDraw = offset + chunk.length
+    const range = startDraw === endDraw ? `${startDraw}/${total}` : `${startDraw}-${endDraw}/${total}`
+    const rarityCounts = formatRarityCounts(chunk)
+    const names = chunk.map((card) => card.name).join('、')
+    segments.push({
+      index: segments.length,
+      startDraw,
+      endDraw,
+      message: fitSegmentMessage(`@${userName} ${total}連 ${range}: ${rarityCounts} / ${names}`),
+    })
+  }
+  return segments
+}

--- a/src/lib/twitch/multi-draw-chat.ts
+++ b/src/lib/twitch/multi-draw-chat.ts
@@ -10,8 +10,8 @@ export const DEFAULT_MULTI_DRAW_CHAT_CHUNK_SIZE = 3
 export const MIN_MULTI_DRAW_CHAT_CHUNK_SIZE = 2
 export const MAX_MULTI_DRAW_CHAT_CHUNK_SIZE = 5
 
-// Twitchの通常チャットは同一チャンネルで1秒に1件を超えないよう余裕を持たせる。
-// 15連をindividualで送っても 14 * 1.6s = 22.4s で完了する。
+// Keep enough headroom above Twitch's one-message-per-second channel boundary.
+// An individual 15-draw sequence takes 14 * 1.6s = 22.4s between first/last sends.
 export const MULTI_DRAW_CHAT_INTERVAL_MS = 1_600
 
 export interface MultiDrawChatSegment {
@@ -38,10 +38,10 @@ export function normalizeMultiDrawChatChunkSize(value: unknown): number {
 
 function rarityLabel(rarity: string): string {
   const labels: Record<string, string> = {
-    common: 'コモン',
-    rare: 'レア',
-    epic: 'エピック',
-    legendary: 'レジェンダリー',
+    common: 'C',
+    rare: 'R',
+    epic: 'E',
+    legendary: 'L',
   }
   return labels[rarity] ?? rarity
 }
@@ -60,7 +60,7 @@ function formatRarityCounts(cards: GachaCard[]): string {
       return (ai === -1 ? order.length : ai) - (bi === -1 ? order.length : bi)
     })
     .map(([rarity, count]) => `${rarityLabel(rarity)}x${count}`)
-    .join('、')
+    .join(', ')
 }
 
 function fitSegmentMessage(message: string): string {
@@ -69,10 +69,9 @@ function fitSegmentMessage(message: string): string {
 }
 
 /**
- * summaryは従来のsendChatAnnouncementに委ねるためsegmentを返さない。
- * individual/chunkedはカード順序から決定的にmessage列を構築する。retry時に
- * delivery_cursorだけで同じindexへ復帰できることが重要なので、時刻・乱数・外部状態を
- * 一切参照しない。
+ * Summary stays on the legacy sendChatAnnouncement path. Individual/chunked messages
+ * are deterministic from card order so delivery_cursor can resume the exact segment
+ * without depending on time, randomness, or mutable external state.
  */
 export function buildMultiDrawChatSegments(
   cards: GachaCard[],
@@ -89,7 +88,7 @@ export function buildMultiDrawChatSegments(
       startDraw: index + 1,
       endDraw: index + 1,
       message: fitSegmentMessage(
-        `@${userName} ${total}連 ${index + 1}/${total}: 【${rarityLabel(card.rarity)}】${card.name}`,
+        `@${userName} ${total}x ${index + 1}/${total}: [${rarityLabel(card.rarity)}] ${card.name}`,
       ),
     }))
   }
@@ -102,12 +101,12 @@ export function buildMultiDrawChatSegments(
     const endDraw = offset + chunk.length
     const range = startDraw === endDraw ? `${startDraw}/${total}` : `${startDraw}-${endDraw}/${total}`
     const rarityCounts = formatRarityCounts(chunk)
-    const names = chunk.map((card) => card.name).join('、')
+    const names = chunk.map((card) => card.name).join(', ')
     segments.push({
       index: segments.length,
       startDraw,
       endDraw,
-      message: fitSegmentMessage(`@${userName} ${total}連 ${range}: ${rarityCounts} / ${names}`),
+      message: fitSegmentMessage(`@${userName} ${total}x ${range}: ${rarityCounts} / ${names}`),
     })
   }
   return segments

--- a/src/lib/twitch/multi-draw-chat.ts
+++ b/src/lib/twitch/multi-draw-chat.ts
@@ -1,5 +1,5 @@
 import { TWITCH_CHAT_MESSAGE_MAX_CHARACTERS } from '@/lib/constants'
-import { truncateCharacters } from '@/lib/text-utils'
+import { countCharacters, truncateCharacters } from '@/lib/text-utils'
 import type { GachaCard } from '@/lib/services/gacha'
 
 export const MULTI_DRAW_CHAT_DELIVERY_MODES = ['summary', 'individual', 'chunked'] as const
@@ -63,9 +63,45 @@ function formatRarityCounts(cards: GachaCard[]): string {
     .join(', ')
 }
 
-function fitSegmentMessage(message: string): string {
-  if (message.length === 0) return message
-  return truncateCharacters(message, TWITCH_CHAT_MESSAGE_MAX_CHARACTERS)
+/**
+ * Fit a list of card names without cutting the structural part of the segment message.
+ *
+ * The legacy multi-draw formatter shortens the card-name list itself and keeps an explicit
+ * omitted-card count. Do the same here instead of truncating the fully rendered segment,
+ * otherwise a long card name can remove the draw range / rarity context or end mid-name.
+ */
+function fitCardNamesForSegment(cardNames: string[], maxCharacters: number): string {
+  if (maxCharacters <= 0 || cardNames.length === 0) return ''
+
+  const fullList = cardNames.join(', ')
+  if (countCharacters(fullList) <= maxCharacters) return fullList
+
+  const displayed: string[] = []
+  for (const cardName of cardNames) {
+    const nextDisplayed = [...displayed, cardName]
+    const remaining = cardNames.length - nextDisplayed.length
+    const suffix = remaining > 0 ? ` …(+${remaining})` : ''
+    const candidate = `${nextDisplayed.join(', ')}${suffix}`
+    if (countCharacters(candidate) > maxCharacters) break
+    displayed.push(cardName)
+  }
+
+  if (displayed.length === 0) {
+    return truncateCharacters(`…(+${cardNames.length})`, maxCharacters)
+  }
+
+  const remaining = cardNames.length - displayed.length
+  return remaining > 0
+    ? `${displayed.join(', ')} …(+${remaining})`
+    : displayed.join(', ')
+}
+
+function fitSegmentWithTail(prefix: string, tail: string): string {
+  const remainingCharacters = TWITCH_CHAT_MESSAGE_MAX_CHARACTERS - countCharacters(prefix)
+  if (remainingCharacters <= 0) {
+    return truncateCharacters(prefix, TWITCH_CHAT_MESSAGE_MAX_CHARACTERS)
+  }
+  return `${prefix}${truncateCharacters(tail, remainingCharacters)}`
 }
 
 /**
@@ -83,14 +119,15 @@ export function buildMultiDrawChatSegments(
 
   const total = cards.length
   if (mode === 'individual') {
-    return cards.map((card, index) => ({
-      index,
-      startDraw: index + 1,
-      endDraw: index + 1,
-      message: fitSegmentMessage(
-        `@${userName} ${total}x ${index + 1}/${total}: [${rarityLabel(card.rarity)}] ${card.name}`,
-      ),
-    }))
+    return cards.map((card, index) => {
+      const prefix = `@${userName} ${total}x ${index + 1}/${total}: [${rarityLabel(card.rarity)}] `
+      return {
+        index,
+        startDraw: index + 1,
+        endDraw: index + 1,
+        message: fitSegmentWithTail(prefix, card.name),
+      }
+    })
   }
 
   const safeChunkSize = normalizeMultiDrawChatChunkSize(chunkSize)
@@ -101,12 +138,16 @@ export function buildMultiDrawChatSegments(
     const endDraw = offset + chunk.length
     const range = startDraw === endDraw ? `${startDraw}/${total}` : `${startDraw}-${endDraw}/${total}`
     const rarityCounts = formatRarityCounts(chunk)
-    const names = chunk.map((card) => card.name).join(', ')
+    const prefix = `@${userName} ${total}x ${range}: ${rarityCounts} / `
+    const names = fitCardNamesForSegment(
+      chunk.map((card) => card.name),
+      TWITCH_CHAT_MESSAGE_MAX_CHARACTERS - countCharacters(prefix),
+    )
     segments.push({
       index: segments.length,
       startDraw,
       endDraw,
-      message: fitSegmentMessage(`@${userName} ${total}x ${range}: ${rarityCounts} / ${names}`),
+      message: fitSegmentWithTail(prefix, names),
     })
   }
   return segments

--- a/src/lib/twitch/paced-multi-draw-sender.ts
+++ b/src/lib/twitch/paced-multi-draw-sender.ts
@@ -1,0 +1,129 @@
+import type { GachaCard } from '@/lib/services/gacha'
+import {
+  TwitchChatService,
+  type ChatSendDegradation,
+  type ChatSendTerminalCode,
+} from '@/lib/twitch/chat-service'
+import {
+  buildMultiDrawChatSegments,
+  MULTI_DRAW_CHAT_INTERVAL_MS,
+  normalizeMultiDrawChatChunkSize,
+  normalizeMultiDrawChatDeliveryMode,
+} from '@/lib/twitch/multi-draw-chat'
+
+export type PacedMultiDrawSendOutcome = (
+  | { outcome: 'sent' }
+  | { outcome: 'skipped' }
+  | { outcome: 'terminal'; code: ChatSendTerminalCode; reason: string }
+  | { outcome: 'retryable'; reason: string }
+  | { outcome: 'aborted'; reason: string }
+) & { degradation?: ChatSendDegradation }
+
+export interface PacedMultiDrawSendOptions {
+  deliveryMode: unknown
+  chunkSize: unknown
+  startCursor: number
+  beforeExternalSend?: () => Promise<boolean>
+  afterSegmentComplete: (nextCursor: number) => Promise<boolean>
+  /** unit test用。productionは固定1.6秒を使用する。 */
+  delay?: (milliseconds: number) => Promise<void>
+  chatService?: Pick<TwitchChatService, 'sendChatMessageDetailed' | 'sendChatMessage'>
+}
+
+const defaultDelay = (milliseconds: number) => new Promise<void>((resolve) => {
+  setTimeout(resolve, milliseconds)
+})
+
+/**
+ * N連のindividual/chunkedを安全な間隔で送る。
+ *
+ * 各segmentのTwitch確定後、次を送る前にdelivery_cursorをowner-fencedで永続化する。
+ * cursor保存に失敗した場合は即停止し、既送信segmentの後へ進まない。429/5xx等の
+ * retryable outcomeはcursorを進めず呼び出し元outbox backoffへ返すため、次claimは
+ * 最後に確定保存できたsegmentから再開できる。
+ */
+export async function sendPacedMultiDrawChatAnnouncement(
+  broadcasterTwitchUserId: string,
+  cards: GachaCard[],
+  userName: string,
+  options: PacedMultiDrawSendOptions,
+): Promise<PacedMultiDrawSendOutcome> {
+  const mode = normalizeMultiDrawChatDeliveryMode(options.deliveryMode)
+  const chunkSize = normalizeMultiDrawChatChunkSize(options.chunkSize)
+  const segments = buildMultiDrawChatSegments(cards, userName, mode, chunkSize)
+  if (segments.length === 0) {
+    return { outcome: 'skipped' }
+  }
+
+  const startCursor = Number.isInteger(options.startCursor)
+    ? Math.max(0, Math.min(options.startCursor, segments.length))
+    : 0
+  if (startCursor >= segments.length) {
+    // 全segment送信済みでackだけ失敗したケース。Twitchへ再送せずoutbox全体をackできる。
+    return { outcome: 'sent' }
+  }
+
+  const chatService = options.chatService ?? new TwitchChatService()
+  const delay = options.delay ?? defaultDelay
+  let degradation: ChatSendDegradation | undefined
+
+  for (let index = startCursor; index < segments.length; index += 1) {
+    if (index > startCursor) {
+      await delay(MULTI_DRAW_CHAT_INTERVAL_MS)
+    }
+
+    const segment = segments[index]
+    if (!segment) {
+      return { outcome: 'retryable', reason: `missing multi-draw segment ${index}` }
+    }
+
+    const rawOutcome = typeof chatService.sendChatMessageDetailed === 'function'
+      ? options.beforeExternalSend
+        ? await chatService.sendChatMessageDetailed(
+            broadcasterTwitchUserId,
+            segment.message,
+            { beforeExternalSend: options.beforeExternalSend },
+          )
+        : await chatService.sendChatMessageDetailed(broadcasterTwitchUserId, segment.message)
+      : (await chatService.sendChatMessage(broadcasterTwitchUserId, segment.message))
+        ? { outcome: 'sent' as const }
+        : { outcome: 'retryable' as const, reason: 'chat send failed' }
+
+    if ('degradation' in rawOutcome && rawOutcome.degradation) {
+      degradation = rawOutcome.degradation
+    }
+
+    if (rawOutcome.outcome === 'sent' || rawOutcome.outcome === 'duplicate') {
+      const persisted = await options.afterSegmentComplete(index + 1)
+      if (!persisted) {
+        return degradation
+          ? {
+              outcome: 'aborted',
+              reason: `multi-draw segment ${index + 1}/${segments.length} sent but cursor update lost its lease`,
+              degradation,
+            }
+          : {
+              outcome: 'aborted',
+              reason: `multi-draw segment ${index + 1}/${segments.length} sent but cursor update lost its lease`,
+            }
+      }
+      continue
+    }
+
+    if (rawOutcome.outcome === 'terminal') {
+      return degradation
+        ? { outcome: 'terminal', code: rawOutcome.code, reason: rawOutcome.reason, degradation }
+        : { outcome: 'terminal', code: rawOutcome.code, reason: rawOutcome.reason }
+    }
+    if (rawOutcome.outcome === 'aborted') {
+      return degradation
+        ? { outcome: 'aborted', reason: rawOutcome.reason, degradation }
+        : { outcome: 'aborted', reason: rawOutcome.reason }
+    }
+    return degradation
+      ? { outcome: 'retryable', reason: rawOutcome.reason, degradation }
+      : { outcome: 'retryable', reason: rawOutcome.reason }
+  }
+
+  return degradation ? { outcome: 'sent', degradation } : { outcome: 'sent' }
+}

--- a/tests/fixtures/paced-multi-draw-chat-postgres.mjs
+++ b/tests/fixtures/paced-multi-draw-chat-postgres.mjs
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict'
+import { execFileSync, spawn } from 'node:child_process'
+
+// No npm dependencies: this runs in the migration job against its disposable PostgreSQL 17.
+const args = ['-X', '-qAt', '-v', 'ON_ERROR_STOP=1',
+  '-h', process.env.PGHOST || '127.0.0.1', '-p', process.env.PGPORT || '5432',
+  '-U', process.env.PGUSER || 'postgres', '-d', process.env.PGDATABASE || 'postgres']
+const query = (sql) => execFileSync('psql', args, { input: sql, encoding: 'utf8' }).trim()
+const streamer = '15490000-0000-4000-8000-000000000001'
+const lease = '15490000-0000-4000-8000-000000000002'
+const staleLease = '15490000-0000-4000-8000-000000000003'
+const id = (n) => `15490000-0000-4000-8000-${String(n).padStart(12, '0')}`
+const resolve = (n, owner = lease) => `SELECT public.resolve_chat_outbox_delivery_mode('${id(n)}', '${owner}');`
+const insert = (n, createdAt, count = 10) => `
+  INSERT INTO public.chat_notification_outbox
+    (id, batch_id, payload, expected_draw_count, assembled_draw_count, status, lease_id, lease_expires_at, created_at)
+  VALUES ('${id(n)}', 'paced-ci-${n}', '{"streamer":{"id":"${streamer}"}}',
+    ${count}, ${count}, 'processing', '${lease}', now() + interval '60 seconds', '${createdAt}');`
+const complete = (n) => query(`UPDATE public.chat_notification_outbox SET status='sent',
+  sent_at=now(), lease_id=NULL, lease_expires_at=NULL WHERE id='${id(n)}';`)
+
+function background(sql) {
+  const child = spawn('psql', args, { stdio: ['pipe', 'pipe', 'pipe'] })
+  let output = ''
+  let error = ''
+  child.stdout.on('data', (data) => { output += data })
+  child.stderr.on('data', (data) => { error += data })
+  const done = new Promise((resolve, reject) => {
+    child.once('error', reject)
+    child.once('close', (code) => code === 0 ? resolve(output.trim()) : reject(new Error(error)))
+  })
+  // A readiness failure still reaches the cleanup below without an unhandled rejection.
+  done.catch(() => {})
+  child.stdin.end(sql)
+  return { child, done }
+}
+
+async function waitForLock(key) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (query(`SELECT pg_try_advisory_xact_lock(1549, ${key});`) === 'f') return
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  throw new Error(`fixture barrier ${key} was not acquired`)
+}
+
+const pending = []
+try {
+  query(`INSERT INTO public.streamers(id,twitch_user_id,twitch_username,twitch_display_name)
+    VALUES('${streamer}','paced-ci','paced-ci','Paced CI');`)
+
+  // No settings: both the migration default and INSERT trigger keep legacy delivery.
+  query(insert(10, '2026-01-01T00:00:00Z'))
+  assert.equal(query(`SELECT delivery_mode || '|' || delivery_cursor || '|' || delivery_chunk_size
+    FROM public.chat_notification_outbox WHERE id='${id(10)}';`), 'summary|0|3')
+  query(`INSERT INTO public.streamer_chat_multi_delivery_settings(streamer_id,delivery_mode,chunk_size)
+    VALUES('${streamer}','individual',3);`)
+  assert.equal(query(resolve(10)), 'summary', 'setting edits cannot alter an existing snapshot')
+  complete(10)
+
+  // Older INSERT remains uncommitted while the newer transaction starts sending.
+  // created_at-only congestion checks incorrectly let BOTH rows choose paced here.
+  const delayedOlder = background(`BEGIN; ${insert(11, '2026-01-01T00:00:01Z')}
+    SELECT pg_advisory_xact_lock(1549,1); SELECT pg_sleep(2); COMMIT; ${resolve(11)}`)
+  pending.push(delayedOlder)
+  await waitForLock(1)
+  query(insert(12, '2026-01-01T00:00:02Z'))
+  assert.equal(query(resolve(12)), 'individual')
+  assert.equal(await delayedOlder.done, 'summary', 'late older commit must see the reserved newer sequence')
+  complete(12)
+  assert.equal(query(resolve(11)), 'summary', 'retry must retain the summary fallback after its blocker finishes')
+  complete(11)
+
+  // Two visible rows deciding concurrently share the same transaction-scoped lock.
+  query(insert(13, '2026-01-01T00:00:03Z') + insert(14, '2026-01-01T00:00:03Z'))
+  const first = background(`BEGIN; ${resolve(13)} SELECT pg_advisory_xact_lock(1549,2);
+    SELECT pg_sleep(2); COMMIT;`)
+  pending.push(first)
+  await waitForLock(2)
+  const second = background(resolve(14))
+  pending.push(second)
+  assert.equal(await first.done, 'individual')
+  assert.equal(await second.done, 'summary', 'same-timestamp rows cannot reserve two paced sequences')
+  assert.equal(query(resolve(13, staleLease)), '', 'a stale owner must not get sending permission')
+  query(`UPDATE public.chat_notification_outbox SET delivery_cursor=6 WHERE id='${id(13)}';`)
+  query(`UPDATE public.streamer_chat_multi_delivery_settings SET delivery_mode='chunked',chunk_size=5
+    WHERE streamer_id='${streamer}';`)
+  assert.equal(query(resolve(13)), 'individual', 'retry preserves the reserved mode and segment layout')
+  assert.equal(query(`SELECT delivery_cursor || '|' || delivery_chunk_size FROM public.chat_notification_outbox
+    WHERE id='${id(13)}';`), '6|3')
+  complete(13)
+  complete(14)
+
+  // A queued older row blocks a new sequence, even while waiting for backoff.
+  query(insert(15, '2026-01-01T00:00:04Z') + insert(16, '2026-01-01T00:00:05Z'))
+  query(`UPDATE public.chat_notification_outbox SET status='pending',next_attempt_at=now()+interval '5 minutes',
+    lease_id=NULL,lease_expires_at=NULL WHERE id='${id(15)}';`)
+  assert.equal(query(resolve(16)), 'summary')
+  complete(15)
+  complete(16)
+
+  // A single draw cannot occupy the paced lane merely because settings say individual.
+  query(insert(17, '2026-01-01T00:00:06Z', 1) + insert(18, '2026-01-01T00:00:07Z'))
+  assert.equal(query(resolve(18)), 'chunked')
+  assert.equal(query(`SELECT has_function_privilege('anon','public.resolve_chat_outbox_delivery_mode(uuid,uuid)','EXECUTE')
+    OR has_function_privilege('authenticated','public.resolve_chat_outbox_delivery_mode(uuid,uuid)','EXECUTE');`), 'f')
+  assert.equal(query(`SET ROLE service_role; ${resolve(18)}`), 'chunked', 'runtime role can execute the resolver')
+  console.log('paced multi-draw PostgreSQL defaults, snapshots, retry reservation, fencing and concurrency checks passed')
+} finally {
+  for (const process of pending) process.child.kill()
+  await Promise.allSettled(pending.map((process) => process.done))
+  query(`DELETE FROM public.chat_notification_outbox WHERE batch_id LIKE 'paced-ci-%';
+    DELETE FROM public.streamers WHERE id='${streamer}';`)
+}

--- a/tests/unit/api/eventsub-replay-route.test.ts
+++ b/tests/unit/api/eventsub-replay-route.test.ts
@@ -1,12 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NextRequest } from 'next/server'
 import { ERROR_MESSAGES, TWITCH_SUBSCRIPTION_TYPE } from '@/lib/constants'
+import { TwitchChatService } from '@/lib/twitch/chat-service'
+import type { RedemptionNotifyData } from '@/lib/services/eventsub-redemption'
 import type { ParkedEventSubRecord } from '@/lib/maintenance/eventsub-park'
 
 const mocks = vi.hoisted(() => ({
   listParkedEventSubNotifications: vi.fn(),
   deleteParkedEventSubNotification: vi.fn(),
+  claimChatNotificationBatch: vi.fn(),
   claimDueChatNotifications: vi.fn(),
+  advanceChatNotificationDeliveryCursor: vi.fn(),
+  resolveChatNotificationDeliveryMode: vi.fn(),
   peekChatNotificationOutboxWork: vi.fn(),
   decodeChatNotificationPayload: vi.fn(),
   markChatNotificationSent: vi.fn(),
@@ -29,13 +34,23 @@ vi.mock('@/lib/maintenance/eventsub-park', () => ({
 }))
 
 vi.mock('@/lib/services/chat-notification-outbox', () => ({
+  claimChatNotificationBatch: mocks.claimChatNotificationBatch,
   claimDueChatNotifications: mocks.claimDueChatNotifications,
+  advanceChatNotificationDeliveryCursor: mocks.advanceChatNotificationDeliveryCursor,
   peekChatNotificationOutboxWork: mocks.peekChatNotificationOutboxWork,
   decodeChatNotificationPayload: mocks.decodeChatNotificationPayload,
   markChatNotificationSent: mocks.markChatNotificationSent,
   renewChatNotificationLease: mocks.renewChatNotificationLease,
   deadLetterChatNotification: mocks.deadLetterChatNotification,
   retryChatNotification: mocks.retryChatNotification,
+}))
+
+vi.mock('@/lib/services/chat-notification-congestion', () => ({
+  resolveChatNotificationDeliveryMode: mocks.resolveChatNotificationDeliveryMode,
+}))
+
+vi.mock('@/lib/overlay-realtime/publisher', () => ({
+  publishCommittedGachaBatch: vi.fn().mockResolvedValue({ outcome: 'skipped', attempts: 0 }),
 }))
 
 vi.mock('@/lib/services/eventsub-redemption', () => ({
@@ -197,10 +212,15 @@ describe('POST /api/admin/eventsub-replay', () => {
     mocks.renewChatNotificationLease.mockResolvedValue(true)
     mocks.deadLetterChatNotification.mockResolvedValue(true)
     mocks.retryChatNotification.mockResolvedValue('pending')
+    mocks.advanceChatNotificationDeliveryCursor.mockReset()
+    mocks.advanceChatNotificationDeliveryCursor.mockResolvedValue(true)
+    mocks.resolveChatNotificationDeliveryMode.mockReset()
+    mocks.resolveChatNotificationDeliveryMode.mockImplementation(async (claim) => claim.deliveryMode)
     mocks.reportError.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.useRealTimers()
     delete process.env.EVENTSUB_REPLAY_SECRET
   })
@@ -316,6 +336,161 @@ describe('POST /api/admin/eventsub-replay', () => {
   })
 
   describe('transactional chat outbox の処理', () => {
+    describe('paced delivery across live owner and relay', () => {
+      function makePacedClaim(cursor = 0) {
+        const cards = Array.from({ length: 10 }, (_, index) => ({
+          id: `card-${index + 1}`, name: `Card ${index + 1}`, description: null,
+          image_url: null, rarity: 'rare', drop_rate: 1,
+        }))
+        return {
+          ...makeChatOutboxClaim({ card: cards[0], cards }),
+          deliveryMode: 'individual' as const,
+          deliveryChunkSize: 3,
+          deliveryCursor: cursor,
+        }
+      }
+
+      it('resumes at segment 7 in the relay after the live owner sends 6 then gets 429', async () => {
+        vi.useFakeTimers()
+        const claim = makePacedClaim()
+        mocks.claimChatNotificationBatch.mockResolvedValue(claim)
+        const successfulMessages: string[] = []
+        let attempts = 0
+        const send = vi.spyOn(TwitchChatService.prototype, 'sendChatMessageDetailed')
+          .mockImplementation(async (_broadcaster, message, options) => {
+            expect(await options?.beforeExternalSend?.()).toBe(true)
+            // Ack must not happen while any segment remains unsent or uncheckpointed.
+            expect(mocks.markChatNotificationSent).not.toHaveBeenCalled()
+            attempts += 1
+            if (attempts === 7) return { outcome: 'retryable', reason: 'Twitch API 429' }
+            successfulMessages.push(message)
+            return { outcome: 'sent' }
+          })
+        const { postRedemptionNotify } = await vi.importActual<
+          typeof import('@/lib/services/eventsub-redemption')
+        >('@/lib/services/eventsub-redemption')
+        const firstAttempt = postRedemptionNotify(claim.payload as RedemptionNotifyData)
+        await vi.advanceTimersByTimeAsync(6 * 1600)
+        await firstAttempt
+
+        expect(claim.deliveryCursor).toBe(6)
+        expect(mocks.retryChatNotification).toHaveBeenCalledExactlyOnceWith(claim, 'Twitch API 429')
+        expect(mocks.markChatNotificationSent).not.toHaveBeenCalled()
+        expect(mocks.sendChatAnnouncement).not.toHaveBeenCalled()
+        expect(mocks.reportError).not.toHaveBeenCalled()
+
+        // A new owner receives the persisted checkpoint and the same snapshotted mode.
+        const retryClaim = { ...claim, leaseId: 'relay-lease', attemptCount: 2 }
+        mocks.claimDueChatNotifications.mockResolvedValueOnce([retryClaim]).mockResolvedValueOnce([])
+        mocks.markChatNotificationSent.mockImplementationOnce(async (completedClaim) => {
+          expect(completedClaim.deliveryCursor).toBe(10)
+          expect(successfulMessages).toHaveLength(10)
+          return true
+        })
+        const { POST } = await import('@/app/api/admin/eventsub-replay/route')
+        const retry = POST(createReplayRequest({}))
+        await vi.advanceTimersByTimeAsync(3 * 1600)
+        const json = await (await retry).json()
+
+        expect(send.mock.calls[7]?.[1]).toContain('7/10')
+        expect(successfulMessages.map((message) => message.match(/ (\d+)\/10:/)?.[1]))
+          .toEqual(['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'])
+        expect(mocks.advanceChatNotificationDeliveryCursor.mock.calls.map(([, cursor]) => cursor))
+          .toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        expect(mocks.renewChatNotificationLease).toHaveBeenCalledTimes(11)
+        expect(mocks.markChatNotificationSent).toHaveBeenCalledExactlyOnceWith(retryClaim)
+        expect(mocks.retryChatNotification).toHaveBeenCalledTimes(1)
+        expect(mocks.sendChatAnnouncement).not.toHaveBeenCalled()
+        expect(json.results[0].outcome).toBe('succeeded')
+      })
+
+      it.each(['lost lease', 'storage exception'])('stops the relay on cursor %s before any later segment', async (failure) => {
+        vi.useFakeTimers()
+        const claim = makePacedClaim(6)
+        mocks.claimDueChatNotifications.mockResolvedValueOnce([claim]).mockResolvedValueOnce([])
+        if (failure === 'lost lease') {
+          mocks.advanceChatNotificationDeliveryCursor.mockResolvedValueOnce(false)
+        } else {
+          mocks.advanceChatNotificationDeliveryCursor.mockRejectedValueOnce(new Error('cursor storage unavailable'))
+        }
+        const send = vi.spyOn(TwitchChatService.prototype, 'sendChatMessageDetailed')
+          .mockImplementation(async (_broadcaster, _message, options) => {
+            expect(await options?.beforeExternalSend?.()).toBe(true)
+            return { outcome: 'sent' }
+          })
+        const { POST } = await import('@/app/api/admin/eventsub-replay/route')
+        const json = await (await POST(createReplayRequest({}))).json()
+
+        expect(send).toHaveBeenCalledTimes(1)
+        expect(send.mock.calls[0]?.[1]).toContain('7/10')
+        expect(mocks.advanceChatNotificationDeliveryCursor).toHaveBeenCalledExactlyOnceWith(claim, 7)
+        expect(claim.deliveryCursor).toBe(6)
+        expect(mocks.markChatNotificationSent).not.toHaveBeenCalled()
+        expect(mocks.sendChatAnnouncement).not.toHaveBeenCalled()
+        if (failure === 'lost lease') expect(mocks.retryChatNotification).not.toHaveBeenCalled()
+        expect(json.results[0].outcome).toBe('failed')
+      })
+
+      it('does not send when resolving the initial delivery mode loses ownership', async () => {
+        const claim = makePacedClaim()
+        mocks.claimDueChatNotifications.mockResolvedValueOnce([claim]).mockResolvedValueOnce([])
+        mocks.resolveChatNotificationDeliveryMode.mockResolvedValueOnce(null)
+        const send = vi.spyOn(TwitchChatService.prototype, 'sendChatMessageDetailed')
+        const { POST } = await import('@/app/api/admin/eventsub-replay/route')
+        const json = await (await POST(createReplayRequest({}))).json()
+
+        expect(send).not.toHaveBeenCalled()
+        expect(mocks.sendChatAnnouncement).not.toHaveBeenCalled()
+        expect(mocks.markChatNotificationSent).not.toHaveBeenCalled()
+        expect(mocks.retryChatNotification).not.toHaveBeenCalled()
+        expect(json.results[0]).toMatchObject({ outcome: 'failed', error: 'Chat delivery mode update lost its lease' })
+      })
+
+      it('checks the lease again before the next segment and aborts without ack or retry when lost', async () => {
+        vi.useFakeTimers()
+        const claim = makePacedClaim(6)
+        mocks.claimDueChatNotifications.mockResolvedValueOnce([claim]).mockResolvedValueOnce([])
+        mocks.renewChatNotificationLease.mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+        const messages: string[] = []
+        vi.spyOn(TwitchChatService.prototype, 'sendChatMessageDetailed')
+          .mockImplementation(async (_broadcaster, message, options) => {
+            if (!await options?.beforeExternalSend?.()) {
+              return { outcome: 'aborted', reason: 'chat delivery ownership lost before send' }
+            }
+            messages.push(message)
+            return { outcome: 'sent' }
+          })
+        const { POST } = await import('@/app/api/admin/eventsub-replay/route')
+        const pending = POST(createReplayRequest({}))
+        await vi.advanceTimersByTimeAsync(1600)
+        const json = await (await pending).json()
+
+        expect(messages).toHaveLength(1)
+        expect(messages[0]).toContain('7/10')
+        expect(claim.deliveryCursor).toBe(7)
+        expect(mocks.renewChatNotificationLease).toHaveBeenCalledTimes(2)
+        expect(mocks.markChatNotificationSent).not.toHaveBeenCalled()
+        expect(mocks.retryChatNotification).not.toHaveBeenCalled()
+        expect(json.results[0].outcome).toBe('failed')
+      })
+
+      it('only acknowledges a completed cursor and reports a lost final lease without resending', async () => {
+        const claim = makePacedClaim(10)
+        mocks.claimDueChatNotifications.mockResolvedValueOnce([claim]).mockResolvedValueOnce([])
+        mocks.markChatNotificationSent.mockResolvedValueOnce(false)
+        const send = vi.spyOn(TwitchChatService.prototype, 'sendChatMessageDetailed')
+        const { POST } = await import('@/app/api/admin/eventsub-replay/route')
+        const json = await (await POST(createReplayRequest({}))).json()
+
+        expect(send).not.toHaveBeenCalled()
+        expect(mocks.sendChatAnnouncement).not.toHaveBeenCalled()
+        expect(mocks.advanceChatNotificationDeliveryCursor).not.toHaveBeenCalled()
+        expect(mocks.markChatNotificationSent).toHaveBeenCalledExactlyOnceWith(claim)
+        expect(json.results[0]).toMatchObject({ outcome: 'failed', error: 'sent, but outbox ack lost its lease' })
+        expect(mocks.reportError).toHaveBeenCalledTimes(1)
+      })
+    })
+
     it('chat送信成功時はowner-fenced sentへ更新する', async () => {
       const claim = makeChatOutboxClaim()
       mocks.claimDueChatNotifications

--- a/tests/unit/chat-multi-delivery-api.test.ts
+++ b/tests/unit/chat-multi-delivery-api.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const mocks = vi.hoisted(() => ({
+  sql: vi.fn(),
+  getDb: vi.fn(),
+  session: vi.fn(),
+  csrf: vi.fn(),
+  limit: vi.fn(),
+  identifier: vi.fn(),
+}))
+
+vi.mock('@/lib/csrf', () => ({ validateCSRFToken: mocks.csrf }))
+vi.mock('@/lib/session', () => ({
+  getSession: mocks.session,
+  canUseStreamerFeatures: () => true,
+}))
+vi.mock('@/lib/db/client', () => ({ getDb: mocks.getDb }))
+vi.mock('@/lib/db/retry', () => ({
+  withDbRetry: async <T>(fn: () => Promise<T>) => fn(),
+}))
+vi.mock('@/lib/rate-limit', () => ({
+  getRateLimitIdentifier: mocks.identifier,
+  checkRateLimit: mocks.limit,
+  rateLimits: { streamerSettings: {} },
+}))
+
+import { GET, PUT } from '@/app/api/streamer/chat-multi-delivery/route'
+
+function request(method: string, body?: unknown) {
+  return new NextRequest('https://twica.live/api/streamer/chat-multi-delivery', {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.sql.mockReset()
+  mocks.getDb.mockResolvedValue({ sql: mocks.sql })
+  mocks.session.mockResolvedValue({ twitchUserId: 'viewer' })
+  mocks.csrf.mockResolvedValue({ valid: true })
+  mocks.identifier.mockResolvedValue('viewer')
+  mocks.limit.mockResolvedValue({ success: true, limit: 30, remaining: 29, reset: 0 })
+})
+
+describe('multi-draw chat delivery settings API', () => {
+  it('returns summary defaults for an existing streamer without saved settings', async () => {
+    mocks.sql.mockResolvedValueOnce([{
+      streamer_id: '00000000-0000-4000-8000-000000000001',
+      delivery_mode: null,
+      chunk_size: null,
+    }])
+
+    const response = await GET(request('GET'))
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      deliveryMode: 'summary',
+      chunkSize: 3,
+      intervalMs: 1600,
+    })
+  })
+
+  it('rejects PUT without CSRF before database access', async () => {
+    mocks.csrf.mockResolvedValue({ valid: false })
+    const response = await PUT(request('PUT', { deliveryMode: 'individual', chunkSize: 3 }))
+    expect(response.status).toBe(403)
+    expect(mocks.getDb).not.toHaveBeenCalled()
+  })
+
+  it('rejects unauthenticated reads', async () => {
+    mocks.session.mockResolvedValue(null)
+    const response = await GET(request('GET'))
+    expect(response.status).toBe(401)
+    expect(mocks.getDb).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unknown delivery mode without SQL', async () => {
+    const response = await PUT(request('PUT', { deliveryMode: 'burst', chunkSize: 3 }))
+    expect(response.status).toBe(400)
+    expect(mocks.getDb).not.toHaveBeenCalled()
+  })
+
+  it.each([1, 6, 2.5, '3'])('rejects invalid chunk size %s without SQL', async (chunkSize) => {
+    const response = await PUT(request('PUT', { deliveryMode: 'chunked', chunkSize }))
+    expect(response.status).toBe(400)
+    expect(mocks.getDb).not.toHaveBeenCalled()
+  })
+
+  it.each(['summary', 'individual', 'chunked'] as const)(
+    'persists valid %s settings for the authenticated streamer',
+    async (deliveryMode) => {
+      mocks.sql
+        .mockResolvedValueOnce([{
+          streamer_id: '00000000-0000-4000-8000-000000000001',
+          delivery_mode: 'summary',
+          chunk_size: 3,
+        }])
+        .mockResolvedValueOnce([])
+
+      const response = await PUT(request('PUT', { deliveryMode, chunkSize: 4 }))
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({
+        success: true,
+        deliveryMode,
+        chunkSize: 4,
+        intervalMs: 1600,
+      })
+      expect(mocks.sql).toHaveBeenCalledTimes(2)
+    },
+  )
+})

--- a/tests/unit/chat-notification-congestion.test.ts
+++ b/tests/unit/chat-notification-congestion.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getDb: vi.fn(),
+  sql: vi.fn(),
+}))
+
+vi.mock('@/lib/db/client', () => ({ getDb: mocks.getDb }))
+vi.mock('@/lib/db/retry', () => ({
+  withDbRetry: async <T>(fn: () => Promise<T>) => fn(),
+}))
+
+import { hasOlderPacedChatNotification } from '@/lib/services/chat-notification-congestion'
+
+const claim = {
+  id: '11111111-1111-4111-8111-111111111111',
+  createdAt: '2026-09-12T00:00:01.000Z',
+}
+
+describe('hasOlderPacedChatNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getDb.mockResolvedValue({ sql: mocks.sql })
+  })
+
+  it('returns true when an older paced row is still pending/processing', async () => {
+    mocks.sql.mockResolvedValue([{ busy: true }])
+
+    await expect(hasOlderPacedChatNotification(claim, 'streamer-1')).resolves.toBe(true)
+
+    const [strings, ...values] = mocks.sql.mock.calls[0] as [TemplateStringsArray, ...unknown[]]
+    const query = strings.join('?')
+    expect(query).toContain("older.status in ('pending', 'processing')")
+    expect(query).toContain("older.delivery_mode in ('individual', 'chunked')")
+    expect(query).toContain("older.payload #>> '{streamer,id}'")
+    expect(query).toContain('older.created_at <')
+    expect(query).toContain('older.id::text <')
+    expect(values).toContain(claim.id)
+    expect(values).toContain(claim.createdAt)
+    expect(values).toContain('streamer-1')
+  })
+
+  it('returns false when the channel has no older paced row', async () => {
+    mocks.sql.mockResolvedValue([{ busy: false }])
+    await expect(hasOlderPacedChatNotification(claim, 'streamer-1')).resolves.toBe(false)
+  })
+
+  it('fails closed to no pacing decision when the query shape is unexpectedly empty', async () => {
+    mocks.sql.mockResolvedValue([])
+    await expect(hasOlderPacedChatNotification(claim, 'streamer-1')).resolves.toBe(false)
+  })
+})

--- a/tests/unit/chat-notification-congestion.test.ts
+++ b/tests/unit/chat-notification-congestion.test.ts
@@ -1,52 +1,38 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mocks = vi.hoisted(() => ({
-  getDb: vi.fn(),
-  sql: vi.fn(),
-}))
-
+const mocks = vi.hoisted(() => ({ getDb: vi.fn(), sql: vi.fn() }))
 vi.mock('@/lib/db/client', () => ({ getDb: mocks.getDb }))
 vi.mock('@/lib/db/retry', () => ({
   withDbRetry: async <T>(fn: () => Promise<T>) => fn(),
 }))
-
-import { hasOlderPacedChatNotification } from '@/lib/services/chat-notification-congestion'
+import { resolveChatNotificationDeliveryMode } from '@/lib/services/chat-notification-congestion'
 
 const claim = {
   id: '11111111-1111-4111-8111-111111111111',
-  createdAt: '2026-09-12T00:00:01.000Z',
+  leaseId: '22222222-2222-4222-8222-222222222222',
 }
 
-describe('hasOlderPacedChatNotification', () => {
+describe('resolveChatNotificationDeliveryMode', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.getDb.mockResolvedValue({ sql: mocks.sql })
   })
 
-  it('returns true when an older paced row is still pending/processing', async () => {
-    mocks.sql.mockResolvedValue([{ busy: true }])
-
-    await expect(hasOlderPacedChatNotification(claim, 'streamer-1')).resolves.toBe(true)
-
+  it.each(['summary', 'individual', 'chunked'] as const)('uses the persisted %s decision from the fenced RPC', async (mode) => {
+    mocks.sql.mockResolvedValue([{ mode }])
+    await expect(resolveChatNotificationDeliveryMode(claim)).resolves.toBe(mode)
     const [strings, ...values] = mocks.sql.mock.calls[0] as [TemplateStringsArray, ...unknown[]]
-    const query = strings.join('?')
-    expect(query).toContain("older.status in ('pending', 'processing')")
-    expect(query).toContain("older.delivery_mode in ('individual', 'chunked')")
-    expect(query).toContain("older.payload #>> '{streamer,id}'")
-    expect(query).toContain('older.created_at <')
-    expect(query).toContain('older.id::text <')
-    expect(values).toContain(claim.id)
-    expect(values).toContain(claim.createdAt)
-    expect(values).toContain('streamer-1')
+    expect(strings.join('?')).toContain('public.resolve_chat_outbox_delivery_mode')
+    expect(values).toEqual([claim.id, claim.leaseId])
   })
 
-  it('returns false when the channel has no older paced row', async () => {
-    mocks.sql.mockResolvedValue([{ busy: false }])
-    await expect(hasOlderPacedChatNotification(claim, 'streamer-1')).resolves.toBe(false)
+  it.each([[{ mode: null }], [], [{ mode: 'unknown' }]])('fails closed on lost lease or invalid response %j', async (...rows) => {
+    mocks.sql.mockResolvedValue(rows)
+    await expect(resolveChatNotificationDeliveryMode(claim)).resolves.toBeNull()
   })
 
-  it('fails closed to no pacing decision when the query shape is unexpectedly empty', async () => {
-    mocks.sql.mockResolvedValue([])
-    await expect(hasOlderPacedChatNotification(claim, 'streamer-1')).resolves.toBe(false)
+  it('does not turn database failure into permission to send', async () => {
+    mocks.sql.mockRejectedValue(new Error('database unavailable'))
+    await expect(resolveChatNotificationDeliveryMode(claim)).rejects.toThrow('database unavailable')
   })
 })

--- a/tests/unit/chat-notification-outbox.test.ts
+++ b/tests/unit/chat-notification-outbox.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDb } from '@/lib/db/client'
 import {
   CHAT_OUTBOX_MAX_ATTEMPTS,
+  advanceChatNotificationDeliveryCursor,
   claimChatNotificationBatch,
   claimDueChatNotifications,
   decodeChatNotificationPayload,
@@ -39,6 +40,42 @@ const CLAIM_ROW = {
 describe('transactional chat outbox claim/ack', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+
+  it('keeps pre-migration claim SQL free of unavailable delivery columns', async () => {
+    const sqlMock = createSqlMock([[CLAIM_ROW]])
+    vi.mocked(getDb).mockResolvedValue({ db: {} as never, sql: sqlMock as never })
+    await claimChatNotificationBatch('batch-1')
+    await claimDueChatNotifications(1, { maintain: false })
+    for (let index = 0; index < 2; index += 1) {
+      expect(renderSqlCall(sqlMock, index).text).not.toContain('delivery_')
+    }
+  })
+
+  it('carries committed segment progress into a reclaimed notification', async () => {
+    const sqlMock = createSqlMock([[{
+      ...CLAIM_ROW, delivery_mode: 'individual', delivery_chunk_size: 3, delivery_cursor: 6,
+    }]])
+    vi.mocked(getDb).mockResolvedValue({ db: {} as never, sql: sqlMock as never })
+    await expect(claimChatNotificationBatch('batch-1')).resolves.toMatchObject({
+      deliveryMode: 'individual', deliveryChunkSize: 3, deliveryCursor: 6,
+    })
+  })
+
+  it('checkpoints only through a processing owner and keeps the cursor monotonic', async () => {
+    const sqlMock = createSqlMock([[{ id: CLAIM_ROW.id }], []])
+    vi.mocked(getDb).mockResolvedValue({ db: {} as never, sql: sqlMock as never })
+    const claim = { id: CLAIM_ROW.id, leaseId: CLAIM_ROW.lease_id }
+    await expect(advanceChatNotificationDeliveryCursor(claim, 6)).resolves.toBe(true)
+    await expect(advanceChatNotificationDeliveryCursor(claim, 7)).resolves.toBe(false)
+    const query = renderSqlCall(sqlMock, 0)
+    expect(query.text).toContain('greatest(delivery_cursor, $::integer)')
+    expect(query.text).toContain("status = 'processing'")
+    expect(query.text).toContain('lease_id = $::uuid')
+    expect(query.values).toContain(CLAIM_ROW.lease_id)
+    await expect(advanceChatNotificationDeliveryCursor(claim, -1)).resolves.toBe(false)
+    expect(sqlMock).toHaveBeenCalledTimes(2)
   })
 
   it('期限到来順をFOR UPDATE SKIP LOCKEDでclaimし、同時relayの重複取得を避ける', async () => {

--- a/tests/unit/multi-draw-chat.test.ts
+++ b/tests/unit/multi-draw-chat.test.ts
@@ -44,7 +44,7 @@ describe('multi-draw chat segmentation', () => {
 
     expect(segments).toHaveLength(5)
     expect(segments[0]?.message).toContain('1-3/15')
-    expect(segments[0]?.message).toContain('レアx1、コモンx2')
+    expect(segments[0]?.message).toContain('Rx1, Cx2')
     expect(segments[4]?.message).toContain('13-15/15')
   })
 

--- a/tests/unit/multi-draw-chat.test.ts
+++ b/tests/unit/multi-draw-chat.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildMultiDrawChatSegments,
+  DEFAULT_MULTI_DRAW_CHAT_CHUNK_SIZE,
+  MULTI_DRAW_CHAT_INTERVAL_MS,
+  normalizeMultiDrawChatChunkSize,
+  normalizeMultiDrawChatDeliveryMode,
+} from '@/lib/twitch/multi-draw-chat'
+import type { GachaCard } from '@/lib/services/gacha'
+
+function card(index: number, rarity = 'common'): GachaCard {
+  return {
+    id: `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+    name: `カード${index}`,
+    description: null,
+    image_url: null,
+    rarity,
+    drop_rate: 1,
+  }
+}
+
+describe('multi-draw chat segmentation', () => {
+  it('summary keeps the legacy one-message path', () => {
+    expect(buildMultiDrawChatSegments([card(1), card(2)], 'user', 'summary')).toEqual([])
+  })
+
+  it.each([5, 10, 15])('individual builds one ordered segment per draw (%i draws)', (count) => {
+    const cards = Array.from({ length: count }, (_, index) => card(index + 1))
+    const segments = buildMultiDrawChatSegments(cards, 'user', 'individual')
+
+    expect(segments).toHaveLength(count)
+    expect(segments[0]?.message).toContain(`1/${count}:`)
+    expect(segments[count - 1]?.message).toContain(`${count}/${count}:`)
+    expect(segments.map((segment) => segment.index)).toEqual(
+      Array.from({ length: count }, (_, index) => index),
+    )
+  })
+
+  it('chunked splits 15 draws into deterministic 3-card messages', () => {
+    const cards = Array.from({ length: 15 }, (_, index) =>
+      card(index + 1, index === 0 ? 'rare' : 'common'),
+    )
+    const segments = buildMultiDrawChatSegments(cards, 'user', 'chunked', 3)
+
+    expect(segments).toHaveLength(5)
+    expect(segments[0]?.message).toContain('1-3/15')
+    expect(segments[0]?.message).toContain('レアx1、コモンx2')
+    expect(segments[4]?.message).toContain('13-15/15')
+  })
+
+  it('chunked preserves the final remainder', () => {
+    const cards = Array.from({ length: 10 }, (_, index) => card(index + 1))
+    const segments = buildMultiDrawChatSegments(cards, 'user', 'chunked', 3)
+
+    expect(segments).toHaveLength(4)
+    expect(segments[3]?.startDraw).toBe(10)
+    expect(segments[3]?.endDraw).toBe(10)
+    expect(segments[3]?.message).toContain('10/10')
+  })
+
+  it('normalizes invalid persisted settings fail-safe to summary / chunk size 3', () => {
+    expect(normalizeMultiDrawChatDeliveryMode('unexpected')).toBe('summary')
+    expect(normalizeMultiDrawChatDeliveryMode(undefined)).toBe('summary')
+    expect(normalizeMultiDrawChatChunkSize(1)).toBe(2)
+    expect(normalizeMultiDrawChatChunkSize(99)).toBe(5)
+    expect(normalizeMultiDrawChatChunkSize('3')).toBe(DEFAULT_MULTI_DRAW_CHAT_CHUNK_SIZE)
+  })
+
+  it('uses a pacing interval above the one-message-per-second boundary', () => {
+    expect(MULTI_DRAW_CHAT_INTERVAL_MS).toBeGreaterThanOrEqual(1_500)
+  })
+})

--- a/tests/unit/multi-draw-chat.test.ts
+++ b/tests/unit/multi-draw-chat.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest'
+import { TWITCH_CHAT_MESSAGE_MAX_CHARACTERS } from '@/lib/constants'
+import { countCharacters } from '@/lib/text-utils'
 import {
   buildMultiDrawChatSegments,
   DEFAULT_MULTI_DRAW_CHAT_CHUNK_SIZE,
@@ -56,6 +58,31 @@ describe('multi-draw chat segmentation', () => {
     expect(segments[3]?.startDraw).toBe(10)
     expect(segments[3]?.endDraw).toBe(10)
     expect(segments[3]?.message).toContain('10/10')
+  })
+
+  it('preserves segment context and reports omitted chunk names within the Twitch limit', () => {
+    const cards = [1, 2, 3].map((index) => ({
+      ...card(index),
+      name: `${index}-${'x'.repeat(300)}`,
+    }))
+    const [segment] = buildMultiDrawChatSegments(cards, 'user', 'chunked', 3)
+
+    expect(segment?.message).toContain('1-3/3: Cx3 / ')
+    expect(segment?.message).toContain('…(+2)')
+    expect(countCharacters(segment?.message ?? '')).toBeLessThanOrEqual(
+      TWITCH_CHAT_MESSAGE_MAX_CHARACTERS,
+    )
+  })
+
+  it('truncates only an oversized individual card-name tail and keeps draw context', () => {
+    const cards = [
+      { ...card(1), name: 'x'.repeat(700) },
+      card(2),
+    ]
+    const [segment] = buildMultiDrawChatSegments(cards, 'user', 'individual')
+
+    expect(segment?.message).toMatch(/^@user 2x 1\/2: \[C\] /)
+    expect(countCharacters(segment?.message ?? '')).toBe(TWITCH_CHAT_MESSAGE_MAX_CHARACTERS)
   })
 
   it('normalizes invalid persisted settings fail-safe to summary / chunk size 3', () => {

--- a/tests/unit/paced-multi-draw-chat-migration.test.ts
+++ b/tests/unit/paced-multi-draw-chat-migration.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const migration = readFileSync(
+  resolve(process.cwd(), 'db/planetscale/migrations/20260912013000_paced_multi_draw_chat.sql'),
+  'utf8',
+)
+
+describe('paced multi-draw chat migration', () => {
+  it('keeps existing streamers and existing outbox rows on summary mode', () => {
+    expect(migration).toContain("delivery_mode text NOT NULL DEFAULT 'summary'")
+    expect(migration).toContain('delivery_chunk_size integer NOT NULL DEFAULT 3')
+    expect(migration).toContain('delivery_cursor integer NOT NULL DEFAULT 0')
+  })
+
+  it('constrains persisted delivery modes, chunk sizes, and cursor', () => {
+    expect(migration).toContain("CHECK (delivery_mode IN ('summary', 'individual', 'chunked'))")
+    expect(migration).toContain('CHECK (chunk_size BETWEEN 2 AND 5)')
+    expect(migration).toContain('CHECK (delivery_cursor >= 0)')
+  })
+
+  it('snapshots streamer delivery settings into each transactional outbox row', () => {
+    expect(migration).toContain('CREATE OR REPLACE FUNCTION public.snapshot_chat_outbox_delivery_settings()')
+    expect(migration).toContain("NEW.payload #>> '{streamer,id}'")
+    expect(migration).toContain('BEFORE INSERT ON public.chat_notification_outbox')
+    expect(migration).toContain('NEW.delivery_cursor := 0')
+  })
+
+  it('keeps settings runtime-only and grants service_role access', () => {
+    expect(migration).toContain(
+      'REVOKE ALL ON TABLE public.streamer_chat_multi_delivery_settings FROM PUBLIC, anon, authenticated',
+    )
+    expect(migration).toContain(
+      'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.streamer_chat_multi_delivery_settings TO service_role',
+    )
+  })
+})

--- a/tests/unit/paced-multi-draw-sender.test.ts
+++ b/tests/unit/paced-multi-draw-sender.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest'
+import { sendPacedMultiDrawChatAnnouncement } from '@/lib/twitch/paced-multi-draw-sender'
+import type { GachaCard } from '@/lib/services/gacha'
+
+function card(index: number): GachaCard {
+  return {
+    id: `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`,
+    name: `カード${index}`,
+    description: null,
+    image_url: null,
+    rarity: 'common',
+    drop_rate: 1,
+  }
+}
+
+describe('sendPacedMultiDrawChatAnnouncement', () => {
+  it('persists cursor after each segment and resumes from it', async () => {
+    const sendChatMessageDetailed = vi.fn()
+      .mockResolvedValueOnce({ outcome: 'sent' })
+      .mockResolvedValueOnce({ outcome: 'sent' })
+    const afterSegmentComplete = vi.fn().mockResolvedValue(true)
+    const delay = vi.fn().mockResolvedValue(undefined)
+
+    await expect(sendPacedMultiDrawChatAnnouncement(
+      'broadcaster',
+      [card(1), card(2), card(3)],
+      'user',
+      {
+        deliveryMode: 'individual',
+        chunkSize: 3,
+        startCursor: 1,
+        afterSegmentComplete,
+        delay,
+        chatService: {
+          sendChatMessageDetailed,
+          sendChatMessage: vi.fn(),
+        },
+      },
+    )).resolves.toEqual({ outcome: 'sent' })
+
+    expect(sendChatMessageDetailed).toHaveBeenCalledTimes(2)
+    expect(sendChatMessageDetailed.mock.calls[0]?.[1]).toContain('2/3')
+    expect(sendChatMessageDetailed.mock.calls[1]?.[1]).toContain('3/3')
+    expect(afterSegmentComplete.mock.calls.map(([cursor]) => cursor)).toEqual([2, 3])
+    expect(delay).toHaveBeenCalledTimes(1)
+    expect(delay).toHaveBeenCalledWith(1600)
+  })
+
+  it('stops before the next segment if cursor persistence loses the lease', async () => {
+    const sendChatMessageDetailed = vi.fn().mockResolvedValue({ outcome: 'sent' })
+
+    const outcome = await sendPacedMultiDrawChatAnnouncement(
+      'broadcaster',
+      [card(1), card(2), card(3)],
+      'user',
+      {
+        deliveryMode: 'individual',
+        chunkSize: 3,
+        startCursor: 0,
+        afterSegmentComplete: vi.fn().mockResolvedValue(false),
+        delay: vi.fn().mockResolvedValue(undefined),
+        chatService: {
+          sendChatMessageDetailed,
+          sendChatMessage: vi.fn(),
+        },
+      },
+    )
+
+    expect(outcome.outcome).toBe('aborted')
+    expect(sendChatMessageDetailed).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps cursor on 429 so retry can restart at the unsent segment', async () => {
+    const afterSegmentComplete = vi.fn().mockResolvedValue(true)
+    const sendChatMessageDetailed = vi.fn()
+      .mockResolvedValueOnce({ outcome: 'sent' })
+      .mockResolvedValueOnce({ outcome: 'retryable', reason: '429 rate limited' })
+
+    const outcome = await sendPacedMultiDrawChatAnnouncement(
+      'broadcaster',
+      [card(1), card(2), card(3)],
+      'user',
+      {
+        deliveryMode: 'individual',
+        chunkSize: 3,
+        startCursor: 0,
+        afterSegmentComplete,
+        delay: vi.fn().mockResolvedValue(undefined),
+        chatService: {
+          sendChatMessageDetailed,
+          sendChatMessage: vi.fn(),
+        },
+      },
+    )
+
+    expect(outcome).toEqual({ outcome: 'retryable', reason: '429 rate limited' })
+    expect(afterSegmentComplete).toHaveBeenCalledTimes(1)
+    expect(afterSegmentComplete).toHaveBeenLastCalledWith(1)
+  })
+
+  it('treats Twitch duplicate as completed and advances the cursor', async () => {
+    const afterSegmentComplete = vi.fn().mockResolvedValue(true)
+    const sendChatMessageDetailed = vi.fn()
+      .mockResolvedValueOnce({ outcome: 'duplicate', reason: 'msg_duplicate' })
+      .mockResolvedValueOnce({ outcome: 'sent' })
+
+    const outcome = await sendPacedMultiDrawChatAnnouncement(
+      'broadcaster',
+      [card(1), card(2)],
+      'user',
+      {
+        deliveryMode: 'individual',
+        chunkSize: 3,
+        startCursor: 0,
+        afterSegmentComplete,
+        delay: vi.fn().mockResolvedValue(undefined),
+        chatService: {
+          sendChatMessageDetailed,
+          sendChatMessage: vi.fn(),
+        },
+      },
+    )
+
+    expect(outcome).toEqual({ outcome: 'sent' })
+    expect(afterSegmentComplete.mock.calls.map(([cursor]) => cursor)).toEqual([1, 2])
+  })
+
+  it('does not re-send when every segment is already cursor-acked', async () => {
+    const sendChatMessageDetailed = vi.fn()
+
+    await expect(sendPacedMultiDrawChatAnnouncement(
+      'broadcaster',
+      [card(1), card(2)],
+      'user',
+      {
+        deliveryMode: 'individual',
+        chunkSize: 3,
+        startCursor: 2,
+        afterSegmentComplete: vi.fn().mockResolvedValue(true),
+        delay: vi.fn().mockResolvedValue(undefined),
+        chatService: {
+          sendChatMessageDetailed,
+          sendChatMessage: vi.fn(),
+        },
+      },
+    )).resolves.toEqual({ outcome: 'sent' })
+
+    expect(sendChatMessageDetailed).not.toHaveBeenCalled()
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     ],
     "paths": {
       "@/lib/services/eventsub-redemption": ["./src/lib/services/eventsub-redemption-delivery.ts"],
+      "@/components/ChatAnnouncementSettings": ["./src/components/ChatAnnouncementSettingsWithDelivery.tsx"],
       "@/*": ["./src/*"]
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,6 @@
       }
     ],
     "paths": {
-      "@/lib/services/eventsub-redemption": ["./src/lib/services/eventsub-redemption-delivery.ts"],
       "@/components/ChatAnnouncementSettings": ["./src/components/ChatAnnouncementSettingsWithDelivery.tsx"],
       "@/*": ["./src/*"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
       }
     ],
     "paths": {
+      "@/lib/services/eventsub-redemption": ["./src/lib/services/eventsub-redemption-delivery.ts"],
       "@/*": ["./src/*"]
     }
   },


### PR DESCRIPTION
## 変更内容

Closes #1549

N連ガチャのチャット通知方式を選択できるようにします。既存ユーザーの既定値は `summary` のまま、従来の本文生成を変更しません。

- `summary`: 従来どおり1投稿
- `individual`: 1枚ずつ約1.6秒間隔で通知
- `chunked`: 2〜5枚ずつ約1.6秒間隔で通知（既定3枚）
- 各segmentは[Twitch Send Chat Message APIの上限](https://dev.twitch.tv/docs/api/reference/#send-chat-message)である500文字以内。長いカード名を省略して、draw範囲とレアリティの情報を保持

## 配送と互換性

- live EventSubと定期relayが同じ配送処理を使用。各segment成功・duplicate確定後にowner-fenced cursorを保存し、429/5xx等の再試行は保存済みcursorから再開
- cursor保存失敗・lease喪失で次segmentを停止し、全segment完了後だけoutbox全体をack
- 配信者ごとのDBロックで初回の配送方式を確定。同一配信者に先行するpending/processingの分割通知がある場合、未開始の後発通知はsummaryへ縮退
- 設定snapshotに加え、分割送信の予約とsummary縮退も永続化。transactionのcommit順逆転や再試行中の設定変更でも配送列・segment構成を維持
- 既存outboxはmigrationでsummary / cursor 0。アプリ配備がmigrationより先でも既存summary配送を継続
- 設定APIは認証・CSRF・rate limit・入力検証・maintenance write surfaceに対応

## 検証

対象HEAD: `c607e8eaf23a9122c8bd8497e4957676fa34e9a3`

- 独立Solレビュー: 必須指摘0件。relay再開漏れ、同時commit競合、app先行配備時の互換性問題を修正して再レビュー済み
- ローカルunit: 345ファイル / 4,050テスト成功
- ローカルintegration: 13成功 / 既存の5テストskip
- PostgreSQL 17.10: baseline等27ファイル適用、既存fixture群と追加した2接続競合fixtureがすべて成功
- 6segment送信→7番目429→relayが7番目から再開、全segment完了後ack、cursor保存失敗、lease喪失を回帰テストで確認
- Typecheck・変更箇所lint・i18nキー・migration順序・maintenance surfaceの確認成功
- ja/enの実コンポーネントと生成CSSを使ったローカルfixtureで、375px幅相当の表示枠、radio 3種、chunked時のみ枚数select、注意文、保存ボタン、折りたたみを確認
- [最終HEADのCI](https://github.com/azumag/twica/actions/runs/34674295169): **success**。Typecheck、unit、integration、PostgreSQL migration＋競合fixture、i18n、workflow lint、analysis build、アプリと補助Worker buildが成功。通常lint jobとrelease template contract本体は既存条件によりskip

## 配備と残る確認

- Cloudflareのfeature branch build/deployはリポジトリのガードでスキップする構成。最終HEADのGitHub deployment記録・Cloudflare用checkは0件で、PRでの自動preview配備は対象外
- previewへのマージは行っていません。preview配備後の実Twitch送信と `docs/QA.md` の実経路1〜7は未確認で、main昇格前に実施が必要
- 375px確認はローカルの測定表示枠です。実previewのログイン済みUIやブラウザviewportそのものの375px検証ではありません
- Twitch送信とDB保存は同一transactionにできないため、送信成功直後・cursor保存前の停止では同一segmentが重複する余地が残ります（既存のat-least-once保証）。保存済みsegmentを通常retryで再送する問題は修正済み

Issue #1548のカード名一覧チェック廃止は含みません。component aliasのテスト整合とDrizzle schemaへの新列反映は将来の改善候補として扱い、今回のraw SQL配送・設定処理への必須指摘にはしていません。
