### PR TITLE
fix: Discord通知メタデータのMarkdown崩れを防ぐ

### DIFF
--- a/.github/workflows/notify-discord-main-merge.yml
+++ b/.github/workflows/notify-discord-main-merge.yml
@@ -188,6 +188,19 @@ jobs:
               value = re.sub(r"(?i)(?<![\w@])(?:https?://|www\.|discord\.gg/)[^\s<>()]+", "", value)
               return value
 
+          def escape_discord_markdown(value):
+              escaped = value
+              for marker in ("\\", "`", "*", "_", "~", "|"):
+                  escaped = escaped.replace(marker, "\\" + marker)
+              return escaped
+
+          def discord_inline_code(value):
+              # Normal refs keep the compact code style. A rare ref containing a
+              # backtick falls back to escaped plain text instead of breaking the span.
+              if "`" in value:
+                  return escape_discord_markdown(value)
+              return f"`{value}`"
+
           release_text = strip_markdown_links(chr(10).join(release_lines)).strip()
           if not release_text or not re.search("[0-9A-Za-zぁ-んァ-ヶ一-龠]", release_text):
               is_promotion = (
@@ -214,10 +227,14 @@ jobs:
                   release_text = strip_markdown_links(
                       os.environ.get("PR_TITLE", "").strip()
                   ).strip()
-          prefix = f"🚀 **{os.environ['REPOSITORY_NAME']} が更新されました**\n\n"
+
+          repository_name = escape_discord_markdown(os.environ["REPOSITORY_NAME"])
+          head_ref = discord_inline_code(os.environ["HEAD_REF"])
+          pr_author = escape_discord_markdown(os.environ["PR_AUTHOR"])
+          prefix = f"🚀 **{repository_name} が更新されました**\n\n"
           suffix = (
-              f"\n\n`{os.environ['HEAD_REF']} → main`\n"
-              f"by {os.environ['PR_AUTHOR']}\n\n"
+              f"\n\n{head_ref} → main\n"
+              f"by {pr_author}\n\n"
               f"🔗 [リリース内容を見る]({os.environ['PR_URL']})"
           )
 

--- a/tests/unit/discord-promotion-metadata-contract.test.ts
+++ b/tests/unit/discord-promotion-metadata-contract.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+const workflow = readFileSync(
+  join(repositoryRoot, ".github/workflows/notify-discord-main-merge.yml"),
+  "utf8"
+);
+
+describe("Discord promotion metadata rendering contract", () => {
+  it("escapes Markdown control characters before rendering repository and author metadata", () => {
+    expect(workflow).toContain("def escape_discord_markdown(value):");
+    expect(workflow).toContain(
+      'for marker in ("\\\\", "`", "*", "_", "~", "|"):'
+    );
+    expect(workflow).toContain(
+      'repository_name = escape_discord_markdown(os.environ["REPOSITORY_NAME"])'
+    );
+    expect(workflow).toContain(
+      'pr_author = escape_discord_markdown(os.environ["PR_AUTHOR"])'
+    );
+    expect(workflow).toContain(
+      'prefix = f"🚀 **{repository_name} が更新されました**\\n\\n"'
+    );
+    expect(workflow).toContain('f"by {pr_author}\\n\\n"');
+  });
+
+  it("keeps normal refs as inline code but escapes refs that contain a backtick", () => {
+    expect(workflow).toContain("def discord_inline_code(value):");
+    expect(workflow).toContain('if "`" in value:');
+    expect(workflow).toContain("return escape_discord_markdown(value)");
+    expect(workflow).toContain('return f"`{value}`"');
+    expect(workflow).toContain(
+      'head_ref = discord_inline_code(os.environ["HEAD_REF"])'
+    );
+    expect(workflow).toContain('f"\\n\\n{head_ref} → main\\n"');
+  });
+
+  it("continues to suppress Discord mention parsing", () => {
+    expect(workflow).toContain("allowed_mentions: {parse: []}");
+  });
+});


### PR DESCRIPTION
Refs #1113

## 概要
- main merge Discord通知で repository name / PR author をMarkdown escapeしてから描画
- head ref は通常どおりinline codeを維持し、backtickを含む稀なrefだけescaped plain textへfail-safe
- `allowed_mentions: {parse: []}` は維持
- workflow上の適用箇所を固定する回帰テストを追加

## 変更範囲
- `.github/workflows/notify-discord-main-merge.yml`
- `tests/unit/discord-promotion-metadata-contract.test.ts`

外部I/O、Webhook URL、権限、trigger、promotion summary抽出契約は変更していません。