### PR TITLE
test: Discord通知の2000 UTF-16上限契約を固定

### DIFF
--- a/tests/unit/discord-promotion-length-contract.test.ts
+++ b/tests/unit/discord-promotion-length-contract.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), '../..')
+const workflow = readFileSync(
+  join(repositoryRoot, '.github/workflows/notify-discord-main-merge.yml'),
+  'utf8',
+)
+
+describe('Discord promotion notification length contract', () => {
+  it('keeps overlong release summaries bounded by 2000 UTF-16 code units', () => {
+    // Discord's content limit is enforced in UTF-16 units. Keep the source-level
+    // contract pinned here so a future refactor cannot silently switch to Python
+    // code-point length or remove the post-truncation fail-closed guard.
+    expect(workflow).toContain('          limit = 2000')
+    expect(workflow).toContain('          def discord_length(value):')
+    expect(workflow).toContain(
+      '              return len(value.encode("utf-16-le")) // 2',
+    )
+    expect(workflow).toContain('          def truncate_utf16(value, max_units):')
+    expect(workflow).toContain(
+      '                  units = len(char.encode("utf-16-le")) // 2',
+    )
+    expect(workflow).toContain(
+      '              available = limit - discord_length(prefix + marker + suffix)',
+    )
+    expect(workflow).toContain(
+      '              release_text = truncate_utf16(release_text, max(0, available)).rstrip()',
+    )
+    expect(workflow).toContain(
+      '          if discord_length(content) > limit:\n              raise SystemExit("Discord notification exceeds 2000 characters after trimming")',
+    )
+  })
+})


### PR DESCRIPTION
Refs #1113

## 概要

Discord mainマージ通知の長文切り詰めについて、2000 UTF-16 code units 上限を守る既存workflow契約をtest-onlyで固定します。

## 変更範囲

- `tests/unit/discord-promotion-length-contract.test.ts` を追加
- `limit = 2000`、UTF-16単位の長さ計算、UTF-16単位の切り詰め、prefix/marker/suffixを差し引いた残量計算、切り詰め後のfail-closed再検査を固定
- runtime workflow / Discord送信処理 / API / DB / 外部I/Oは変更しない

#1113 の「コメントのみ・見出し無し・2000文字超などを単体テストで固定する」残件のうち、前者2件は #1559 で完了したため、本PRでは2000文字超の境界契約だけを独立して補強します。Markdown構造を壊さない切り詰め方式やPython共通script化などの設計残件には触れません。