### PR TITLE
chore: N連配送のDrizzle schema型をmigrationへ合わせる

### DIFF
--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -217,9 +217,22 @@ export const gachaHistory = pgTable('gacha_history', {
 })
 
 // -----------------------------------------------------------------------------
+// streamer_chat_multi_delivery_settings（Issue #1549: N連チャット配送方式）
+// 根拠: 20260912013000 paced multi draw chat
+// -----------------------------------------------------------------------------
+export const streamerChatMultiDeliverySettings = pgTable('streamer_chat_multi_delivery_settings', {
+  streamer_id: uuid('streamer_id').primaryKey(),
+  delivery_mode: text('delivery_mode').notNull().default('summary'),
+  chunk_size: integer('chunk_size').notNull().default(3),
+  created_at: timestamp('created_at', { withTimezone: true, mode: 'string' }).notNull().default(sql`now()`),
+  updated_at: timestamp('updated_at', { withTimezone: true, mode: 'string' }).notNull().default(sql`now()`),
+})
+
+// -----------------------------------------------------------------------------
 // chat_notification_outbox（Issue #708: transactional chat outbox）
 // Twitch API配送はat-least-once。processing leaseで通常の同時送信を防ぐが、
 // Twitch送信成功後〜sent記録前の停止時だけは重複送信を許容する。
+// 20260912013000でN連チャットの配送snapshot/cursor列を追加（Issue #1549）。
 // -----------------------------------------------------------------------------
 export const chatNotificationOutbox = pgTable('chat_notification_outbox', {
   id: uuid('id').primaryKey().default(sql`extensions.uuid_generate_v4()`),
@@ -228,6 +241,10 @@ export const chatNotificationOutbox = pgTable('chat_notification_outbox', {
   payload: jsonb('payload').$type<Json>().notNull(),
   expected_draw_count: integer('expected_draw_count').notNull(),
   assembled_draw_count: integer('assembled_draw_count').notNull(),
+  delivery_mode: text('delivery_mode').notNull().default('summary'),
+  delivery_chunk_size: integer('delivery_chunk_size').notNull().default(3),
+  delivery_cursor: integer('delivery_cursor').notNull().default(0),
+  delivery_mode_resolved: boolean('delivery_mode_resolved').notNull().default(false),
   status: text('status').notNull().default('pending'),
   attempt_count: integer('attempt_count').notNull().default(0),
   next_attempt_at: timestamp('next_attempt_at', { withTimezone: true, mode: 'string' }).notNull().default(sql`now()`),

--- a/tests/unit/paced-multi-draw-drizzle-schema.test.ts
+++ b/tests/unit/paced-multi-draw-drizzle-schema.test.ts
@@ -1,0 +1,47 @@
+import { getTableColumns } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import {
+  chatNotificationOutbox,
+  streamerChatMultiDeliverySettings,
+} from '@/lib/db/schema'
+
+describe('paced multi-draw Drizzle schema', () => {
+  it('配信者ごとの配送設定テーブルをmigrationと同じ列で型付けする', () => {
+    const columns = getTableColumns(streamerChatMultiDeliverySettings)
+
+    expect(Object.keys(columns)).toEqual([
+      'streamer_id',
+      'delivery_mode',
+      'chunk_size',
+      'created_at',
+      'updated_at',
+    ])
+    expect(columns.streamer_id.primary).toBe(true)
+    expect(columns.delivery_mode.notNull).toBe(true)
+    expect(columns.delivery_mode.hasDefault).toBe(true)
+    expect(columns.chunk_size.notNull).toBe(true)
+    expect(columns.chunk_size.hasDefault).toBe(true)
+  })
+
+  it('outboxの分割配送snapshot/cursor列を型付けする', () => {
+    const columns = getTableColumns(chatNotificationOutbox)
+
+    expect(Object.keys(columns)).toEqual(
+      expect.arrayContaining([
+        'delivery_mode',
+        'delivery_chunk_size',
+        'delivery_cursor',
+        'delivery_mode_resolved',
+      ])
+    )
+    for (const name of [
+      'delivery_mode',
+      'delivery_chunk_size',
+      'delivery_cursor',
+      'delivery_mode_resolved',
+    ] as const) {
+      expect(columns[name].notNull).toBe(true)
+      expect(columns[name].hasDefault).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## 概要

Issue #1561 の残件として、PR #1552 / migration `20260912013000_paced_multi_draw_chat.sql` で追加済みのN連チャット配送設定を Drizzle schema へ型定義として反映します。

## 変更

- `streamer_chat_multi_delivery_settings` を `src/lib/db/schema.ts` に追加
- `chat_notification_outbox` の `delivery_mode` / `delivery_chunk_size` / `delivery_cursor` / `delivery_mode_resolved` を追加
- migrationを正本として NOT NULL / DEFAULT を一致させる
- CHECK制約は既存schema方針どおりDB側を正本とし、Drizzle側には重複定義しない
- `getTableColumns()` を使った回帰テストでテーブル/列・primary/notNull/default契約を固定

## 非変更

- migration / 実DB / raw SQL配送処理 / API / UI / 外部I/O は変更しません
- 既存の配送順序・retry・cursor・lease fencingには影響しません

Refs #1561 #1552 #1549