### PR TITLE
fix: 未終端HTMLコメントで昇格要約を消さない

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -31,7 +31,10 @@ jobs:
           import re
 
           body = os.environ.get("PR_BODY", "")
-          body = re.sub(r"<!--.*?(?:-->|$)", "", body, flags=re.DOTALL)
+          # Complete comment pairs hide their contents. A stray opener can be
+          # explanatory text, so remove only its delimiter instead of consuming EOF.
+          body = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
+          body = body.replace("<!--", "")
           lines = body.splitlines()
           section_heading = "## このリリースで変わること"
           release_lines = []
@@ -116,10 +119,11 @@ jobs:
           # Fork PRs fall back to a sanitized title below.
           if os.environ.get("HEAD_REPOSITORY") != os.environ.get("GITHUB_REPOSITORY"):
               body = ""
-          # Template guidance and other HTML comments are not user-facing release
-          # text. Strip them before section extraction so comments-only input is
-          # treated as empty and falls back to the PR title.
-          body = re.sub(r"<!--.*?(?:-->|$)", "", body, flags=re.DOTALL)
+          # Template guidance and other complete HTML comments are not user-facing.
+          # A stray opener may be explanatory text, so discard only the delimiter
+          # instead of swallowing all following release text through EOF.
+          body = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
+          body = body.replace("<!--", "")
           lines = body.splitlines()
 
           release_lines = []

--- a/tests/unit/discord-promotion-fork-guard.test.ts
+++ b/tests/unit/discord-promotion-fork-guard.test.ts
@@ -84,17 +84,22 @@ describe("Discord promotion validation fork guard", () => {
       notifyBodyStart
     );
     const discardBody = workflow.indexOf('body = ""', forkGuard);
-    const sanitizeBody = workflow.indexOf(
-      'body = re.sub(r"<!--.*?(?:-->|$)", "", body, flags=re.DOTALL)',
+    const stripClosedComments = workflow.indexOf(
+      'body = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)',
       discardBody
     );
-    const splitBody = workflow.indexOf("lines = body.splitlines()", sanitizeBody);
+    const stripStrayOpeners = workflow.indexOf(
+      'body = body.replace("<!--", "")',
+      stripClosedComments
+    );
+    const splitBody = workflow.indexOf("lines = body.splitlines()", stripStrayOpeners);
 
     expect(notifyBodyStart).toBeGreaterThan(-1);
     expect(forkGuard).toBeGreaterThan(notifyBodyStart);
     expect(discardBody).toBeGreaterThan(forkGuard);
-    expect(sanitizeBody).toBeGreaterThan(discardBody);
-    expect(splitBody).toBeGreaterThan(sanitizeBody);
+    expect(stripClosedComments).toBeGreaterThan(discardBody);
+    expect(stripStrayOpeners).toBeGreaterThan(stripClosedComments);
+    expect(splitBody).toBeGreaterThan(stripStrayOpeners);
   });
 
   it("falls back to bounded metadata before trimming release text", () => {

--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -45,14 +45,16 @@ const REQUIRED_CONFIRMATION_LABELS = [
 const BROWSER_CONFIRMATION_HINT = "<!-- 対象外の場合は理由を記載 -->";
 
 function headingScanLines(source: string): string[] {
-  // The promotion workflow removes HTML comments before heading extraction.
+  // The promotion workflow removes complete HTML comments before heading extraction.
   // Preserve their newline count here so scan-line indexes still map to the
-  // original source used by the rest of the contract assertions.
-  const withoutHtmlCommentText = source.replace(
-    /<!--[\s\S]*?(?:-->|$)/g,
+  // original source used by the rest of the contract assertions. A stray opener
+  // drops only the delimiter so later release text/headings are not swallowed.
+  const withoutClosedHtmlComments = source.replace(
+    /<!--[\s\S]*?-->/g,
     (comment) => comment.replace(/[^\r\n]/g, "")
   );
-  return withoutHtmlCommentText.split(/\r?\n/);
+  const withoutStrayOpeners = withoutClosedHtmlComments.replace(/<!--/g, "");
+  return withoutStrayOpeners.split(/\r?\n/);
 }
 
 function normalizedHeading(line: string): string {
@@ -107,6 +109,30 @@ describe("preview -> main release PR template contract", () => {
     expect(h2Section(source, "## visible heading")).toBe(
       "  ## visible heading  \n  release text <!-- keep this in the returned contract section -->"
     );
+  });
+
+  it("does not swallow later headings after an unmatched HTML comment opener", () => {
+    const source = [
+      "<!-- literal opener used in explanatory text",
+      "## visible heading",
+      "release text",
+      "## next heading",
+    ].join("\n");
+
+    expect(h2Headings(source)).toEqual([
+      "## visible heading",
+      "## next heading",
+    ]);
+  });
+
+  it("keeps both promotion workflow paths on bounded HTML-comment sanitization", () => {
+    const boundedCommentSanitizer =
+      'body = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)';
+    const strayOpenerSanitizer = 'body = body.replace("<!--", "")';
+
+    expect(notifyWorkflow.split(boundedCommentSanitizer)).toHaveLength(3);
+    expect(notifyWorkflow.split(strayOpenerSanitizer)).toHaveLength(3);
+    expect(notifyWorkflow).not.toContain('r"<!--.*?(?:-->|$)"');
   });
 
   it("reports the logical contract name when a source file is missing", () => {


### PR DESCRIPTION
## 変更内容
- promotion summary のHTMLコメント除去を「閉じたコメント本文だけ」に限定
- 未終端の `<!--` は開始記号だけを除去し、後続の利用者向け本文を保持
- validate / Discord notify の両経路を同じ契約に揃える
- release PR contract test に未終端 opener の回帰ケースと workflow 二経路の sanitizer 契約を追加

## 安全性
- runtime / API / DB / secrets / permissions / Discord送信条件は変更しない
- 正常に閉じたHTMLコメントは従来どおり非表示
- `preview` の exact HEAD `9717f4addbddb395c856e68dc26f21466721f533` から作成

Refs #1113