### PR TITLE
docs: proxy移行のbundle検証条件を固定

### DIFF
--- a/docs/cloudflare-proxy-migration.md
+++ b/docs/cloudflare-proxy-migration.md
@@ -15,6 +15,11 @@ predates the adapter's Node.js middleware / `proxy.ts` support.
   `opennextjs/opennextjs-cloudflare#1309` added experimental Node.js middleware
   (`proxy.ts`) support directly to `@opennextjs/cloudflare`, and it shipped in
   1.20.3. The support requires the `nodejs_compat` compatibility flag.
+- Treat bundle size as an explicit migration gate. PR #1309 lists increased
+  worker size as a known limitation, and `opennextjs-cloudflare#1373` reports a
+  roughly 4.6 MB total bundle in a minimal no-op `proxy.ts` reproduction on
+  1.20.4. That upstream report is not a TwiCa measurement, so TwiCa must compare
+  its own before/after artifacts before accepting the migration.
 - Accept the Next.js deprecated convention warning as the smaller operational
   risk until the dependency is upgraded and `npm run workers:build` is verified
   on TwiCa's actual middleware path.
@@ -36,18 +41,23 @@ was closed on 2026-08-25 when
 merged. `@opennextjs/cloudflare` 1.20.3, published on 2026-08-26, includes that
 experimental `proxy.ts` support.
 
-Upstream status last checked: **2026-09-09**. The recheck confirms #1277 remains
-closed and #1309 remains merged. TwiCa is still pinned to
-`@opennextjs/cloudflare` 1.20.2, so the upstream fix has not yet changed the
-repository's verified deployment contract.
+Upstream status last checked: **2026-09-13**. The recheck confirms #1277 remains
+closed, #1309 remains merged, and
+[`opennextjs-cloudflare#1373`](https://github.com/opennextjs/opennextjs-cloudflare/issues/1373)
+remains open as a bundle-size regression report for the Node.js middleware
+path. TwiCa is still pinned to `@opennextjs/cloudflare` 1.20.2, so the upstream
+support has not yet changed the repository's verified deployment contract.
 
 ## Revisit Conditions
 
 Revisit this decision when either of these is true:
 
 - TwiCa upgrades to an `@opennextjs/cloudflare` release containing #1309
-  (1.20.3 or newer) and `npm run workers:build` succeeds with `src/proxy.ts`
-  while the existing session refresh, protected-route, and middleware contract
-  tests remain green.
+  (1.20.3 or newer), `npm run workers:build` succeeds with `src/proxy.ts`, and
+  the existing session refresh, protected-route, and middleware contract tests
+  remain green. Before accepting the migration, also compare the generated
+  middleware / total Worker bundle size with the current Edge Middleware
+  baseline and confirm the increase is acceptable for TwiCa's Cloudflare
+  deployment limits and operating cost. A successful build alone is not enough.
 - TwiCa changes deployment architecture so request interception no longer needs
   to run in Cloudflare Workers middleware.

--- a/tests/unit/cloudflare-proxy-migration.test.ts
+++ b/tests/unit/cloudflare-proxy-migration.test.ts
@@ -26,6 +26,8 @@ describe("Cloudflare proxy migration policy", () => {
     expect(adapterVersion).toBeDefined();
     expect(doc).toContain(`@opennextjs/cloudflare\` ${adapterVersion}`);
     expect(doc).toContain("opennextjs-cloudflare#1309");
+    expect(doc).toContain("opennextjs-cloudflare#1373");
+    expect(doc).toContain("bundle size");
     expect(doc).toContain("Upstream status last checked");
     expect(doc).toContain("npm run workers:build");
     expect(middleware).toContain("export async function middleware");


### PR DESCRIPTION
## 概要

Issue #417 の Cloudflare Proxy 移行方針を、現在の上流状況に合わせて補強します。

`@opennextjs/cloudflare` では #1309 により Node.js middleware (`proxy.ts`) の実験的サポートが追加されましたが、上流 #1373 では no-op `proxy.ts` でも bundle が大きく増える再現報告があります。TwiCa は現在 1.20.2 のままなので runtime 移行は行わず、将来の再評価時に build 成功だけでなく bundle size も必須ゲートとして比較する契約を追加します。

## 変更

- `docs/cloudflare-proxy-migration.md`
  - upstream status の確認日を 2026-09-13 へ更新
  - #1373 の bundle-size regression 報告を記録
  - TwiCa 自身の before/after bundle size を確認するまで migration を受け入れない条件を追加
- `tests/unit/cloudflare-proxy-migration.test.ts`
  - #1373 と bundle-size gate が policy から消えないことを最小限に回帰固定

## 非スコープ

- `@opennextjs/cloudflare` のアップグレード
- `src/middleware.ts` → `src/proxy.ts` の移行
- `nodejs_compat` や Cloudflare 設定変更
- production / preview deploy

CI で既存の migration policy test と通常契約を確認します。

Refs #417