### PR TITLE
test: collection completions の SELECT 対象テーブルを固定する

### DIFF
--- a/tests/unit/collection-completions.test.ts
+++ b/tests/unit/collection-completions.test.ts
@@ -154,7 +154,12 @@ describe('collection-completions', () => {
         const response = responses[Math.min(index, responses.length - 1)];
         index += 1;
         const builder: any = {
-          from: vi.fn(() => builder),
+          from: vi.fn((table: unknown) => {
+            if (table !== collectionCompletionsTable) {
+              throw new Error('unexpected table in collection completions fixture');
+            }
+            return builder;
+          }),
           where: vi.fn(() => builder),
           orderBy: vi.fn(() => builder),
           limit: vi.fn(() => {


### PR DESCRIPTION
## 概要

`getCollectionCompletions` のDrizzle read-pathが `collectionCompletionsTable` を参照する契約を、想定外テーブルでfail-fastするtest-only回帰テストとして固定します。

## 変更

- 既存 `primeSelectResponses` fixture の `.from(...)` で対象テーブルを検証
- `collectionCompletionsTable` 以外なら即座に失敗
- 既存の通常取得・legacy column fallback・エラー時空配列・接続断retryのテストをそのまま利用

runtimeコード、DB schema、API、外部I/Oは変更しません。

Refs #1555