### PR TITLE
fix: promotion summary内のfenced H2を境界扱いしない

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -43,9 +43,27 @@ jobs:
               if line.strip() == section_heading:
                   start = index + 1
                   break
+          fence_char = None
+          fence_len = 0
           if start is not None:
               for line in lines[start:]:
-                  if line.strip().startswith("## "):
+                  stripped = line.lstrip()
+                  fence_match = re.match(r"^(`{3,}|~{3,})", stripped)
+                  if fence_match:
+                      marker = fence_match.group(1)
+                      if fence_char is None:
+                          fence_char = marker[0]
+                          fence_len = len(marker)
+                      elif (
+                          marker[0] == fence_char
+                          and len(marker) >= fence_len
+                          and stripped[len(marker):].strip() == ""
+                      ):
+                          fence_char = None
+                          fence_len = 0
+                      release_lines.append(line)
+                      continue
+                  if fence_char is None and line.strip().startswith("## "):
                       break
                   release_lines.append(line)
 
@@ -133,9 +151,27 @@ jobs:
                   start = index + 1
                   break
 
+          fence_char = None
+          fence_len = 0
           if start is not None:
               for line in lines[start:]:
-                  if line.strip().startswith("## "):
+                  stripped = line.lstrip()
+                  fence_match = re.match(r"^(`{3,}|~{3,})", stripped)
+                  if fence_match:
+                      marker = fence_match.group(1)
+                      if fence_char is None:
+                          fence_char = marker[0]
+                          fence_len = len(marker)
+                      elif (
+                          marker[0] == fence_char
+                          and len(marker) >= fence_len
+                          and stripped[len(marker):].strip() == ""
+                      ):
+                          fence_char = None
+                          fence_len = 0
+                      release_lines.append(line)
+                      continue
+                  if fence_char is None and line.strip().startswith("## "):
                       break
                   release_lines.append(line)
 

--- a/tests/unit/release-summary-fenced-heading.test.ts
+++ b/tests/unit/release-summary-fenced-heading.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const notifyWorkflow = readFileSync(
+  join(repositoryRoot, ".github/workflows/notify-discord-main-merge.yml"),
+  "utf8"
+);
+const releaseHeading = "## このリリースで変わること";
+
+function extractReleaseSection(source: string): string {
+  const body = source
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/<!--/g, "");
+  const lines = body.split(/\r\n?|\n/);
+  const start = lines.findIndex((line) => line.trim() === releaseHeading);
+  if (start === -1) return "";
+
+  const releaseLines: string[] = [];
+  let fenceChar: "`" | "~" | null = null;
+  let fenceLength = 0;
+
+  for (const line of lines.slice(start + 1)) {
+    const stripped = line.trimStart();
+    const fenceMatch = stripped.match(/^(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1] ?? "";
+      if (fenceChar === null) {
+        fenceChar = marker[0] as "`" | "~";
+        fenceLength = marker.length;
+      } else if (
+        marker[0] === fenceChar &&
+        marker.length >= fenceLength &&
+        stripped.slice(marker.length).trim() === ""
+      ) {
+        fenceChar = null;
+        fenceLength = 0;
+      }
+      releaseLines.push(line);
+      continue;
+    }
+
+    if (fenceChar === null && line.trim().startsWith("## ")) break;
+    releaseLines.push(line);
+  }
+
+  return releaseLines.join("\n").trim();
+}
+
+describe("promotion summary fenced heading contract", () => {
+  it("keeps H2-looking lines inside backtick fences and stops at the next real H2", () => {
+    const body = [
+      releaseHeading,
+      "利用者向け説明",
+      "```text",
+      "## これはコード例の見出し",
+      "value=1",
+      "```",
+      "続きの説明",
+      "## 対象PRと固定SHA",
+      "- #123",
+    ].join("\n");
+
+    expect(extractReleaseSection(body)).toBe(
+      [
+        "利用者向け説明",
+        "```text",
+        "## これはコード例の見出し",
+        "value=1",
+        "```",
+        "続きの説明",
+      ].join("\n")
+    );
+  });
+
+  it("supports tilde fences and a longer matching closing fence", () => {
+    const body = [
+      releaseHeading,
+      "~~~~text",
+      "## fenced",
+      "~~~~~",
+      "after fence",
+      "## 確認済み",
+    ].join("\n");
+
+    expect(extractReleaseSection(body)).toContain("## fenced");
+    expect(extractReleaseSection(body)).toContain("after fence");
+    expect(extractReleaseSection(body)).not.toContain("## 確認済み");
+  });
+
+  it("keeps both embedded Python paths on the same fence-aware boundary contract", () => {
+    const fenceMatcher = 'fence_match = re.match(r"^(`{3,}|~{3,})", stripped)';
+    const boundaryCheck =
+      'if fence_char is None and line.strip().startswith("## "):';
+    const closeLengthCheck = "and len(marker) >= fence_len";
+
+    expect(notifyWorkflow.split(fenceMatcher)).toHaveLength(3);
+    expect(notifyWorkflow.split(boundaryCheck)).toHaveLength(3);
+    expect(notifyWorkflow.split(closeLengthCheck)).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
Refs #1113

## 概要

Preview→main 昇格PRの利用者向けsummary抽出で、Markdown fenced code block 内の `## ` 行を次セクション境界と誤認しないようにします。

## 変更内容

- validate / Discord notify の埋め込みPython双方で backtick / tilde fence を追跡
- fence内の `## ...` はsummary本文として保持
- 同種かつ開きfence以上の長さで、後続が空白だけのmarkerをclosing fenceとして扱う
- fence外の次H2は従来どおりsummary終端
- backtick / tilde / longer closing fence と、両Python経路の契約を unit test で固定

## 変更範囲

- `.github/workflows/notify-discord-main-merge.yml`
- `tests/unit/release-summary-fenced-heading.test.ts`
- API / DB / OAuth / Twitch / Cloudflare / Secret / permissions の変更なし

`preview` HEAD `96c902dd4621014accea0ac062a47e306b0f51b5` から作成。既存open PRの変更ファイルとは重複していません。