### PR TITLE
test: promotion summary欠落ケースを固定

### DIFF
--- a/tests/unit/release-pr-template-contract.test.ts
+++ b/tests/unit/release-pr-template-contract.test.ts
@@ -142,6 +142,20 @@ describe("preview -> main release PR template contract", () => {
     ]);
   });
 
+  it("keeps comment-only and heading-less bodies without a release section", () => {
+    const commentOnly = [
+      "<!--",
+      "## このリリースで変わること",
+      "hidden guidance only",
+      "-->",
+    ].join("\n");
+    const headingLess = "利用者向け本文だけがあり、必須見出しがない";
+
+    expect(h2Headings(commentOnly)).toEqual([]);
+    expect(h2Section(commentOnly, REQUIRED_TEMPLATE_HEADINGS[0])).toBe("");
+    expect(h2Section(headingLess, REQUIRED_TEMPLATE_HEADINGS[0])).toBe("");
+  });
+
   it("keeps both promotion workflow paths on bounded HTML-comment sanitization", () => {
     const boundedCommentSanitizer =
       'body = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)';


### PR DESCRIPTION
Refs #1113

## 概要

Discord mainマージ通知のrelease契約テストへ、以下の欠落ケースを追加します。

- HTMLコメントだけの本文では、コメント内の見出しをrelease sectionとして扱わない
- 利用者向け本文があっても必須H2見出しが無ければrelease sectionとして扱わない

## 変更範囲

- `tests/unit/release-pr-template-contract.test.ts` のみ
- runtime workflow / API / DB / 外部I/Oの変更なし
- 最新 `preview` から1 commit、1 file / +14 -0

#1113 の「コメントのみ・見出し無し等を単体テストで固定する」残件のうち、上記2ケースだけを低リスクに固定します。2000文字超やPython共通script化など他の残件は本PRへ含めません。